### PR TITLE
docs: rewrite README around skills-first six-stage flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ Everything in the default workflow runs on your own computer:
 
 - `scan`, `serve`, `inbox`, `search`, `score`, `export`, and `bundle-export` all run locally.
 - The review UI opens on `localhost:8384` in your own browser — no account, no cloud service.
+- `scan` auto-runs a secrets + PII findings pipeline per session. Findings are stored as hashed references in your local SQLite DB — plaintext is never persisted.
 - `bundle-export` writes redacted files to your disk. It does not upload them.
 - Uploading is a separate, opt-in flow. If you never configure an ingest endpoint and never run a share command, nothing is sent anywhere.
 
 ## If you decide to share
 
-Sharing is fully opt-in and separate from local review. When you do choose to export or upload, ClawJournal runs automatic redaction first (paths, usernames, emails, API keys, tokens, private keys, and similar) and can layer AI-assisted PII review on top.
+Sharing is fully opt-in and separate from local review. When you do choose to export or upload, ClawJournal re-applies regex redaction (paths, usernames, emails, API keys, tokens, private keys, and similar) on top of the scan-time findings, and the workbench Share flow adds an AI-assisted PII review on top of that.
+
+The AI-assisted PII review uses the same backend as `score` — your current coding agent's automation CLI (e.g. `codex exec`, the Claude CLI). Home-dir paths and usernames are anonymized locally before anything is sent to the agent; if your agent routes to a cloud provider, that's where the PII review happens. Override with `--backend` to keep the call on a local model.
 
 See [PRIVACY.md](PRIVACY.md) for the full redaction list and the two sharing paths (local file vs. self-configured upload).
 
@@ -21,49 +24,187 @@ See [PRIVACY.md](PRIVACY.md) for the full redaction list and the two sharing pat
 
 ## Quickstart
 
