### PR TITLE
fix(parsing): handle list-form codex tool output

### DIFF
--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -1554,6 +1554,26 @@ class _CodexParseState:
     tool_result_map: dict[str, dict] = dataclasses.field(default_factory=dict)
 
 
+def _coalesce_codex_output(raw: Any) -> str:
+    """Normalize a Codex tool `output` field to a string.
+
+    Codex may deliver output as a plain string or as a list of OpenAI-style
+    content blocks (``input_text``, ``input_image``). Only text is preserved;
+    non-text blocks are dropped.
+    """
+    if isinstance(raw, str):
+        return raw
+    if isinstance(raw, list):
+        parts: list[str] = []
+        for block in raw:
+            if isinstance(block, dict) and block.get("type") == "input_text":
+                text = block.get("text")
+                if isinstance(text, str):
+                    parts.append(text)
+        return "\n".join(parts)
+    return ""
+
+
 def _build_codex_tool_result_map(entries: list[dict[str, Any]], anonymizer: Anonymizer) -> dict[str, dict]:
     """Pre-pass: build call_id -> {output, status} from function_call_output and custom_tool_call_output."""
     result: dict[str, dict] = {}
@@ -1567,44 +1587,53 @@ def _build_codex_tool_result_map(entries: list[dict[str, Any]], anonymizer: Anon
             continue
 
         if pt == "function_call_output":
-            raw = p.get("output", "")
-            # Parse "Exit code: N\nWall time: ...\nOutput:\n..." format
+            raw_output = p.get("output", "")
             out: dict = {}
-            lines = raw.splitlines()
-            output_lines: list[str] = []
-            in_output = False
-            for line in lines:
-                if line.startswith("Exit code: "):
-                    try:
-                        out["exit_code"] = int(line[len("Exit code: "):].strip())
-                    except ValueError:
-                        out["exit_code"] = line[len("Exit code: "):].strip()
-                elif line.startswith("Wall time: "):
-                    out["wall_time"] = line[len("Wall time: "):].strip()
-                elif line == "Output:":
-                    in_output = True
-                elif in_output:
-                    output_lines.append(line)
-            if output_lines:
-                out["output"] = anonymizer.text("\n".join(output_lines).strip())
+            if isinstance(raw_output, str):
+                # Parse "Exit code: N\nWall time: ...\nOutput:\n..." format
+                output_lines: list[str] = []
+                in_output = False
+                for line in raw_output.splitlines():
+                    if line.startswith("Exit code: "):
+                        try:
+                            out["exit_code"] = int(line[len("Exit code: "):].strip())
+                        except ValueError:
+                            out["exit_code"] = line[len("Exit code: "):].strip()
+                    elif line.startswith("Wall time: "):
+                        out["wall_time"] = line[len("Wall time: "):].strip()
+                    elif line == "Output:":
+                        in_output = True
+                    elif in_output:
+                        output_lines.append(line)
+                if output_lines:
+                    out["output"] = anonymizer.text("\n".join(output_lines).strip())
+            else:
+                text = _coalesce_codex_output(raw_output)
+                if text:
+                    out["output"] = anonymizer.text(text)
             result[call_id] = {"output": out, "status": "success"}
 
         elif pt == "custom_tool_call_output":
-            raw = p.get("output", "")
+            raw_output = p.get("output", "")
             out = {}
-            try:
-                parsed = json.loads(raw)
-                text = parsed.get("output", "")
+            if isinstance(raw_output, str):
+                try:
+                    parsed = json.loads(raw_output)
+                    text = parsed.get("output", "")
+                    if text:
+                        out["output"] = anonymizer.text(str(text))
+                    meta = parsed.get("metadata", {})
+                    if "exit_code" in meta:
+                        out["exit_code"] = meta["exit_code"]
+                    if "duration_seconds" in meta:
+                        out["duration_seconds"] = meta["duration_seconds"]
+                except (json.JSONDecodeError, AttributeError):
+                    if raw_output:
+                        out["output"] = anonymizer.text(raw_output)
+            else:
+                text = _coalesce_codex_output(raw_output)
                 if text:
-                    out["output"] = anonymizer.text(str(text))
-                meta = parsed.get("metadata", {})
-                if "exit_code" in meta:
-                    out["exit_code"] = meta["exit_code"]
-                if "duration_seconds" in meta:
-                    out["duration_seconds"] = meta["duration_seconds"]
-            except (json.JSONDecodeError, AttributeError):
-                if raw:
-                    out["output"] = anonymizer.text(raw)
+                    out["output"] = anonymizer.text(text)
             result[call_id] = {"output": out, "status": "success"}
 
     return result

--- a/tests/parsing/test_parser.py
+++ b/tests/parsing/test_parser.py
@@ -1341,6 +1341,62 @@ class TestBuildCodexToolResultMap:
         assert "Successfully applied patch" in result["call-2"]["output"]["output"]
         assert result["call-2"]["output"]["duration_seconds"] == 0.5
 
+    def test_function_call_output_list_form(self, mock_anonymizer):
+        """Codex sessions may deliver output as a list of content blocks (e.g. images)."""
+        entries = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call-img",
+                    "output": [
+                        {"type": "input_text", "text": "screenshot captured"},
+                        {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+                    ],
+                },
+            }
+        ]
+        result = _build_codex_tool_result_map(entries, mock_anonymizer)
+        assert "call-img" in result
+        assert result["call-img"]["status"] == "success"
+        assert "screenshot captured" in result["call-img"]["output"]["output"]
+
+    def test_function_call_output_list_image_only(self, mock_anonymizer):
+        """List-form output with only images should not raise."""
+        entries = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": "call-img2",
+                    "output": [
+                        {"type": "input_image", "image_url": "data:image/png;base64,AAAA"},
+                    ],
+                },
+            }
+        ]
+        result = _build_codex_tool_result_map(entries, mock_anonymizer)
+        assert "call-img2" in result
+        assert result["call-img2"]["status"] == "success"
+
+    def test_custom_tool_call_output_list_form(self, mock_anonymizer):
+        """Custom tool output may also arrive as a list of content blocks."""
+        entries = [
+            {
+                "type": "response_item",
+                "payload": {
+                    "type": "custom_tool_call_output",
+                    "call_id": "call-custom-list",
+                    "output": [
+                        {"type": "input_text", "text": "patch applied"},
+                    ],
+                },
+            }
+        ]
+        result = _build_codex_tool_result_map(entries, mock_anonymizer)
+        assert "call-custom-list" in result
+        assert "patch applied" in result["call-custom-list"]["output"]["output"]
+
     def test_non_response_item_ignored(self, mock_anonymizer):
         entries = [
             {


### PR DESCRIPTION
## Summary
- Codex sessions may deliver `function_call_output` / `custom_tool_call_output` as a list of OpenAI-style content blocks (e.g. `input_text`, `input_image`) when a tool returns images. The previous code assumed a string and crashed with `AttributeError: 'list' object has no attribute 'splitlines'`, which aborted the scan for any project containing such a session.
- Normalize list-form output by concatenating `input_text` block text and dropping non-text blocks. String form still parses the `Exit code / Wall time / Output:` envelope as before.
- On my machine, this unblocked **16 previously-skipped codex sessions** on re-scan.

## Test plan
- [x] New unit tests in `tests/parsing/test_parser.py::TestBuildCodexToolResultMap`:
  - `test_function_call_output_list_form` — mixed text + image blocks
  - `test_function_call_output_list_image_only` — image-only list does not raise
  - `test_custom_tool_call_output_list_form` — custom tool list form
- [x] Full suite: `pytest` → 806 passed
- [x] Manual: `clawjournal scan` now indexes previously-failing codex sessions without tracebacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)