### PR TITLE
feat(share): Review-step ergonomics — bulk-include, remove-undo, restore drawer

### DIFF
--- a/clawjournal/web/frontend/src/components/Toast.tsx
+++ b/clawjournal/web/frontend/src/components/Toast.tsx
@@ -1,14 +1,26 @@
 import { createContext, useContext, useState, useCallback, useRef } from 'react';
 import { colors } from '../theme.ts';
 
+export interface ToastAction {
+  label: string;
+  onClick: () => void;
+}
+
+export interface ToastOptions {
+  type?: 'success' | 'error' | 'info';
+  duration?: number;          // ms, default 3500
+  action?: ToastAction;
+}
+
 interface ToastItem {
   id: number;
   message: string;
   type: 'success' | 'error' | 'info';
+  action?: ToastAction;
 }
 
 interface ToastCtx {
-  toast: (message: string, type?: 'success' | 'error' | 'info') => void;
+  toast: (message: string, typeOrOptions?: 'success' | 'error' | 'info' | ToastOptions) => void;
 }
 
 const Ctx = createContext<ToastCtx>({ toast: () => {} });
@@ -21,10 +33,18 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
   const [items, setItems] = useState<ToastItem[]>([]);
   const counter = useRef(0);
 
-  const toast = useCallback((message: string, type: 'success' | 'error' | 'info' = 'info') => {
+  const toast = useCallback((
+    message: string,
+    typeOrOptions?: 'success' | 'error' | 'info' | ToastOptions,
+  ) => {
+    const opts: ToastOptions =
+      typeof typeOrOptions === 'string' ? { type: typeOrOptions }
+      : typeOrOptions ?? {};
     const id = ++counter.current;
-    setItems(prev => [...prev, { id, message, type }]);
-    setTimeout(() => setItems(prev => prev.filter(t => t.id !== id)), 3500);
+    const type = opts.type ?? 'info';
+    const duration = opts.duration ?? 3500;
+    setItems(prev => [...prev, { id, message, type, action: opts.action }]);
+    setTimeout(() => setItems(prev => prev.filter(t => t.id !== id)), duration);
   }, []);
 
   const bgMap = { success: colors.green700, error: colors.red500, info: colors.gray800 };
@@ -55,7 +75,29 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
             pointerEvents: 'auto',
             maxWidth: 360,
           }}>
-            {t.message}
+            <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
+              <span>{t.message}</span>
+              {t.action && (
+                <button
+                  onClick={() => {
+                    t.action!.onClick();
+                    setItems(prev => prev.filter(x => x.id !== t.id));
+                  }}
+                  style={{
+                    background: 'transparent',
+                    border: '1px solid rgba(255,255,255,0.35)',
+                    color: colors.white,
+                    borderRadius: 6,
+                    padding: '4px 10px',
+                    fontSize: 13,
+                    fontWeight: 500,
+                    cursor: 'pointer',
+                  }}
+                >
+                  {t.action.label}
+                </button>
+              )}
+            </div>
           </div>
         ))}
       </div>

