### PR TITLE
fix(share): align token totals to input+output, matching SessionDetail

### DIFF
--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -160,7 +160,7 @@ export const api = {
     return request('/projects');
   },
 
-  shareReady(opts?: { includeUnapproved?: boolean }): Promise<{ count: number; total_approved: number; projects: string[]; models: string[]; recommended_session_ids: string[]; sessions: Array<{ session_id: string; project: string; model: string | null; source: string; display_title: string; ai_quality_score: number | null; user_messages: number; assistant_messages: number; tool_uses: number; input_tokens: number; outcome_badge: string | null; client_origin: string | null; runtime_channel: string | null; start_time: string | null; review_status?: string }> }> {
+  shareReady(opts?: { includeUnapproved?: boolean }): Promise<{ count: number; total_approved: number; projects: string[]; models: string[]; recommended_session_ids: string[]; sessions: Array<{ session_id: string; project: string; model: string | null; source: string; display_title: string; ai_quality_score: number | null; user_messages: number; assistant_messages: number; tool_uses: number; input_tokens: number; output_tokens: number; outcome_badge: string | null; client_origin: string | null; runtime_channel: string | null; start_time: string | null; review_status?: string }> }> {
     const q = opts?.includeUnapproved ? '?include_unapproved=1' : '';
     return request(`/share-ready${q}`);
   },

--- a/clawjournal/web/frontend/src/views/Share.tsx
+++ b/clawjournal/web/frontend/src/views/Share.tsx
@@ -102,6 +102,10 @@ function outcomeBadge(outcome: string | null): string {
 
 const formatTokens = (t: number) => t >= 1_000_000 ? `${(t / 1_000_000).toFixed(1)}M` : `${(t / 1000).toFixed(0)}k`;
 
+// Matches SessionDetail's formula: input + output (cache tokens excluded).
+const sessionTotalTokens = (s: { input_tokens?: number; output_tokens?: number }) =>
+  (s.input_tokens || 0) + (s.output_tokens || 0);
+
 // Map raw redaction-log `type` strings into a small set of buckets the UI
 // surfaces on Redact and Review. Everything else collapses to `other`.
 type RedactionBucket = 'tokens' | 'emails' | 'paths' | 'timestamps' | 'urls' | 'other';
@@ -152,6 +156,7 @@ interface ReadySession {
   assistant_messages: number;
   tool_uses: number;
   input_tokens: number;
+  output_tokens: number;
   outcome_badge: string | null;
   client_origin?: string | null;
   runtime_channel?: string | null;
@@ -956,7 +961,7 @@ export function Share() {
 
       // Bundle info — use `undefined` locale (empty-array form is a known
       // source of RangeError in some Intl configs).
-      const totalTokens = approvedList.reduce((sum, s) => sum + (s.input_tokens || 0), 0);
+      const totalTokens = approvedList.reduce((sum, s) => sum + sessionTotalTokens(s), 0);
       const approxMB = Math.max(0.1, (totalTokens * 0.3) / (1024 * 1024));
       try {
         setBundleInfo({
@@ -1231,7 +1236,7 @@ function QueueStep(p: QueueStepProps) {
   const [dragId, setDragId] = useState<string | null>(null);
 
   const allSessions = p.readyStats?.sessions || [];
-  const totalTokens = p.queuedSessions.reduce((sum, s) => sum + (s.input_tokens || 0), 0);
+  const totalTokens = p.queuedSessions.reduce((sum, s) => sum + sessionTotalTokens(s), 0);
   const uniqueProjects = [...new Set(p.queuedSessions.map(s => s.project).filter(Boolean))];
 
   const onDragStart = (e: React.DragEvent, id: string) => {
@@ -1424,7 +1429,7 @@ function QueueStep(p: QueueStepProps) {
                       <SourceBadge s={s} />
                       <span>{s.project}</span>
                       <span style={{ opacity: 0.5 }}>&middot;</span>
-                      <span>{formatTokens(s.input_tokens)} tokens</span>
+                      <span>{formatTokens(sessionTotalTokens(s))} tokens</span>
                       {s.tool_uses > 0 && (<>
                         <span style={{ opacity: 0.5 }}>&middot;</span>
                         <span>{s.tool_uses} tools</span>
@@ -1553,7 +1558,7 @@ function QueueStep(p: QueueStepProps) {
                           <SourceBadge s={s} />
                           <span>{s.project}</span>
                           <span style={{ opacity: 0.5 }}>&middot;</span>
-                          <span>{formatTokens(s.input_tokens)} tokens</span>
+                          <span>{formatTokens(sessionTotalTokens(s))} tokens</span>
                           {s.review_status && s.review_status !== 'approved' && (<>
                             <span style={{ opacity: 0.5 }}>&middot;</span>
                             <span style={{ color: colors.gray400, fontStyle: 'italic' }}>{s.review_status}</span>
@@ -1829,7 +1834,7 @@ function RedactStep(p: RedactStepProps) {
                 <SourceBadge s={s} />
                 <span>{s.project}</span>
                 <span style={{ opacity: 0.5 }}>&middot;</span>
-                <span>{formatTokens(s.input_tokens)} tokens</span>
+                <span>{formatTokens(sessionTotalTokens(s))} tokens</span>
               </div>
             </div>
             <div style={{ display: 'flex', gap: 5, alignItems: 'center', flexWrap: 'wrap', justifyContent: 'flex-end' }}>
@@ -2129,7 +2134,7 @@ function ReviewRow({
             <SourceBadge s={session} />
             <span>{session.project}</span>
             <span style={{ opacity: 0.5 }}>&middot;</span>
-            <span>{formatTokens(session.input_tokens)} tokens</span>
+            <span>{formatTokens(sessionTotalTokens(session))} tokens</span>
             {metaPhrase && (<>
               <span style={{ opacity: 0.5 }}>&middot;</span>
               <span style={{ color: colors.yellow700 }}>{metaPhrase}</span>

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -2854,8 +2854,8 @@ def get_share_ready_stats(
     rows = conn.execute(
         "SELECT session_id, project, model, source, display_title,"
         " ai_quality_score, user_messages, assistant_messages, tool_uses,"
-        " input_tokens, outcome_badge, client_origin, runtime_channel,"
-        " start_time, review_status"
+        " input_tokens, output_tokens, outcome_badge, client_origin,"
+        " runtime_channel, start_time, review_status"
         " FROM sessions"
         f"{where_status}"
         f"{' AND' if where_status else ' WHERE'} session_id NOT IN ("
@@ -2876,7 +2876,7 @@ def get_share_ready_stats(
     ).fetchall()
     cols = ["session_id", "project", "model", "source", "display_title",
             "ai_quality_score", "user_messages", "assistant_messages",
-            "tool_uses", "input_tokens", "outcome_badge",
+            "tool_uses", "input_tokens", "output_tokens", "outcome_badge",
             "client_origin", "runtime_channel", "start_time", "review_status"]
     sessions = [dict(zip(cols, r)) for r in rows]
     if excluded_projects:


### PR DESCRIPTION
## Summary

- The Share queue displayed only `input_tokens` (`Share.tsx:1427,1556,1832,2132` and the two `reduce` accumulators at `:959,:1234`). Prompt caching drops raw `input_tokens` to near zero on long sessions — one real trace of 207 messages / 200k output tokens / 28M cache-read tokens rendered as **0k tokens**.
- Fix aligns the six Share-tab display and aggregation sites to `input_tokens + output_tokens`, matching the formula already used in `SessionDetail.tsx:294` and `clawjournal inbox --json`.
- `get_share_ready_stats` (`workbench/index.py`) and the `shareReady()` API return type now include `output_tokens` so the frontend can sum without a second round-trip.

## Test plan

- [x] `pytest tests/workbench/` — all 259 pass locally
- [x] `npm run build` inside `clawjournal/web/frontend` — compiles clean (`tsc -b && vite build`)
- [ ] Open `/share` on a workbench with ≥1 heavily-cached session; the draft-bundle row tokens and the header total are no longer `0k` / `2k` but reflect input + output
- [x] `SessionDetail` "Tokens" row for the same session matches what `/share` now shows