### PR TITLE
feat(capture): ingest adapter for Claude and Codex JSONLs

### DIFF
--- a/clawjournal/capture/__init__.py
+++ b/clawjournal/capture/__init__.py
@@ -1,0 +1,39 @@
+"""Capture adapter for coding-agent session logs.
+
+Owns file discovery, per-consumer cursor tracking, and change detection
+for supported client JSONL directories. Downstream consumers (the
+workbench Scanner adapter and the upcoming normalized-event pipeline)
+read from this module rather than rediscovering files themselves.
+Contract: docs/plans/phase-1/01-capture-pipeline.md.
+"""
+
+from clawjournal.capture.changes import (
+    LineBatch,
+    cursor_after,
+    cursor_to_eof,
+    file_has_changed,
+    iter_new_lines,
+)
+from clawjournal.capture.cursors import (
+    Cursor,
+    ensure_schema,
+    get_cursor,
+    list_cursors,
+    set_cursor,
+)
+from clawjournal.capture.discovery import SourceFile, iter_source_files
+
+__all__ = [
+    "Cursor",
+    "LineBatch",
+    "SourceFile",
+    "cursor_after",
+    "cursor_to_eof",
+    "ensure_schema",
+    "file_has_changed",
+    "get_cursor",
+    "iter_new_lines",
+    "iter_source_files",
+    "list_cursors",
+    "set_cursor",
+]

--- a/clawjournal/capture/__init__.py
+++ b/clawjournal/capture/__init__.py
@@ -21,17 +21,19 @@ from clawjournal.capture.cursors import (
     list_cursors,
     set_cursor,
 )