--- a/clawjournal/web/frontend/src/views/Share.tsx
+++ b/clawjournal/web/frontend/src/views/Share.tsx
@@ -171,7 +171,8 @@ interface RemovedEntry {
   id: string;
   title: string;
   removedAt: number;
-  originalIndex: number;
+  beforeId: string | null;
+  afterId: string | null;
 }
 
 interface ShareReadyStats {
@@ -654,17 +655,50 @@ export function Share() {
   // Queue actions
   // =================================================
 
+  const insertRestored = (queue: string[], entry: RemovedEntry): string[] => {
+    if (queue.includes(entry.id)) return queue;
+    const next = [...queue];
+    // Prefer afterId: an item's successor at removal time is more reliable than
+    // its predecessor when multiple adjacent items were removed and are being
+    // restored in reverse order.
+    if (entry.afterId) {
+      const aIdx = next.indexOf(entry.afterId);
+      if (aIdx >= 0) {
+        next.splice(aIdx, 0, entry.id);
+        return next;
+      }
+    }
+    if (entry.beforeId) {
+      const bIdx = next.indexOf(entry.beforeId);
+      if (bIdx >= 0) {
+        next.splice(bIdx + 1, 0, entry.id);
+        return next;
+      }
+    }
+    if (!entry.beforeId && !entry.afterId) {
+      next.unshift(entry.id);
+      return next;
+    }
+    if (!entry.beforeId) {
+      next.unshift(entry.id);
+      return next;
+    }
+    next.push(entry.id);
+    return next;
+  };
+
   const removeFromQueue = (id: string) => {
-    const originalIndex = queueOrder.indexOf(id);
+    const idx = queueOrder.indexOf(id);
+    if (idx < 0) return;
+    const beforeId = idx > 0 ? queueOrder[idx - 1] : null;
+    const afterId = idx < queueOrder.length - 1 ? queueOrder[idx + 1] : null;
     const session = sessionById[id];
     const title = session?.display_title || id;
     setQueueOrder((prev) => prev.filter((x) => x !== id));
-    if (originalIndex >= 0) {
-      setRemovedSessions((prev) => [
-        ...prev,
-        { id, title, removedAt: Date.now(), originalIndex },
-      ]);
-    }
+    setRemovedSessions((prev) => [
+      ...prev,
+      { id, title, removedAt: Date.now(), beforeId, afterId },
+    ]);
     toast(`Removed "${truncateTitle(title)}"`, {
       type: 'info',
       duration: 8000,
@@ -676,29 +710,21 @@ export function Share() {
     setRemovedSessions((prev) => {
       const entry = prev.find((e) => e.id === id);
       if (!entry) return prev;
-      setQueueOrder((q) => {
-        if (q.includes(id)) return q;
-        const clamped = Math.min(entry.originalIndex, q.length);
-        const next = [...q];
-        next.splice(clamped, 0, id);
-        return next;
-      });
+      setQueueOrder((q) => insertRestored(q, entry));
       return prev.filter((e) => e.id !== id);
     });
   };
 
   const restoreAll = () => {
     if (removedSessions.length === 0) return;
-    // Sort by originalIndex asc so earlier-indexed items go first; later ones
-    // get clamped correctly as the queue grows.
-    const sorted = [...removedSessions].sort((a, b) => a.originalIndex - b.originalIndex);
+    // Process newest removals first. The most recent removal captured the
+    // freshest neighbor snapshot; restoring it first unwinds the state closest
+    // to just-before-last-removal, and earlier removals anchor onto items that
+    // are progressively restored around them.
+    const entries = [...removedSessions].sort((a, b) => b.removedAt - a.removedAt);
     setQueueOrder((q) => {
-      const next = [...q];
-      for (const entry of sorted) {
-        if (next.includes(entry.id)) continue;
-        const clamped = Math.min(entry.originalIndex, next.length);
-        next.splice(clamped, 0, entry.id);
-      }
+      let next = q;
+      for (const entry of entries) next = insertRestored(next, entry);
       return next;
     });
     setRemovedSessions([]);
@@ -924,7 +950,7 @@ export function Share() {
     const candidates = queuedSessions
       .filter((s) =>
         !approvedIds.has(s.session_id) &&
-        classify(redactedSessions[s.session_id]) !== 'clear'
+        classify(redactedSessions[s.session_id]) === 'review'
       )
       .map((s) => s.session_id);
     if (candidates.length === 0) return;

--- a/clawjournal/web/frontend/src/views/Share.tsx
+++ b/clawjournal/web/frontend/src/views/Share.tsx
@@ -106,6 +106,9 @@ const formatTokens = (t: number) => t >= 1_000_000 ? `${(t / 1_000_000).toFixed(
 const sessionTotalTokens = (s: { input_tokens?: number; output_tokens?: number }) =>
   (s.input_tokens || 0) + (s.output_tokens || 0);
 
+const truncateTitle = (s: string, max = 48) =>
+  s.length > max ? s.slice(0, max - 1) + '…' : s;
+
 // Map raw redaction-log `type` strings into a small set of buckets the UI
 // surfaces on Redact and Review. Everything else collapses to `other`.
 type RedactionBucket = 'tokens' | 'emails' | 'paths' | 'timestamps' | 'urls' | 'other';
@@ -162,6 +165,13 @@ interface ReadySession {
   runtime_channel?: string | null;
   start_time?: string | null;
   review_status?: string;
+}
+
+interface RemovedEntry {
+  id: string;
+  title: string;
+  removedAt: number;
+  originalIndex: number;
 }
 
 interface ShareReadyStats {
@@ -519,6 +529,7 @@ export function Share() {
   // Review state
   const [approvedIds, setApprovedIds] = useState<Set<string>>(new Set());
   const [expandedReviewIds, setExpandedReviewIds] = useState<Set<string>>(new Set());
+  const [removedSessions, setRemovedSessions] = useState<RemovedEntry[]>([]);
 
   // Package state
   const [packagedShareId, setPackagedShareId] = useState<string | null>(
@@ -588,13 +599,17 @@ export function Share() {
     }, { replace: true });
   }, [activeStep, queueOrder, note, packagedShareId, setSearchParams]);
 
-  // Drop cached redacted entries when sessions leave the queue.
+  // Drop cached redacted entries and approvals when sessions leave the queue
+  // AND are not sitting in the removed-drawer waiting for restore.
   useEffect(() => {
+    const removedIds = new Set(removedSessions.map((e) => e.id));
+    const keep = (sid: string) => queueSet.has(sid) || removedIds.has(sid);
+
     setRedactedSessions((prev) => {
       let changed = false;
       const next: Record<string, RedactedSessionData> = {};
       for (const [sid, data] of Object.entries(prev)) {
-        if (queueSet.has(sid)) next[sid] = data;
+        if (keep(sid)) next[sid] = data;
         else changed = true;
       }
       return changed ? next : prev;
@@ -603,12 +618,12 @@ export function Share() {
       let changed = false;
       const next = new Set<string>();
       for (const id of prev) {
-        if (queueSet.has(id)) next.add(id);
+        if (keep(id)) next.add(id);
         else changed = true;
       }
       return changed ? next : prev;
     });
-  }, [queueSet]);
+  }, [queueSet, removedSessions]);
 
   const reload = () => {
     api.shareReady({ includeUnapproved: true }).then((stats) => {
@@ -640,7 +655,53 @@ export function Share() {
   // =================================================
 
   const removeFromQueue = (id: string) => {
+    const originalIndex = queueOrder.indexOf(id);
+    const session = sessionById[id];
+    const title = session?.display_title || id;
     setQueueOrder((prev) => prev.filter((x) => x !== id));
+    if (originalIndex >= 0) {
+      setRemovedSessions((prev) => [
+        ...prev,
+        { id, title, removedAt: Date.now(), originalIndex },
+      ]);
+    }
+    toast(`Removed "${truncateTitle(title)}"`, {
+      type: 'info',
+      duration: 8000,
+      action: { label: 'Undo', onClick: () => restoreSession(id) },
+    });
+  };
+
+  const restoreSession = (id: string) => {
+    setRemovedSessions((prev) => {
+      const entry = prev.find((e) => e.id === id);
+      if (!entry) return prev;
+      setQueueOrder((q) => {
+        if (q.includes(id)) return q;
+        const clamped = Math.min(entry.originalIndex, q.length);
+        const next = [...q];
+        next.splice(clamped, 0, id);
+        return next;
+      });
+      return prev.filter((e) => e.id !== id);
+    });
+  };
+
+  const restoreAll = () => {
+    if (removedSessions.length === 0) return;
+    // Sort by originalIndex asc so earlier-indexed items go first; later ones
+    // get clamped correctly as the queue grows.
+    const sorted = [...removedSessions].sort((a, b) => a.originalIndex - b.originalIndex);
+    setQueueOrder((q) => {
+      const next = [...q];
+      for (const entry of sorted) {
+        if (next.includes(entry.id)) continue;
+        const clamped = Math.min(entry.originalIndex, next.length);
+        next.splice(clamped, 0, entry.id);
+      }
+      return next;
+    });
+    setRemovedSessions([]);
   };
 
   const addToQueue = (id: string) => {
@@ -830,13 +891,63 @@ export function Share() {
   };
 
   const approveAllClean = () => {
+    const candidates = queuedSessions
+      .filter((s) =>
+        !approvedIds.has(s.session_id) &&
+        classify(redactedSessions[s.session_id]) === 'clear'
+      )
+      .map((s) => s.session_id);
+    if (candidates.length === 0) return;
     setApprovedIds((prev) => {
-      const n = new Set(prev);
-      queuedSessions.forEach((s) => {
-        if (classify(redactedSessions[s.session_id]) === 'clear') n.add(s.session_id);
-      });
-      return n;
+      const next = new Set(prev);
+      for (const id of candidates) next.add(id);
+      return next;
     });
+    toast(
+      `Included ${candidates.length} clean trace${candidates.length === 1 ? '' : 's'}`,
+      {
+        type: 'info',
+        duration: 8000,
+        action: {
+          label: 'Undo',
+          onClick: () => setApprovedIds((prev) => {
+            const next = new Set(prev);
+            for (const id of candidates) next.delete(id);
+            return next;
+          }),
+        },
+      },
+    );
+  };
+
+  const approveAllWithFlags = () => {
+    const candidates = queuedSessions
+      .filter((s) =>
+        !approvedIds.has(s.session_id) &&
+        classify(redactedSessions[s.session_id]) !== 'clear'
+      )
+      .map((s) => s.session_id);
+    if (candidates.length === 0) return;
+    setApprovedIds((prev) => {
+      const next = new Set(prev);
+      for (const id of candidates) next.add(id);
+      return next;
+    });
+    toast(
+      `Included ${candidates.length} flagged trace${candidates.length === 1 ? '' : 's'}`,
+      {
+        type: 'info',
+        duration: 8000,
+        action: {
+          label: 'Undo',
+          onClick: () => setApprovedIds((prev) => {
+            const next = new Set(prev);
+            for (const id of candidates) next.delete(id);
+            return next;
+          }),
+        },
+      },
+    );
   };
 
   const retryAiReview = async (id: string) => {
@@ -1020,6 +1131,7 @@ export function Share() {
     if (activeStep === 'package' && packagedShareId && packageProgress >= 100 && !packagingFailed) {
       setCompletedKeys((prev) => new Set([...prev, 'package']));
       setActiveStep('done');
+      setRemovedSessions([]);
     }
   }, [activeStep, packagedShareId, packageProgress, packagingFailed]);
 
@@ -1109,6 +1221,9 @@ export function Share() {
         showHelp={showHelp}
         setShowHelp={setShowHelp}
         toast={toast}
+        removedSessions={removedSessions}
+        onRestore={restoreSession}
+        onRestoreAll={restoreAll}
       />
     );
   }
@@ -1146,6 +1261,10 @@ export function Share() {
         onToggleExpand={toggleReviewExpand}
         onApprove={approveTrace}
         onApproveAllClean={approveAllClean}
+        onApproveAllWithFlags={approveAllWithFlags}
+        removedSessions={removedSessions}
+        onRestore={restoreSession}
+        onRestoreAll={restoreAll}
         onRemove={removeFromQueue}
         onRetryAi={retryAiReview}
         onBack={() => setActiveStep('redact')}
@@ -1230,6 +1349,9 @@ interface QueueStepProps {
   showHelp: boolean;
   setShowHelp: (b: boolean) => void;
   toast: (msg: string, kind?: 'success' | 'error') => void;
+  removedSessions: RemovedEntry[];
+  onRestore: (id: string) => void;
+  onRestoreAll: () => void;
 }
 
 function QueueStep(p: QueueStepProps) {
@@ -1360,6 +1482,11 @@ function QueueStep(p: QueueStepProps) {
               </button>
             </div>
           )}
+          <RemovedDrawer
+            entries={p.removedSessions}
+            onRestore={p.onRestore}
+            onRestoreAll={p.onRestoreAll}
+          />
         </>
       ) : (
         <>
@@ -1575,6 +1702,12 @@ function QueueStep(p: QueueStepProps) {
               </div>
             )}
           </div>
+
+          <RemovedDrawer
+            entries={p.removedSessions}
+            onRestore={p.onRestore}
+            onRestoreAll={p.onRestoreAll}
+          />
 
           {/* Note */}
           <div style={{ marginBottom: 18 }}>
@@ -1926,6 +2059,10 @@ interface ReviewStepProps {
   onToggleExpand: (id: string) => void;
   onApprove: (id: string) => void;
   onApproveAllClean: () => void;
+  onApproveAllWithFlags: () => void;
+  removedSessions: RemovedEntry[];
+  onRestore: (id: string) => void;
+  onRestoreAll: () => void;
   onRemove: (id: string) => void;
   onRetryAi: (id: string) => void;
   onBack: () => void;
@@ -1949,6 +2086,25 @@ function ReviewStep(p: ReviewStepProps) {
   const cleanUnapprovedCount = p.queuedSessions.filter((s) => (
     classify(p.redactedSessions[s.session_id]) === 'clear' && !p.approvedIds.has(s.session_id)
   )).length;
+
+  const flaggedUnapprovedCount = p.queuedSessions.filter((s) => (
+    classify(p.redactedSessions[s.session_id]) !== 'clear' && !p.approvedIds.has(s.session_id)
+  )).length;
+
+  const flagBreakdown = (() => {
+    let ai = 0;
+    let residual = 0;
+    for (const s of p.queuedSessions) {
+      if (p.approvedIds.has(s.session_id)) continue;
+      const d = p.redactedSessions[s.session_id];
+      if (!d) continue;
+      if (classify(d) === 'clear') continue;
+      const hasAi = (d.buckets?.other ?? 0) > 0 || ((d.aiPiiFindings ?? []).length > 0);
+      if (hasAi) ai += 1;
+      else residual += 1;
+    }
+    return { ai, residual };
+  })();
 
   return (
     <div style={{ padding: '24px', maxWidth: '960px', margin: '0 auto' }}>
@@ -2001,6 +2157,59 @@ function ReviewStep(p: ReviewStepProps) {
         >
           Include all clean ({cleanUnapprovedCount})
         </button>
+
+        <div
+          style={{ position: 'relative', display: 'inline-block' }}
+          onMouseEnter={(e) => {
+            const tt = e.currentTarget.querySelector('[data-ttip]') as HTMLElement | null;
+            if (tt) tt.style.opacity = '1';
+          }}
+          onMouseLeave={(e) => {
+            const tt = e.currentTarget.querySelector('[data-ttip]') as HTMLElement | null;
+            if (tt) tt.style.opacity = '0';
+          }}
+        >
+          <button
+            onClick={p.onApproveAllWithFlags}
+            disabled={flaggedUnapprovedCount === 0}
+            style={{
+              ...btnSecondary, padding: '6px 12px', fontSize: 12.5,
+              opacity: flaggedUnapprovedCount === 0 ? 0.4 : 1,
+              cursor: flaggedUnapprovedCount === 0 ? 'not-allowed' : 'pointer',
+            }}
+          >
+            Include all with flags ({flaggedUnapprovedCount})
+            <span style={{ marginLeft: 6 }}>⚠</span>
+          </button>
+          {flaggedUnapprovedCount > 0 && (
+            <div
+              data-ttip
+              style={{
+                position: 'absolute', bottom: 'calc(100% + 8px)', right: 0,
+                minWidth: 240, padding: '10px 12px',
+                background: colors.gray900, color: colors.white,
+                borderRadius: 6, fontSize: 12, lineHeight: 1.5,
+                boxShadow: '0 4px 12px rgba(0,0,0,0.15)',
+                opacity: 0, pointerEvents: 'none',
+                transition: 'opacity 0.15s',
+                zIndex: 10,
+                whiteSpace: 'nowrap',
+              }}
+            >
+              <div style={{ fontWeight: 600, marginBottom: 4 }}>
+                {flaggedUnapprovedCount} trace{flaggedUnapprovedCount === 1 ? '' : 's'} with review items:
+              </div>
+              <ul style={{ margin: 0, paddingLeft: 18 }}>
+                {flagBreakdown.ai > 0 && (
+                  <li>{flagBreakdown.ai} AI-flagged (names, orgs, etc.)</li>
+                )}
+                {flagBreakdown.residual > 0 && (
+                  <li>{flagBreakdown.residual} with residual redactions</li>
+                )}
+              </ul>
+            </div>
+          )}
+        </div>
       </div>
 
       <div>
@@ -2018,6 +2227,12 @@ function ReviewStep(p: ReviewStepProps) {
           />
         ))}
       </div>
+
+      <RemovedDrawer
+        entries={p.removedSessions}
+        onRestore={p.onRestore}
+        onRestoreAll={p.onRestoreAll}
+      />
 
       <div style={{
         position: 'sticky', bottom: 0, marginTop: 14, paddingTop: 14,
@@ -2326,6 +2541,93 @@ function ReviewRow({
               </button>
             )}
           </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function formatRelative(ts: number): string {
+  const sec = Math.max(0, Math.floor((Date.now() - ts) / 1000));
+  if (sec < 30) return 'just now';
+  if (sec < 60) return `${sec}s ago`;
+  if (sec < 3600) return `${Math.floor(sec / 60)} min ago`;
+  if (sec < 86400) return `${Math.floor(sec / 3600)}h ago`;
+  return `${Math.floor(sec / 86400)}d ago`;
+}
+
+function RemovedDrawer({
+  entries,
+  onRestore,
+  onRestoreAll,
+}: {
+  entries: RemovedEntry[];
+  onRestore: (id: string) => void;
+  onRestoreAll: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  if (entries.length === 0) return null;
+  return (
+    <div style={{
+      border: `1px solid ${colors.gray200}`,
+      borderRadius: 8,
+      background: colors.gray50,
+      margin: '14px 0',
+      overflow: 'hidden',
+    }}>
+      <div style={{
+        padding: '10px 14px',
+        fontSize: 13,
+        color: colors.gray700,
+        userSelect: 'none',
+        display: 'flex', alignItems: 'center', gap: 8,
+      }}>
+        <span
+          onClick={() => setOpen((v) => !v)}
+          style={{
+            cursor: 'pointer',
+            display: 'flex', alignItems: 'center', gap: 8,
+            flex: 1,
+          }}
+        >
+          <span style={{
+            display: 'inline-block',
+            transition: 'transform 0.15s',
+            transform: open ? 'rotate(90deg)' : 'rotate(0deg)',
+          }}>▸</span>
+          <strong>{entries.length} removed from bundle</strong>
+        </span>
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onRestoreAll();
+          }}
+          style={{ ...btnSecondary, padding: '4px 12px', fontSize: 12.5 }}
+        >
+          Restore all
+        </button>
+      </div>
+      {open && (
+        <div style={{ padding: '0 14px 14px' }}>
+          {entries.map((e) => (
+            <div key={e.id} style={{
+              display: 'flex', alignItems: 'center', gap: 12,
+              padding: '10px 0',
+              borderTop: `1px solid ${colors.gray200}`,
+              fontSize: 13,
+            }}>
+              <span style={{ flex: 1, color: colors.gray900 }}>{e.title}</span>
+              <span style={{ fontSize: 12, color: colors.gray500, marginRight: 12 }}>
+                {formatRelative(e.removedAt)}
+              </span>
+              <button
+                onClick={() => onRestore(e.id)}
+                style={{ ...btnSecondary, padding: '4px 12px', fontSize: 12.5 }}
+              >
+                Restore
+              </button>
+            </div>
+          ))}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

Two UX friction points in the Share wizard's Review step, addressed in a single client-side change to `Share.tsx` and a backward-compatible extension to `Toast.tsx`.

**Problem 1 — Bulk-include was nearly unusable.** `Include all clean (N)` requires `classify() === 'clear'`, i.e. zero AI-flagged items *and* zero residual redactions. In real traces nearly every session carries at least one AI flag (org/person names), so the button sat at `(0)` most of the time and users had to approve each card manually.

**Problem 2 — Remove had no safety net.** `Remove from bundle` called `removeFromQueue` which filtered the id out of `queueOrder` immediately. The session vanished from view. The only recovery was going back to Queue and re-picking from "Add more traces" (potentially 100+ candidates). Misclicks were unrecoverable.

## What this changes

### 1. Tiered bulk-include

A second button next to the existing "Include all clean": **"Include all with flags (N) ⚠"**. Eligibility: `!approvedIds.has(id) && classify() !== 'clear'`. A hover tooltip breaks down the flag composition ("N AI-flagged (names, orgs, etc.)", "N with residual redactions"). The existing `Include all clean` button keeps its exact behavior and eligibility — no regression.

Both bulk actions now fire an **8s undo toast** ("Included N traces · Undo") that reverses only the ids *that bulk added* (manual approvals stay).

### 2. Remove safety net

Two layers, shared between Queue step and Review step:

- **Transient undo toast** (8s): every `Remove from bundle` click shows "Removed '…' · Undo" bottom-right. Click Undo → session restored to its exact previous slot via a captured `originalIndex` (clamped).
- **Persistent removed-drawer**: below the card list (on both Queue and Review steps). Collapsed by default with count (`▸ N removed from bundle`). Expanded shows per-entry title + relative time + individual `Restore` button. A **`Restore all`** button on the drawer header puts every removed entry back in one click (sorted by `originalIndex` for deterministic placement).

### 3. Cache preservation across remove/restore

The existing useEffect that purged `redactedSessions[id]` and `approvedIds` when an id left `queueOrder` was too aggressive for the new flow. Restored a removed session → expensive AI redaction re-ran and the user's approval status was lost. Fix keeps entries whose id is in the queue **OR** in the removed-drawer. Cache is purged only when the session genuinely leaves the wizard (neither queued nor removed).

### 4. Toast component

Extended `toast(message, typeOrOptions?)` to accept `{ type, duration, action: { label, onClick } }` as the second arg. All existing callers (`toast('msg')`, `toast('msg', 'info')`, `toast('msg', 'success')`) are unaffected — the union preserves the string overload.

## Scope

- **Client-side only.** No backend, no API, no DB, no schema.
- Only two files touched: `clawjournal/web/frontend/src/components/Toast.tsx` (+47 / -5), `clawjournal/web/frontend/src/views/Share.tsx` (+311 / -9).
- No new tests — the frontend has no test framework yet; verified live against a populated workbench (163 indexed sessions).

## Test plan

- [ ] `cd clawjournal/web/frontend && npm run build` passes cleanly.
- [ ] `/share` Queue step: click any Remove → toast with Undo → click Undo within 8s → session returns to its original slot.
- [ ] After 8s timeout: session stays in drawer (`▸ 1 removed from bundle`). Expand, click Restore → session returns.
- [ ] Click `Include all with flags (N) ⚠` on Review step → all flagged traces become approved; toast shows `Included N flagged traces · Undo`; clicking Undo removes only those ids from approvedIds.
- [ ] Hover the `⚠` button → tooltip lists AI-flagged vs residual counts.
- [ ] Remove all sessions from the queue → empty-bundle state appears on Queue step → drawer is still visible there with `Restore all` → click it → all sessions restored at their original indices.
- [ ] Approve + remove a session → restore → approval + redaction cache preserved (no re-run).
- [ ] Successful package clears the drawer.

## Screenshots

*(intentionally omitted — happy to add if useful; the change is navigable via the live workbench)*