-### Install from PyPI (recommended)
-
-One line, no Node toolchain, no cloning — the published wheel includes the pre-built browser workbench.
-
-```bash
-pipx install clawjournal     # or: pip install clawjournal
-clawjournal scan             # Index local sessions from Claude Code, Codex, etc.
-clawjournal serve            # Open review UI at http://localhost:8384 (your machine only)
-```
-
-Requires Python 3.10+. `pipx` is preferred because it isolates the CLI in its own environment and puts `clawjournal` on your `PATH`.
-
-### Let your coding agent set it up
-
-Prefer to skip the terminal? Paste this into any coding agent (Claude Code, Codex, Cursor, etc.):
-
-```
-Install ClawJournal from PyPI (`pipx install clawjournal`), run `clawjournal scan`, and start `clawjournal serve`.
-Keep everything local unless I explicitly ask to share data.
-```
-
-The agent will install the package, scan your sessions, and open the workbench at `http://localhost:8384`. Nothing leaves your machine.
-
-### Install as a skill for repeat use
-
-If you plan to use ClawJournal more than once, install it as a skill. Works with Claude Code, Codex, Cursor, Gemini CLI, OpenCode, and [many more](https://github.com/nicepkg/skills). Requires Node.js for the one-time `npx` command.
+Inside any compatible coding agent (Claude Code, Codex, Cursor, Gemini CLI, OpenCode, [many more](https://github.com/nicepkg/skills)):
 
 ```bash
 npx skills add kai-rayward/clawjournal
 ```
 
-Then inside your coding agent, say:
+Then tell the agent: *"setup clawjournal"*. It installs the PyPI package, scans your local sessions with default settings, and opens the workbench at `http://localhost:8384`. Nothing is uploaded.
 
-```text
-setup clawjournal
+Prefer the terminal? See Stage 1 in the flow below — every stage shows both skills and shell commands.
+
+---
+
+## End-to-end flow
+
+Six stages from a blank machine to a shared bundle. Each stage shows the skills-first way (inside your coding agent) and the shell-direct way.
+
+```
+ Install ──► Configure ──► Scan ──► Triage ──► Score ──► Package & Share
+    1            2           3          4          5              6
 ```
 
-The setup skill installs ClawJournal on your machine, scans your local sessions, and launches the workbench in your browser. Nothing is uploaded. It adds:
-- **clawjournal-setup** — interactive wizard to install, scan sessions, and launch the workbench
-- **clawjournal** — review, triage, and share traces
-- **clawjournal-score** — AI-assisted quality scoring
+**Three skills are installed by `npx skills add`:**
 
-### Build from source (contributors)
+| Skill | Covers stages |
+|-------|---------------|
+| **clawjournal-setup** | 1 Install · 3 Scan · workbench launch |
+| **clawjournal** | 4 Triage · 6 Package & Share |
+| **clawjournal-score** | 5 Score |
+
+Day-to-day, prompts like *"triage my new sessions"*, *"score everything unscored"*, or *"package my approved sessions for export"* route to the right skill automatically.
+
+### 1. Install
+
+**Skills — in your coding agent (Claude Code, Codex, Cursor, …):**
+
+```bash
+npx skills add kai-rayward/clawjournal
+```
+
+Adds the three ClawJournal skills to your agent. The PyPI package itself is installed in Stage 2 as part of `setup clawjournal`.
+
+**Shell — in any bash/zsh terminal:**
+
+```bash
+pipx install clawjournal        # or: pip install clawjournal
+```
+
+Requires Python 3.10+. `pipx` is preferred because it isolates the CLI in its own environment and puts `clawjournal` on your `PATH`. The PyPI wheel already includes the pre-built browser workbench — no frontend build required.
+
+### 2. Configure
+
+Tell ClawJournal which agents' sessions to scan and what to exclude or redact.
+
+**Skills — in your coding agent (Claude Code, Codex, Cursor, …):**
+
+For a first-time run with defaults (all sources, no exclusions), say:
+
+> *"setup clawjournal"*
+
+The skill installs the PyPI package, runs a first scan, and opens the workbench. Later, to narrow scope or add redactions:
+
+> *"Configure clawjournal to scan only claude and codex, exclude the `scratch` project, and always redact the string `acme-internal`."*
+
+Subsequent scans pick up the new settings automatically.
+
+**Shell — in any bash/zsh terminal:**
+
+```bash
+clawjournal config --source all                   # claude | codex | gemini | opencode | openclaw | kimi | custom | all
+clawjournal list                                  # see discovered projects
+clawjournal config --exclude "project1,project2"  # optional: exclude projects
+clawjournal config --redact "string1,string2"     # optional: custom redactions (appends)
+clawjournal config --redact-usernames "handle1"   # optional: anonymize usernames (appends)
+clawjournal config --confirm-projects             # lock in project selection
+```
+
+`--exclude`, `--redact`, and `--redact-usernames` all append; they never overwrite. Safe to call repeatedly.
+
+### 3. Scan
+
+Reads your local session files into a SQLite DB and runs a per-session findings pipeline (secrets engine + PII engine). Findings are stored as hashed references — plaintext is never persisted.
+
+**Skills — in your coding agent (Claude Code, Codex, Cursor, …):**
+
+Your agent runs scan as part of `setup clawjournal`. Re-scan any time with: *"scan my sessions again."*
+
+**Shell — in any bash/zsh terminal:**
+
+```bash
+clawjournal scan
+```
+
+The workbench daemon (`clawjournal serve`) also scans continuously in the background.
+
+### 4. Triage
+
+Approve sessions worth keeping, block the rest. Happens in the workbench (Sessions page) or the CLI.
+
+**Skills — in your coding agent (Claude Code, Codex, Cursor, …):**
+
+> *"Open clawjournal and help me triage the unreviewed sessions."*
+
+**Shell — in any bash/zsh terminal:**
+
+```bash
+clawjournal serve                                    # workbench UI — the primary review surface
+# or directly in the terminal:
+clawjournal inbox --json --limit 20                  # list sessions
+clawjournal search "refactor auth" --json            # full-text search
+clawjournal approve <session_id> --reason "clean"    # approve
+clawjournal block <session_id> --reason "private"    # block
+clawjournal shortlist <session_id>                   # mark for deeper review
+```
+
+Optional hold-state controls — useful when you want to quarantine a session without blocking it (CLI only):
+
+```bash
+clawjournal hold <id> --reason "pending legal review"
+clawjournal release <id>
+clawjournal embargo <id> --until 2026-06-01
+clawjournal hold-history <id>
+```
+
+### 5. Score
+
+AI-assisted quality scoring on a 1–5 scale (1 = noise, 5 = excellent). Home-dir paths and usernames are anonymized before anything is sent to the judge.
+
+**Skills — in your coding agent (Claude Code, Codex, Cursor, …):**
+
+> *"Score my unscored sessions."*
+
+This runs through the `clawjournal-score` skill and uses your current agent's automation CLI.
+
+**Shell — in any bash/zsh terminal:**
+
+```bash
+clawjournal score --batch --auto-triage              # batch-score; auto-blocks noise (score 1) sessions
+clawjournal score-view <id>                          # show score details
+clawjournal set-score <id> --quality 4               # manual override
+```
+
+`--auto-triage` moves sessions with quality score 1 to `blocked`. Sessions scored 2–5 stay visible for you to decide.
+
+By default scoring uses the current agent's automation CLI (e.g. `codex exec` inside Codex, the Claude CLI inside Claude Code). Use `--backend` to override. For Codex specifically, `codex exec` reuses saved CLI authentication by default; for automation the recommended explicit credential is `CODEX_API_KEY`.
+
+### 6. Package & Share
+
+Bundle approved sessions into a redacted export on disk. Uploading that bundle is a separate, opt-in step.
+
+**Skills — in your coding agent (Claude Code, Codex, Cursor, …):**
+
+> *"Package my approved sessions and export them locally."*
+>
+> *(optional)* *"Then share the bundle through the ingest service."*
+
+**Workbench — in your browser:**
+
+Open the workbench (`clawjournal serve`) and walk the Share page: **Queue → Redact → Review → Package → Done**. The Redact step layers AI-assisted PII detection on top of the scan-time findings.
+
+**Shell — in any bash/zsh terminal:**
+
+```bash
+clawjournal bundle-create --status approved          # bundle all approved sessions
+clawjournal bundle-list
+clawjournal bundle-view <bundle_id>                  # inspect before exporting
+clawjournal bundle-export <bundle_id>                # write sessions.jsonl + manifest.json to disk
+```
+
+Optional upload:
+
+```bash
+clawjournal verify-email you@university.edu          # one-time email verification
+clawjournal share --preview --status approved        # dry-run
+clawjournal bundle-share <bundle_id>                 # upload through the configured ingest service
+```
+
+Upload is gated on hold-state: only sessions in `auto_redacted` or `released` can leave the machine.
+
+---
+
+## Build from source (contributors)
 
 You only need this path if you're developing ClawJournal itself — the PyPI wheel is the right choice for everyone else.
 
@@ -117,9 +258,9 @@ python -m pip install -e .
 </details>
 
 <details>
-<summary><b>Node.js required for the browser UI</b></summary>
+<summary><b>Node.js required only when building from source</b></summary>
 
-`clawjournal serve` uses a frontend built from `clawjournal/web/frontend`. Build it once before your first browser launch.
+The PyPI wheel ships the pre-built workbench. You only need Node if you're building from source.
 
 | Platform | Install command |
 |----------|----------------|
@@ -133,78 +274,18 @@ npm install
 npm run build
 ```
 
-If you only use terminal commands such as `scan`, `inbox`, `search`, or `export`, you can skip the frontend build.
-
 </details>
 
-### Supported agents
+## Supported agents
 
 ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline.
 
-### Project docs
+## Project docs
 
 - [PRIVACY.md](PRIVACY.md) — what stays local, what gets redacted, and how optional sharing works
 - [ARCHITECTURE.md](ARCHITECTURE.md) — public architecture overview
 - [CONTRIBUTING.md](CONTRIBUTING.md) — contribution guidelines
 - [SECURITY.md](SECURITY.md) — security reporting and threat-model scope
-
----
-
-## Workflow
-
-The core local-review flow runs entirely on your machine. Steps 2-3 are required before anything else; Step 4 is where you actually review traces in the workbench.
-
-```
- Scan ──> Configure ──> Confirm ──> Triage
-  1           2            3           4
-           required ──────┘
-```
-
-### Step 1 — Scan
-
-```bash
-clawjournal scan
-```
-
-Reads your local session files and indexes them into a SQLite DB in your home directory. Run this first so later steps have data to work with.
-
-### Step 2 — Configure source (required)
-
-```bash
-clawjournal config --source all
-# Options: claude, codex, gemini, opencode, openclaw, kimi, custom, all
-```
-
-### Step 3 — Review and confirm projects (required)
-
-```bash
-clawjournal list                                     # See all discovered projects
-clawjournal config --exclude "project1,project2"     # Optional: exclude projects
-clawjournal config --confirm-projects                # Required: lock in project selection
-```
-
-### Step 4 — Triage sessions (recommended)
-
-```bash
-# Browse and search
-clawjournal inbox --json --limit 20
-clawjournal search "refactor auth" --json
-
-# Approve or block
-clawjournal approve <session_id> --reason "clean trace"
-clawjournal block <session_id> --reason "proprietary code"
-
-# Optional: AI-assisted scoring with the current agent's automation CLI (auto-approves 4-5, blocks 1-2)
-clawjournal score --batch --auto-triage
-```
-
-By default, `clawjournal score` uses the current agent's automation CLI. For example, inside Codex it uses `codex exec`; inside Claude Code it uses the Claude CLI; inside OpenClaw it uses `openclaw agent --json`. It does not attach to the live interactive session or use Codex subagents. Use `--backend` to override when needed.
-
-For Codex specifically, this follows Codex non-interactive mode: `codex exec` reuses saved CLI authentication by default, and for automation the recommended explicit credential is `CODEX_API_KEY`.
-
-For a visual review experience: `clawjournal serve` opens the workbench on `localhost:8384` on your own machine. `clawjournal serve --remote` prints an SSH tunnel command so you can reach the same local server on a remote VM. Build the frontend once first if you installed from source.
-
-If you later decide to export or share traces, see [PRIVACY.md](PRIVACY.md) and the `export`, `bundle-*`, and `share` commands in the reference below.
 
 ---
 
@@ -217,13 +298,57 @@ If you later decide to export or share traces, see [PRIVACY.md](PRIVACY.md) and 
 
 | Command | Description |
 |---------|-------------|
-| `clawjournal scan` | Index local sessions into workbench DB |
-| `clawjournal serve` | Open workbench UI at localhost:8384 (after the one-time frontend build) |
-| `clawjournal config --source all` | Select source scope — `claude`, `codex`, `gemini`, `opencode`, `openclaw`, `kimi`, `custom`, or `all` (required) |
+| `clawjournal scan` | Index local sessions + run findings pipeline |
+| `clawjournal serve` | Open workbench UI at localhost:8384 |
+| `clawjournal config --source all` | Select source scope (required) |
 | `clawjournal config --confirm-projects` | Confirm project selection (required before export) |
-| `clawjournal score --batch --auto-triage` | AI-score sessions with the current agent's automation CLI, auto-approve 4-5 and block 1-2 |
-| `clawjournal export --pii-review --pii-apply` | Export with PII redaction (recommended before any sharing) |
-| `clawjournal bundle-export <bundle_id>` | Export a redacted bundle to disk as `sessions.jsonl` + `manifest.json` |
+| `clawjournal score --batch --auto-triage` | AI-score sessions; auto-block noise (score 1) |
+| `clawjournal bundle-create --status approved` | Bundle approved sessions |
+| `clawjournal bundle-export <bundle_id>` | Export bundle to disk as `sessions.jsonl` + `manifest.json` |
+
+### Triage & review
+
+| Command | Description |
+|---------|-------------|
+| `clawjournal inbox --json --limit 20` | List sessions as JSON |
+| `clawjournal search <query> --json` | Full-text search |
+| `clawjournal approve <id> [id ...]` | Approve sessions |
+| `clawjournal block <id> [id ...]` | Block sessions |
+| `clawjournal shortlist <id> [id ...]` | Shortlist sessions |
+| `clawjournal score --batch --limit 20` | AI-score up to 20 sessions |
+| `clawjournal score-view <id>` | View score details |
+| `clawjournal set-score <id> --quality <1-5>` | Manually set a quality score |
+
+### Hold-state gate
+
+| Command | Description |
+|---------|-------------|
+| `clawjournal hold <id>` | Move session to `pending_review` (blocks upload) |
+| `clawjournal release <id>` | Release a held session for share |
+| `clawjournal embargo <id> --until <ISO>` | Time-lock a session (auto-releases on expiry) |
+| `clawjournal hold-history <id>` | Show the full hold-state timeline |
+
+### Findings & allowlist
+
+| Command | Description |
+|---------|-------------|
+| `clawjournal findings <id>` | List findings (hashed entities) for a session |
+| `clawjournal findings <id> --accept <ref>` | Accept a finding (will be redacted at export) |
+| `clawjournal findings <id> --ignore <ref>` | Ignore a finding |
+| `clawjournal findings <id> --accept-all` / `--ignore-all` | Bulk decision on open findings |
+| `clawjournal allowlist list` | Show global allowlist |
+| `clawjournal allowlist add ...` | Allowlist an entity (hashed locally) |
+| `clawjournal allowlist remove <id>` | Remove an allowlist entry |
+
+### Bundles
+
+| Command | Description |
+|---------|-------------|
+| `clawjournal bundle-create --status approved` | Create bundle from all approved sessions |
+| `clawjournal bundle-list` | List bundles |
+| `clawjournal bundle-view <bundle_id>` | View bundle details |
+| `clawjournal bundle-export <bundle_id>` | Export bundle to disk |
+| `clawjournal bundle-share <bundle_id>` | Upload via configured ingest service |
 
 ### Quick share
 
@@ -235,47 +360,13 @@ If you later decide to export or share traces, see [PRIVACY.md](PRIVACY.md) and 
 | `clawjournal card <id> --depth workflow` | Workflow-only card (safe for public channels) |
 | `clawjournal card <id> --depth full` | Full card with redacted content |
 
-### Review & triage
-
-| Command | Description |
-|---------|-------------|
-| `clawjournal inbox --json --limit 20` | List sessions as JSON (for agent parsing) |
-| `clawjournal search <query> --json` | Full-text search across sessions |
-| `clawjournal approve <id> [id ...]` | Approve sessions by ID |
-| `clawjournal block <id> [id ...]` | Block sessions by ID |
-| `clawjournal shortlist <id> [id ...]` | Shortlist sessions for review |
-| `clawjournal score --batch --limit 20` | AI-score up to 20 sessions with the current agent's automation CLI |
-| `clawjournal score-view <id>` | View score details for a session |
-| `clawjournal set-score <id> --quality <1-5>` | Manually set a quality score |
-
-### Bundles
-
-| Command | Description |
-|---------|-------------|
-| `clawjournal bundle-create --status approved` | Create bundle from all approved sessions |
-| `clawjournal bundle-list` | List all bundles |
-| `clawjournal bundle-view <bundle_id>` | View bundle details and sessions |
-| `clawjournal bundle-export <bundle_id>` | Export bundle to disk (JSONL + manifest) |
-| `clawjournal bundle-share <bundle_id>` | Upload bundle to an ingest service (optional) |
-
 ### Optional upload
 
 | Command | Description |
 |---------|-------------|
 | `clawjournal verify-email you@university.edu` | Verify a `.edu` email for upload authorization |
 | `clawjournal share --preview --status approved` | Preview what would be shared without uploading |
-| `clawjournal share --status approved` | Create a bundle and upload it through the configured ingest service |
-
-### Export & PII
-
-| Command | Description |
-|---------|-------------|
-| `clawjournal export` | Export to local JSONL |
-| `clawjournal export --no-thinking` | Exclude extended thinking blocks |
-| `clawjournal export --pii-review --pii-apply` | Export, generate PII findings, and produce sanitized JSONL |
-| `clawjournal pii-review --file <file> --output <findings.json>` | Run PII detection on an exported file |
-| `clawjournal pii-apply --file <file> --findings <findings.json> --output <sanitized.jsonl>` | Apply PII redactions to an exported file |
-| `clawjournal pii-rubric` | Show PII entity types and detection rules |
+| `clawjournal share --status approved` | Create a bundle and upload through the ingest service |
 
 ### Configuration
 
@@ -286,8 +377,21 @@ If you later decide to export or share traces, see [PRIVACY.md](PRIVACY.md) and 
 | `clawjournal config --redact-usernames "u1,u2"` | Add usernames to anonymize (appends) |
 | `clawjournal list` | List all projects with exclusion status |
 | `clawjournal status` | Show current stage and next steps (JSON) |
-| `clawjournal update-skill claude` | Install/update the clawjournal skill for a specific agent |
+| `clawjournal update-skill <agent>` | Install/update the clawjournal skill for an agent |
 | `clawjournal serve --remote` | Print SSH tunnel command for remote VM access |
+
+### Export & sanitize (advanced)
+
+| Command | Description |
+|---------|-------------|
+| `clawjournal export` | Export to local JSONL |
+| `clawjournal export --no-thinking` | Exclude extended thinking blocks |
+| `clawjournal export --pii-review --pii-apply` | Legacy LLM-PII path — export + AI-PII review + sanitize |
+| `clawjournal pii-review --file <file> --output <findings.json>` | Legacy — run PII detection on an exported file |
+| `clawjournal pii-apply --file <file> --findings <findings.json> --output <sanitized.jsonl>` | Legacy — apply PII redactions to an exported file |
+| `clawjournal pii-rubric` | Show PII entity types and detection rules |
+
+**Legacy note:** `pii-review` and `pii-apply` remain for AI-based PII review of already-exported files, but deterministic secrets/PII detection has moved to the `findings` + `bundle-export` flow above. Prefer the new path.
 
 </details>
 
@@ -343,9 +447,10 @@ Each line in the exported JSONL is one session:
 <summary><b>Gotchas</b></summary>
 
 - **`--exclude`, `--redact`, `--redact-usernames` APPEND** — they never overwrite. Safe to call repeatedly.
-- **Source and project confirmation are required** — the CLI will block export until both are set.
-- **Run PII review before sharing** — automated redaction is good but not foolproof. `--pii-review --pii-apply` adds AI-assisted detection.
-- **Large exports take time** — 500+ sessions may take 1-3 minutes.
+- **Source and project confirmation are required** — the CLI blocks export until both are set.
+- **`scan` already redacts.** Secrets and PII findings are computed and stored as hashed references at scan time. For additional LLM-PII review, use the workbench Share page. The legacy `--pii-review` / `--pii-apply` CLI path still works for sanitizing already-exported files.
+- **Hold-state gates uploads.** Sessions in `pending_review` or active `embargoed` cannot be shared; `auto_redacted` (default) and `released` can.
+- **Large exports take time** — 500+ sessions may take 1–3 minutes.
 - **Virtual environment recommended** — modern Linux (and some macOS setups) block system-wide pip installs. Use a venv to avoid issues.
 
 </details>


### PR DESCRIPTION
## Summary

Rewrite the README to align with the current code and skills packaging. The old README mixed skills, CLI, and a legacy export workflow; this version leads with a skills-first Quickstart and promotes a six-stage end-to-end flow (Install → Configure → Scan → Triage → Score → Package & Share) to the top of the doc, with both invocation paths shown under every stage.

- **Skills label:** `Skills — in your coding agent (Claude Code, Codex, Cursor, …)`
- **Shell label:** `Shell — in any bash/zsh terminal`
- **Workbench label** (Stage 6 only): `Workbench — in your browser` — walks the new Queue → Redact → Review → Package → Done wizard from #7

### Corrections to documented behavior

- `scan` now advertises that it runs the secrets + PII findings pipeline and stores hashed references (plaintext never persisted).
- `score --auto-triage` fixed to "blocks substance-1 (noise)". The prior "auto-approves 4-5 and blocks 1-2" description did not match the code.
- Surface the hold-state gate (`hold` / `release` / `embargo` / `hold-history`) and the `findings` / `allowlist` verbs in the command reference.
- Flag `pii-review` / `pii-apply` as the legacy LLM-PII path — mirrors the stderr notice the CLI already prints.

### Trust-boundary clarifications

- Name the AI-PII review backend in "If you decide to share": same backend as `score`, paths and usernames anonymized locally before the call, `--backend` override for fully-local operation.
- State explicitly what defaults `setup clawjournal` uses (source=all, no exclusions, no custom redactions) so first-time readers aren't confused by Configure (Stage 2) coming before Scan (Stage 3) in the flow.

## Test plan

- [ ] Render the README on GitHub and skim the six-stage flow top-to-bottom.
- [ ] Click every relative link (PRIVACY.md / ARCHITECTURE.md / CONTRIBUTING.md / SECURITY.md).
- [ ] Cross-check `score --auto-triage` claim against `cli.py:2594`.
- [ ] Cross-check "scan runs findings pipeline" against `workbench/daemon.py:178`.
- [ ] Cross-check Share wizard step names against #7.
- [ ] Confirm "Queue → Redact → Review → Package → Done" matches the workbench UI after `clawjournal serve`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)