-from clawjournal.capture.discovery import SourceFile, iter_source_files
+from clawjournal.capture.discovery import ParseInput, SourceFile, iter_parse_inputs, iter_source_files
 
 __all__ = [
     "Cursor",
     "LineBatch",
+    "ParseInput",
     "SourceFile",
     "cursor_after",
     "cursor_for_reparse",
     "ensure_schema",
     "file_has_changed",
     "get_cursor",
+    "iter_parse_inputs",
     "iter_new_lines",
     "iter_source_files",
     "list_cursors",

--- a/clawjournal/capture/__init__.py
+++ b/clawjournal/capture/__init__.py
@@ -10,7 +10,7 @@ Contract: docs/plans/phase-1/01-capture-pipeline.md.
 from clawjournal.capture.changes import (
     LineBatch,
     cursor_after,
-    cursor_to_eof,
+    cursor_for_reparse,
     file_has_changed,
     iter_new_lines,
 )
@@ -28,7 +28,7 @@ __all__ = [
     "LineBatch",
     "SourceFile",
     "cursor_after",
-    "cursor_to_eof",
+    "cursor_for_reparse",
     "ensure_schema",
     "file_has_changed",
     "get_cursor",

--- a/clawjournal/capture/changes.py
+++ b/clawjournal/capture/changes.py
@@ -5,10 +5,10 @@ Two consumer models are supported:
 - **Line-level deltas** (`iter_new_lines` / `cursor_after`) — streaming
   consumers (the 02 normalized-event pipeline) read appended lines since
   the cursor and advance one line-batch at a time. The cursor they
-  persist is derived from the stat snapshot captured at the moment the
-  batch was read, not a fresh stat, so a file replacement between read
-  and sink commit cannot move the cursor into an unrelated file's
-  middle.
+  persist is derived from the descriptor-backed stat snapshot captured
+  for the file ACTUALLY opened for the batch, not a fresh path stat, so
+  a file replacement before or after the read cannot move the cursor
+  into an unrelated file's middle.
 
 - **File-level change detection** (`file_has_changed` /
   `cursor_for_reparse`) — whole-file-reparse consumers (the workbench
@@ -38,6 +38,7 @@ rotation always produces a new inode via rename and is caught.
 
 from __future__ import annotations
 
+import os
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -59,20 +60,25 @@ def iter_new_lines(
     path: Path, cursor: Cursor | None, *, client: str
 ) -> LineBatch | None:
     try:
-        st = path.stat()
+        with path.open("rb") as f:
+            st = os.fstat(f.fileno())
+            start_offset = 0
+            if (
+                cursor is not None
+                and cursor.inode == st.st_ino
+                and cursor.last_offset <= st.st_size
+            ):
+                start_offset = cursor.last_offset
+
+            if start_offset >= st.st_size:
+                return None
+
+            # Read against the same descriptor we snapshotted so batch
+            # metadata matches the bytes we actually consumed.
+            f.seek(start_offset)
+            raw = f.read(st.st_size - start_offset)
     except FileNotFoundError:
         return None
-
-    start_offset = 0
-    if cursor is not None and cursor.inode == st.st_ino and cursor.last_offset <= st.st_size:
-        start_offset = cursor.last_offset
-
-    if start_offset >= st.st_size:
-        return None
-
-    with path.open("rb") as f:
-        f.seek(start_offset)
-        raw = f.read(st.st_size - start_offset)
 
     last_newline = raw.rfind(b"\n")
     if last_newline < 0:

--- a/clawjournal/capture/changes.py
+++ b/clawjournal/capture/changes.py
@@ -13,6 +13,14 @@ Two consumer models are supported:
 Each consumer holds its own cursor (see cursors.py) and advances only
 after its own sink commit, so one consumer cannot cause another to miss
 data and crashes replay cleanly.
+
+Rotation detection is best-effort at the stat level. Inode change,
+size decrease, and mtime regression all signal rotation/truncation.
+Unlink-then-recreate on Linux often reuses the inode immediately; if
+the replacement file is also larger than the prior cursor offset, it
+is indistinguishable from a plain append at stat(2). Vendor JSONLs
+are append-only, so this is not a production concern — logrotate-style
+rotation always produces a new inode via rename and is caught.
 """
 
 from __future__ import annotations

--- a/clawjournal/capture/changes.py
+++ b/clawjournal/capture/changes.py
@@ -1,0 +1,117 @@
+"""Change detection for the capture adapter.
+
+Two consumer models are supported:
+
+- **Line-level deltas** (`iter_new_lines` / `cursor_after`) — streaming
+  consumers (the 02 normalized-event pipeline) read appended lines since
+  the cursor and advance one line-batch at a time.
+- **File-level change detection** (`file_has_changed` / `cursor_to_eof`)
+  — whole-file-reparse consumers (the workbench Scanner adapter in
+  migration step 2) ask whether a file has changed, reparse it fully,
+  then advance the cursor to EOF after their sink commit.
+
+Each consumer holds its own cursor (see cursors.py) and advances only
+after its own sink commit, so one consumer cannot cause another to miss
+data and crashes replay cleanly.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+
+from clawjournal.capture.cursors import Cursor
+
+
+@dataclass(frozen=True)
+class LineBatch:
+    path: Path
+    client: str
+    start_offset: int
+    end_offset: int
+    lines: list[str]
+
+
+def iter_new_lines(
+    path: Path, cursor: Cursor | None, *, client: str
+) -> LineBatch | None:
+    try:
+        st = path.stat()
+    except FileNotFoundError:
+        return None
+
+    start_offset = 0
+    if cursor is not None and cursor.inode == st.st_ino and cursor.last_offset <= st.st_size:
+        start_offset = cursor.last_offset
+
+    if start_offset >= st.st_size:
+        return None
+
+    with path.open("rb") as f:
+        f.seek(start_offset)
+        raw = f.read(st.st_size - start_offset)
+
+    last_newline = raw.rfind(b"\n")
+    if last_newline < 0:
+        return None
+    complete = raw[: last_newline + 1]
+    text_lines = [
+        line.decode("utf-8", errors="replace")
+        for line in complete.splitlines()
+    ]
+    end_offset = start_offset + last_newline + 1
+
+    return LineBatch(
+        path=path,
+        client=client,
+        start_offset=start_offset,
+        end_offset=end_offset,
+        lines=text_lines,
+    )
+
+
+def cursor_after(batch: LineBatch, path: Path, *, consumer_id: str) -> Cursor:
+    """Cursor a line-level consumer should persist after its sink commit."""
+    st = path.stat()
+    return Cursor(
+        consumer_id=consumer_id,
+        source_path=str(path),
+        inode=st.st_ino,
+        last_offset=batch.end_offset,
+        last_modified=st.st_mtime,
+        client=batch.client,
+    )
+
+
+def file_has_changed(path: Path, cursor: Cursor | None) -> bool:
+    """Cheap gate for whole-file-reparse consumers.
+
+    Returns True if `path` differs from the cursor's recorded state in
+    inode, size, or mtime. Missing files return False (nothing to do).
+    """
+    try:
+        st = path.stat()
+    except FileNotFoundError:
+        return False
+    if cursor is None:
+        return st.st_size > 0
+    if cursor.inode != st.st_ino:
+        return True
+    if cursor.last_offset != st.st_size:
+        return True
+    return cursor.last_modified != st.st_mtime
+
+
+def cursor_to_eof(
+    path: Path, *, consumer_id: str, client: str
+) -> Cursor:
+    """Cursor a file-level consumer should persist after reparsing to EOF."""
+    st = path.stat()
+    return Cursor(
+        consumer_id=consumer_id,
+        source_path=str(path),
+        inode=st.st_ino,
+        last_offset=st.st_size,
+        last_modified=st.st_mtime,
+        client=client,
+    )

--- a/clawjournal/capture/changes.py
+++ b/clawjournal/capture/changes.py
@@ -4,15 +4,28 @@ Two consumer models are supported:
 
 - **Line-level deltas** (`iter_new_lines` / `cursor_after`) — streaming
   consumers (the 02 normalized-event pipeline) read appended lines since
-  the cursor and advance one line-batch at a time.
-- **File-level change detection** (`file_has_changed` / `cursor_to_eof`)
-  — whole-file-reparse consumers (the workbench Scanner adapter in
-  migration step 2) ask whether a file has changed, reparse it fully,
-  then advance the cursor to EOF after their sink commit.
+  the cursor and advance one line-batch at a time. The cursor they
+  persist is derived from the stat snapshot captured at the moment the
+  batch was read, not a fresh stat, so a file replacement between read
+  and sink commit cannot move the cursor into an unrelated file's
+  middle.
+
+- **File-level change detection** (`file_has_changed` /
+  `cursor_for_reparse`) — whole-file-reparse consumers (the workbench
+  Scanner adapter in migration step 2). The required ordering is:
+
+      snap = cursor_for_reparse(path, ...)   # stat snapshot BEFORE parse
+      # parse the file (may read bytes appended during the parse)
+      # write to the sink and commit
+      set_cursor(conn, snap)                  # persist the pre-parse cursor
+
+  If the file grows between the snapshot and the commit, the cursor
+  stays at the pre-parse size and the next poll's `file_has_changed`
+  sees the growth. The sink's idempotency (`upsert_sessions` keyed on
+  session_id, the `events` UNIQUE index) absorbs any replayed bytes.
 
 Each consumer holds its own cursor (see cursors.py) and advances only
-after its own sink commit, so one consumer cannot cause another to miss
-data and crashes replay cleanly.
+after its own sink commit.
 
 Rotation detection is best-effort at the stat level. Inode change,
 size decrease, and mtime regression all signal rotation/truncation.
@@ -38,6 +51,8 @@ class LineBatch:
     start_offset: int
     end_offset: int
     lines: list[str]
+    inode: int
+    last_modified: float
 
 
 def iter_new_lines(
@@ -75,18 +90,24 @@ def iter_new_lines(
         start_offset=start_offset,
         end_offset=end_offset,
         lines=text_lines,
+        inode=st.st_ino,
+        last_modified=st.st_mtime,
     )
 
 
-def cursor_after(batch: LineBatch, path: Path, *, consumer_id: str) -> Cursor:
-    """Cursor a line-level consumer should persist after its sink commit."""
-    st = path.stat()
+def cursor_after(batch: LineBatch, *, consumer_id: str) -> Cursor:
+    """Build the Cursor a line-level consumer should persist after its
+    sink commit. Uses the stat snapshot captured when the batch was read
+    (`batch.inode`, `batch.last_modified`), not a fresh stat, so a file
+    replacement between read and commit cannot move the cursor into an
+    unrelated file's middle.
+    """
     return Cursor(
         consumer_id=consumer_id,
-        source_path=str(path),
-        inode=st.st_ino,
+        source_path=str(batch.path),
+        inode=batch.inode,
         last_offset=batch.end_offset,
-        last_modified=st.st_mtime,
+        last_modified=batch.last_modified,
         client=batch.client,
     )
 
@@ -110,11 +131,29 @@ def file_has_changed(path: Path, cursor: Cursor | None) -> bool:
     return cursor.last_modified != st.st_mtime
 
 
-def cursor_to_eof(
+def cursor_for_reparse(
     path: Path, *, consumer_id: str, client: str
-) -> Cursor:
-    """Cursor a file-level consumer should persist after reparsing to EOF."""
-    st = path.stat()
+) -> Cursor | None:
+    """Snapshot the file's stat and return the cursor a whole-file-reparse
+    consumer should persist AFTER its sink commit.
+
+    Contract: call BEFORE parsing the file. The returned cursor captures
+    the pre-parse `(inode, size, mtime)`. If the file grows during the
+    parse, the cursor stays at the pre-parse size, and the next poll's
+    `file_has_changed` returns True because the new size differs from
+    the cursor's recorded size. The sink's idempotency absorbs the
+    replayed bytes.
+
+    Calling this AFTER the parse is the bug the rename guards against:
+    the cursor would advance past any bytes appended during the parse,
+    and those bytes would be lost.
+
+    Returns None if the file is missing.
+    """
+    try:
+        st = path.stat()
+    except FileNotFoundError:
+        return None
     return Cursor(
         consumer_id=consumer_id,
         source_path=str(path),

--- a/clawjournal/capture/changes.py
+++ b/clawjournal/capture/changes.py
@@ -117,6 +117,14 @@ def file_has_changed(path: Path, cursor: Cursor | None) -> bool:
 
     Returns True if `path` differs from the cursor's recorded state in
     inode, size, or mtime. Missing files return False (nothing to do).
+
+    Designed for `cursor_for_reparse` cursors, where `last_offset`
+    equals the file size at snapshot time. A `cursor_after` cursor's
+    `last_offset` can legitimately trail the file size (the file ended
+    in a partial line at read time), so this function will return True
+    in steady state on such cursors even when no new bytes have been
+    written. Line-level consumers should use `iter_new_lines` directly
+    rather than gating on `file_has_changed`.
     """
     try:
         st = path.stat()

--- a/clawjournal/capture/cursors.py
+++ b/clawjournal/capture/cursors.py
@@ -1,0 +1,112 @@
+"""Capture cursor persistence.
+
+Cursors are per-consumer. Each downstream consumer (the workbench Scanner
+adapter, the 02 normalized-event pipeline, ...) owns its own cursor rows.
+The primary key is (consumer_id, source_path). A consumer advances its
+cursor only after its own sink commit, so one consumer cannot cause
+another to miss data and a crash between cursor advance and sink commit
+cannot lose data — the retry re-reads the unadvanced range.
+
+Stored in the clawjournal workbench index.db so capture and workbench
+share one data root.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+CURSOR_SCHEMA = """
+CREATE TABLE IF NOT EXISTS capture_cursors (
+    consumer_id   TEXT NOT NULL,
+    source_path   TEXT NOT NULL,
+    inode         INTEGER NOT NULL,
+    last_offset   INTEGER NOT NULL,
+    last_modified REAL NOT NULL,
+    client        TEXT NOT NULL,
+    first_seen    TEXT NOT NULL,
+    last_seen     TEXT NOT NULL,
+    PRIMARY KEY (consumer_id, source_path)
+);
+CREATE INDEX IF NOT EXISTS idx_capture_cursors_client ON capture_cursors(client);
+CREATE INDEX IF NOT EXISTS idx_capture_cursors_path ON capture_cursors(source_path);
+"""
+
+
+@dataclass(frozen=True)
+class Cursor:
+    consumer_id: str
+    source_path: str
+    inode: int
+    last_offset: int
+    last_modified: float
+    client: str
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(CURSOR_SCHEMA)
+
+
+def get_cursor(
+    conn: sqlite3.Connection, consumer_id: str, source_path: Path | str
+) -> Cursor | None:
+    row = conn.execute(
+        "SELECT consumer_id, source_path, inode, last_offset, last_modified, client "
+        "FROM capture_cursors WHERE consumer_id = ? AND source_path = ?",
+        (consumer_id, str(source_path)),
+    ).fetchone()
+    if row is None:
+        return None
+    return Cursor(*row)
+
+
+def set_cursor(conn: sqlite3.Connection, cursor: Cursor) -> None:
+    now_iso = datetime.now(timezone.utc).isoformat()
+    conn.execute(
+        """
+        INSERT INTO capture_cursors
+            (consumer_id, source_path, inode, last_offset, last_modified, client, first_seen, last_seen)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        ON CONFLICT(consumer_id, source_path) DO UPDATE SET
+            inode = excluded.inode,
+            last_offset = excluded.last_offset,
+            last_modified = excluded.last_modified,
+            client = excluded.client,
+            last_seen = excluded.last_seen
+        """,
+        (
+            cursor.consumer_id,
+            cursor.source_path,
+            cursor.inode,
+            cursor.last_offset,
+            cursor.last_modified,
+            cursor.client,
+            now_iso,
+            now_iso,
+        ),
+    )
+
+
+def list_cursors(
+    conn: sqlite3.Connection,
+    *,
+    consumer_id: str | None = None,
+    client: str | None = None,
+) -> list[Cursor]:
+    clauses: list[str] = []
+    params: list[str] = []
+    if consumer_id is not None:
+        clauses.append("consumer_id = ?")
+        params.append(consumer_id)
+    if client is not None:
+        clauses.append("client = ?")
+        params.append(client)
+    where = f"WHERE {' AND '.join(clauses)}" if clauses else ""
+    rows = conn.execute(
+        "SELECT consumer_id, source_path, inode, last_offset, last_modified, client "
+        f"FROM capture_cursors {where} ORDER BY consumer_id, source_path",
+        params,
+    ).fetchall()
+    return [Cursor(*row) for row in rows]

--- a/clawjournal/capture/discovery.py
+++ b/clawjournal/capture/discovery.py
@@ -3,13 +3,21 @@
 Phase 1 steps 1 and 1b cover:
 - Claude Code native projects (`~/.claude/projects/**`), including subagent
   streams under nested session dirs.
-- Claude Desktop local-agent-mode sessions (`LOCAL_AGENT_DIR`), with the
-  same workspace-key derivation the parser uses — `userSelectedFolders`
-  converts to a dash-joined grouping key, falling back to
-  `_cowork_<session_id>` when no folder is attached.
+- Claude Desktop local-agent-mode sessions (`LOCAL_AGENT_DIR`), mirroring
+  `parser._scan_local_agent_sessions()`:
+    - Wrappers with malformed JSON, non-dict payloads, or no `cliSessionId`
+      are skipped entirely. The parser drops those wrappers at parser.py
+      lines ~220 / ~227; the capture adapter must drop the same ones so a
+      step-2 Scanner rewire does not regress behavior.
+    - Inside a wrapper's session dir, the nested
+      `.claude/projects/-sessions-<processName>` directory is preferred,
+      with a first-subdirectory fallback when no match exists. Only that
+      single nested project dir is tailed, matching the parser's
+      behavior (which never walks multiple nested project dirs).
+    - `workspace_key` comes from `userSelectedFolders[0]` with a
+      `_cowork_<session_id>` fallback.
 - Codex (`~/.codex/sessions/**`, `~/.codex/archived_sessions/*.jsonl`),
-  grouped by the cwd extracted from each session's metadata (matches
-  parser grouping, so a step-2 Scanner adapter preserves parity).
+  grouped by the cwd extracted from each session's metadata.
 
 Other clients (Gemini, OpenCode, OpenClaw, Kimi, Cursor, Copilot, Aider,
 Custom) stay on the legacy direct-scan path until migration step 5.
@@ -115,39 +123,38 @@ def _iter_workspace_files(workspace_dir: Path) -> Iterator[SourceFile]:
         session_dir = wrapper_path.with_suffix("")
         if not session_dir.is_dir():
             continue
-        workspace_key = _local_agent_workspace_key(wrapper_path, session_dir)
-
-        nested_projects = session_dir / ".claude" / "projects"
-        if nested_projects.is_dir():
-            for proj_dir in sorted(nested_projects.iterdir()):
-                if not proj_dir.is_dir():
-                    continue
-                for jsonl in sorted(proj_dir.glob("*.jsonl")):
-                    yield _make_source_file(
-                        jsonl, parser.CLAUDE_SOURCE, workspace_key
-                    )
-                for child in sorted(proj_dir.iterdir()):
-                    if not child.is_dir():
-                        continue
-                    subagents = child / "subagents"
-                    if subagents.is_dir():
-                        for jsonl in sorted(subagents.glob("agent-*.jsonl")):
-                            yield _make_source_file(
-                                jsonl, parser.CLAUDE_SOURCE, workspace_key
-                            )
-
-        audit = session_dir / "audit.jsonl"
-        if audit.is_file():
-            yield _make_source_file(audit, parser.CLAUDE_SOURCE, workspace_key)
+        wrapper = _load_local_agent_wrapper(wrapper_path)
+        if wrapper is None:
+            # Wrapper failed a validity gate (malformed JSON, non-dict,
+            # or missing cliSessionId). Parser drops these too — skip
+            # the whole workspace session rather than tailing files
+            # that will never be indexed downstream.
+            continue
+        workspace_key = _workspace_key_from_wrapper(wrapper, session_dir)
+        yield from _iter_local_agent_session_files(
+            session_dir, wrapper, workspace_key
+        )
 
 
-def _local_agent_workspace_key(wrapper_path: Path, session_dir: Path) -> str:
+def _load_local_agent_wrapper(wrapper_path: Path) -> dict | None:
+    """Mirror the parser's wrapper validity gates (parser.py:220-227).
+
+    Returns None for malformed JSON, non-dict payloads, or missing
+    `cliSessionId`. The capture adapter and the parser must skip the
+    same wrappers, or step-2 Scanner parity regresses.
+    """
     try:
-        wrapper = json.loads(wrapper_path.read_text())
+        payload = json.loads(wrapper_path.read_text())
     except (OSError, ValueError):
-        return session_dir.name
-    if not isinstance(wrapper, dict):
-        return session_dir.name
+        return None
+    if not isinstance(payload, dict):
+        return None
+    if not payload.get("cliSessionId"):
+        return None
+    return payload
+
+
+def _workspace_key_from_wrapper(wrapper: dict, session_dir: Path) -> str:
     user_folders = wrapper.get("userSelectedFolders") or []
     if (
         isinstance(user_folders, list)
@@ -161,6 +168,51 @@ def _local_agent_workspace_key(wrapper_path: Path, session_dir: Path) -> str:
         wrapper.get("sessionId") or wrapper.get("cliSessionId") or session_dir.name
     )
     return f"_cowork_{session_id}"
+
+
+def _iter_local_agent_session_files(
+    session_dir: Path, wrapper: dict, workspace_key: str
+) -> Iterator[SourceFile]:
+    nested_projects_root = session_dir / ".claude" / "projects"
+    nested_project_dir = _pick_nested_project_dir(nested_projects_root, wrapper)
+    if nested_project_dir is not None:
+        for jsonl in sorted(nested_project_dir.glob("*.jsonl")):
+            yield _make_source_file(jsonl, parser.CLAUDE_SOURCE, workspace_key)
+        for child in sorted(nested_project_dir.iterdir()):
+            if not child.is_dir():
+                continue
+            subagents = child / "subagents"
+            if subagents.is_dir():
+                for jsonl in sorted(subagents.glob("agent-*.jsonl")):
+                    yield _make_source_file(
+                        jsonl, parser.CLAUDE_SOURCE, workspace_key
+                    )
+    audit = session_dir / "audit.jsonl"
+    if audit.is_file():
+        yield _make_source_file(audit, parser.CLAUDE_SOURCE, workspace_key)
+
+
+def _pick_nested_project_dir(
+    nested_projects_root: Path, wrapper: dict
+) -> Path | None:
+    """Mirror parser.py:247-253 — prefer `-sessions-<processName>`, else
+    fall back to a single subdirectory. The parser uses unsorted iterdir
+    for the fallback and picks the first match, which is OS-dependent; we
+    sort so capture is reproducible. The only observable difference is
+    in workspaces with multiple nested project dirs AND no match for the
+    wrapper's processName — already an irregular state.
+    """
+    if not nested_projects_root.is_dir():
+        return None
+    process_name = wrapper.get("processName", "") or ""
+    safe_process_name = process_name.replace("/", "-")
+    candidate = nested_projects_root / f"-sessions-{safe_process_name}"
+    if candidate.is_dir():
+        return candidate
+    for d in sorted(nested_projects_root.iterdir()):
+        if d.is_dir():
+            return d
+    return None
 
 
 # ---------- Codex ----------

--- a/clawjournal/capture/discovery.py
+++ b/clawjournal/capture/discovery.py
@@ -21,10 +21,15 @@ Phase 1 steps 1 and 1b cover:
       OS-dependent). Only one nested project dir is tailed per wrapper.
     - Only `{chosen_nested_project_dir}/{cliSessionId}.jsonl` is yielded
       per wrapper — the single transcript file the current parser reads.
-    - Wrappers whose `cliSessionId` matches a native session UUID in the
-      SAME workspace_key are dropped, mirroring the dedupe at
-      parser.py:399-400. Prevents step-2 Scanner from double-ingesting a
-      session that exists in both native and local-agent layouts.
+    - Semantic dedupe against native Claude sessions is intentionally
+      deferred to downstream consumers. The current parser suppresses a
+      local-agent duplicate only after a native transcript actually
+      parses successfully; discovery cannot know that from filenames
+      alone without risking fallback loss.
+    - Duplicate local-agent wrappers with the same `cliSessionId` are
+      likewise surfaced individually. The parser handles those with
+      session-level dedupe and fallback; capture stays at the physical
+      source-file layer.
     - Workspaces without a nested project dir surface nothing
       (parser.py:415 filters those out of discovery).
     - `workspace_key` comes from `userSelectedFolders[0]` with a
@@ -33,18 +38,33 @@ Phase 1 steps 1 and 1b cover:
 - Codex (`~/.codex/sessions/**`, `~/.codex/archived_sessions/*.jsonl`),
   grouped by the cwd extracted from each session's metadata.
 
+- OpenClaw (`~/.openclaw/agents/*/sessions/*.jsonl`), grouped by the cwd
+  read from each file's first-line `type: "session"` header (mirrors
+  `parser._build_openclaw_project_index` / `_extract_openclaw_cwd`).
+  Unparseable or header-less files fall back to `UNKNOWN_OPENCLAW_CWD`
+  so step-2 Scanner preserves the `openclaw:<cwd-name>` project group.
+
 Broader coverage (audit files, local-agent subagents, other clients) is
 deferred to migration step 5, when the legacy parser discovery is folded
 into the capture adapter.
+
+`iter_source_files()` stays at the physical-file layer because cursoring
+and line-level streaming are file-based. Parser-facing consumers should
+use `iter_parse_inputs()` to recover the current parser's logical units:
+native subagent-only sessions collapse to their enclosing session dir,
+and native/local-agent duplicates share a `session_key` with explicit
+priority ordering instead of forcing each consumer to rediscover Claude
+precedence rules.
 """
 
 from __future__ import annotations
 
 import json
 import re
+from collections import defaultdict
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Iterator
+from typing import Iterable, Iterator
 
 from clawjournal.parsing import parser
 
@@ -60,6 +80,22 @@ class SourceFile:
     client: str
     project_dir_name: str
     size_bytes: int
+    session_key: str
+    parse_path: Path
+    parse_kind: str
+    parse_priority: int
+
+
+@dataclass(frozen=True)
+class ParseInput:
+    session_key: str
+    client: str
+    project_dir_name: str
+    parse_path: Path
+    parse_kind: str
+    priority: int
+    source_paths: tuple[Path, ...]
+    size_bytes: int
 
 
 def iter_source_files(
@@ -68,42 +104,69 @@ def iter_source_files(
     normalized = (source_filter or "").strip().lower()
     want_claude = normalized in ("", "auto", "all", "both", parser.CLAUDE_SOURCE)
     want_codex = normalized in ("", "auto", "all", "both", parser.CODEX_SOURCE)
+    want_openclaw = normalized in ("", "auto", "all", "both", parser.OPENCLAW_SOURCE)
 
     if want_claude:
-        native_ids_by_project = _compute_native_session_ids()
         yield from _iter_claude_native_files()
-        yield from _iter_local_agent_files(native_ids_by_project)
+        yield from _iter_local_agent_files()
     if want_codex:
         yield from _iter_codex_files()
+    if want_openclaw:
+        yield from _iter_openclaw_files()
+
+
+def iter_parse_inputs(
+    *,
+    source_filter: str | None = None,
+    source_files: Iterable[SourceFile] | None = None,
+) -> Iterator[ParseInput]:
+    """Coalesce physical source files into parser-facing logical inputs.
+
+    The current parser consumes some Claude sources at a coarser grain than
+    individual files:
+    - native subagent-only sessions parse as one session-dir merge,
+    - native/local-agent duplicates are a single logical session with
+      precedence (native first, then local-agent fallback),
+    - duplicate local-agent wrappers are multiple fallback candidates for
+      the same logical session.
+
+    `iter_parse_inputs()` preserves the physical file layer for cursoring,
+    but emits parser-ready candidates ordered by `(session_key, priority,
+    parse_path)`. Downstream consumers can group consecutive entries by
+    `session_key` and try candidates in order until one parses.
+    """
+
+    files = list(source_files) if source_files is not None else list(
+        iter_source_files(source_filter=source_filter)
+    )
+    groups: dict[tuple[str, str, str, Path, str, int], list[SourceFile]] = defaultdict(list)
+    for source in files:
+        groups[
+            (
+                source.session_key,
+                source.client,
+                source.project_dir_name,
+                source.parse_path,
+                source.parse_kind,
+                source.parse_priority,
+            )
+        ].append(source)
+
+    for key in sorted(groups, key=lambda item: (item[0], item[5], str(item[3]))):
+        members = sorted(groups[key], key=lambda source: str(source.path))
+        yield ParseInput(
+            session_key=key[0],
+            client=key[1],
+            project_dir_name=key[2],
+            parse_path=key[3],
+            parse_kind=key[4],
+            priority=key[5],
+            source_paths=tuple(member.path for member in members),
+            size_bytes=sum(member.size_bytes for member in members),
+        )
 
 
 # ---------- Claude native ----------
-
-
-def _compute_native_session_ids() -> dict[str, set[str]]:
-    """Return {project_dir_name: {session UUIDs with a native transcript}}.
-
-    Mirrors `parser._get_native_session_ids`: a UUID counts as native if it
-    appears as a root `<uuid>.jsonl` file OR as a subagent-only session
-    directory (a UUID-named dir with subagents but no root jsonl). Used to
-    dedupe local-agent wrappers whose `cliSessionId` matches a native
-    session in the same workspace (parser.py:399-400).
-    """
-    projects_dir = parser.PROJECTS_DIR
-    result: dict[str, set[str]] = {}
-    if not projects_dir.exists():
-        return result
-    for project_dir in projects_dir.iterdir():
-        if not project_dir.is_dir():
-            continue
-        ids: set[str] = {f.stem for f in project_dir.glob("*.jsonl")}
-        for entry in project_dir.iterdir():
-            if entry.is_dir() and entry.name not in ids:
-                subagents = entry / "subagents"
-                if subagents.is_dir() and any(subagents.glob("agent-*.jsonl")):
-                    ids.add(entry.name)
-        result[project_dir.name] = ids
-    return result
 
 
 def _iter_claude_native_files() -> Iterator[SourceFile]:
@@ -116,7 +179,15 @@ def _iter_claude_native_files() -> Iterator[SourceFile]:
         root_stems: set[str] = set()
         for jsonl in sorted(project_dir.glob("*.jsonl")):
             root_stems.add(jsonl.stem)
-            yield _make_source_file(jsonl, parser.CLAUDE_SOURCE, project_dir.name)
+            yield _make_source_file(
+                jsonl,
+                parser.CLAUDE_SOURCE,
+                project_dir.name,
+                session_key=_claude_session_key(project_dir.name, jsonl.stem),
+                parse_path=jsonl,
+                parse_kind="file",
+                parse_priority=0,
+            )
         # Subagent-only sessions: only yield for UUID-named dirs with no
         # sibling <uuid>.jsonl. Mirrors parser._find_subagent_only_sessions.
         # For rooted sessions, subagents are consumed as part of the root
@@ -129,16 +200,20 @@ def _iter_claude_native_files() -> Iterator[SourceFile]:
             if subagents.is_dir():
                 for jsonl in sorted(subagents.glob("agent-*.jsonl")):
                     yield _make_source_file(
-                        jsonl, parser.CLAUDE_SOURCE, project_dir.name
+                        jsonl,
+                        parser.CLAUDE_SOURCE,
+                        project_dir.name,
+                        session_key=_claude_session_key(project_dir.name, child.name),
+                        parse_path=child,
+                        parse_kind="claude_subagent_session",
+                        parse_priority=0,
                     )
 
 
 # ---------- Claude Desktop local-agent-mode ----------
 
 
-def _iter_local_agent_files(
-    native_ids_by_project: dict[str, set[str]],
-) -> Iterator[SourceFile]:
+def _iter_local_agent_files() -> Iterator[SourceFile]:
     root = parser.LOCAL_AGENT_DIR
     if not root.exists():
         return
@@ -156,12 +231,11 @@ def _iter_local_agent_files(
         for workspace_entry in workspaces:
             if not (workspace_entry.is_dir() and _UUID_RE.match(workspace_entry.name)):
                 continue
-            yield from _iter_workspace_files(workspace_entry, native_ids_by_project)
+            yield from _iter_workspace_files(workspace_entry)
 
 
 def _iter_workspace_files(
     workspace_dir: Path,
-    native_ids_by_project: dict[str, set[str]],
 ) -> Iterator[SourceFile]:
     try:
         entries = sorted(workspace_dir.iterdir())
@@ -181,12 +255,6 @@ def _iter_workspace_files(
         if wrapper is None:
             continue
         workspace_key = _workspace_key_from_wrapper(wrapper, session_dir)
-        cli_session_id = wrapper["cliSessionId"]
-        # Dedupe: if a native project at this workspace_key already has a
-        # session with the same UUID, skip the local-agent transcript to
-        # avoid double-ingest. Mirrors parser.py:399-400.
-        if cli_session_id in native_ids_by_project.get(workspace_key, ()):
-            continue
         yield from _iter_local_agent_transcript(
             session_dir, wrapper, workspace_key
         )
@@ -251,7 +319,15 @@ def _iter_local_agent_transcript(
     cli_session_id = wrapper["cliSessionId"]
     transcript = nested_project_dir / f"{cli_session_id}.jsonl"
     if transcript.is_file():
-        yield _make_source_file(transcript, parser.CLAUDE_SOURCE, workspace_key)
+        yield _make_source_file(
+            transcript,
+            parser.CLAUDE_SOURCE,
+            workspace_key,
+            session_key=_claude_session_key(workspace_key, cli_session_id),
+            parse_path=transcript,
+            parse_kind="file",
+            parse_priority=1,
+        )
 
 
 def _pick_nested_project_dir(
@@ -287,13 +363,29 @@ def _iter_codex_files() -> Iterator[SourceFile]:
             if path in seen:
                 continue
             seen.add(path)
-            yield _make_source_file(path, parser.CODEX_SOURCE, _codex_cwd(path))
+            yield _make_source_file(
+                path,
+                parser.CODEX_SOURCE,
+                _codex_cwd(path),
+                session_key=f"codex:{path}",
+                parse_path=path,
+                parse_kind="file",
+                parse_priority=0,
+            )
     if parser.CODEX_ARCHIVED_DIR.exists():
         for path in sorted(parser.CODEX_ARCHIVED_DIR.glob("*.jsonl")):
             if path in seen:
                 continue
             seen.add(path)
-            yield _make_source_file(path, parser.CODEX_SOURCE, _codex_cwd(path))
+            yield _make_source_file(
+                path,
+                parser.CODEX_SOURCE,
+                _codex_cwd(path),
+                session_key=f"codex:{path}",
+                parse_path=path,
+                parse_kind="file",
+                parse_priority=0,
+            )
 
 
 def _codex_cwd(session_file: Path) -> str:
@@ -301,10 +393,51 @@ def _codex_cwd(session_file: Path) -> str:
     return cwd or parser.UNKNOWN_CODEX_CWD
 
 
+# ---------- OpenClaw ----------
+
+
+def _iter_openclaw_files() -> Iterator[SourceFile]:
+    agents_dir = parser.OPENCLAW_AGENTS_DIR
+    if not agents_dir.exists():
+        return
+    try:
+        agent_dirs = sorted(agents_dir.iterdir())
+    except OSError:
+        return
+    for agent_dir in agent_dirs:
+        sessions_dir = agent_dir / "sessions"
+        if not sessions_dir.is_dir():
+            continue
+        for session_file in sorted(sessions_dir.glob("*.jsonl")):
+            cwd = parser._extract_openclaw_cwd(session_file) or parser.UNKNOWN_OPENCLAW_CWD
+            yield _make_source_file(
+                session_file,
+                parser.OPENCLAW_SOURCE,
+                cwd,
+                session_key=f"openclaw:{session_file}",
+                parse_path=session_file,
+                parse_kind="file",
+                parse_priority=0,
+            )
+
+
 # ---------- shared ----------
 
 
-def _make_source_file(path: Path, client: str, project_dir_name: str) -> SourceFile:
+def _claude_session_key(project_dir_name: str, session_id: str) -> str:
+    return f"claude:{project_dir_name}:{session_id}"
+
+
+def _make_source_file(
+    path: Path,
+    client: str,
+    project_dir_name: str,
+    *,
+    session_key: str,
+    parse_path: Path,
+    parse_kind: str,
+    parse_priority: int,
+) -> SourceFile:
     try:
         size = path.stat().st_size
     except FileNotFoundError:
@@ -314,4 +447,8 @@ def _make_source_file(path: Path, client: str, project_dir_name: str) -> SourceF
         client=client,
         project_dir_name=project_dir_name,
         size_bytes=size,
+        session_key=session_key,
+        parse_path=parse_path,
+        parse_kind=parse_kind,
+        parse_priority=parse_priority,
     )

--- a/clawjournal/capture/discovery.py
+++ b/clawjournal/capture/discovery.py
@@ -4,23 +4,30 @@ Phase 1 steps 1 and 1b cover:
 - Claude Code native projects (`~/.claude/projects/**`), including subagent
   streams under nested session dirs.
 - Claude Desktop local-agent-mode sessions (`LOCAL_AGENT_DIR`), mirroring
-  `parser._scan_local_agent_sessions()`:
-    - Wrappers with malformed JSON, non-dict payloads, or no `cliSessionId`
-      are skipped entirely. The parser drops those wrappers at parser.py
-      lines ~220 / ~227; the capture adapter must drop the same ones so a
-      step-2 Scanner rewire does not regress behavior.
-    - Inside a wrapper's session dir, the nested
-      `.claude/projects/-sessions-<processName>` directory is preferred,
-      with a first-subdirectory fallback when no match exists. Only that
-      single nested project dir is tailed, matching the parser's
-      behavior (which never walks multiple nested project dirs).
+  `parser._scan_local_agent_sessions()` plus the transcript selection at
+  `parser.py:862`:
+    - Wrappers with malformed JSON, non-dict payloads, or no
+      `cliSessionId` are skipped entirely (parity with parser.py:220-227).
+    - The nested `.claude/projects/-sessions-<processName>` directory is
+      preferred, with a first-subdirectory fallback when no match exists
+      (sorted for reproducibility; parser uses unsorted iterdir which is
+      OS-dependent). Only one nested project dir is tailed per wrapper.
+    - Only `{chosen_nested_project_dir}/{cliSessionId}.jsonl` is yielded
+      per wrapper — the single transcript file the current parser
+      actually reads. Other `.jsonl` files in the same dir, subagent
+      streams under it, and per-session `audit.jsonl` are deliberately
+      skipped: the parser doesn't consume them in local-agent mode, so
+      step-2 Scanner parity requires capture to ignore them too.
+    - Workspaces without a nested project dir surface nothing
+      (parser.py:415 filters those out of discovery).
     - `workspace_key` comes from `userSelectedFolders[0]` with a
       `_cowork_<session_id>` fallback.
 - Codex (`~/.codex/sessions/**`, `~/.codex/archived_sessions/*.jsonl`),
   grouped by the cwd extracted from each session's metadata.
 
-Other clients (Gemini, OpenCode, OpenClaw, Kimi, Cursor, Copilot, Aider,
-Custom) stay on the legacy direct-scan path until migration step 5.
+Broader coverage (audit, local-agent subagents, other clients) is deferred
+to migration step 5, when the legacy parser discovery is folded into the
+capture adapter.
 """
 
 from __future__ import annotations
@@ -125,13 +132,9 @@ def _iter_workspace_files(workspace_dir: Path) -> Iterator[SourceFile]:
             continue
         wrapper = _load_local_agent_wrapper(wrapper_path)
         if wrapper is None:
-            # Wrapper failed a validity gate (malformed JSON, non-dict,
-            # or missing cliSessionId). Parser drops these too — skip
-            # the whole workspace session rather than tailing files
-            # that will never be indexed downstream.
             continue
         workspace_key = _workspace_key_from_wrapper(wrapper, session_dir)
-        yield from _iter_local_agent_session_files(
+        yield from _iter_local_agent_transcript(
             session_dir, wrapper, workspace_key
         )
 
@@ -170,26 +173,32 @@ def _workspace_key_from_wrapper(wrapper: dict, session_dir: Path) -> str:
     return f"_cowork_{session_id}"
 
 
-def _iter_local_agent_session_files(
+def _iter_local_agent_transcript(
     session_dir: Path, wrapper: dict, workspace_key: str
 ) -> Iterator[SourceFile]:
+    """Yield the single transcript file the parser actually reads for this
+    wrapper: `{chosen_nested_project_dir}/{cliSessionId}.jsonl`.
+
+    Deliberately does NOT yield:
+    - other `.jsonl` files in the chosen nested project dir (parser
+      consumes only the cliSessionId-named one per wrapper, parser.py:862),
+    - subagent streams under the chosen nested project dir (parser does
+      not recurse into them for local-agent mode),
+    - per-session `audit.jsonl` at the session-dir root (parser records
+      its path for metadata/size accounting only, parser.py:264).
+
+    Wrappers without a nested project dir yield nothing, mirroring
+    parser.py:415's `parseable` filter that excludes such descriptors
+    from discovery.
+    """
     nested_projects_root = session_dir / ".claude" / "projects"
     nested_project_dir = _pick_nested_project_dir(nested_projects_root, wrapper)
-    if nested_project_dir is not None:
-        for jsonl in sorted(nested_project_dir.glob("*.jsonl")):
-            yield _make_source_file(jsonl, parser.CLAUDE_SOURCE, workspace_key)
-        for child in sorted(nested_project_dir.iterdir()):
-            if not child.is_dir():
-                continue
-            subagents = child / "subagents"
-            if subagents.is_dir():
-                for jsonl in sorted(subagents.glob("agent-*.jsonl")):
-                    yield _make_source_file(
-                        jsonl, parser.CLAUDE_SOURCE, workspace_key
-                    )
-    audit = session_dir / "audit.jsonl"
-    if audit.is_file():
-        yield _make_source_file(audit, parser.CLAUDE_SOURCE, workspace_key)
+    if nested_project_dir is None:
+        return
+    cli_session_id = wrapper["cliSessionId"]
+    transcript = nested_project_dir / f"{cli_session_id}.jsonl"
+    if transcript.is_file():
+        yield _make_source_file(transcript, parser.CLAUDE_SOURCE, workspace_key)
 
 
 def _pick_nested_project_dir(
@@ -197,10 +206,10 @@ def _pick_nested_project_dir(
 ) -> Path | None:
     """Mirror parser.py:247-253 — prefer `-sessions-<processName>`, else
     fall back to a single subdirectory. The parser uses unsorted iterdir
-    for the fallback and picks the first match, which is OS-dependent; we
-    sort so capture is reproducible. The only observable difference is
-    in workspaces with multiple nested project dirs AND no match for the
-    wrapper's processName — already an irregular state.
+    for the fallback, which is OS-dependent; we sort so capture is
+    reproducible. The only observable difference is in workspaces with
+    multiple nested project dirs AND no match for the wrapper's
+    processName — already an irregular state.
     """
     if not nested_projects_root.is_dir():
         return None

--- a/clawjournal/capture/discovery.py
+++ b/clawjournal/capture/discovery.py
@@ -1,33 +1,41 @@
 """Source file discovery for the capture adapter.
 
 Phase 1 steps 1 and 1b cover:
-- Claude Code native projects (`~/.claude/projects/**`), including subagent
-  streams under nested session dirs.
+
+- Claude Code native projects (`~/.claude/projects/**`). Root `<uuid>.jsonl`
+  files are always yielded. Subagent streams under `<uuid>/subagents/` are
+  yielded ONLY when there is no sibling `<uuid>.jsonl` (mirrors
+  `parser._find_subagent_only_sessions` + the root_stems check at
+  parser.py:1088). For rooted sessions the parser consumes the subagents
+  as part of the root transcript, not separately, so the adapter must
+  skip them to avoid step-2 double-ingestion.
+
 - Claude Desktop local-agent-mode sessions (`LOCAL_AGENT_DIR`), mirroring
   `parser._scan_local_agent_sessions()` plus the transcript selection at
-  `parser.py:862`:
+  parser.py:862:
     - Wrappers with malformed JSON, non-dict payloads, or no
       `cliSessionId` are skipped entirely (parity with parser.py:220-227).
     - The nested `.claude/projects/-sessions-<processName>` directory is
       preferred, with a first-subdirectory fallback when no match exists
-      (sorted for reproducibility; parser uses unsorted iterdir which is
+      (sorted for reproducibility; the parser's unsorted iterdir is
       OS-dependent). Only one nested project dir is tailed per wrapper.
     - Only `{chosen_nested_project_dir}/{cliSessionId}.jsonl` is yielded
-      per wrapper — the single transcript file the current parser
-      actually reads. Other `.jsonl` files in the same dir, subagent
-      streams under it, and per-session `audit.jsonl` are deliberately
-      skipped: the parser doesn't consume them in local-agent mode, so
-      step-2 Scanner parity requires capture to ignore them too.
+      per wrapper — the single transcript file the current parser reads.
+    - Wrappers whose `cliSessionId` matches a native session UUID in the
+      SAME workspace_key are dropped, mirroring the dedupe at
+      parser.py:399-400. Prevents step-2 Scanner from double-ingesting a
+      session that exists in both native and local-agent layouts.
     - Workspaces without a nested project dir surface nothing
       (parser.py:415 filters those out of discovery).
     - `workspace_key` comes from `userSelectedFolders[0]` with a
       `_cowork_<session_id>` fallback.
+
 - Codex (`~/.codex/sessions/**`, `~/.codex/archived_sessions/*.jsonl`),
   grouped by the cwd extracted from each session's metadata.
 
-Broader coverage (audit, local-agent subagents, other clients) is deferred
-to migration step 5, when the legacy parser discovery is folded into the
-capture adapter.
+Broader coverage (audit files, local-agent subagents, other clients) is
+deferred to migration step 5, when the legacy parser discovery is folded
+into the capture adapter.
 """
 
 from __future__ import annotations
@@ -62,13 +70,40 @@ def iter_source_files(
     want_codex = normalized in ("", "auto", "all", "both", parser.CODEX_SOURCE)
 
     if want_claude:
+        native_ids_by_project = _compute_native_session_ids()
         yield from _iter_claude_native_files()
-        yield from _iter_local_agent_files()
+        yield from _iter_local_agent_files(native_ids_by_project)
     if want_codex:
         yield from _iter_codex_files()
 
 
 # ---------- Claude native ----------
+
+
+def _compute_native_session_ids() -> dict[str, set[str]]:
+    """Return {project_dir_name: {session UUIDs with a native transcript}}.
+
+    Mirrors `parser._get_native_session_ids`: a UUID counts as native if it
+    appears as a root `<uuid>.jsonl` file OR as a subagent-only session
+    directory (a UUID-named dir with subagents but no root jsonl). Used to
+    dedupe local-agent wrappers whose `cliSessionId` matches a native
+    session in the same workspace (parser.py:399-400).
+    """
+    projects_dir = parser.PROJECTS_DIR
+    result: dict[str, set[str]] = {}
+    if not projects_dir.exists():
+        return result
+    for project_dir in projects_dir.iterdir():
+        if not project_dir.is_dir():
+            continue
+        ids: set[str] = {f.stem for f in project_dir.glob("*.jsonl")}
+        for entry in project_dir.iterdir():
+            if entry.is_dir() and entry.name not in ids:
+                subagents = entry / "subagents"
+                if subagents.is_dir() and any(subagents.glob("agent-*.jsonl")):
+                    ids.add(entry.name)
+        result[project_dir.name] = ids
+    return result
 
 
 def _iter_claude_native_files() -> Iterator[SourceFile]:
@@ -78,10 +113,17 @@ def _iter_claude_native_files() -> Iterator[SourceFile]:
     for project_dir in sorted(projects_dir.iterdir()):
         if not project_dir.is_dir():
             continue
+        root_stems: set[str] = set()
         for jsonl in sorted(project_dir.glob("*.jsonl")):
+            root_stems.add(jsonl.stem)
             yield _make_source_file(jsonl, parser.CLAUDE_SOURCE, project_dir.name)
+        # Subagent-only sessions: only yield for UUID-named dirs with no
+        # sibling <uuid>.jsonl. Mirrors parser._find_subagent_only_sessions.
+        # For rooted sessions, subagents are consumed as part of the root
+        # transcript, so surfacing them here would double-ingest under
+        # step-2 parity.
         for child in sorted(project_dir.iterdir()):
-            if not child.is_dir():
+            if not child.is_dir() or child.name in root_stems:
                 continue
             subagents = child / "subagents"
             if subagents.is_dir():
@@ -94,7 +136,9 @@ def _iter_claude_native_files() -> Iterator[SourceFile]:
 # ---------- Claude Desktop local-agent-mode ----------
 
 
-def _iter_local_agent_files() -> Iterator[SourceFile]:
+def _iter_local_agent_files(
+    native_ids_by_project: dict[str, set[str]],
+) -> Iterator[SourceFile]:
     root = parser.LOCAL_AGENT_DIR
     if not root.exists():
         return
@@ -112,10 +156,13 @@ def _iter_local_agent_files() -> Iterator[SourceFile]:
         for workspace_entry in workspaces:
             if not (workspace_entry.is_dir() and _UUID_RE.match(workspace_entry.name)):
                 continue
-            yield from _iter_workspace_files(workspace_entry)
+            yield from _iter_workspace_files(workspace_entry, native_ids_by_project)
 
 
-def _iter_workspace_files(workspace_dir: Path) -> Iterator[SourceFile]:
+def _iter_workspace_files(
+    workspace_dir: Path,
+    native_ids_by_project: dict[str, set[str]],
+) -> Iterator[SourceFile]:
     try:
         entries = sorted(workspace_dir.iterdir())
     except OSError:
@@ -134,6 +181,12 @@ def _iter_workspace_files(workspace_dir: Path) -> Iterator[SourceFile]:
         if wrapper is None:
             continue
         workspace_key = _workspace_key_from_wrapper(wrapper, session_dir)
+        cli_session_id = wrapper["cliSessionId"]
+        # Dedupe: if a native project at this workspace_key already has a
+        # session with the same UUID, skip the local-agent transcript to
+        # avoid double-ingest. Mirrors parser.py:399-400.
+        if cli_session_id in native_ids_by_project.get(workspace_key, ()):
+            continue
         yield from _iter_local_agent_transcript(
             session_dir, wrapper, workspace_key
         )
@@ -181,15 +234,15 @@ def _iter_local_agent_transcript(
 
     Deliberately does NOT yield:
     - other `.jsonl` files in the chosen nested project dir (parser
-      consumes only the cliSessionId-named one per wrapper, parser.py:862),
+      consumes only the cliSessionId-named one per wrapper at
+      parser.py:862),
     - subagent streams under the chosen nested project dir (parser does
       not recurse into them for local-agent mode),
     - per-session `audit.jsonl` at the session-dir root (parser records
-      its path for metadata/size accounting only, parser.py:264).
+      its path for metadata/size accounting only at parser.py:264).
 
     Wrappers without a nested project dir yield nothing, mirroring
-    parser.py:415's `parseable` filter that excludes such descriptors
-    from discovery.
+    parser.py:415's `parseable` filter.
     """
     nested_projects_root = session_dir / ".claude" / "projects"
     nested_project_dir = _pick_nested_project_dir(nested_projects_root, wrapper)
@@ -205,11 +258,11 @@ def _pick_nested_project_dir(
     nested_projects_root: Path, wrapper: dict
 ) -> Path | None:
     """Mirror parser.py:247-253 — prefer `-sessions-<processName>`, else
-    fall back to a single subdirectory. The parser uses unsorted iterdir
-    for the fallback, which is OS-dependent; we sort so capture is
-    reproducible. The only observable difference is in workspaces with
-    multiple nested project dirs AND no match for the wrapper's
-    processName — already an irregular state.
+    fall back to a single subdirectory. Parser uses unsorted iterdir,
+    which is OS-dependent; we sort for reproducibility. Any observable
+    difference is limited to workspaces with multiple nested project
+    dirs AND no match for the wrapper's processName — already an
+    irregular state.
     """
     if not nested_projects_root.is_dir():
         return None

--- a/clawjournal/capture/discovery.py
+++ b/clawjournal/capture/discovery.py
@@ -16,9 +16,10 @@ Phase 1 steps 1 and 1b cover:
     - Wrappers with malformed JSON, non-dict payloads, or no
       `cliSessionId` are skipped entirely (parity with parser.py:220-227).
     - The nested `.claude/projects/-sessions-<processName>` directory is
-      preferred, with a first-subdirectory fallback when no match exists
-      (sorted for reproducibility; the parser's unsorted iterdir is
-      OS-dependent). Only one nested project dir is tailed per wrapper.
+      preferred, with a first-subdirectory fallback when no match exists.
+      The fallback mirrors the parser's raw `iterdir()` order exactly,
+      even though that order is OS/filesystem dependent. Only one nested
+      project dir is tailed per wrapper.
     - Only `{chosen_nested_project_dir}/{cliSessionId}.jsonl` is yielded
       per wrapper — the single transcript file the current parser reads.
     - Semantic dedupe against native Claude sessions is intentionally
@@ -54,7 +55,10 @@ use `iter_parse_inputs()` to recover the current parser's logical units:
 native subagent-only sessions collapse to their enclosing session dir,
 and native/local-agent duplicates share a `session_key` with explicit
 priority ordering instead of forcing each consumer to rediscover Claude
-precedence rules.
+precedence rules. When callers pass only a changed-file subset,
+`iter_parse_inputs()` rehydrates the full discovered Claude session
+family for those `session_key`s before grouping so native-first fallback
+and subagent-session merging still match the current parser.
 """
 
 from __future__ import annotations
@@ -131,14 +135,20 @@ def iter_parse_inputs(
       the same logical session.
 
     `iter_parse_inputs()` preserves the physical file layer for cursoring,
-    but emits parser-ready candidates ordered by `(session_key, priority,
-    parse_path)`. Downstream consumers can group consecutive entries by
-    `session_key` and try candidates in order until one parses.
+    but emits parser-ready candidates ordered by session-family discovery
+    order, with candidates for the same session kept consecutive and
+    ordered by priority / first-seen position. If callers provide only a
+    changed-file subset, Claude `session_key`s are first expanded back
+    to the full discovered family so native/local fallback precedence
+    and subagent-session merging are still preserved. Downstream
+    consumers can group consecutive entries by `session_key` and try
+    candidates in order until one parses.
     """
 
     files = list(source_files) if source_files is not None else list(
         iter_source_files(source_filter=source_filter)
     )
+    files = _expand_claude_parse_families(files)
     groups: dict[tuple[str, str, str, Path, str, int], list[SourceFile]] = defaultdict(list)
     for source in files:
         groups[
@@ -152,8 +162,25 @@ def iter_parse_inputs(
             )
         ].append(source)
 
-    for key in sorted(groups, key=lambda item: (item[0], item[5], str(item[3]))):
-        members = sorted(groups[key], key=lambda source: str(source.path))
+    session_first_seen: dict[str, int] = {}
+    first_seen: dict[tuple[str, str, str, Path, str, int], int] = {}
+    for index, source in enumerate(files):
+        session_first_seen.setdefault(source.session_key, index)
+        key = (
+            source.session_key,
+            source.client,
+            source.project_dir_name,
+            source.parse_path,
+            source.parse_kind,
+            source.parse_priority,
+        )
+        first_seen.setdefault(key, index)
+
+    for key in sorted(
+        groups,
+        key=lambda item: (session_first_seen[item[0]], item[5], first_seen[item]),
+    ):
+        members = groups[key]
         yield ParseInput(
             session_key=key[0],
             client=key[1],
@@ -218,14 +245,14 @@ def _iter_local_agent_files() -> Iterator[SourceFile]:
     if not root.exists():
         return
     try:
-        roots = sorted(root.iterdir())
+        roots = list(root.iterdir())
     except OSError:
         return
     for root_entry in roots:
         if not (root_entry.is_dir() and _UUID_RE.match(root_entry.name)):
             continue
         try:
-            workspaces = sorted(root_entry.iterdir())
+            workspaces = list(root_entry.iterdir())
         except OSError:
             continue
         for workspace_entry in workspaces:
@@ -238,7 +265,7 @@ def _iter_workspace_files(
     workspace_dir: Path,
 ) -> Iterator[SourceFile]:
     try:
-        entries = sorted(workspace_dir.iterdir())
+        entries = list(workspace_dir.iterdir())
     except OSError:
         return
     for wrapper_path in entries:
@@ -333,12 +360,8 @@ def _iter_local_agent_transcript(
 def _pick_nested_project_dir(
     nested_projects_root: Path, wrapper: dict
 ) -> Path | None:
-    """Mirror parser.py:247-253 — prefer `-sessions-<processName>`, else
-    fall back to a single subdirectory. Parser uses unsorted iterdir,
-    which is OS-dependent; we sort for reproducibility. Any observable
-    difference is limited to workspaces with multiple nested project
-    dirs AND no match for the wrapper's processName — already an
-    irregular state.
+    """Mirror parser.py:247-253 exactly — prefer `-sessions-<processName>`,
+    else fall back to the first subdirectory yielded by raw `iterdir()`.
     """
     if not nested_projects_root.is_dir():
         return None
@@ -347,7 +370,7 @@ def _pick_nested_project_dir(
     candidate = nested_projects_root / f"-sessions-{safe_process_name}"
     if candidate.is_dir():
         return candidate
-    for d in sorted(nested_projects_root.iterdir()):
+    for d in nested_projects_root.iterdir():
         if d.is_dir():
             return d
     return None
@@ -426,6 +449,61 @@ def _iter_openclaw_files() -> Iterator[SourceFile]:
 
 def _claude_session_key(project_dir_name: str, session_id: str) -> str:
     return f"claude:{project_dir_name}:{session_id}"
+
+
+def _expand_claude_parse_families(files: list[SourceFile]) -> list[SourceFile]:
+    """Expand a changed-file subset back to full Claude session families.
+
+    The current parser resolves Claude precedence at the session level:
+    - native root/local-agent duplicates compete within one session key,
+    - duplicate local-agent wrappers are alternate candidates,
+    - subagent-only sessions merge every `agent-*.jsonl` file in the dir.
+
+    If a caller hands us only changed `SourceFile`s, grouping those files
+    directly would lose that context. Re-scan Claude discovery and pull in
+    every physical source whose `session_key` matches a changed Claude
+    source before we coalesce into parser-facing `ParseInput`s.
+    """
+    claude_keys = {
+        source.session_key
+        for source in files
+        if source.client == parser.CLAUDE_SOURCE
+    }
+    if not claude_keys:
+        return files
+
+    discovered_by_session: dict[str, list[SourceFile]] = defaultdict(list)
+    for source in iter_source_files(source_filter=parser.CLAUDE_SOURCE):
+        if source.session_key in claude_keys:
+            discovered_by_session[source.session_key].append(source)
+
+    expanded: list[SourceFile] = []
+    seen_paths: set[Path] = set()
+    emitted_sessions: set[str] = set()
+
+    for source in files:
+        if source.client != parser.CLAUDE_SOURCE:
+            if source.path not in seen_paths:
+                expanded.append(source)
+                seen_paths.add(source.path)
+            continue
+
+        if source.session_key in emitted_sessions:
+            continue
+        emitted_sessions.add(source.session_key)
+
+        family = discovered_by_session.get(source.session_key)
+        if family:
+            for member in family:
+                if member.path not in seen_paths:
+                    expanded.append(member)
+                    seen_paths.add(member.path)
+            continue
+
+        if source.path not in seen_paths:
+            expanded.append(source)
+            seen_paths.add(source.path)
+    return expanded
 
 
 def _make_source_file(

--- a/clawjournal/capture/discovery.py
+++ b/clawjournal/capture/discovery.py
@@ -1,0 +1,203 @@
+"""Source file discovery for the capture adapter.
+
+Phase 1 steps 1 and 1b cover:
+- Claude Code native projects (`~/.claude/projects/**`), including subagent
+  streams under nested session dirs.
+- Claude Desktop local-agent-mode sessions (`LOCAL_AGENT_DIR`), with the
+  same workspace-key derivation the parser uses — `userSelectedFolders`
+  converts to a dash-joined grouping key, falling back to
+  `_cowork_<session_id>` when no folder is attached.
+- Codex (`~/.codex/sessions/**`, `~/.codex/archived_sessions/*.jsonl`),
+  grouped by the cwd extracted from each session's metadata (matches
+  parser grouping, so a step-2 Scanner adapter preserves parity).
+
+Other clients (Gemini, OpenCode, OpenClaw, Kimi, Cursor, Copilot, Aider,
+Custom) stay on the legacy direct-scan path until migration step 5.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator
+
+from clawjournal.parsing import parser
+
+_UUID_RE = re.compile(
+    r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$",
+    re.IGNORECASE,
+)
+
+
+@dataclass(frozen=True)
+class SourceFile:
+    path: Path
+    client: str
+    project_dir_name: str
+    size_bytes: int
+
+
+def iter_source_files(
+    *, source_filter: str | None = None
+) -> Iterator[SourceFile]:
+    normalized = (source_filter or "").strip().lower()
+    want_claude = normalized in ("", "auto", "all", "both", parser.CLAUDE_SOURCE)
+    want_codex = normalized in ("", "auto", "all", "both", parser.CODEX_SOURCE)
+
+    if want_claude:
+        yield from _iter_claude_native_files()
+        yield from _iter_local_agent_files()
+    if want_codex:
+        yield from _iter_codex_files()
+
+
+# ---------- Claude native ----------
+
+
+def _iter_claude_native_files() -> Iterator[SourceFile]:
+    projects_dir = parser.PROJECTS_DIR
+    if not projects_dir.exists():
+        return
+    for project_dir in sorted(projects_dir.iterdir()):
+        if not project_dir.is_dir():
+            continue
+        for jsonl in sorted(project_dir.glob("*.jsonl")):
+            yield _make_source_file(jsonl, parser.CLAUDE_SOURCE, project_dir.name)
+        for child in sorted(project_dir.iterdir()):
+            if not child.is_dir():
+                continue
+            subagents = child / "subagents"
+            if subagents.is_dir():
+                for jsonl in sorted(subagents.glob("agent-*.jsonl")):
+                    yield _make_source_file(
+                        jsonl, parser.CLAUDE_SOURCE, project_dir.name
+                    )
+
+
+# ---------- Claude Desktop local-agent-mode ----------
+
+
+def _iter_local_agent_files() -> Iterator[SourceFile]:
+    root = parser.LOCAL_AGENT_DIR
+    if not root.exists():
+        return
+    try:
+        roots = sorted(root.iterdir())
+    except OSError:
+        return
+    for root_entry in roots:
+        if not (root_entry.is_dir() and _UUID_RE.match(root_entry.name)):
+            continue
+        try:
+            workspaces = sorted(root_entry.iterdir())
+        except OSError:
+            continue
+        for workspace_entry in workspaces:
+            if not (workspace_entry.is_dir() and _UUID_RE.match(workspace_entry.name)):
+                continue
+            yield from _iter_workspace_files(workspace_entry)
+
+
+def _iter_workspace_files(workspace_dir: Path) -> Iterator[SourceFile]:
+    try:
+        entries = sorted(workspace_dir.iterdir())
+    except OSError:
+        return
+    for wrapper_path in entries:
+        if not (
+            wrapper_path.is_file()
+            and wrapper_path.name.startswith("local_")
+            and wrapper_path.name.endswith(".json")
+        ):
+            continue
+        session_dir = wrapper_path.with_suffix("")
+        if not session_dir.is_dir():
+            continue
+        workspace_key = _local_agent_workspace_key(wrapper_path, session_dir)
+
+        nested_projects = session_dir / ".claude" / "projects"
+        if nested_projects.is_dir():
+            for proj_dir in sorted(nested_projects.iterdir()):
+                if not proj_dir.is_dir():
+                    continue
+                for jsonl in sorted(proj_dir.glob("*.jsonl")):
+                    yield _make_source_file(
+                        jsonl, parser.CLAUDE_SOURCE, workspace_key
+                    )
+                for child in sorted(proj_dir.iterdir()):
+                    if not child.is_dir():
+                        continue
+                    subagents = child / "subagents"
+                    if subagents.is_dir():
+                        for jsonl in sorted(subagents.glob("agent-*.jsonl")):
+                            yield _make_source_file(
+                                jsonl, parser.CLAUDE_SOURCE, workspace_key
+                            )
+
+        audit = session_dir / "audit.jsonl"
+        if audit.is_file():
+            yield _make_source_file(audit, parser.CLAUDE_SOURCE, workspace_key)
+
+
+def _local_agent_workspace_key(wrapper_path: Path, session_dir: Path) -> str:
+    try:
+        wrapper = json.loads(wrapper_path.read_text())
+    except (OSError, ValueError):
+        return session_dir.name
+    if not isinstance(wrapper, dict):
+        return session_dir.name
+    user_folders = wrapper.get("userSelectedFolders") or []
+    if (
+        isinstance(user_folders, list)
+        and user_folders
+        and isinstance(user_folders[0], str)
+        and user_folders[0]
+        and user_folders[0] != "/"
+    ):
+        return user_folders[0].rstrip("/").replace("/", "-")
+    session_id = (
+        wrapper.get("sessionId") or wrapper.get("cliSessionId") or session_dir.name
+    )
+    return f"_cowork_{session_id}"
+
+
+# ---------- Codex ----------
+
+
+def _iter_codex_files() -> Iterator[SourceFile]:
+    seen: set[Path] = set()
+    if parser.CODEX_SESSIONS_DIR.exists():
+        for path in sorted(parser.CODEX_SESSIONS_DIR.rglob("*.jsonl")):
+            if path in seen:
+                continue
+            seen.add(path)
+            yield _make_source_file(path, parser.CODEX_SOURCE, _codex_cwd(path))
+    if parser.CODEX_ARCHIVED_DIR.exists():
+        for path in sorted(parser.CODEX_ARCHIVED_DIR.glob("*.jsonl")):
+            if path in seen:
+                continue
+            seen.add(path)
+            yield _make_source_file(path, parser.CODEX_SOURCE, _codex_cwd(path))
+
+
+def _codex_cwd(session_file: Path) -> str:
+    cwd = parser._extract_codex_cwd(session_file)
+    return cwd or parser.UNKNOWN_CODEX_CWD
+
+
+# ---------- shared ----------
+
+
+def _make_source_file(path: Path, client: str, project_dir_name: str) -> SourceFile:
+    try:
+        size = path.stat().st_size
+    except FileNotFoundError:
+        size = 0
+    return SourceFile(
+        path=path,
+        client=client,
+        project_dir_name=project_dir_name,
+        size_bytes=size,
+    )

--- a/tests/capture/test_changes.py
+++ b/tests/capture/test_changes.py
@@ -68,7 +68,12 @@ def test_rotation_resets_offset(tmp_path):
     p.write_bytes(b'{"a":1}\n')
     batch = iter_new_lines(p, None, client="claude")
     cur = cursor_after(batch, p, consumer_id="events")
-    p.unlink()
+    # Logrotate-style rotation: move the old file aside, then write a
+    # fresh file at the original path. Guarantees a new inode on any
+    # POSIX filesystem. Unlink-then-recreate on Linux often reuses the
+    # inode immediately, making stat(2) unable to distinguish rotation
+    # from a plain append — see the rotation note in changes.py.
+    p.rename(tmp_path / "a.jsonl.1")
     p.write_bytes(b'{"new":1}\n')
     batch2 = iter_new_lines(p, cur, client="claude")
     assert batch2 is not None
@@ -131,7 +136,9 @@ def test_file_has_changed_detects_rotation(tmp_path):
     p = tmp_path / "a.jsonl"
     p.write_bytes(b'{"a":1}\n')
     cur = cursor_to_eof(p, consumer_id="scanner", client="claude")
-    p.unlink()
+    # Rename-then-recreate so the test doesn't depend on inode-reuse
+    # behavior of the underlying filesystem.
+    p.rename(tmp_path / "a.jsonl.1")
     p.write_bytes(b'{"new":1}\n')
     assert file_has_changed(p, cur) is True
 

--- a/tests/capture/test_changes.py
+++ b/tests/capture/test_changes.py
@@ -198,6 +198,29 @@ def test_cursor_for_reparse_returns_none_for_missing_file(tmp_path):
     )
 
 
+def test_file_has_changed_returns_true_for_line_level_cursor_with_partial_tail(
+    tmp_path,
+):
+    """Documents that file_has_changed is a whole-file-reparse gate. A
+    line-level cursor (from cursor_after) can legitimately sit behind
+    the live file size when the file ends in a partial trailing line;
+    file_has_changed sees `last_offset < size` and returns True even
+    though no new complete lines are available. Line-level consumers
+    must use iter_new_lines directly to check for actual progress."""
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n{"partial')  # partial trailing line after the first
+    batch = iter_new_lines(p, None, client="claude")
+    assert batch is not None
+    assert batch.end_offset < p.stat().st_size  # cursor legitimately trails
+    cur = cursor_after(batch, consumer_id="events")
+    # No new writes; the file is in steady state from the consumer's
+    # point of view — but file_has_changed still flags it because the
+    # size does not equal last_offset.
+    assert file_has_changed(p, cur) is True
+    # The correct staleness check for a line-level consumer:
+    assert iter_new_lines(p, cur, client="claude") is None
+
+
 def test_cursor_for_reparse_snapshot_survives_concurrent_append(tmp_path):
     """TOCTOU-safe usage: snapshot BEFORE parse, persist AFTER sink
     commit. If the file grows during the parse, the cursor stays at

--- a/tests/capture/test_changes.py
+++ b/tests/capture/test_changes.py
@@ -1,0 +1,154 @@
+from pathlib import Path
+
+from clawjournal.capture.changes import (
+    cursor_after,
+    cursor_to_eof,
+    file_has_changed,
+    iter_new_lines,
+)
+from clawjournal.capture.cursors import Cursor
+
+
+def _append(path: Path, content: bytes) -> None:
+    with path.open("ab") as f:
+        f.write(content)
+
+
+# ---------- line-level deltas ----------
+
+
+def test_first_read_returns_all_complete_lines(tmp_path):
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n{"b":2}\n')
+    batch = iter_new_lines(p, None, client="claude")
+    assert batch is not None
+    assert batch.lines == ['{"a":1}', '{"b":2}']
+    assert batch.start_offset == 0
+    assert batch.end_offset == len(b'{"a":1}\n{"b":2}\n')
+    assert batch.client == "claude"
+
+
+def test_incremental_append_reads_only_new(tmp_path):
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n')
+    batch1 = iter_new_lines(p, None, client="claude")
+    cur = cursor_after(batch1, p, consumer_id="events")
+    _append(p, b'{"b":2}\n')
+    batch2 = iter_new_lines(p, cur, client="claude")
+    assert batch2 is not None
+    assert batch2.lines == ['{"b":2}']
+    assert batch2.start_offset == batch1.end_offset
+
+
+def test_no_change_returns_none(tmp_path):
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n')
+    batch = iter_new_lines(p, None, client="claude")
+    cur = cursor_after(batch, p, consumer_id="events")
+    assert iter_new_lines(p, cur, client="claude") is None
+
+
+def test_partial_trailing_line_is_not_consumed(tmp_path):
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n{"incomple')
+    batch = iter_new_lines(p, None, client="claude")
+    assert batch is not None
+    assert batch.lines == ['{"a":1}']
+    assert batch.end_offset == len(b'{"a":1}\n')
+
+    cur = cursor_after(batch, p, consumer_id="events")
+    _append(p, b'te":true}\n{"c":3}\n')
+    batch2 = iter_new_lines(p, cur, client="claude")
+    assert batch2 is not None
+    assert batch2.lines == ['{"incomplete":true}', '{"c":3}']
+
+
+def test_rotation_resets_offset(tmp_path):
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n')
+    batch = iter_new_lines(p, None, client="claude")
+    cur = cursor_after(batch, p, consumer_id="events")
+    p.unlink()
+    p.write_bytes(b'{"new":1}\n')
+    batch2 = iter_new_lines(p, cur, client="claude")
+    assert batch2 is not None
+    assert batch2.start_offset == 0
+    assert batch2.lines == ['{"new":1}']
+
+
+def test_truncation_resets_offset(tmp_path):
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n{"b":2}\n')
+    batch = iter_new_lines(p, None, client="claude")
+    cur = cursor_after(batch, p, consumer_id="events")
+    p.write_bytes(b'{"x":1}\n')
+    batch2 = iter_new_lines(p, cur, client="claude")
+    assert batch2 is not None
+    assert batch2.start_offset == 0
+    assert batch2.lines == ['{"x":1}']
+
+
+def test_missing_file_returns_none(tmp_path):
+    assert iter_new_lines(tmp_path / "nope.jsonl", None, client="claude") is None
+
+
+def test_empty_file_returns_none(tmp_path):
+    p = tmp_path / "empty.jsonl"
+    p.write_bytes(b"")
+    assert iter_new_lines(p, None, client="claude") is None
+
+
+# ---------- file-level change detection ----------
+
+
+def test_file_has_changed_no_cursor(tmp_path):
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b"x")
+    assert file_has_changed(p, None) is True
+
+
+def test_file_has_changed_no_cursor_empty_file(tmp_path):
+    p = tmp_path / "empty.jsonl"
+    p.write_bytes(b"")
+    # Empty file, no cursor: nothing to do yet
+    assert file_has_changed(p, None) is False
+
+
+def test_file_has_changed_missing_file_is_false(tmp_path):
+    assert file_has_changed(tmp_path / "nope.jsonl", None) is False
+
+
+def test_file_has_changed_detects_append(tmp_path):
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n')
+    cur = cursor_to_eof(p, consumer_id="scanner", client="claude")
+    assert file_has_changed(p, cur) is False
+    _append(p, b'{"b":2}\n')
+    assert file_has_changed(p, cur) is True
+
+
+def test_file_has_changed_detects_rotation(tmp_path):
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n')
+    cur = cursor_to_eof(p, consumer_id="scanner", client="claude")
+    p.unlink()
+    p.write_bytes(b'{"new":1}\n')
+    assert file_has_changed(p, cur) is True
+
+
+def test_file_has_changed_detects_truncation(tmp_path):
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n{"b":2}\n')
+    cur = cursor_to_eof(p, consumer_id="scanner", client="claude")
+    p.write_bytes(b'{"x":1}\n')
+    assert file_has_changed(p, cur) is True
+
+
+def test_cursor_to_eof_points_at_file_end(tmp_path):
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n{"b":2}\n')
+    cur = cursor_to_eof(p, consumer_id="scanner", client="claude")
+    assert cur.consumer_id == "scanner"
+    assert cur.client == "claude"
+    assert cur.last_offset == p.stat().st_size
+    assert cur.inode == p.stat().st_ino

--- a/tests/capture/test_changes.py
+++ b/tests/capture/test_changes.py
@@ -1,4 +1,6 @@
+import os
 from pathlib import Path
+from unittest.mock import patch
 
 from clawjournal.capture.changes import (
     cursor_after,
@@ -131,6 +133,36 @@ def test_cursor_after_is_immune_to_replacement_between_read_and_commit(tmp_path)
     assert batch2 is not None
     assert batch2.start_offset == 0
     assert batch2.lines == ['{"new":"much longer"}', '{"more":"stuff"}']
+
+
+def test_iter_new_lines_binds_batch_to_opened_file(tmp_path):
+    """If the path is replaced immediately before open(), the batch must
+    describe the replacement file we actually read, not the pre-open
+    inode that used to live at the path.
+    """
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"old":1}\n')
+    replacement = b'{"new":1}\n{"new":2}\n'
+    original_open = Path.open
+    swapped = False
+
+    def fake_open(self, *args, **kwargs):
+        nonlocal swapped
+        if self == p and not swapped:
+            os.rename(p, tmp_path / "a.jsonl.old")
+            with open(p, "wb") as f:
+                f.write(replacement)
+            swapped = True
+        return original_open(self, *args, **kwargs)
+
+    with patch.object(Path, "open", fake_open):
+        batch = iter_new_lines(p, None, client="claude")
+
+    assert batch is not None
+    assert batch.lines == ['{"new":1}', '{"new":2}']
+    assert batch.inode == p.stat().st_ino
+    cur = cursor_after(batch, consumer_id="events")
+    assert iter_new_lines(p, cur, client="claude") is None
 
 
 # ---------- file-level change detection ----------

--- a/tests/capture/test_changes.py
+++ b/tests/capture/test_changes.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 from clawjournal.capture.changes import (
     cursor_after,
-    cursor_to_eof,
+    cursor_for_reparse,
     file_has_changed,
     iter_new_lines,
 )
@@ -26,13 +26,17 @@ def test_first_read_returns_all_complete_lines(tmp_path):
     assert batch.start_offset == 0
     assert batch.end_offset == len(b'{"a":1}\n{"b":2}\n')
     assert batch.client == "claude"
+    # LineBatch carries the stat snapshot captured at read time.
+    st = p.stat()
+    assert batch.inode == st.st_ino
+    assert batch.last_modified == st.st_mtime
 
 
 def test_incremental_append_reads_only_new(tmp_path):
     p = tmp_path / "a.jsonl"
     p.write_bytes(b'{"a":1}\n')
     batch1 = iter_new_lines(p, None, client="claude")
-    cur = cursor_after(batch1, p, consumer_id="events")
+    cur = cursor_after(batch1, consumer_id="events")
     _append(p, b'{"b":2}\n')
     batch2 = iter_new_lines(p, cur, client="claude")
     assert batch2 is not None
@@ -44,7 +48,7 @@ def test_no_change_returns_none(tmp_path):
     p = tmp_path / "a.jsonl"
     p.write_bytes(b'{"a":1}\n')
     batch = iter_new_lines(p, None, client="claude")
-    cur = cursor_after(batch, p, consumer_id="events")
+    cur = cursor_after(batch, consumer_id="events")
     assert iter_new_lines(p, cur, client="claude") is None
 
 
@@ -56,7 +60,7 @@ def test_partial_trailing_line_is_not_consumed(tmp_path):
     assert batch.lines == ['{"a":1}']
     assert batch.end_offset == len(b'{"a":1}\n')
 
-    cur = cursor_after(batch, p, consumer_id="events")
+    cur = cursor_after(batch, consumer_id="events")
     _append(p, b'te":true}\n{"c":3}\n')
     batch2 = iter_new_lines(p, cur, client="claude")
     assert batch2 is not None
@@ -67,7 +71,7 @@ def test_rotation_resets_offset(tmp_path):
     p = tmp_path / "a.jsonl"
     p.write_bytes(b'{"a":1}\n')
     batch = iter_new_lines(p, None, client="claude")
-    cur = cursor_after(batch, p, consumer_id="events")
+    cur = cursor_after(batch, consumer_id="events")
     # Logrotate-style rotation: move the old file aside, then write a
     # fresh file at the original path. Guarantees a new inode on any
     # POSIX filesystem. Unlink-then-recreate on Linux often reuses the
@@ -85,7 +89,7 @@ def test_truncation_resets_offset(tmp_path):
     p = tmp_path / "a.jsonl"
     p.write_bytes(b'{"a":1}\n{"b":2}\n')
     batch = iter_new_lines(p, None, client="claude")
-    cur = cursor_after(batch, p, consumer_id="events")
+    cur = cursor_after(batch, consumer_id="events")
     p.write_bytes(b'{"x":1}\n')
     batch2 = iter_new_lines(p, cur, client="claude")
     assert batch2 is not None
@@ -103,6 +107,32 @@ def test_empty_file_returns_none(tmp_path):
     assert iter_new_lines(p, None, client="claude") is None
 
 
+def test_cursor_after_is_immune_to_replacement_between_read_and_commit(tmp_path):
+    """Regression for the TOCTOU where cursor_after used to re-stat the
+    live path: if the file was replaced after iter_new_lines but before
+    cursor_after, the cursor bound the NEW inode to the OLD end_offset
+    and the next read silently resumed partway into the replacement.
+    The fixed API captures the stat inside LineBatch at read time, so
+    cursor_after uses the batch's snapshot and never re-stats."""
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n')  # 8 bytes
+    batch = iter_new_lines(p, None, client="claude")
+    assert batch is not None
+    old_inode = batch.inode
+    # Simulate a concurrent replacement between read and commit
+    p.rename(tmp_path / "a.jsonl.old")
+    p.write_bytes(b'{"new":"much longer"}\n{"more":"stuff"}\n')
+    cur = cursor_after(batch, consumer_id="events")
+    assert cur.inode == old_inode
+    assert cur.last_offset == 8
+    # Next poll sees a different inode and rewinds to offset 0 —
+    # no bytes from the replacement are skipped.
+    batch2 = iter_new_lines(p, cur, client="claude")
+    assert batch2 is not None
+    assert batch2.start_offset == 0
+    assert batch2.lines == ['{"new":"much longer"}', '{"more":"stuff"}']
+
+
 # ---------- file-level change detection ----------
 
 
@@ -115,7 +145,6 @@ def test_file_has_changed_no_cursor(tmp_path):
 def test_file_has_changed_no_cursor_empty_file(tmp_path):
     p = tmp_path / "empty.jsonl"
     p.write_bytes(b"")
-    # Empty file, no cursor: nothing to do yet
     assert file_has_changed(p, None) is False
 
 
@@ -126,7 +155,7 @@ def test_file_has_changed_missing_file_is_false(tmp_path):
 def test_file_has_changed_detects_append(tmp_path):
     p = tmp_path / "a.jsonl"
     p.write_bytes(b'{"a":1}\n')
-    cur = cursor_to_eof(p, consumer_id="scanner", client="claude")
+    cur = cursor_for_reparse(p, consumer_id="scanner", client="claude")
     assert file_has_changed(p, cur) is False
     _append(p, b'{"b":2}\n')
     assert file_has_changed(p, cur) is True
@@ -135,9 +164,7 @@ def test_file_has_changed_detects_append(tmp_path):
 def test_file_has_changed_detects_rotation(tmp_path):
     p = tmp_path / "a.jsonl"
     p.write_bytes(b'{"a":1}\n')
-    cur = cursor_to_eof(p, consumer_id="scanner", client="claude")
-    # Rename-then-recreate so the test doesn't depend on inode-reuse
-    # behavior of the underlying filesystem.
+    cur = cursor_for_reparse(p, consumer_id="scanner", client="claude")
     p.rename(tmp_path / "a.jsonl.1")
     p.write_bytes(b'{"new":1}\n')
     assert file_has_changed(p, cur) is True
@@ -146,16 +173,44 @@ def test_file_has_changed_detects_rotation(tmp_path):
 def test_file_has_changed_detects_truncation(tmp_path):
     p = tmp_path / "a.jsonl"
     p.write_bytes(b'{"a":1}\n{"b":2}\n')
-    cur = cursor_to_eof(p, consumer_id="scanner", client="claude")
+    cur = cursor_for_reparse(p, consumer_id="scanner", client="claude")
     p.write_bytes(b'{"x":1}\n')
     assert file_has_changed(p, cur) is True
 
 
-def test_cursor_to_eof_points_at_file_end(tmp_path):
+def test_cursor_for_reparse_points_at_current_state(tmp_path):
     p = tmp_path / "a.jsonl"
     p.write_bytes(b'{"a":1}\n{"b":2}\n')
-    cur = cursor_to_eof(p, consumer_id="scanner", client="claude")
+    cur = cursor_for_reparse(p, consumer_id="scanner", client="claude")
+    assert cur is not None
     assert cur.consumer_id == "scanner"
     assert cur.client == "claude"
     assert cur.last_offset == p.stat().st_size
     assert cur.inode == p.stat().st_ino
+
+
+def test_cursor_for_reparse_returns_none_for_missing_file(tmp_path):
+    assert (
+        cursor_for_reparse(
+            tmp_path / "nope.jsonl", consumer_id="scanner", client="claude"
+        )
+        is None
+    )
+
+
+def test_cursor_for_reparse_snapshot_survives_concurrent_append(tmp_path):
+    """TOCTOU-safe usage: snapshot BEFORE parse, persist AFTER sink
+    commit. If the file grows during the parse, the cursor stays at
+    the pre-parse size and the next poll's file_has_changed sees the
+    growth. The sink's idempotency absorbs the replayed bytes."""
+    p = tmp_path / "a.jsonl"
+    p.write_bytes(b'{"a":1}\n')  # 8 bytes
+    # Pre-parse snapshot
+    cur = cursor_for_reparse(p, consumer_id="scanner", client="claude")
+    assert cur is not None
+    # Simulate an append that lands during the "parse" phase
+    _append(p, b'{"b":2}\n')  # 16 bytes now
+    # The cursor still points at the pre-parse size. Persisting it means
+    # the next poll will see the growth rather than marking the file clean.
+    assert cur.last_offset == 8
+    assert file_has_changed(p, cur) is True

--- a/tests/capture/test_cursors.py
+++ b/tests/capture/test_cursors.py
@@ -1,0 +1,113 @@
+import sqlite3
+
+from clawjournal.capture.cursors import (
+    Cursor,
+    ensure_schema,
+    get_cursor,
+    list_cursors,
+    set_cursor,
+)
+
+
+def _open() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    ensure_schema(conn)
+    return conn
+
+
+def _cursor(
+    *,
+    consumer_id: str = "scanner",
+    source_path: str = "/tmp/a.jsonl",
+    inode: int = 1,
+    last_offset: int = 0,
+    last_modified: float = 0.0,
+    client: str = "claude",
+) -> Cursor:
+    return Cursor(
+        consumer_id=consumer_id,
+        source_path=source_path,
+        inode=inode,
+        last_offset=last_offset,
+        last_modified=last_modified,
+        client=client,
+    )
+
+
+def test_ensure_schema_is_idempotent():
+    conn = _open()
+    ensure_schema(conn)
+    cols = {row[1] for row in conn.execute("PRAGMA table_info(capture_cursors)")}
+    assert {
+        "consumer_id",
+        "source_path",
+        "inode",
+        "last_offset",
+        "last_modified",
+        "client",
+        "first_seen",
+        "last_seen",
+    } <= cols
+
+
+def test_set_then_get_round_trip():
+    conn = _open()
+    cursor = _cursor(inode=42, last_offset=1024, last_modified=1700000000.0)
+    set_cursor(conn, cursor)
+    assert get_cursor(conn, "scanner", "/tmp/a.jsonl") == cursor
+
+
+def test_set_cursor_upserts_on_conflict_same_consumer():
+    conn = _open()
+    set_cursor(conn, _cursor(inode=1, last_offset=0))
+    set_cursor(conn, _cursor(inode=2, last_offset=100, last_modified=1.0))
+    got = get_cursor(conn, "scanner", "/tmp/a.jsonl")
+    assert got.inode == 2
+    assert got.last_offset == 100
+    assert got.last_modified == 1.0
+
+
+def test_two_consumers_same_file_are_independent():
+    conn = _open()
+    set_cursor(conn, _cursor(consumer_id="scanner", last_offset=50))
+    set_cursor(conn, _cursor(consumer_id="events", last_offset=10))
+    scanner = get_cursor(conn, "scanner", "/tmp/a.jsonl")
+    events = get_cursor(conn, "events", "/tmp/a.jsonl")
+    assert scanner.last_offset == 50
+    assert events.last_offset == 10
+    # Advancing one does not advance the other
+    set_cursor(conn, _cursor(consumer_id="events", last_offset=100))
+    assert get_cursor(conn, "scanner", "/tmp/a.jsonl").last_offset == 50
+    assert get_cursor(conn, "events", "/tmp/a.jsonl").last_offset == 100
+
+
+def test_get_cursor_missing_returns_none():
+    conn = _open()
+    assert get_cursor(conn, "scanner", "/does/not/exist.jsonl") is None
+
+
+def test_get_cursor_wrong_consumer_returns_none():
+    conn = _open()
+    set_cursor(conn, _cursor(consumer_id="scanner"))
+    assert get_cursor(conn, "events", "/tmp/a.jsonl") is None
+
+
+def test_list_cursors_filters_by_consumer_and_client():
+    conn = _open()
+    set_cursor(conn, _cursor(consumer_id="scanner", source_path="/tmp/a.jsonl", client="claude"))
+    set_cursor(conn, _cursor(consumer_id="scanner", source_path="/tmp/b.jsonl", client="codex"))
+    set_cursor(conn, _cursor(consumer_id="events", source_path="/tmp/a.jsonl", client="claude"))
+
+    scanner_rows = list_cursors(conn, consumer_id="scanner")
+    assert {(c.consumer_id, c.source_path) for c in scanner_rows} == {
+        ("scanner", "/tmp/a.jsonl"),
+        ("scanner", "/tmp/b.jsonl"),
+    }
+    claude_rows = list_cursors(conn, client="claude")
+    assert {(c.consumer_id, c.source_path) for c in claude_rows} == {
+        ("scanner", "/tmp/a.jsonl"),
+        ("events", "/tmp/a.jsonl"),
+    }
+    scanner_claude = list_cursors(conn, consumer_id="scanner", client="claude")
+    assert [c.source_path for c in scanner_claude] == ["/tmp/a.jsonl"]
+    assert len(list_cursors(conn)) == 3

--- a/tests/capture/test_cursors.py
+++ b/tests/capture/test_cursors.py
@@ -92,6 +92,29 @@ def test_get_cursor_wrong_consumer_returns_none():
     assert get_cursor(conn, "events", "/tmp/a.jsonl") is None
 
 
+def test_set_cursor_preserves_first_seen_across_updates():
+    """first_seen records when the cursor was initially created; updates
+    should leave it unchanged while advancing last_seen. The ON CONFLICT
+    DO UPDATE clause must not include first_seen in its SET list."""
+    conn = _open()
+    set_cursor(conn, _cursor(last_offset=0))
+    first_row = conn.execute(
+        "SELECT first_seen, last_seen FROM capture_cursors "
+        "WHERE consumer_id = ? AND source_path = ?",
+        ("scanner", "/tmp/a.jsonl"),
+    ).fetchone()
+    original_first_seen = first_row[0]
+    # Advance the cursor; first_seen should stick, last_seen should refresh
+    set_cursor(conn, _cursor(last_offset=100))
+    second_row = conn.execute(
+        "SELECT first_seen, last_seen FROM capture_cursors "
+        "WHERE consumer_id = ? AND source_path = ?",
+        ("scanner", "/tmp/a.jsonl"),
+    ).fetchone()
+    assert second_row[0] == original_first_seen
+    assert second_row[1] >= first_row[1]
+
+
 def test_list_cursors_filters_by_consumer_and_client():
     conn = _open()
     set_cursor(conn, _cursor(consumer_id="scanner", source_path="/tmp/a.jsonl", client="claude"))

--- a/tests/capture/test_discovery.py
+++ b/tests/capture/test_discovery.py
@@ -50,6 +50,13 @@ def _write_local_agent_wrapper(
     return wrapper, session_dir
 
 
+def _make_workspace_dirs(isolated_homedir):
+    root_uuid = isolated_homedir / "local_agent" / "11111111-2222-3333-4444-555555555555"
+    workspace_uuid = root_uuid / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    workspace_uuid.mkdir(parents=True)
+    return workspace_uuid
+
+
 # ---------- Claude native ----------
 
 
@@ -76,41 +83,37 @@ def test_claude_native_discovery_yields_sessions_and_subagents(isolated_homedir)
 # ---------- Claude Desktop local-agent (step 1b) ----------
 
 
-def test_local_agent_discovery_uses_user_folder_workspace_key(isolated_homedir):
-    root_uuid = isolated_homedir / "local_agent" / "11111111-2222-3333-4444-555555555555"
-    workspace_uuid = root_uuid / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-    workspace_uuid.mkdir(parents=True)
-
+def test_local_agent_yields_only_cli_session_id_transcript(isolated_homedir):
+    """parser.py:862 reads only `{nested_project_dir}/{cli_session_id}.jsonl`
+    per wrapper. Other `.jsonl` files in the same dir, subagent streams,
+    and audit.jsonl are deliberately skipped so step-2 Scanner parity
+    holds."""
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
     _, session_dir = _write_local_agent_wrapper(
         workspace_uuid,
         "abc",
-        cli_session_id="cli-1",
-        session_id="sess-1",
+        cli_session_id="cli-42",
+        session_id="sess-42",
         process_name="myproc",
         user_folder="/Users/me/ws-one",
     )
-    projects_dir = session_dir / ".claude" / "projects" / "-sessions-myproc"
-    projects_dir.mkdir(parents=True)
-    (projects_dir / "inside.jsonl").write_text("{}\n")
-    subagents = projects_dir / "inside" / "subagents"
+    proj = session_dir / ".claude" / "projects" / "-sessions-myproc"
+    proj.mkdir(parents=True)
+    (proj / "cli-42.jsonl").write_text("{}\n")          # matches cliSessionId
+    (proj / "stale-session.jsonl").write_text("{}\n")   # parser ignores
+    subagents = proj / "cli-42" / "subagents"
     subagents.mkdir(parents=True)
-    (subagents / "agent-9.jsonl").write_text("{}\n")
-    (session_dir / "audit.jsonl").write_text("{}\n")
+    (subagents / "agent-1.jsonl").write_text("{}\n")    # parser ignores
+    (session_dir / "audit.jsonl").write_text("{}\n")    # metadata, not a transcript
 
     files = list(discovery.iter_source_files(source_filter="claude"))
-    names = sorted(f.path.name for f in files)
-    assert names == ["agent-9.jsonl", "audit.jsonl", "inside.jsonl"]
-    assert {f.project_dir_name for f in files} == {"-Users-me-ws-one"}
-    assert all(f.client == "claude" for f in files)
+    assert [f.path.name for f in files] == ["cli-42.jsonl"]
+    assert files[0].project_dir_name == "-Users-me-ws-one"
+    assert files[0].client == "claude"
 
 
-def test_local_agent_discovery_falls_back_to_cowork_key_without_user_folder(
-    isolated_homedir,
-):
-    root_uuid = isolated_homedir / "local_agent" / "11111111-2222-3333-4444-555555555555"
-    workspace_uuid = root_uuid / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-    workspace_uuid.mkdir(parents=True)
-
+def test_local_agent_falls_back_to_cowork_key_without_user_folder(isolated_homedir):
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
     _, session_dir = _write_local_agent_wrapper(
         workspace_uuid,
         "def",
@@ -118,13 +121,55 @@ def test_local_agent_discovery_falls_back_to_cowork_key_without_user_folder(
         session_id="sess-2",
         process_name="otherproc",
     )
-    projects_dir = session_dir / ".claude" / "projects" / "-sessions-otherproc"
-    projects_dir.mkdir(parents=True)
-    (projects_dir / "inside2.jsonl").write_text("{}\n")
+    proj = session_dir / ".claude" / "projects" / "-sessions-otherproc"
+    proj.mkdir(parents=True)
+    (proj / "cli-2.jsonl").write_text("{}\n")
 
     files = list(discovery.iter_source_files(source_filter="claude"))
     assert len(files) == 1
     assert files[0].project_dir_name == "_cowork_sess-2"
+    assert files[0].path.name == "cli-2.jsonl"
+
+
+def test_local_agent_skips_workspace_without_nested_project_dir(isolated_homedir):
+    """parser.py:415 filters out local-agent descriptors without a
+    nested_project_dir. A wrapper whose session dir has no
+    `.claude/projects` subtree yields nothing downstream, so the adapter
+    yields nothing either — even if audit.jsonl is present."""
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    _, session_dir = _write_local_agent_wrapper(
+        workspace_uuid,
+        "noproj",
+        cli_session_id="cli-nodir",
+        session_id="sess-nodir",
+        process_name="x",
+    )
+    (session_dir / "audit.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    assert files == []
+
+
+def test_local_agent_skips_when_cli_session_transcript_missing(isolated_homedir):
+    """Only the cliSessionId-named transcript is read. If it doesn't
+    exist in the chosen nested project dir, the wrapper yields nothing,
+    matching parser.py:862 `if not jsonl_path: continue`."""
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    _, session_dir = _write_local_agent_wrapper(
+        workspace_uuid,
+        "nomatch",
+        cli_session_id="cli-expected",
+        session_id="sess-nomatch",
+        process_name="myproc",
+        user_folder="/Users/me/ws",
+    )
+    proj = session_dir / ".claude" / "projects" / "-sessions-myproc"
+    proj.mkdir(parents=True)
+    # Non-matching session file exists but the cliSessionId-named one does not
+    (proj / "cli-different.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    assert files == []
 
 
 def test_local_agent_skips_non_uuid_directories(isolated_homedir):
@@ -138,19 +183,11 @@ def test_local_agent_skips_non_uuid_directories(isolated_homedir):
 
 
 def test_local_agent_missing_directory_is_a_no_op(isolated_homedir):
-    # local_agent dir never created
     files = list(discovery.iter_source_files(source_filter="claude"))
     assert files == []
 
 
 # ---------- wrapper validity gates (mirror parser.py:220-227) ----------
-
-
-def _make_workspace_dirs(isolated_homedir):
-    root_uuid = isolated_homedir / "local_agent" / "11111111-2222-3333-4444-555555555555"
-    workspace_uuid = root_uuid / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
-    workspace_uuid.mkdir(parents=True)
-    return workspace_uuid
 
 
 def test_local_agent_skips_wrapper_with_malformed_json(isolated_homedir):
@@ -161,8 +198,7 @@ def test_local_agent_skips_wrapper_with_malformed_json(isolated_homedir):
     session_dir.mkdir()
     proj_dir = session_dir / ".claude" / "projects" / "-sessions-x"
     proj_dir.mkdir(parents=True)
-    (proj_dir / "should-not-show.jsonl").write_text("{}\n")
-    (session_dir / "audit.jsonl").write_text("{}\n")
+    (proj_dir / "anything.jsonl").write_text("{}\n")
 
     files = list(discovery.iter_source_files(source_filter="claude"))
     assert files == []
@@ -176,7 +212,7 @@ def test_local_agent_skips_wrapper_that_is_not_a_dict(isolated_homedir):
     session_dir.mkdir()
     proj_dir = session_dir / ".claude" / "projects" / "-sessions-x"
     proj_dir.mkdir(parents=True)
-    (proj_dir / "should-not-show.jsonl").write_text("{}\n")
+    (proj_dir / "anything.jsonl").write_text("{}\n")
 
     files = list(discovery.iter_source_files(source_filter="claude"))
     assert files == []
@@ -190,7 +226,7 @@ def test_local_agent_skips_wrapper_without_cli_session_id(isolated_homedir):
     session_dir.mkdir()
     proj_dir = session_dir / ".claude" / "projects" / "-sessions-x"
     proj_dir.mkdir(parents=True)
-    (proj_dir / "should-not-show.jsonl").write_text("{}\n")
+    (proj_dir / "anything.jsonl").write_text("{}\n")
 
     files = list(discovery.iter_source_files(source_filter="claude"))
     assert files == []
@@ -211,15 +247,16 @@ def test_local_agent_prefers_sessions_processname_dir_over_others(isolated_homed
     )
     expected = session_dir / ".claude" / "projects" / "-sessions-myproc"
     expected.mkdir(parents=True)
-    (expected / "match.jsonl").write_text("{}\n")
-    # Extra unrelated dir — must not be tailed when the processName dir exists
+    (expected / "cli-5.jsonl").write_text("{}\n")
+    # Unrelated dir: even if the selection logic changed, its transcript
+    # should never be reached when -sessions-myproc is present.
     stray = session_dir / ".claude" / "projects" / "stray"
     stray.mkdir(parents=True)
-    (stray / "stray.jsonl").write_text("{}\n")
+    (stray / "cli-5.jsonl").write_text("{}\n")
 
     files = list(discovery.iter_source_files(source_filter="claude"))
-    names = sorted(f.path.name for f in files)
-    assert names == ["match.jsonl"]
+    assert len(files) == 1
+    assert files[0].path == expected / "cli-5.jsonl"
 
 
 def test_local_agent_falls_back_to_a_single_nested_dir_when_processname_missing(
@@ -236,16 +273,15 @@ def test_local_agent_falls_back_to_a_single_nested_dir_when_processname_missing(
     )
     alt = session_dir / ".claude" / "projects" / "-sessions-fallback"
     alt.mkdir(parents=True)
-    (alt / "picked.jsonl").write_text("{}\n")
+    (alt / "cli-6.jsonl").write_text("{}\n")
     extra = session_dir / ".claude" / "projects" / "-sessions-other"
     extra.mkdir(parents=True)
-    (extra / "skipped.jsonl").write_text("{}\n")
+    (extra / "cli-6.jsonl").write_text("{}\n")
 
     files = list(discovery.iter_source_files(source_filter="claude"))
-    names = sorted(f.path.name for f in files)
-    # Only the alphabetically-first fallback dir is picked (sorted iterdir).
-    # Parser's unsorted fallback is OS-dependent; the adapter is deterministic.
-    assert names == ["picked.jsonl"]
+    # Alphabetically-first fallback dir wins; the other is ignored.
+    assert len(files) == 1
+    assert files[0].path == alt / "cli-6.jsonl"
 
 
 # ---------- Codex ----------

--- a/tests/capture/test_discovery.py
+++ b/tests/capture/test_discovery.py
@@ -60,24 +60,58 @@ def _make_workspace_dirs(isolated_homedir):
 # ---------- Claude native ----------
 
 
-def test_claude_native_discovery_yields_sessions_and_subagents(isolated_homedir):
+def test_claude_native_discovery_yields_root_jsonls_and_subagent_only_sessions(
+    isolated_homedir,
+):
+    """Root `<uuid>.jsonl` files are always yielded. Subagent streams are
+    yielded only for UUID-named dirs that have NO sibling `<uuid>.jsonl`
+    — mirrors parser._find_subagent_only_sessions. Rooted sessions'
+    subagents are consumed as part of the root transcript, so the
+    adapter must skip them to avoid step-2 double-ingestion."""
     proj = isolated_homedir / "claude" / "projects" / "myproject"
     proj.mkdir(parents=True)
-    (proj / "session-a.jsonl").write_text("{}\n")
-    (proj / "session-b.jsonl").write_text("{}\n")
-    subagents = proj / "session-a" / "subagents"
-    subagents.mkdir(parents=True)
-    (subagents / "agent-1.jsonl").write_text("{}\n")
+    # Rooted session: root jsonl plus subagents — only the root file is
+    # yielded, because the parser treats the subagents as part of the root.
+    (proj / "rooted.jsonl").write_text("{}\n")
+    rooted_sub = proj / "rooted" / "subagents"
+    rooted_sub.mkdir(parents=True)
+    (rooted_sub / "agent-r.jsonl").write_text("{}\n")  # skipped
+    # Subagent-only session: no root jsonl; its subagents ARE yielded.
+    sub_only = proj / "subagent-only-uuid" / "subagents"
+    sub_only.mkdir(parents=True)
+    (sub_only / "agent-s.jsonl").write_text("{}\n")
 
     files = list(discovery.iter_source_files(source_filter="claude"))
-    rel = sorted(str(f.path.relative_to(isolated_homedir)) for f in files)
-    assert rel == [
-        "claude/projects/myproject/session-a.jsonl",
-        "claude/projects/myproject/session-a/subagents/agent-1.jsonl",
-        "claude/projects/myproject/session-b.jsonl",
-    ]
+    names = sorted(f.path.name for f in files)
+    assert names == ["agent-s.jsonl", "rooted.jsonl"]
     assert all(f.client == "claude" for f in files)
     assert all(f.project_dir_name == "myproject" for f in files)
+
+
+def test_claude_native_subagent_of_rooted_session_is_skipped(isolated_homedir):
+    proj = isolated_homedir / "claude" / "projects" / "p"
+    proj.mkdir(parents=True)
+    (proj / "abc.jsonl").write_text("{}\n")
+    subs = proj / "abc" / "subagents"
+    subs.mkdir(parents=True)
+    (subs / "agent-1.jsonl").write_text("{}\n")
+    (subs / "agent-2.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    names = sorted(f.path.name for f in files)
+    assert names == ["abc.jsonl"]  # no agent-*.jsonl
+
+
+def test_claude_native_subagent_only_session_is_included(isolated_homedir):
+    proj = isolated_homedir / "claude" / "projects" / "p"
+    proj.mkdir(parents=True)
+    subs = proj / "only-uuid" / "subagents"
+    subs.mkdir(parents=True)
+    (subs / "agent-1.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    names = sorted(f.path.name for f in files)
+    assert names == ["agent-1.jsonl"]
 
 
 # ---------- Claude Desktop local-agent (step 1b) ----------
@@ -132,10 +166,6 @@ def test_local_agent_falls_back_to_cowork_key_without_user_folder(isolated_homed
 
 
 def test_local_agent_skips_workspace_without_nested_project_dir(isolated_homedir):
-    """parser.py:415 filters out local-agent descriptors without a
-    nested_project_dir. A wrapper whose session dir has no
-    `.claude/projects` subtree yields nothing downstream, so the adapter
-    yields nothing either — even if audit.jsonl is present."""
     workspace_uuid = _make_workspace_dirs(isolated_homedir)
     _, session_dir = _write_local_agent_wrapper(
         workspace_uuid,
@@ -151,9 +181,6 @@ def test_local_agent_skips_workspace_without_nested_project_dir(isolated_homedir
 
 
 def test_local_agent_skips_when_cli_session_transcript_missing(isolated_homedir):
-    """Only the cliSessionId-named transcript is read. If it doesn't
-    exist in the chosen nested project dir, the wrapper yields nothing,
-    matching parser.py:862 `if not jsonl_path: continue`."""
     workspace_uuid = _make_workspace_dirs(isolated_homedir)
     _, session_dir = _write_local_agent_wrapper(
         workspace_uuid,
@@ -165,7 +192,6 @@ def test_local_agent_skips_when_cli_session_transcript_missing(isolated_homedir)
     )
     proj = session_dir / ".claude" / "projects" / "-sessions-myproc"
     proj.mkdir(parents=True)
-    # Non-matching session file exists but the cliSessionId-named one does not
     (proj / "cli-different.jsonl").write_text("{}\n")
 
     files = list(discovery.iter_source_files(source_filter="claude"))
@@ -248,8 +274,6 @@ def test_local_agent_prefers_sessions_processname_dir_over_others(isolated_homed
     expected = session_dir / ".claude" / "projects" / "-sessions-myproc"
     expected.mkdir(parents=True)
     (expected / "cli-5.jsonl").write_text("{}\n")
-    # Unrelated dir: even if the selection logic changed, its transcript
-    # should never be reached when -sessions-myproc is present.
     stray = session_dir / ".claude" / "projects" / "stray"
     stray.mkdir(parents=True)
     (stray / "cli-5.jsonl").write_text("{}\n")
@@ -268,7 +292,7 @@ def test_local_agent_falls_back_to_a_single_nested_dir_when_processname_missing(
         "fb",
         cli_session_id="cli-6",
         session_id="sess-6",
-        process_name="unexpected",  # no -sessions-unexpected dir below
+        process_name="unexpected",
         user_folder="/Users/me/ws",
     )
     alt = session_dir / ".claude" / "projects" / "-sessions-fallback"
@@ -279,9 +303,91 @@ def test_local_agent_falls_back_to_a_single_nested_dir_when_processname_missing(
     (extra / "cli-6.jsonl").write_text("{}\n")
 
     files = list(discovery.iter_source_files(source_filter="claude"))
-    # Alphabetically-first fallback dir wins; the other is ignored.
     assert len(files) == 1
     assert files[0].path == alt / "cli-6.jsonl"
+
+
+# ---------- cross-source dedupe (mirror parser.py:399-400) ----------
+
+
+def test_local_agent_skipped_when_matching_native_session_exists(isolated_homedir):
+    """A local-agent wrapper whose cliSessionId matches a native session
+    UUID in the same workspace is dropped, so the Scanner doesn't
+    double-ingest the same session."""
+    # Native project at workspace_key `-Users-me-shared` with session UUID `dup`
+    native = isolated_homedir / "claude" / "projects" / "-Users-me-shared"
+    native.mkdir(parents=True)
+    (native / "dup.jsonl").write_text("{}\n")
+
+    # LA wrapper in a matching workspace (userSelectedFolders → same key)
+    # with cliSessionId == "dup" — should be skipped.
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    _, session_dir = _write_local_agent_wrapper(
+        workspace_uuid,
+        "dup",
+        cli_session_id="dup",
+        session_id="sess-dup",
+        process_name="proc",
+        user_folder="/Users/me/shared",
+    )
+    proj = session_dir / ".claude" / "projects" / "-sessions-proc"
+    proj.mkdir(parents=True)
+    (proj / "dup.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    paths = sorted(str(f.path.relative_to(isolated_homedir)) for f in files)
+    assert paths == ["claude/projects/-Users-me-shared/dup.jsonl"]
+
+
+def test_local_agent_included_when_session_id_differs_from_native(isolated_homedir):
+    native = isolated_homedir / "claude" / "projects" / "-Users-me-shared"
+    native.mkdir(parents=True)
+    (native / "native-only.jsonl").write_text("{}\n")
+
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    _, session_dir = _write_local_agent_wrapper(
+        workspace_uuid,
+        "la",
+        cli_session_id="la-only",  # different UUID
+        session_id="sess-la",
+        process_name="proc",
+        user_folder="/Users/me/shared",
+    )
+    proj = session_dir / ".claude" / "projects" / "-sessions-proc"
+    proj.mkdir(parents=True)
+    (proj / "la-only.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    names = sorted(f.path.name for f in files)
+    assert names == ["la-only.jsonl", "native-only.jsonl"]
+
+
+def test_local_agent_dedupe_matches_native_subagent_only_session(isolated_homedir):
+    """Native subagent-only sessions also count as native IDs for dedupe —
+    parser._get_native_session_ids treats them as transcripts."""
+    native = isolated_homedir / "claude" / "projects" / "-Users-me-shared"
+    native.mkdir(parents=True)
+    # Subagent-only native session with UUID "sub-dup"
+    subs = native / "sub-dup" / "subagents"
+    subs.mkdir(parents=True)
+    (subs / "agent-1.jsonl").write_text("{}\n")
+
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    _, session_dir = _write_local_agent_wrapper(
+        workspace_uuid,
+        "ladup",
+        cli_session_id="sub-dup",  # matches native subagent-only UUID
+        session_id="sess-sub",
+        process_name="proc",
+        user_folder="/Users/me/shared",
+    )
+    proj = session_dir / ".claude" / "projects" / "-sessions-proc"
+    proj.mkdir(parents=True)
+    (proj / "sub-dup.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    # Only the native subagent file is yielded; the LA transcript is deduped.
+    assert [f.path.name for f in files] == ["agent-1.jsonl"]
 
 
 # ---------- Codex ----------

--- a/tests/capture/test_discovery.py
+++ b/tests/capture/test_discovery.py
@@ -586,9 +586,15 @@ def test_parse_inputs_preserve_duplicate_local_agent_candidates_stably(
     assert len(inputs) == 2
     assert inputs[0].session_key == inputs[1].session_key == "claude:-Users-me-ws:dup-cli"
     assert [parse_input.priority for parse_input in inputs] == [1, 1]
-    assert tuple(str(parse_input.parse_path) for parse_input in inputs) == tuple(
-        sorted(str(parse_input.parse_path) for parse_input in inputs)
-    )
+    # Both physical candidates are surfaced. Filesystem iterdir order is
+    # OS-dependent — macOS happens to return entries alphabetically, but
+    # Linux ext4 uses hash order. That's deliberate parser parity; the
+    # sibling test_..._preserve_raw_wrapper_order_... pins ordering via a
+    # patched iterdir. Here we only check presence.
+    assert {parse_input.parse_path for parse_input in inputs} == {
+        proj_one / "dup-cli.jsonl",
+        proj_two / "dup-cli.jsonl",
+    }
     assert all(len(parse_input.source_paths) == 1 for parse_input in inputs)
 
 

--- a/tests/capture/test_discovery.py
+++ b/tests/capture/test_discovery.py
@@ -1,0 +1,202 @@
+import json
+
+import pytest
+
+from clawjournal.capture import discovery
+from clawjournal.parsing import parser
+
+
+@pytest.fixture
+def isolated_homedir(tmp_path, monkeypatch):
+    """Monkeypatch every parser path the capture adapter looks at so a test
+    exercising Claude doesn't pick up the developer's real Codex history.
+    Tests populate whichever subdirectory they care about."""
+    monkeypatch.setattr(parser, "PROJECTS_DIR", tmp_path / "claude" / "projects")
+    monkeypatch.setattr(parser, "CODEX_SESSIONS_DIR", tmp_path / "codex" / "sessions")
+    monkeypatch.setattr(
+        parser, "CODEX_ARCHIVED_DIR", tmp_path / "codex" / "archived_sessions"
+    )
+    monkeypatch.setattr(parser, "LOCAL_AGENT_DIR", tmp_path / "local_agent")
+    return tmp_path
+
+
+def _write_codex_session(path, cwd):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"type": "session_meta", "payload": {"cwd": cwd}}) + "\n"
+    )
+
+
+def _write_local_agent_wrapper(
+    workspace_dir,
+    name,
+    *,
+    cli_session_id,
+    session_id,
+    process_name,
+    user_folder=None,
+):
+    wrapper = workspace_dir / f"local_{name}.json"
+    payload = {
+        "cliSessionId": cli_session_id,
+        "sessionId": session_id,
+        "processName": process_name,
+    }
+    if user_folder is not None:
+        payload["userSelectedFolders"] = [user_folder]
+    wrapper.write_text(json.dumps(payload))
+    session_dir = wrapper.with_suffix("")
+    session_dir.mkdir()
+    return wrapper, session_dir
+
+
+# ---------- Claude native ----------
+
+
+def test_claude_native_discovery_yields_sessions_and_subagents(isolated_homedir):
+    proj = isolated_homedir / "claude" / "projects" / "myproject"
+    proj.mkdir(parents=True)
+    (proj / "session-a.jsonl").write_text("{}\n")
+    (proj / "session-b.jsonl").write_text("{}\n")
+    subagents = proj / "session-a" / "subagents"
+    subagents.mkdir(parents=True)
+    (subagents / "agent-1.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    rel = sorted(str(f.path.relative_to(isolated_homedir)) for f in files)
+    assert rel == [
+        "claude/projects/myproject/session-a.jsonl",
+        "claude/projects/myproject/session-a/subagents/agent-1.jsonl",
+        "claude/projects/myproject/session-b.jsonl",
+    ]
+    assert all(f.client == "claude" for f in files)
+    assert all(f.project_dir_name == "myproject" for f in files)
+
+
+# ---------- Claude Desktop local-agent (step 1b) ----------
+
+
+def test_local_agent_discovery_uses_user_folder_workspace_key(isolated_homedir):
+    root_uuid = isolated_homedir / "local_agent" / "11111111-2222-3333-4444-555555555555"
+    workspace_uuid = root_uuid / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    workspace_uuid.mkdir(parents=True)
+
+    _, session_dir = _write_local_agent_wrapper(
+        workspace_uuid,
+        "abc",
+        cli_session_id="cli-1",
+        session_id="sess-1",
+        process_name="myproc",
+        user_folder="/Users/me/ws-one",
+    )
+    projects_dir = session_dir / ".claude" / "projects" / "-sessions-myproc"
+    projects_dir.mkdir(parents=True)
+    (projects_dir / "inside.jsonl").write_text("{}\n")
+    subagents = projects_dir / "inside" / "subagents"
+    subagents.mkdir(parents=True)
+    (subagents / "agent-9.jsonl").write_text("{}\n")
+    (session_dir / "audit.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    names = sorted(f.path.name for f in files)
+    assert names == ["agent-9.jsonl", "audit.jsonl", "inside.jsonl"]
+    assert {f.project_dir_name for f in files} == {"-Users-me-ws-one"}
+    assert all(f.client == "claude" for f in files)
+
+
+def test_local_agent_discovery_falls_back_to_cowork_key_without_user_folder(
+    isolated_homedir,
+):
+    root_uuid = isolated_homedir / "local_agent" / "11111111-2222-3333-4444-555555555555"
+    workspace_uuid = root_uuid / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    workspace_uuid.mkdir(parents=True)
+
+    _, session_dir = _write_local_agent_wrapper(
+        workspace_uuid,
+        "def",
+        cli_session_id="cli-2",
+        session_id="sess-2",
+        process_name="otherproc",
+    )
+    projects_dir = session_dir / ".claude" / "projects" / "-sessions-otherproc"
+    projects_dir.mkdir(parents=True)
+    (projects_dir / "inside2.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    assert len(files) == 1
+    assert files[0].project_dir_name == "_cowork_sess-2"
+
+
+def test_local_agent_skips_non_uuid_directories(isolated_homedir):
+    root = isolated_homedir / "local_agent"
+    root.mkdir()
+    (root / "not-a-uuid").mkdir()
+    (root / "not-a-uuid" / "stray.json").write_text("{}")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    assert files == []
+
+
+def test_local_agent_missing_directory_is_a_no_op(isolated_homedir):
+    # local_agent dir never created
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    assert files == []
+
+
+# ---------- Codex ----------
+
+
+def test_codex_discovery_uses_extracted_cwd(isolated_homedir):
+    sessions = isolated_homedir / "codex" / "sessions" / "2026" / "04" / "19"
+    _write_codex_session(sessions / "rollout-a.jsonl", "/Users/me/proj-active")
+    archived = isolated_homedir / "codex" / "archived_sessions"
+    _write_codex_session(archived / "rollout-old.jsonl", "/Users/me/proj-old")
+
+    files = list(discovery.iter_source_files(source_filter="codex"))
+    by_name = {f.path.name: f for f in files}
+    assert set(by_name) == {"rollout-a.jsonl", "rollout-old.jsonl"}
+    assert by_name["rollout-a.jsonl"].project_dir_name == "/Users/me/proj-active"
+    assert by_name["rollout-old.jsonl"].project_dir_name == "/Users/me/proj-old"
+    assert all(f.client == "codex" for f in files)
+
+
+def test_codex_discovery_falls_back_to_unknown_cwd_when_missing_metadata(
+    isolated_homedir,
+):
+    archived = isolated_homedir / "codex" / "archived_sessions"
+    archived.mkdir(parents=True)
+    (archived / "rollout-nometa.jsonl").write_text(
+        json.dumps({"type": "turn_start"}) + "\n"
+    )
+
+    files = list(discovery.iter_source_files(source_filter="codex"))
+    assert len(files) == 1
+    assert files[0].project_dir_name == parser.UNKNOWN_CODEX_CWD
+
+
+# ---------- auto and unknown filters ----------
+
+
+def test_auto_filter_yields_all_supported_clients(isolated_homedir):
+    native_proj = isolated_homedir / "claude" / "projects" / "p1"
+    native_proj.mkdir(parents=True)
+    (native_proj / "s.jsonl").write_text("{}\n")
+    codex = isolated_homedir / "codex" / "sessions"
+    _write_codex_session(codex / "r.jsonl", "/cwd")
+
+    files = list(discovery.iter_source_files())
+    clients = {f.client for f in files}
+    assert clients == {"claude", "codex"}
+
+
+def test_unknown_source_returns_nothing(isolated_homedir):
+    files = list(discovery.iter_source_files(source_filter="gemini"))
+    assert files == []
+
+
+def test_size_bytes_matches_file_size(isolated_homedir):
+    proj = isolated_homedir / "claude" / "projects" / "p"
+    proj.mkdir(parents=True)
+    (proj / "s.jsonl").write_text("{}\n")
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    assert all(f.size_bytes == 3 for f in files)

--- a/tests/capture/test_discovery.py
+++ b/tests/capture/test_discovery.py
@@ -143,6 +143,111 @@ def test_local_agent_missing_directory_is_a_no_op(isolated_homedir):
     assert files == []
 
 
+# ---------- wrapper validity gates (mirror parser.py:220-227) ----------
+
+
+def _make_workspace_dirs(isolated_homedir):
+    root_uuid = isolated_homedir / "local_agent" / "11111111-2222-3333-4444-555555555555"
+    workspace_uuid = root_uuid / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    workspace_uuid.mkdir(parents=True)
+    return workspace_uuid
+
+
+def test_local_agent_skips_wrapper_with_malformed_json(isolated_homedir):
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    wrapper = workspace_uuid / "local_bad.json"
+    wrapper.write_text("{not json")
+    session_dir = wrapper.with_suffix("")
+    session_dir.mkdir()
+    proj_dir = session_dir / ".claude" / "projects" / "-sessions-x"
+    proj_dir.mkdir(parents=True)
+    (proj_dir / "should-not-show.jsonl").write_text("{}\n")
+    (session_dir / "audit.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    assert files == []
+
+
+def test_local_agent_skips_wrapper_that_is_not_a_dict(isolated_homedir):
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    wrapper = workspace_uuid / "local_list.json"
+    wrapper.write_text(json.dumps([1, 2, 3]))
+    session_dir = wrapper.with_suffix("")
+    session_dir.mkdir()
+    proj_dir = session_dir / ".claude" / "projects" / "-sessions-x"
+    proj_dir.mkdir(parents=True)
+    (proj_dir / "should-not-show.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    assert files == []
+
+
+def test_local_agent_skips_wrapper_without_cli_session_id(isolated_homedir):
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    wrapper = workspace_uuid / "local_missing.json"
+    wrapper.write_text(json.dumps({"sessionId": "sess-3", "processName": "x"}))
+    session_dir = wrapper.with_suffix("")
+    session_dir.mkdir()
+    proj_dir = session_dir / ".claude" / "projects" / "-sessions-x"
+    proj_dir.mkdir(parents=True)
+    (proj_dir / "should-not-show.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    assert files == []
+
+
+# ---------- nested project dir selection (mirror parser.py:247-253) ----------
+
+
+def test_local_agent_prefers_sessions_processname_dir_over_others(isolated_homedir):
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    _, session_dir = _write_local_agent_wrapper(
+        workspace_uuid,
+        "pref",
+        cli_session_id="cli-5",
+        session_id="sess-5",
+        process_name="myproc",
+        user_folder="/Users/me/ws",
+    )
+    expected = session_dir / ".claude" / "projects" / "-sessions-myproc"
+    expected.mkdir(parents=True)
+    (expected / "match.jsonl").write_text("{}\n")
+    # Extra unrelated dir — must not be tailed when the processName dir exists
+    stray = session_dir / ".claude" / "projects" / "stray"
+    stray.mkdir(parents=True)
+    (stray / "stray.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    names = sorted(f.path.name for f in files)
+    assert names == ["match.jsonl"]
+
+
+def test_local_agent_falls_back_to_a_single_nested_dir_when_processname_missing(
+    isolated_homedir,
+):
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    _, session_dir = _write_local_agent_wrapper(
+        workspace_uuid,
+        "fb",
+        cli_session_id="cli-6",
+        session_id="sess-6",
+        process_name="unexpected",  # no -sessions-unexpected dir below
+        user_folder="/Users/me/ws",
+    )
+    alt = session_dir / ".claude" / "projects" / "-sessions-fallback"
+    alt.mkdir(parents=True)
+    (alt / "picked.jsonl").write_text("{}\n")
+    extra = session_dir / ".claude" / "projects" / "-sessions-other"
+    extra.mkdir(parents=True)
+    (extra / "skipped.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    names = sorted(f.path.name for f in files)
+    # Only the alphabetically-first fallback dir is picked (sorted iterdir).
+    # Parser's unsorted fallback is OS-dependent; the adapter is deterministic.
+    assert names == ["picked.jsonl"]
+
+
 # ---------- Codex ----------
 
 

--- a/tests/capture/test_discovery.py
+++ b/tests/capture/test_discovery.py
@@ -17,6 +17,7 @@ def isolated_homedir(tmp_path, monkeypatch):
         parser, "CODEX_ARCHIVED_DIR", tmp_path / "codex" / "archived_sessions"
     )
     monkeypatch.setattr(parser, "LOCAL_AGENT_DIR", tmp_path / "local_agent")
+    monkeypatch.setattr(parser, "OPENCLAW_AGENTS_DIR", tmp_path / "openclaw" / "agents")
     return tmp_path
 
 
@@ -307,20 +308,22 @@ def test_local_agent_falls_back_to_a_single_nested_dir_when_processname_missing(
     assert files[0].path == alt / "cli-6.jsonl"
 
 
-# ---------- cross-source dedupe (mirror parser.py:399-400) ----------
+# ---------- duplicate preservation / parser-level fallback ----------
 
 
-def test_local_agent_skipped_when_matching_native_session_exists(isolated_homedir):
-    """A local-agent wrapper whose cliSessionId matches a native session
-    UUID in the same workspace is dropped, so the Scanner doesn't
-    double-ingest the same session."""
-    # Native project at workspace_key `-Users-me-shared` with session UUID `dup`
+def test_local_agent_matching_native_session_is_still_surfaced(isolated_homedir):
+    """Discovery must preserve both physical sources when native and
+    local-agent layouts share a session UUID.
+
+    The current parser only suppresses the local-agent copy after the
+    native transcript actually parses. If discovery dropped the LA file
+    based on filenames alone, an empty or malformed native transcript
+    would block the LA fallback entirely.
+    """
     native = isolated_homedir / "claude" / "projects" / "-Users-me-shared"
     native.mkdir(parents=True)
-    (native / "dup.jsonl").write_text("{}\n")
+    (native / "dup.jsonl").write_text("")
 
-    # LA wrapper in a matching workspace (userSelectedFolders → same key)
-    # with cliSessionId == "dup" — should be skipped.
     workspace_uuid = _make_workspace_dirs(isolated_homedir)
     _, session_dir = _write_local_agent_wrapper(
         workspace_uuid,
@@ -336,7 +339,10 @@ def test_local_agent_skipped_when_matching_native_session_exists(isolated_homedi
 
     files = list(discovery.iter_source_files(source_filter="claude"))
     paths = sorted(str(f.path.relative_to(isolated_homedir)) for f in files)
-    assert paths == ["claude/projects/-Users-me-shared/dup.jsonl"]
+    assert paths == [
+        "claude/projects/-Users-me-shared/dup.jsonl",
+        "local_agent/11111111-2222-3333-4444-555555555555/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/local_dup/.claude/projects/-sessions-proc/dup.jsonl",
+    ]
 
 
 def test_local_agent_included_when_session_id_differs_from_native(isolated_homedir):
@@ -362,32 +368,137 @@ def test_local_agent_included_when_session_id_differs_from_native(isolated_homed
     assert names == ["la-only.jsonl", "native-only.jsonl"]
 
 
-def test_local_agent_dedupe_matches_native_subagent_only_session(isolated_homedir):
-    """Native subagent-only sessions also count as native IDs for dedupe —
-    parser._get_native_session_ids treats them as transcripts."""
+def test_duplicate_local_agent_wrappers_same_cli_session_id_are_both_surfaced(
+    isolated_homedir,
+):
+    """Capture stays at the physical source-file layer.
+
+    Multiple wrappers can point at the same logical session UUID. The
+    parser handles session-level dedupe and fallback; discovery should
+    surface both raw transcripts rather than picking one prematurely.
+    """
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    _, session_one = _write_local_agent_wrapper(
+        workspace_uuid,
+        "one",
+        cli_session_id="dup-cli",
+        session_id="sess-one",
+        process_name="proc",
+        user_folder="/Users/me/ws",
+    )
+    proj_one = session_one / ".claude" / "projects" / "-sessions-proc"
+    proj_one.mkdir(parents=True)
+    (proj_one / "dup-cli.jsonl").write_text("{}\n")
+
+    _, session_two = _write_local_agent_wrapper(
+        workspace_uuid,
+        "two",
+        cli_session_id="dup-cli",
+        session_id="sess-two",
+        process_name="proc",
+        user_folder="/Users/me/ws",
+    )
+    proj_two = session_two / ".claude" / "projects" / "-sessions-proc"
+    proj_two.mkdir(parents=True)
+    (proj_two / "dup-cli.jsonl").write_text("{}\n")
+
+    files = list(discovery.iter_source_files(source_filter="claude"))
+    paths = sorted(str(f.path.relative_to(isolated_homedir)) for f in files)
+    assert paths == [
+        "local_agent/11111111-2222-3333-4444-555555555555/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/local_one/.claude/projects/-sessions-proc/dup-cli.jsonl",
+        "local_agent/11111111-2222-3333-4444-555555555555/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/local_two/.claude/projects/-sessions-proc/dup-cli.jsonl",
+    ]
+
+
+# ---------- parser-facing logical inputs ----------
+
+
+def test_parse_inputs_collapse_native_subagent_only_session(isolated_homedir):
+    proj = isolated_homedir / "claude" / "projects" / "p"
+    proj.mkdir(parents=True)
+    session_dir = proj / "only-uuid"
+    subagents = session_dir / "subagents"
+    subagents.mkdir(parents=True)
+    (subagents / "agent-1.jsonl").write_text("{}\n")
+    (subagents / "agent-2.jsonl").write_text("{}\n")
+
+    inputs = list(discovery.iter_parse_inputs(source_filter="claude"))
+    assert len(inputs) == 1
+    parse_input = inputs[0]
+    assert parse_input.session_key == "claude:p:only-uuid"
+    assert parse_input.parse_kind == "claude_subagent_session"
+    assert parse_input.priority == 0
+    assert parse_input.parse_path == session_dir
+    assert tuple(path.name for path in parse_input.source_paths) == (
+        "agent-1.jsonl",
+        "agent-2.jsonl",
+    )
+
+
+def test_parse_inputs_encode_native_then_local_agent_fallback_order(
+    isolated_homedir,
+):
     native = isolated_homedir / "claude" / "projects" / "-Users-me-shared"
     native.mkdir(parents=True)
-    # Subagent-only native session with UUID "sub-dup"
-    subs = native / "sub-dup" / "subagents"
-    subs.mkdir(parents=True)
-    (subs / "agent-1.jsonl").write_text("{}\n")
+    (native / "dup.jsonl").write_text("")
 
     workspace_uuid = _make_workspace_dirs(isolated_homedir)
     _, session_dir = _write_local_agent_wrapper(
         workspace_uuid,
-        "ladup",
-        cli_session_id="sub-dup",  # matches native subagent-only UUID
-        session_id="sess-sub",
+        "dup",
+        cli_session_id="dup",
+        session_id="sess-dup",
         process_name="proc",
         user_folder="/Users/me/shared",
     )
     proj = session_dir / ".claude" / "projects" / "-sessions-proc"
     proj.mkdir(parents=True)
-    (proj / "sub-dup.jsonl").write_text("{}\n")
+    (proj / "dup.jsonl").write_text("{}\n")
 
-    files = list(discovery.iter_source_files(source_filter="claude"))
-    # Only the native subagent file is yielded; the LA transcript is deduped.
-    assert [f.path.name for f in files] == ["agent-1.jsonl"]
+    inputs = list(discovery.iter_parse_inputs(source_filter="claude"))
+    assert len(inputs) == 2
+    assert [parse_input.priority for parse_input in inputs] == [0, 1]
+    assert inputs[0].session_key == inputs[1].session_key == "claude:-Users-me-shared:dup"
+    assert inputs[0].parse_path == native / "dup.jsonl"
+    assert inputs[1].parse_path == proj / "dup.jsonl"
+
+
+def test_parse_inputs_preserve_duplicate_local_agent_candidates_stably(
+    isolated_homedir,
+):
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    _, session_one = _write_local_agent_wrapper(
+        workspace_uuid,
+        "one",
+        cli_session_id="dup-cli",
+        session_id="sess-one",
+        process_name="proc",
+        user_folder="/Users/me/ws",
+    )
+    proj_one = session_one / ".claude" / "projects" / "-sessions-proc"
+    proj_one.mkdir(parents=True)
+    (proj_one / "dup-cli.jsonl").write_text("{}\n")
+
+    _, session_two = _write_local_agent_wrapper(
+        workspace_uuid,
+        "two",
+        cli_session_id="dup-cli",
+        session_id="sess-two",
+        process_name="proc",
+        user_folder="/Users/me/ws",
+    )
+    proj_two = session_two / ".claude" / "projects" / "-sessions-proc"
+    proj_two.mkdir(parents=True)
+    (proj_two / "dup-cli.jsonl").write_text("{}\n")
+
+    inputs = list(discovery.iter_parse_inputs(source_filter="claude"))
+    assert len(inputs) == 2
+    assert inputs[0].session_key == inputs[1].session_key == "claude:-Users-me-ws:dup-cli"
+    assert [parse_input.priority for parse_input in inputs] == [1, 1]
+    assert tuple(str(parse_input.parse_path) for parse_input in inputs) == tuple(
+        sorted(str(parse_input.parse_path) for parse_input in inputs)
+    )
+    assert all(len(parse_input.source_paths) == 1 for parse_input in inputs)
 
 
 # ---------- Codex ----------
@@ -421,6 +532,59 @@ def test_codex_discovery_falls_back_to_unknown_cwd_when_missing_metadata(
     assert files[0].project_dir_name == parser.UNKNOWN_CODEX_CWD
 
 
+# ---------- OpenClaw ----------
+
+
+def _write_openclaw_session(path, cwd):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"type": "session", "cwd": cwd}) + "\n")
+
+
+def test_openclaw_discovery_groups_by_header_cwd(isolated_homedir):
+    agents = isolated_homedir / "openclaw" / "agents"
+    _write_openclaw_session(agents / "coder" / "sessions" / "s1.jsonl", "/Users/me/projA")
+    _write_openclaw_session(agents / "coder" / "sessions" / "s2.jsonl", "/Users/me/projB")
+    _write_openclaw_session(agents / "reviewer" / "sessions" / "s3.jsonl", "/Users/me/projA")
+
+    files = list(discovery.iter_source_files(source_filter="openclaw"))
+    by_name = {f.path.name: f for f in files}
+    assert set(by_name) == {"s1.jsonl", "s2.jsonl", "s3.jsonl"}
+    assert by_name["s1.jsonl"].project_dir_name == "/Users/me/projA"
+    assert by_name["s2.jsonl"].project_dir_name == "/Users/me/projB"
+    assert by_name["s3.jsonl"].project_dir_name == "/Users/me/projA"
+    assert all(f.client == "openclaw" for f in files)
+
+
+def test_openclaw_discovery_falls_back_to_unknown_cwd(isolated_homedir):
+    """Files without a first-line `type: session` header, or with no cwd,
+    group under UNKNOWN_OPENCLAW_CWD — mirrors parser._extract_openclaw_cwd."""
+    sessions = isolated_homedir / "openclaw" / "agents" / "a" / "sessions"
+    sessions.mkdir(parents=True)
+    (sessions / "no-header.jsonl").write_text(json.dumps({"type": "message"}) + "\n")
+    (sessions / "empty.jsonl").write_text("")
+    (sessions / "bad-json.jsonl").write_text("{not valid json\n")
+
+    files = list(discovery.iter_source_files(source_filter="openclaw"))
+    assert {f.path.name for f in files} == {
+        "no-header.jsonl",
+        "empty.jsonl",
+        "bad-json.jsonl",
+    }
+    assert all(f.project_dir_name == parser.UNKNOWN_OPENCLAW_CWD for f in files)
+
+
+def test_openclaw_discovery_skips_agent_dirs_without_sessions_subdir(isolated_homedir):
+    agents = isolated_homedir / "openclaw" / "agents"
+    # Agent dir with the required sessions/ subdir.
+    _write_openclaw_session(agents / "with" / "sessions" / "s.jsonl", "/cwd")
+    # Sibling agent dir missing the sessions/ subdir — must be ignored.
+    (agents / "without").mkdir(parents=True)
+    (agents / "without" / "notes.txt").write_text("stray file")
+
+    files = list(discovery.iter_source_files(source_filter="openclaw"))
+    assert [f.path.name for f in files] == ["s.jsonl"]
+
+
 # ---------- auto and unknown filters ----------
 
 
@@ -430,10 +594,14 @@ def test_auto_filter_yields_all_supported_clients(isolated_homedir):
     (native_proj / "s.jsonl").write_text("{}\n")
     codex = isolated_homedir / "codex" / "sessions"
     _write_codex_session(codex / "r.jsonl", "/cwd")
+    _write_openclaw_session(
+        isolated_homedir / "openclaw" / "agents" / "a" / "sessions" / "oc.jsonl",
+        "/cwd",
+    )
 
     files = list(discovery.iter_source_files())
     clients = {f.client for f in files}
-    assert clients == {"claude", "codex"}
+    assert clients == {"claude", "codex", "openclaw"}
 
 
 def test_unknown_source_returns_nothing(isolated_homedir):

--- a/tests/capture/test_discovery.py
+++ b/tests/capture/test_discovery.py
@@ -1,4 +1,5 @@
 import json
+from unittest.mock import patch
 
 import pytest
 
@@ -308,6 +309,40 @@ def test_local_agent_falls_back_to_a_single_nested_dir_when_processname_missing(
     assert files[0].path == alt / "cli-6.jsonl"
 
 
+def test_local_agent_fallback_uses_raw_iterdir_order_when_processname_missing(
+    isolated_homedir,
+):
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    _, session_dir = _write_local_agent_wrapper(
+        workspace_uuid,
+        "raworder",
+        cli_session_id="cli-raw",
+        session_id="sess-raw",
+        process_name="unexpected",
+        user_folder="/Users/me/ws",
+    )
+    nested_root = session_dir / ".claude" / "projects"
+    alt = nested_root / "-sessions-fallback"
+    alt.mkdir(parents=True)
+    (alt / "cli-raw.jsonl").write_text("{}\n")
+    extra = nested_root / "-sessions-other"
+    extra.mkdir(parents=True)
+    (extra / "cli-raw.jsonl").write_text("{}\n")
+
+    original_iterdir = discovery.Path.iterdir
+
+    def fake_iterdir(self):
+        if self == nested_root:
+            return iter([extra, alt])
+        return original_iterdir(self)
+
+    with patch.object(discovery.Path, "iterdir", fake_iterdir):
+        files = list(discovery.iter_source_files(source_filter="claude"))
+
+    assert len(files) == 1
+    assert files[0].path == extra / "cli-raw.jsonl"
+
+
 # ---------- duplicate preservation / parser-level fallback ----------
 
 
@@ -463,6 +498,62 @@ def test_parse_inputs_encode_native_then_local_agent_fallback_order(
     assert inputs[1].parse_path == proj / "dup.jsonl"
 
 
+def test_parse_inputs_expand_changed_local_agent_duplicate_to_full_fallback_set(
+    isolated_homedir,
+):
+    native = isolated_homedir / "claude" / "projects" / "-Users-me-shared"
+    native.mkdir(parents=True)
+    (native / "dup.jsonl").write_text("{}\n")
+
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    _, session_dir = _write_local_agent_wrapper(
+        workspace_uuid,
+        "dup",
+        cli_session_id="dup",
+        session_id="sess-dup",
+        process_name="proc",
+        user_folder="/Users/me/shared",
+    )
+    proj = session_dir / ".claude" / "projects" / "-sessions-proc"
+    proj.mkdir(parents=True)
+    la_file = proj / "dup.jsonl"
+    la_file.write_text("{}\n")
+
+    all_files = list(discovery.iter_source_files(source_filter="claude"))
+    changed_only = [source for source in all_files if source.path == la_file]
+
+    inputs = list(discovery.iter_parse_inputs(source_files=changed_only))
+    assert len(inputs) == 2
+    assert [parse_input.priority for parse_input in inputs] == [0, 1]
+    assert inputs[0].parse_path == native / "dup.jsonl"
+    assert inputs[1].parse_path == la_file
+
+
+def test_parse_inputs_expand_changed_subagent_file_to_full_session(
+    isolated_homedir,
+):
+    proj = isolated_homedir / "claude" / "projects" / "p"
+    proj.mkdir(parents=True)
+    session_dir = proj / "only-uuid"
+    subagents = session_dir / "subagents"
+    subagents.mkdir(parents=True)
+    agent_one = subagents / "agent-1.jsonl"
+    agent_two = subagents / "agent-2.jsonl"
+    agent_one.write_text("{}\n")
+    agent_two.write_text("{}\n")
+
+    all_files = list(discovery.iter_source_files(source_filter="claude"))
+    changed_only = [source for source in all_files if source.path == agent_one]
+
+    inputs = list(discovery.iter_parse_inputs(source_files=changed_only))
+    assert len(inputs) == 1
+    assert inputs[0].parse_path == session_dir
+    assert tuple(path.name for path in inputs[0].source_paths) == (
+        "agent-1.jsonl",
+        "agent-2.jsonl",
+    )
+
+
 def test_parse_inputs_preserve_duplicate_local_agent_candidates_stably(
     isolated_homedir,
 ):
@@ -499,6 +590,209 @@ def test_parse_inputs_preserve_duplicate_local_agent_candidates_stably(
         sorted(str(parse_input.parse_path) for parse_input in inputs)
     )
     assert all(len(parse_input.source_paths) == 1 for parse_input in inputs)
+
+
+def test_parse_inputs_preserve_raw_wrapper_order_for_duplicate_local_agent_candidates(
+    isolated_homedir,
+):
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    wrapper_one, session_one = _write_local_agent_wrapper(
+        workspace_uuid,
+        "one",
+        cli_session_id="dup-cli",
+        session_id="sess-one",
+        process_name="proc",
+        user_folder="/Users/me/ws",
+    )
+    proj_one = session_one / ".claude" / "projects" / "-sessions-proc"
+    proj_one.mkdir(parents=True)
+    file_one = proj_one / "dup-cli.jsonl"
+    file_one.write_text("{}\n")
+
+    wrapper_two, session_two = _write_local_agent_wrapper(
+        workspace_uuid,
+        "two",
+        cli_session_id="dup-cli",
+        session_id="sess-two",
+        process_name="proc",
+        user_folder="/Users/me/ws",
+    )
+    proj_two = session_two / ".claude" / "projects" / "-sessions-proc"
+    proj_two.mkdir(parents=True)
+    file_two = proj_two / "dup-cli.jsonl"
+    file_two.write_text("{}\n")
+
+    original_iterdir = discovery.Path.iterdir
+
+    def fake_iterdir(self):
+        if self == workspace_uuid:
+            return iter([wrapper_two, session_two, wrapper_one, session_one])
+        return original_iterdir(self)
+
+    with patch.object(discovery.Path, "iterdir", fake_iterdir):
+        inputs = list(discovery.iter_parse_inputs(source_filter="claude"))
+
+    assert len(inputs) == 2
+    assert [parse_input.priority for parse_input in inputs] == [1, 1]
+    assert [parse_input.parse_path for parse_input in inputs] == [file_two, file_one]
+
+
+def test_parse_inputs_preserve_raw_wrapper_order_for_distinct_local_agent_sessions(
+    isolated_homedir,
+):
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    wrapper_a, session_a = _write_local_agent_wrapper(
+        workspace_uuid,
+        "a",
+        cli_session_id="a",
+        session_id="sess-a",
+        process_name="proc",
+        user_folder="/Users/me/ws",
+    )
+    proj_a = session_a / ".claude" / "projects" / "-sessions-proc"
+    proj_a.mkdir(parents=True)
+    file_a = proj_a / "a.jsonl"
+    file_a.write_text("{}\n")
+
+    wrapper_z, session_z = _write_local_agent_wrapper(
+        workspace_uuid,
+        "z",
+        cli_session_id="z",
+        session_id="sess-z",
+        process_name="proc",
+        user_folder="/Users/me/ws",
+    )
+    proj_z = session_z / ".claude" / "projects" / "-sessions-proc"
+    proj_z.mkdir(parents=True)
+    file_z = proj_z / "z.jsonl"
+    file_z.write_text("{}\n")
+
+    original_iterdir = discovery.Path.iterdir
+
+    def fake_iterdir(self):
+        if self == workspace_uuid:
+            return iter([wrapper_z, session_z, wrapper_a, session_a])
+        return original_iterdir(self)
+
+    with patch.object(discovery.Path, "iterdir", fake_iterdir):
+        inputs = list(discovery.iter_parse_inputs(source_filter="claude"))
+
+    assert len(inputs) == 2
+    assert [parse_input.priority for parse_input in inputs] == [1, 1]
+    assert [parse_input.parse_path for parse_input in inputs] == [file_z, file_a]
+
+
+def test_parse_inputs_expand_changed_local_agent_candidate_to_all_duplicate_wrappers(
+    isolated_homedir,
+):
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    _, session_one = _write_local_agent_wrapper(
+        workspace_uuid,
+        "one",
+        cli_session_id="dup-cli",
+        session_id="sess-one",
+        process_name="proc",
+        user_folder="/Users/me/ws",
+    )
+    proj_one = session_one / ".claude" / "projects" / "-sessions-proc"
+    proj_one.mkdir(parents=True)
+    file_one = proj_one / "dup-cli.jsonl"
+    file_one.write_text("{}\n")
+
+    _, session_two = _write_local_agent_wrapper(
+        workspace_uuid,
+        "two",
+        cli_session_id="dup-cli",
+        session_id="sess-two",
+        process_name="proc",
+        user_folder="/Users/me/ws",
+    )
+    proj_two = session_two / ".claude" / "projects" / "-sessions-proc"
+    proj_two.mkdir(parents=True)
+    file_two = proj_two / "dup-cli.jsonl"
+    file_two.write_text("{}\n")
+
+    all_files = list(discovery.iter_source_files(source_filter="claude"))
+    changed_only = [source for source in all_files if source.path == file_one]
+
+    inputs = list(discovery.iter_parse_inputs(source_files=changed_only))
+    assert len(inputs) == 2
+    assert [parse_input.priority for parse_input in inputs] == [1, 1]
+    assert {parse_input.parse_path for parse_input in inputs} == {file_one, file_two}
+
+
+def test_parse_inputs_expand_changed_duplicate_local_agent_in_raw_wrapper_order(
+    isolated_homedir,
+):
+    workspace_uuid = _make_workspace_dirs(isolated_homedir)
+    wrapper_one, session_one = _write_local_agent_wrapper(
+        workspace_uuid,
+        "one",
+        cli_session_id="dup-cli",
+        session_id="sess-one",
+        process_name="proc",
+        user_folder="/Users/me/ws",
+    )
+    proj_one = session_one / ".claude" / "projects" / "-sessions-proc"
+    proj_one.mkdir(parents=True)
+    file_one = proj_one / "dup-cli.jsonl"
+    file_one.write_text("{}\n")
+
+    wrapper_two, session_two = _write_local_agent_wrapper(
+        workspace_uuid,
+        "two",
+        cli_session_id="dup-cli",
+        session_id="sess-two",
+        process_name="proc",
+        user_folder="/Users/me/ws",
+    )
+    proj_two = session_two / ".claude" / "projects" / "-sessions-proc"
+    proj_two.mkdir(parents=True)
+    file_two = proj_two / "dup-cli.jsonl"
+    file_two.write_text("{}\n")
+
+    original_iterdir = discovery.Path.iterdir
+
+    def fake_iterdir(self):
+        if self == workspace_uuid:
+            return iter([wrapper_two, session_two, wrapper_one, session_one])
+        return original_iterdir(self)
+
+    with patch.object(discovery.Path, "iterdir", fake_iterdir):
+        all_files = list(discovery.iter_source_files(source_filter="claude"))
+        changed_only = [source for source in all_files if source.path == file_one]
+        inputs = list(discovery.iter_parse_inputs(source_files=changed_only))
+
+    assert len(inputs) == 2
+    assert [parse_input.priority for parse_input in inputs] == [1, 1]
+    assert [parse_input.parse_path for parse_input in inputs] == [file_two, file_one]
+
+
+# ---------- mixed-source ordering ----------
+
+
+def test_parse_inputs_preserve_mixed_source_order_when_expanding_claude_families(
+    isolated_homedir,
+):
+    native = isolated_homedir / "claude" / "projects" / "p"
+    native.mkdir(parents=True)
+    claude_file = native / "c.jsonl"
+    claude_file.write_text("{}\n")
+
+    codex = isolated_homedir / "codex" / "sessions" / "2026" / "04" / "19"
+    _write_codex_session(codex / "rollout-k.jsonl", "/cwd")
+
+    files = list(discovery.iter_source_files())
+    assert [(source.client, source.path.name) for source in files] == [
+        ("claude", "c.jsonl"),
+        ("codex", "rollout-k.jsonl"),
+    ]
+
+    inputs = list(discovery.iter_parse_inputs(source_files=files))
+    assert [(parse_input.client, parse_input.parse_path.name) for parse_input in inputs] == [
+        ("claude", "c.jsonl"),
+        ("codex", "rollout-k.jsonl"),
+    ]
 
 
 # ---------- Codex ----------


### PR DESCRIPTION
## Summary

- New `clawjournal/capture/` module — source-of-truth ingest adapter for Claude Code (native projects + subagents), Claude Desktop local-agent-mode sessions, and Codex (sessions + archived_sessions). Downstream consumers read from this layer instead of rediscovering files themselves.
- Per-consumer cursor model: PK `(consumer_id, source_path)` in `~/.clawjournal/index.db`, with sink-first / cursor-second commit ordering so a crash replays idempotently and one consumer cannot cause another to miss data.
- Two read surfaces — file-level (`file_has_changed` / `cursor_to_eof`) for whole-file-reparse consumers like today's Scanner, and line-level (`iter_new_lines` / `cursor_after`) for streaming consumers. Handles append, rotation, truncation, partial lines.
- Vendor JSONLs stay the unredacted source of truth on disk; the capture layer persists cursors only, never raw bytes.
- No consumers wired yet — foundational work. Step 2 (adapter-first Scanner behind a feature flag) is next.

## Test plan

- [ ] `python -m pytest tests/capture/` passes (32 unit tests covering cursor schema/upsert/per-consumer independence, Claude native + local-agent discovery, Codex cwd extraction and `UNKNOWN_CODEX_CWD` fallback, and the full append/rotation/truncation/partial-line matrix)
- [ ] No behavioral change to the existing Scanner (capture module is unwired)

🤖 Generated with [Claude Code](https://claude.com/claude-code)