### PR TITLE
feat(events): execution recorder with raw-preserving event stream

### DIFF
--- a/clawjournal/capture/changes.py
+++ b/clawjournal/capture/changes.py
@@ -52,6 +52,7 @@ class LineBatch:
     start_offset: int
     end_offset: int
     lines: list[str]
+    line_offsets: list[int]
     inode: int
     last_modified: float
 
@@ -84,10 +85,15 @@ def iter_new_lines(
     if last_newline < 0:
         return None
     complete = raw[: last_newline + 1]
-    text_lines = [
-        line.decode("utf-8", errors="replace")
-        for line in complete.splitlines()
-    ]
+    text_lines: list[str] = []
+    line_offsets: list[int] = []
+    offset = start_offset
+    for raw_line in complete.splitlines(keepends=True):
+        line_offsets.append(offset)
+        text_lines.append(
+            raw_line.rstrip(b"\r\n").decode("utf-8", errors="replace")
+        )
+        offset += len(raw_line)
     end_offset = start_offset + last_newline + 1
 
     return LineBatch(
@@ -96,6 +102,7 @@ def iter_new_lines(
         start_offset=start_offset,
         end_offset=end_offset,
         lines=text_lines,
+        line_offsets=line_offsets,
         inode=st.st_ino,
         last_modified=st.st_mtime,
     )

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -61,6 +61,7 @@ SETUP_TO_PUBLISH_STEPS = [
 EXPLICIT_SOURCE_CHOICES = {"claude", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "all", "both"}
 SOURCE_CHOICES = ["auto", "claude", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "all"]
 WORKBENCH_SOURCE_CHOICES = ["claude", "codex", "openclaw", "cursor", "copilot", "aider"]
+EVENT_SOURCE_CHOICES = ["auto", "claude", "codex", "openclaw", "all"]
 PII_PROVIDER_CHOICES = ("rules", "ai", "hybrid")
 
 
@@ -3185,6 +3186,19 @@ def main() -> None:
     cfg.add_argument("--confirm-projects", action="store_true",
                      help="Mark project selection as confirmed (include all)")
 
+    events_parser = sub.add_parser("events", help="Execution recorder commands")
+    events_sub = events_parser.add_subparsers(dest="events_command", required=True)
+    events_ingest = events_sub.add_parser(
+        "ingest",
+        help="Drain pending raw execution events into index.db",
+    )
+    events_ingest.add_argument("--source", choices=EVENT_SOURCE_CHOICES, default="auto")
+    events_ingest.add_argument("--json", action="store_true", help="Output JSON summary")
+    events_sub.add_parser(
+        "capabilities",
+        help="Dump the execution-recorder capability matrix as JSON",
+    )
+
     # Workbench commands
     serve_parser = sub.add_parser("serve", help="Start the workbench daemon + web UI")
     serve_parser.add_argument("--port", type=int, default=8384, help="Port (default: 8384)")
@@ -3676,6 +3690,10 @@ def main() -> None:
         _handle_config(args)
         return
 
+    if command == "events":
+        _run_events(args)
+        return
+
     _run_export(args)
 
 
@@ -3839,6 +3857,31 @@ def _run_training_format(args) -> None:
         return
     print(f"Training format: {summary['turns']} turns from {summary['sessions']} sessions")
     print(f"Output written to {args.output}")
+
+
+def _run_events(args) -> None:
+    from .events import capabilities_json, ingest_pending
+    from .workbench.index import open_index
+
+    if args.events_command == "capabilities":
+        print(json.dumps(capabilities_json(), indent=2, sort_keys=True))
+        return
+
+    conn = open_index()
+    try:
+        summary = ingest_pending(conn, source_filter=args.source)
+    finally:
+        conn.close()
+
+    payload = summary.to_dict()
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    print(
+        f"Ingested {payload['event_rows']} event rows from "
+        f"{payload['files_with_changes']} changed files "
+        f"({payload['lines_read']} lines, {payload['sessions_touched']} sessions)."
+    )
 
 
 def _generate_pii_findings(file_path: Path, output_path: Path, provider: str, min_confidence: float = 0.0, backend: str = "auto") -> dict[str, Any]:

--- a/clawjournal/events/__init__.py
+++ b/clawjournal/events/__init__.py
@@ -1,0 +1,22 @@
+"""Execution recorder for phase-1 plan 02."""
+
+from clawjournal.events.capabilities import CAPABILITY_MATRIX, capabilities_json
+from clawjournal.events.ingest import EVENT_CONSUMER_ID, IngestSummary, ingest_pending
+from clawjournal.events.schema import ensure_schema
+from clawjournal.events.types import (
+    EVENT_TYPES,
+    ClassifiedEvent,
+    SessionMeta,
+)
+
+__all__ = [
+    "CAPABILITY_MATRIX",
+    "EVENT_CONSUMER_ID",
+    "EVENT_TYPES",
+    "ClassifiedEvent",
+    "IngestSummary",
+    "SessionMeta",
+    "capabilities_json",
+    "ensure_schema",
+    "ingest_pending",
+]

--- a/clawjournal/events/capabilities.py
+++ b/clawjournal/events/capabilities.py
@@ -1,0 +1,79 @@
+"""Static client capability matrix for the execution recorder."""
+
+from __future__ import annotations
+
+from clawjournal.events.types import EVENT_TYPES
+
+CAPABILITY_MATRIX: dict[tuple[str, str], tuple[bool, str]] = {}
+
+for client in ("claude", "codex", "openclaw"):
+    for event_type in EVENT_TYPES:
+        CAPABILITY_MATRIX[(client, event_type)] = (
+            False,
+            "not emitted by this client",
+        )
+
+
+def _set(client: str, event_type: str, supported: bool, reason: str) -> None:
+    CAPABILITY_MATRIX[(client, event_type)] = (supported, reason)
+
+
+for event_type, reason in (
+    ("user_message", "direct"),
+    ("assistant_message", "direct"),
+    ("tool_call", "direct"),
+    ("tool_result", "direct"),
+    ("file_read", "inferred from tool name"),
+    ("file_write", "inferred from tool name"),
+    ("patch", "inferred from tool name"),
+    ("command_start", "direct for shell-like tools"),
+    ("stdout_chunk", "best-effort from bashExecution output"),
+    ("command_exit", "direct for bashExecution exit codes"),
+    ("schema_unknown", "fallback for parseable but unsupported lines"),
+):
+    _set("claude", event_type, True, reason)
+
+for event_type, reason in (
+    ("session_open", "direct from session header"),
+    ("user_message", "direct"),
+    ("assistant_message", "direct"),
+    ("tool_call", "direct"),
+    ("tool_result", "direct"),
+    ("file_read", "inferred from tool name"),
+    ("file_write", "inferred from tool name"),
+    ("patch", "inferred from tool name"),
+    ("command_start", "inferred from shell-like tool names"),
+    ("command_exit", "direct when output carries exit metadata"),
+    ("schema_unknown", "fallback for parseable but unsupported lines"),
+):
+    _set("codex", event_type, True, reason)
+
+for event_type, reason in (
+    ("session_open", "direct from session header"),
+    ("user_message", "direct"),
+    ("assistant_message", "direct"),
+    ("tool_call", "direct"),
+    ("tool_result", "direct"),
+    ("file_read", "inferred from tool name"),
+    ("file_write", "inferred from tool name"),
+    ("patch", "inferred from tool name"),
+    ("command_start", "direct for shell-like tools"),
+    ("stdout_chunk", "best-effort from bashExecution output"),
+    ("command_exit", "direct for bashExecution exit codes"),
+    ("compaction", "direct"),
+    ("schema_unknown", "fallback for parseable but unsupported lines"),
+):
+    _set("openclaw", event_type, True, reason)
+
+
+def capabilities_json() -> dict[str, dict[str, dict[str, object]]]:
+    payload: dict[str, dict[str, dict[str, object]]] = {}
+    for client in ("claude", "codex", "openclaw"):
+        payload[client] = {}
+        for event_type in EVENT_TYPES:
+            supported, reason = CAPABILITY_MATRIX[(client, event_type)]
+            payload[client][event_type] = {
+                "supported": supported,
+                "reason": reason,
+            }
+    return payload

--- a/clawjournal/events/classify/__init__.py
+++ b/clawjournal/events/classify/__init__.py
@@ -1,0 +1,33 @@
+"""Per-client line classifiers for the execution recorder."""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from clawjournal.events.classify import claude, codex, openclaw
+from clawjournal.events.types import ClassifiedEvent, SessionMeta
+
+Classifier = Callable[[dict], list[ClassifiedEvent]]
+SessionMetaFn = Callable[[dict], SessionMeta]
+
+_CLASSIFIERS: dict[str, tuple[Classifier, SessionMetaFn]] = {
+    "claude": (claude.classify, claude.session_meta),
+    "codex": (codex.classify, codex.session_meta),
+    "openclaw": (openclaw.classify, openclaw.session_meta),
+}
+
+
+def classify_line(client: str, line: dict) -> list[ClassifiedEvent]:
+    try:
+        classifier = _CLASSIFIERS[client][0]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported events client: {client}") from exc
+    return classifier(line)
+
+
+def session_meta_for_line(client: str, line: dict) -> SessionMeta:
+    try:
+        meta_fn = _CLASSIFIERS[client][1]
+    except KeyError as exc:
+        raise ValueError(f"Unsupported events client: {client}") from exc
+    return meta_fn(line)

--- a/clawjournal/events/classify/claude.py
+++ b/clawjournal/events/classify/claude.py
@@ -1,0 +1,242 @@
+"""Claude JSONL line classifier."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawjournal.events.classify.common import (
+    event,
+    is_shell_tool,
+    resolve_timestamp,
+    schema_unknown,
+    tool_secondary_type,
+)
+from clawjournal.events.types import ClassifiedEvent, SessionMeta
+
+
+def classify(line: dict) -> list[ClassifiedEvent]:
+    message = line.get("message", {})
+    event_at, confidence, lossiness = resolve_timestamp(
+        message.get("timestamp") if isinstance(message, dict) else None,
+        line.get("timestamp"),
+    )
+    entry_type = line.get("type")
+    role = message.get("role") if isinstance(message, dict) else None
+
+    if entry_type == "compaction":
+        return [
+            event(
+                "compaction",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness="compacted",
+            )
+        ]
+    if entry_type in {"session_close", "session_end"}:
+        return [
+            event(
+                "session_close",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    if role == "bashExecution":
+        return _classify_bash_execution(message, event_at)
+    if entry_type == "user":
+        return _classify_user_message(message, event_at, confidence, lossiness)
+    if entry_type == "assistant":
+        return _classify_assistant_message(
+            message, event_at, confidence, lossiness
+        )
+    if entry_type in {"approval_request", "approval_decision"}:
+        return [
+            event(
+                entry_type,
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    return [schema_unknown(event_at)]
+
+
+def session_meta(line: dict) -> SessionMeta:
+    message = line.get("message", {})
+    parent_id = _first_string(
+        line.get("parentSessionId"),
+        line.get("parent_session_id"),
+        message.get("parentSessionId") if isinstance(message, dict) else None,
+        message.get("parent_session_id") if isinstance(message, dict) else None,
+    )
+    closure_seen = line.get("type") in {"session_close", "session_end", "closed"}
+    client_version = line.get("version")
+    if not isinstance(client_version, str) or not client_version.strip():
+        client_version = None
+    return SessionMeta(
+        client_version=client_version,
+        parent_session_id=parent_id,
+        closure_seen=closure_seen,
+    )
+
+
+def _classify_user_message(
+    message: Any,
+    event_at: str | None,
+    confidence: str,
+    lossiness: str,
+) -> list[ClassifiedEvent]:
+    if not isinstance(message, dict):
+        return [schema_unknown(event_at)]
+    content = message.get("content")
+    events: list[ClassifiedEvent] = []
+    has_text = False
+
+    if isinstance(content, str):
+        has_text = bool(content.strip())
+    elif isinstance(content, list):
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") == "text" and _has_text(block.get("text")):
+                has_text = True
+            elif block.get("type") == "tool_result":
+                tool_id = _first_string(
+                    block.get("tool_use_id"),
+                    block.get("toolUseId"),
+                )
+                events.append(
+                    event(
+                        "tool_result",
+                        event_at=event_at,
+                        event_key=(
+                            f"tool_result:{tool_id}" if tool_id is not None else None
+                        ),
+                        confidence=confidence,
+                        lossiness=lossiness,
+                    )
+                )
+
+    if has_text:
+        events.insert(
+            0,
+            event(
+                "user_message",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            ),
+        )
+    return events or [schema_unknown(event_at)]
+
+
+def _classify_assistant_message(
+    message: Any,
+    event_at: str | None,
+    confidence: str,
+    lossiness: str,
+) -> list[ClassifiedEvent]:
+    if not isinstance(message, dict):
+        return [schema_unknown(event_at)]
+    content = message.get("content")
+    if not isinstance(content, list):
+        return [schema_unknown(event_at)]
+
+    events: list[ClassifiedEvent] = []
+    has_assistant_text = False
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type in {"text", "thinking"}:
+            if _has_text(block.get("text")) or _has_text(block.get("thinking")):
+                has_assistant_text = True
+        elif block_type in {"tool_use", "toolCall"}:
+            tool_name = block.get("name")
+            tool_id = _first_string(block.get("id"), block.get("toolUseId"))
+            events.append(
+                event(
+                    "tool_call",
+                    event_at=event_at,
+                    event_key=f"tool_call:{tool_id}" if tool_id is not None else None,
+                    confidence=confidence,
+                    lossiness=lossiness,
+                )
+            )
+            secondary = tool_secondary_type(tool_name)
+            if secondary is not None:
+                events.append(
+                    event(
+                        secondary,
+                        event_at=event_at,
+                        event_key=(
+                            f"{secondary}:{tool_id}" if tool_id is not None else None
+                        ),
+                        confidence=confidence,
+                        lossiness=lossiness,
+                    )
+                )
+            if is_shell_tool(tool_name):
+                events.append(
+                    event(
+                        "command_start",
+                        event_at=event_at,
+                        event_key=(
+                            f"command_start:{tool_id}"
+                            if tool_id is not None
+                            else None
+                        ),
+                        confidence=confidence,
+                        lossiness=lossiness,
+                    )
+                )
+
+    if has_assistant_text:
+        events.insert(
+            0,
+            event(
+                "assistant_message",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            ),
+        )
+    return events or [schema_unknown(event_at)]
+
+
+def _classify_bash_execution(
+    message: Any,
+    event_at: str | None,
+) -> list[ClassifiedEvent]:
+    if not isinstance(message, dict):
+        return [schema_unknown(event_at)]
+
+    events: list[ClassifiedEvent] = []
+    command = message.get("command")
+    output = message.get("output")
+    exit_code = message.get("exitCode")
+    if isinstance(command, str) and command.strip():
+        events.append(event("command_start", event_at=event_at))
+    if isinstance(output, str) and output.strip():
+        events.append(
+            event(
+                "stdout_chunk",
+                event_at=event_at,
+                confidence="low",
+                lossiness="unknown",
+            )
+        )
+    if exit_code is not None:
+        events.append(event("command_exit", event_at=event_at))
+    return events or [schema_unknown(event_at)]
+
+
+def _has_text(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _first_string(*values: object) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value
+    return None

--- a/clawjournal/events/classify/codex.py
+++ b/clawjournal/events/classify/codex.py
@@ -1,0 +1,266 @@
+"""Codex rollout line classifier."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from clawjournal.events.classify.common import (
+    event,
+    is_shell_tool,
+    resolve_timestamp,
+    schema_unknown,
+    tool_secondary_type,
+)
+from clawjournal.events.types import ClassifiedEvent, SessionMeta
+
+
+def classify(line: dict) -> list[ClassifiedEvent]:
+    event_at, confidence, lossiness = resolve_timestamp(line.get("timestamp"))
+    entry_type = line.get("type")
+
+    if entry_type == "session_meta":
+        return [
+            event(
+                "session_open",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    if entry_type in {"session_close", "session_end"}:
+        return [
+            event(
+                "session_close",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    if entry_type == "turn_context":
+        return [schema_unknown(event_at)]
+    if entry_type == "response_item":
+        return _classify_response_item(
+            line.get("payload"), event_at, confidence, lossiness
+        )
+    if entry_type == "event_msg":
+        return _classify_event_msg(
+            line.get("payload"), event_at, confidence, lossiness
+        )
+    if entry_type in {"approval_request", "approval_decision"}:
+        return [
+            event(
+                entry_type,
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    return [schema_unknown(event_at)]
+
+
+def session_meta(line: dict) -> SessionMeta:
+    payload = line.get("payload", {})
+    if not isinstance(payload, dict):
+        payload = {}
+    client_version = payload.get("version")
+    if not isinstance(client_version, str) or not client_version.strip():
+        client_version = None
+    closure_seen = line.get("type") in {"session_close", "session_end"}
+    if line.get("type") == "event_msg":
+        closure_seen = closure_seen or payload.get("type") in {
+            "session_close",
+            "session_end",
+        }
+    return SessionMeta(client_version=client_version, closure_seen=closure_seen)
+
+
+def _classify_response_item(
+    payload: Any,
+    event_at: str | None,
+    confidence: str,
+    lossiness: str,
+) -> list[ClassifiedEvent]:
+    if not isinstance(payload, dict):
+        return [schema_unknown(event_at)]
+    payload_type = payload.get("type")
+    if payload_type in {"function_call", "custom_tool_call"}:
+        tool_name = payload.get("name")
+        call_id = _as_string(payload.get("call_id"))
+        events: list[ClassifiedEvent] = [
+            event(
+                "tool_call",
+                event_at=event_at,
+                event_key=f"tool_call:{call_id}" if call_id is not None else None,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+        secondary = tool_secondary_type(tool_name)
+        if secondary is not None:
+            events.append(
+                event(
+                    secondary,
+                    event_at=event_at,
+                    event_key=f"{secondary}:{call_id}" if call_id is not None else None,
+                    confidence=confidence,
+                    lossiness=lossiness,
+                )
+            )
+        if is_shell_tool(tool_name):
+            events.append(
+                event(
+                    "command_start",
+                    event_at=event_at,
+                    event_key=(
+                        f"command_start:{call_id}" if call_id is not None else None
+                    ),
+                    confidence=confidence,
+                    lossiness=lossiness,
+                )
+            )
+        return events
+    if payload_type in {"function_call_output", "custom_tool_call_output"}:
+        call_id = _as_string(payload.get("call_id"))
+        events = [
+            event(
+                "tool_result",
+                event_at=event_at,
+                event_key=f"tool_result:{call_id}" if call_id is not None else None,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+        if _has_direct_exit_metadata(payload):
+            events.append(
+                event(
+                    "command_exit",
+                    event_at=event_at,
+                    event_key=f"command_exit:{call_id}" if call_id is not None else None,
+                    confidence=confidence,
+                    lossiness=lossiness,
+                )
+            )
+        return events
+    if payload_type == "reasoning":
+        return [
+            event(
+                "assistant_message",
+                event_at=event_at,
+                confidence="medium",
+                lossiness="partial",
+            )
+        ]
+    if payload_type in {"approval_request", "approval_decision"}:
+        return [
+            event(
+                payload_type,
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    if payload_type in {"session_close", "session_end"}:
+        return [
+            event(
+                "session_close",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    return [schema_unknown(event_at)]
+
+
+def _classify_event_msg(
+    payload: Any,
+    event_at: str | None,
+    confidence: str,
+    lossiness: str,
+) -> list[ClassifiedEvent]:
+    if not isinstance(payload, dict):
+        return [schema_unknown(event_at)]
+    payload_type = payload.get("type")
+    if payload_type == "user_message":
+        return [
+            event(
+                "user_message",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    if payload_type == "agent_message":
+        return [
+            event(
+                "assistant_message",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    if payload_type == "agent_reasoning":
+        return [
+            event(
+                "assistant_message",
+                event_at=event_at,
+                confidence="medium",
+                lossiness="partial",
+            )
+        ]
+    if payload_type in {"approval_request", "approval_decision"}:
+        return [
+            event(
+                payload_type,
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    if payload_type in {"session_close", "session_end"}:
+        return [
+            event(
+                "session_close",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    return [schema_unknown(event_at)]
+
+
+def _as_string(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value
+    return None
+
+
+def _has_direct_exit_metadata(payload: dict[str, Any]) -> bool:
+    raw_output = payload.get("output")
+    if isinstance(raw_output, str):
+        if any(
+            line.startswith("Exit code: ")
+            for line in raw_output.splitlines()
+        ):
+            return True
+        try:
+            parsed = json.loads(raw_output)
+        except json.JSONDecodeError:
+            return False
+        metadata = parsed.get("metadata", {}) if isinstance(parsed, dict) else {}
+        return "exit_code" in metadata
+    if not isinstance(raw_output, list):
+        return False
+
+    for block in raw_output:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "input_text":
+            continue
+        text = block.get("text")
+        if isinstance(text, str) and any(
+            line.startswith("Exit code: ")
+            for line in text.splitlines()
+        ):
+            return True
+    return False

--- a/clawjournal/events/classify/common.py
+++ b/clawjournal/events/classify/common.py
@@ -1,0 +1,91 @@
+"""Shared classifier helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawjournal.events.types import ClassifiedEvent, normalize_vendor_timestamp
+
+READ_TOOL_NAMES = {
+    "read",
+    "read_file",
+    "readmanyfiles",
+    "view",
+    "view_image",
+}
+WRITE_TOOL_NAMES = {
+    "write",
+    "write_file",
+    "edit",
+    "edit_file",
+    "multiedit",
+    "notebookedit",
+}
+PATCH_TOOL_NAMES = {
+    "apply_patch",
+    "patch",
+}
+SHELL_TOOL_NAMES = {
+    "bash",
+    "exec",
+    "exec_command",
+    "shell",
+    "shell_command",
+}
+
+
+def resolve_timestamp(*candidates: object) -> tuple[str | None, str, str]:
+    for candidate in candidates:
+        normalized, naive = normalize_vendor_timestamp(candidate)
+        if normalized is not None:
+            return normalized, "high", "none"
+        if naive:
+            return None, "low", "unknown"
+    return None, "high", "none"
+
+
+def event(
+    event_type: str,
+    *,
+    event_at: str | None,
+    event_key: str | None = None,
+    confidence: str = "high",
+    lossiness: str = "none",
+) -> ClassifiedEvent:
+    return ClassifiedEvent(
+        type=event_type,
+        event_at=event_at,
+        event_key=event_key,
+        confidence=confidence,
+        lossiness=lossiness,
+    )
+
+
+def schema_unknown(event_at: str | None, *, lossiness: str = "none") -> ClassifiedEvent:
+    return event(
+        "schema_unknown",
+        event_at=event_at,
+        confidence="low",
+        lossiness=lossiness,
+    )
+
+
+def tool_secondary_type(name: Any) -> str | None:
+    normalized = _normalize_tool_name(name)
+    if normalized in READ_TOOL_NAMES:
+        return "file_read"
+    if normalized in WRITE_TOOL_NAMES:
+        return "file_write"
+    if normalized in PATCH_TOOL_NAMES:
+        return "patch"
+    return None
+
+
+def is_shell_tool(name: Any) -> bool:
+    return _normalize_tool_name(name) in SHELL_TOOL_NAMES
+
+
+def _normalize_tool_name(name: Any) -> str:
+    if not isinstance(name, str):
+        return ""
+    return name.strip().lower().replace("-", "_")

--- a/clawjournal/events/classify/openclaw.py
+++ b/clawjournal/events/classify/openclaw.py
@@ -1,0 +1,247 @@
+"""OpenClaw JSONL line classifier."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawjournal.events.classify.common import (
+    event,
+    is_shell_tool,
+    resolve_timestamp,
+    schema_unknown,
+    tool_secondary_type,
+)
+from clawjournal.events.types import ClassifiedEvent, SessionMeta
+
+
+def classify(line: dict) -> list[ClassifiedEvent]:
+    message = line.get("message", {})
+    event_at, confidence, lossiness = resolve_timestamp(
+        message.get("timestamp") if isinstance(message, dict) else None,
+        line.get("timestamp"),
+    )
+    entry_type = line.get("type")
+    if entry_type == "session":
+        return [
+            event(
+                "session_open",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    if entry_type == "compaction":
+        return [
+            event(
+                "compaction",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness="compacted",
+            )
+        ]
+    if entry_type in {"session_close", "session_end"}:
+        return [
+            event(
+                "session_close",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    if entry_type in {"approval_request", "approval_decision"}:
+        return [
+            event(
+                entry_type,
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    if entry_type != "message":
+        return [schema_unknown(event_at)]
+    return _classify_message(message, event_at, confidence, lossiness)
+
+
+def session_meta(line: dict) -> SessionMeta:
+    client_version = line.get("version")
+    if not isinstance(client_version, str) or not client_version.strip():
+        client_version = None
+    closure_seen = line.get("type") in {"session_close", "session_end", "closed"}
+    return SessionMeta(client_version=client_version, closure_seen=closure_seen)
+
+
+def _classify_message(
+    message: Any,
+    event_at: str | None,
+    confidence: str,
+    lossiness: str,
+) -> list[ClassifiedEvent]:
+    if not isinstance(message, dict):
+        return [schema_unknown(event_at)]
+    role = message.get("role")
+    if role == "user":
+        return _classify_user_message(message, event_at, confidence, lossiness)
+    if role == "assistant":
+        return _classify_assistant_message(message, event_at, confidence, lossiness)
+    if role == "toolResult":
+        tool_id = _as_string(message.get("toolCallId"))
+        return [
+            event(
+                "tool_result",
+                event_at=event_at,
+                event_key=f"tool_result:{tool_id}" if tool_id is not None else None,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    if role == "bashExecution":
+        return _classify_bash_execution(message, event_at)
+    if role in {"approval_request", "approval_decision"}:
+        return [
+            event(
+                role,
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    return [schema_unknown(event_at)]
+
+
+def _classify_user_message(
+    message: Any,
+    event_at: str | None,
+    confidence: str,
+    lossiness: str,
+) -> list[ClassifiedEvent]:
+    if not isinstance(message, dict):
+        return [schema_unknown(event_at)]
+    content = message.get("content")
+    if isinstance(content, str) and content.strip():
+        return [
+            event(
+                "user_message",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            )
+        ]
+    if isinstance(content, list):
+        for block in content:
+            if isinstance(block, dict) and _has_text(block.get("text")):
+                return [
+                    event(
+                        "user_message",
+                        event_at=event_at,
+                        confidence=confidence,
+                        lossiness=lossiness,
+                    )
+                ]
+    return [schema_unknown(event_at)]
+
+
+def _classify_assistant_message(
+    message: Any,
+    event_at: str | None,
+    confidence: str,
+    lossiness: str,
+) -> list[ClassifiedEvent]:
+    if not isinstance(message, dict):
+        return [schema_unknown(event_at)]
+    content = message.get("content")
+    if not isinstance(content, list):
+        return [schema_unknown(event_at)]
+
+    events: list[ClassifiedEvent] = []
+    has_assistant_text = False
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type in {"text", "thinking"}:
+            if _has_text(block.get("text")) or _has_text(block.get("thinking")):
+                has_assistant_text = True
+        elif block_type == "toolCall":
+            tool_name = block.get("name")
+            tool_id = _as_string(block.get("id"))
+            events.append(
+                event(
+                    "tool_call",
+                    event_at=event_at,
+                    event_key=f"tool_call:{tool_id}" if tool_id is not None else None,
+                    confidence=confidence,
+                    lossiness=lossiness,
+                )
+            )
+            secondary = tool_secondary_type(tool_name)
+            if secondary is not None:
+                events.append(
+                    event(
+                        secondary,
+                        event_at=event_at,
+                        event_key=f"{secondary}:{tool_id}" if tool_id is not None else None,
+                        confidence=confidence,
+                        lossiness=lossiness,
+                    )
+                )
+            if is_shell_tool(tool_name):
+                events.append(
+                    event(
+                        "command_start",
+                        event_at=event_at,
+                        event_key=(
+                            f"command_start:{tool_id}" if tool_id is not None else None
+                        ),
+                        confidence=confidence,
+                        lossiness=lossiness,
+                    )
+                )
+
+    if has_assistant_text:
+        events.insert(
+            0,
+            event(
+                "assistant_message",
+                event_at=event_at,
+                confidence=confidence,
+                lossiness=lossiness,
+            ),
+        )
+    return events or [schema_unknown(event_at)]
+
+
+def _classify_bash_execution(
+    message: Any,
+    event_at: str | None,
+) -> list[ClassifiedEvent]:
+    if not isinstance(message, dict):
+        return [schema_unknown(event_at)]
+
+    events: list[ClassifiedEvent] = []
+    command = message.get("command")
+    output = message.get("output")
+    exit_code = message.get("exitCode")
+    if isinstance(command, str) and command.strip():
+        events.append(event("command_start", event_at=event_at))
+    if isinstance(output, str) and output.strip():
+        events.append(
+            event(
+                "stdout_chunk",
+                event_at=event_at,
+                confidence="low",
+                lossiness="unknown",
+            )
+        )
+    if exit_code is not None:
+        events.append(event("command_exit", event_at=event_at))
+    return events or [schema_unknown(event_at)]
+
+
+def _has_text(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _as_string(value: object) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value
+    return None

--- a/clawjournal/events/ingest.py
+++ b/clawjournal/events/ingest.py
@@ -1,0 +1,386 @@
+"""Ingest capture line batches into the execution recorder tables."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+
+from clawjournal.capture import (
+    cursor_after,
+    get_cursor,
+    iter_new_lines,
+    iter_source_files,
+    set_cursor,
+)
+from clawjournal.capture.cursors import ensure_schema as ensure_capture_schema
+from clawjournal.capture.discovery import SourceFile
+from clawjournal.events.classify import classify_line, session_meta_for_line
+from clawjournal.events.schema import ensure_schema as ensure_event_schema
+from clawjournal.events.types import ClassifiedEvent, validate_classified_event
+
+EVENT_CONSUMER_ID = "events"
+IDLE_END_AFTER_SECONDS = 3600
+
+_SOURCE_BY_CLIENT = {
+    "claude": "claude-jsonl",
+    "codex": "codex-rollout",
+    "openclaw": "openclaw-jsonl",
+}
+
+_UPSERT_EVENT_SESSION_SQL = """
+INSERT INTO event_sessions (
+    session_key,
+    parent_session_key,
+    parent_session_id,
+    client,
+    client_version,
+    started_at,
+    ended_at,
+    status
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(session_key) DO UPDATE SET
+    parent_session_key = COALESCE(
+        event_sessions.parent_session_key,
+        excluded.parent_session_key
+    ),
+    parent_session_id = COALESCE(
+        event_sessions.parent_session_id,
+        excluded.parent_session_id
+    ),
+    client_version = COALESCE(
+        event_sessions.client_version,
+        excluded.client_version
+    ),
+    started_at = CASE
+        WHEN event_sessions.started_at IS NULL THEN excluded.started_at
+        WHEN excluded.started_at IS NULL THEN event_sessions.started_at
+        WHEN excluded.started_at < event_sessions.started_at THEN excluded.started_at
+        ELSE event_sessions.started_at
+    END,
+    ended_at = CASE
+        WHEN event_sessions.ended_at IS NULL THEN excluded.ended_at
+        WHEN excluded.ended_at IS NULL THEN event_sessions.ended_at
+        WHEN excluded.ended_at > event_sessions.ended_at THEN excluded.ended_at
+        ELSE event_sessions.ended_at
+    END,
+    status = CASE
+        WHEN event_sessions.status = 'ended' THEN 'ended'
+        ELSE excluded.status
+    END
+"""
+
+_INSERT_EVENT_SQL = """
+INSERT OR IGNORE INTO events (
+    session_id,
+    type,
+    event_key,
+    event_at,
+    ingested_at,
+    source,
+    source_path,
+    source_offset,
+    seq,
+    client,
+    confidence,
+    lossiness,
+    raw_json
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+
+@dataclass
+class IngestSummary:
+    files_scanned: int = 0
+    files_with_changes: int = 0
+    batches: int = 0
+    lines_read: int = 0
+    event_rows: int = 0
+    _session_keys: set[str] = field(default_factory=set, repr=False)
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "files_scanned": self.files_scanned,
+            "files_with_changes": self.files_with_changes,
+            "batches": self.batches,
+            "lines_read": self.lines_read,
+            "event_rows": self.event_rows,
+            "sessions_touched": len(self._session_keys),
+        }
+
+
+def ingest_pending(
+    conn: sqlite3.Connection,
+    *,
+    source_filter: str | None = None,
+    now: datetime | None = None,
+) -> IngestSummary:
+    ensure_capture_schema(conn)
+    ensure_event_schema(conn)
+
+    summary = IngestSummary()
+    latest_mtime_by_session_key: dict[str, float] = {}
+    for source in iter_source_files(source_filter=source_filter):
+        summary.files_scanned += 1
+        latest_mtime_by_session_key[source.session_key] = max(
+            latest_mtime_by_session_key.get(source.session_key, float("-inf")),
+            _source_last_modified(source),
+        )
+        cursor = get_cursor(conn, EVENT_CONSUMER_ID, source.path)
+        batch = iter_new_lines(source.path, cursor, client=source.client)
+        if batch is None:
+            continue
+        summary.files_with_changes += 1
+        summary.batches += 1
+        summary.lines_read += len(batch.lines)
+        summary._session_keys.add(source.session_key)
+        summary.event_rows += _ingest_batch(conn, source, batch, now=now)
+    _sweep_idle_sessions(conn, latest_mtime_by_session_key, now=now)
+    return summary
+
+
+def _ingest_batch(
+    conn: sqlite3.Connection,
+    source: SourceFile,
+    batch,
+    *,
+    now: datetime | None,
+) -> int:
+    ingested_at = _utc_now_iso(now)
+    source_name = _SOURCE_BY_CLIENT[source.client]
+
+    event_rows: list[tuple[Any, ...]] = []
+    client_version: str | None = None
+    parent_session_id_raw: str | None = None
+    closure_seen = False
+    started_at: str | None = None
+    ended_at: str | None = None
+
+    for line_offset, line_text in zip(batch.line_offsets, batch.lines):
+        try:
+            parsed = json.loads(line_text)
+        except json.JSONDecodeError:
+            raw_json = json.dumps(
+                {"_unparseable": True, "raw_text": line_text},
+                sort_keys=True,
+            )
+            event_rows.append(
+                (
+                    "schema_unknown",
+                    None,
+                    None,
+                    ingested_at,
+                    source_name,
+                    str(source.path),
+                    line_offset,
+                    0,
+                    source.client,
+                    "low",
+                    "unknown",
+                    raw_json,
+                )
+            )
+            continue
+
+        raw_json = json.dumps(parsed, sort_keys=True)
+        classified = classify_line(source.client, parsed) or []
+        if not classified:
+            classified = [
+                ClassifiedEvent(
+                    type="schema_unknown",
+                    event_at=None,
+                    event_key=None,
+                    confidence="low",
+                    lossiness="none",
+                )
+            ]
+        meta = session_meta_for_line(source.client, parsed)
+        if client_version is None and meta.client_version:
+            client_version = meta.client_version
+        if parent_session_id_raw is None and meta.parent_session_id:
+            parent_session_id_raw = meta.parent_session_id
+        closure_seen = closure_seen or meta.closure_seen
+
+        for seq, classified_event in enumerate(classified):
+            validate_classified_event(classified_event)
+            if classified_event.event_at is not None:
+                started_at = _min_iso(started_at, classified_event.event_at)
+                ended_at = _max_iso(ended_at, classified_event.event_at)
+            event_rows.append(
+                (
+                    classified_event.type,
+                    classified_event.event_key,
+                    classified_event.event_at,
+                    ingested_at,
+                    source_name,
+                    str(source.path),
+                    line_offset,
+                    seq,
+                    source.client,
+                    classified_event.confidence,
+                    classified_event.lossiness,
+                    raw_json,
+                )
+            )
+
+    parent_session_key = _parent_session_key(source, parent_session_id_raw)
+    status = "ended" if closure_seen or _is_idle_stable(batch, now=now) else "active"
+
+    with conn:
+        parent_session_id = _lookup_session_id(conn, parent_session_key)
+        conn.execute(
+            _UPSERT_EVENT_SESSION_SQL,
+            (
+                source.session_key,
+                parent_session_key,
+                parent_session_id,
+                source.client,
+                client_version,
+                started_at,
+                ended_at,
+                status,
+            ),
+        )
+        session_id = _lookup_session_id(conn, source.session_key)
+        assert session_id is not None
+        conn.executemany(
+            _INSERT_EVENT_SQL,
+            [
+                (
+                    session_id,
+                    event_type,
+                    event_key,
+                    event_at,
+                    ingested_at_value,
+                    source_name_value,
+                    source_path,
+                    source_offset,
+                    seq,
+                    client,
+                    confidence,
+                    lossiness,
+                    raw_json,
+                )
+                for (
+                    event_type,
+                    event_key,
+                    event_at,
+                    ingested_at_value,
+                    source_name_value,
+                    source_path,
+                    source_offset,
+                    seq,
+                    client,
+                    confidence,
+                    lossiness,
+                    raw_json,
+                ) in event_rows
+            ],
+        )
+        _backfill_parent_links(conn)
+
+    with conn:
+        set_cursor(conn, cursor_after(batch, consumer_id=EVENT_CONSUMER_ID))
+
+    return len(event_rows)
+
+
+def _lookup_session_id(
+    conn: sqlite3.Connection, session_key: str | None
+) -> int | None:
+    if session_key is None:
+        return None
+    row = conn.execute(
+        "SELECT id FROM event_sessions WHERE session_key = ?",
+        (session_key,),
+    ).fetchone()
+    if row is None:
+        return None
+    return int(row[0])
+
+
+def _backfill_parent_links(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        UPDATE event_sessions
+           SET parent_session_id = (
+               SELECT parent.id
+                 FROM event_sessions AS parent
+                WHERE parent.session_key = event_sessions.parent_session_key
+           )
+         WHERE parent_session_id IS NULL
+           AND parent_session_key IS NOT NULL
+           AND EXISTS (
+               SELECT 1
+                 FROM event_sessions AS parent
+                WHERE parent.session_key = event_sessions.parent_session_key
+           )
+        """
+    )
+
+
+def _sweep_idle_sessions(
+    conn: sqlite3.Connection,
+    latest_mtime_by_session_key: dict[str, float],
+    *,
+    now: datetime | None,
+) -> None:
+    effective_now = now or datetime.now(timezone.utc)
+    idle_keys = [
+        session_key
+        for session_key, last_modified in latest_mtime_by_session_key.items()
+        if (effective_now.timestamp() - last_modified) >= IDLE_END_AFTER_SECONDS
+    ]
+    if not idle_keys:
+        return
+
+    with conn:
+        conn.executemany(
+            "UPDATE event_sessions SET status = 'ended' WHERE session_key = ? AND status != 'ended'",
+            [(session_key,) for session_key in idle_keys],
+        )
+
+
+def _parent_session_key(
+    source: SourceFile, parent_session_id_raw: str | None
+) -> str | None:
+    if parent_session_id_raw is None:
+        return None
+    if parent_session_id_raw.startswith("claude:"):
+        return parent_session_id_raw
+    if source.client != "claude":
+        return None
+    return f"claude:{source.project_dir_name}:{parent_session_id_raw}"
+
+
+def _is_idle_stable(batch, *, now: datetime | None) -> bool:
+    effective_now = now or datetime.now(timezone.utc)
+    return (effective_now.timestamp() - batch.last_modified) >= IDLE_END_AFTER_SECONDS
+
+
+def _source_last_modified(source: SourceFile) -> float:
+    try:
+        return source.path.stat().st_mtime
+    except FileNotFoundError:
+        return float("-inf")
+
+
+def _utc_now_iso(now: datetime | None) -> str:
+    effective_now = now or datetime.now(timezone.utc)
+    return effective_now.astimezone(timezone.utc).isoformat().replace(
+        "+00:00", "Z"
+    )
+
+
+def _min_iso(current: str | None, incoming: str) -> str:
+    if current is None:
+        return incoming
+    return incoming if incoming < current else current
+
+
+def _max_iso(current: str | None, incoming: str) -> str:
+    if current is None:
+        return incoming
+    return incoming if incoming > current else current

--- a/clawjournal/events/schema.py
+++ b/clawjournal/events/schema.py
@@ -1,0 +1,71 @@
+"""SQLite schema for the execution recorder."""
+
+from __future__ import annotations
+
+import sqlite3
+
+EVENT_SESSIONS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS event_sessions (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_key        TEXT    NOT NULL UNIQUE,
+    parent_session_key TEXT,
+    parent_session_id  INTEGER REFERENCES event_sessions(id) ON DELETE SET NULL,
+    client             TEXT    NOT NULL,
+    client_version     TEXT,
+    started_at         TEXT,
+    ended_at           TEXT,
+    status             TEXT    NOT NULL DEFAULT 'active'
+);
+"""
+
+EVENTS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id    INTEGER NOT NULL REFERENCES event_sessions(id) ON DELETE CASCADE,
+    type          TEXT    NOT NULL,
+    event_key     TEXT,
+    event_at      TEXT,
+    ingested_at   TEXT    NOT NULL,
+    source        TEXT    NOT NULL,
+    source_path   TEXT    NOT NULL,
+    source_offset INTEGER NOT NULL,
+    seq           INTEGER NOT NULL DEFAULT 0,
+    client        TEXT    NOT NULL,
+    confidence    TEXT    NOT NULL,
+    lossiness     TEXT    NOT NULL,
+    raw_json      TEXT    NOT NULL,
+    UNIQUE (source, source_path, source_offset, seq)
+);
+CREATE INDEX IF NOT EXISTS idx_events_session_time
+    ON events(session_id, event_at);
+CREATE INDEX IF NOT EXISTS idx_events_session_source
+    ON events(session_id, source, source_path, source_offset, seq);
+CREATE INDEX IF NOT EXISTS idx_events_event_key
+    ON events(session_id, event_key)
+    WHERE event_key IS NOT NULL;
+"""
+
+EVENT_SESSIONS_PARENT_INDEX_SQL = """
+CREATE INDEX IF NOT EXISTS idx_event_sessions_parent_key
+    ON event_sessions(parent_session_key)
+    WHERE parent_session_key IS NOT NULL;
+"""
+
+
+def ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.execute(EVENT_SESSIONS_TABLE_SQL)
+
+    existing = {
+        row[1] for row in conn.execute("PRAGMA table_info(event_sessions)")
+    }
+    if "parent_session_key" not in existing:
+        conn.execute("ALTER TABLE event_sessions ADD COLUMN parent_session_key TEXT")
+    if "parent_session_id" not in existing:
+        conn.execute(
+            "ALTER TABLE event_sessions "
+            "ADD COLUMN parent_session_id INTEGER REFERENCES event_sessions(id) ON DELETE SET NULL"
+        )
+
+    conn.executescript(EVENT_SESSIONS_PARENT_INDEX_SQL)
+    conn.executescript(EVENTS_TABLE_SQL)

--- a/clawjournal/events/types.py
+++ b/clawjournal/events/types.py
@@ -1,0 +1,89 @@
+"""Shared types and validation for the execution recorder."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import NamedTuple
+
+EVENT_TYPES = (
+    "user_message",
+    "assistant_message",
+    "tool_call",
+    "tool_result",
+    "file_read",
+    "file_write",
+    "patch",
+    "command_start",
+    "command_exit",
+    "stdout_chunk",
+    "stderr_chunk",
+    "approval_request",
+    "approval_decision",
+    "compaction",
+    "session_open",
+    "session_close",
+    "schema_unknown",
+)
+EVENT_TYPE_SET = set(EVENT_TYPES)
+
+VALID_SOURCES = {
+    "claude-jsonl",
+    "codex-rollout",
+    "openclaw-jsonl",
+    "hook",
+    "flightrec-derived",
+}
+VALID_CONFIDENCE = {"high", "medium", "low", "missing"}
+VALID_LOSSINESS = {"none", "partial", "unknown", "compacted"}
+
+
+class ClassifiedEvent(NamedTuple):
+    type: str
+    event_at: str | None
+    event_key: str | None
+    confidence: str
+    lossiness: str
+
+
+class SessionMeta(NamedTuple):
+    client_version: str | None = None
+    # Raw parent id from the vendor line. The ingest layer turns this into a
+    # concrete session_key using the current SourceFile context.
+    parent_session_id: str | None = None
+    closure_seen: bool = False
+
+
+def validate_classified_event(event: ClassifiedEvent) -> None:
+    if event.type not in EVENT_TYPE_SET:
+        raise ValueError(f"Unsupported event type: {event.type}")
+    if event.confidence not in VALID_CONFIDENCE:
+        raise ValueError(f"Unsupported event confidence: {event.confidence}")
+    if event.lossiness not in VALID_LOSSINESS:
+        raise ValueError(f"Unsupported event lossiness: {event.lossiness}")
+
+
+def normalize_vendor_timestamp(
+    value: object,
+) -> tuple[str | None, bool]:
+    """Return `(utc_iso_z, was_timezone_naive)` for a vendor timestamp."""
+
+    if value is None:
+        return None, False
+    if isinstance(value, (int, float)):
+        dt = datetime.fromtimestamp(value / 1000, tz=timezone.utc)
+        return dt.isoformat().replace("+00:00", "Z"), False
+    if not isinstance(value, str):
+        return None, False
+
+    raw = value.strip()
+    if not raw:
+        return None, False
+
+    normalized = raw[:-1] + "+00:00" if raw.endswith("Z") else raw
+    try:
+        dt = datetime.fromisoformat(normalized)
+    except ValueError:
+        return None, False
+    if dt.tzinfo is None:
+        return None, True
+    return dt.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"), False

--- a/tests/capture/test_changes.py
+++ b/tests/capture/test_changes.py
@@ -25,6 +25,7 @@ def test_first_read_returns_all_complete_lines(tmp_path):
     batch = iter_new_lines(p, None, client="claude")
     assert batch is not None
     assert batch.lines == ['{"a":1}', '{"b":2}']
+    assert batch.line_offsets == [0, len(b'{"a":1}\n')]
     assert batch.start_offset == 0
     assert batch.end_offset == len(b'{"a":1}\n{"b":2}\n')
     assert batch.client == "claude"
@@ -43,6 +44,7 @@ def test_incremental_append_reads_only_new(tmp_path):
     batch2 = iter_new_lines(p, cur, client="claude")
     assert batch2 is not None
     assert batch2.lines == ['{"b":2}']
+    assert batch2.line_offsets == [batch1.end_offset]
     assert batch2.start_offset == batch1.end_offset
 
 
@@ -60,6 +62,7 @@ def test_partial_trailing_line_is_not_consumed(tmp_path):
     batch = iter_new_lines(p, None, client="claude")
     assert batch is not None
     assert batch.lines == ['{"a":1}']
+    assert batch.line_offsets == [0]
     assert batch.end_offset == len(b'{"a":1}\n')
 
     cur = cursor_after(batch, consumer_id="events")
@@ -67,6 +70,10 @@ def test_partial_trailing_line_is_not_consumed(tmp_path):
     batch2 = iter_new_lines(p, cur, client="claude")
     assert batch2 is not None
     assert batch2.lines == ['{"incomplete":true}', '{"c":3}']
+    assert batch2.line_offsets == [
+        len(b'{"a":1}\n'),
+        len(b'{"a":1}\n{"incomplete":true}\n'),
+    ]
 
 
 def test_rotation_resets_offset(tmp_path):

--- a/tests/events/_fixtures.py
+++ b/tests/events/_fixtures.py
@@ -1,0 +1,801 @@
+"""Shared classifier corpora for per-client pinning + matrix drift tests.
+
+Each fixture declares the exact list of events the classifier should
+emit for a realistic (or deliberately crafted) vendor line, as tuples
+of `(type, event_key, event_at, confidence, lossiness)`.
+
+`realistic=True` fixtures mirror shapes actually observed in vendor
+JSONL and are used by both the per-client classifier tests and the
+capability-matrix pinning test in test_invariants.py.
+
+`realistic=False` fixtures exercise defensive / dead-branch code paths
+that today's vendors don't emit. They stay in the per-client tests
+(to pin behavior if those branches ever fire) but are filtered out of
+matrix pinning so that known drift doesn't make the tripwire useless.
+"""
+
+from __future__ import annotations
+
+from typing import NamedTuple
+
+# Whole-second UTC timestamps so input == `normalize_vendor_timestamp` output.
+TS = "2026-04-20T10:00:00Z"
+TS_NAIVE = "2026-04-20T10:00:00"  # no tz → confidence=low, lossiness=unknown
+
+
+class ExpectedEvent(NamedTuple):
+    type: str
+    event_key: str | None
+    event_at: str | None
+    confidence: str
+    lossiness: str
+
+
+class Fixture(NamedTuple):
+    name: str
+    line: dict
+    expected: list[ExpectedEvent]
+    realistic: bool = True
+
+
+def _ev(
+    type_: str,
+    event_key: str | None = None,
+    event_at: str | None = TS,
+    confidence: str = "high",
+    lossiness: str = "none",
+) -> ExpectedEvent:
+    return ExpectedEvent(type_, event_key, event_at, confidence, lossiness)
+
+
+def _schema_unknown(event_at: str | None = TS) -> ExpectedEvent:
+    return _ev("schema_unknown", event_at=event_at, confidence="low")
+
+
+# --------------------------------------------------------------------------- #
+# Claude
+# --------------------------------------------------------------------------- #
+
+CLAUDE_CORPUS: list[Fixture] = [
+    # --- user messages ---
+    Fixture(
+        "user_plain_string",
+        {"type": "user", "timestamp": TS, "message": {"content": "hi"}},
+        [_ev("user_message")],
+    ),
+    Fixture(
+        "user_empty_string_is_schema_unknown",
+        {"type": "user", "timestamp": TS, "message": {"content": "   "}},
+        [_schema_unknown()],
+    ),
+    Fixture(
+        "user_content_none_is_schema_unknown",
+        {"type": "user", "timestamp": TS, "message": {"content": None}},
+        [_schema_unknown()],
+    ),
+    Fixture(
+        "user_empty_list_is_schema_unknown",
+        {"type": "user", "timestamp": TS, "message": {"content": []}},
+        [_schema_unknown()],
+    ),
+    Fixture(
+        "user_list_text_block",
+        {
+            "type": "user",
+            "timestamp": TS,
+            "message": {"content": [{"type": "text", "text": "hi"}]},
+        },
+        [_ev("user_message")],
+    ),
+    Fixture(
+        "user_list_tool_result_with_id",
+        {
+            "type": "user",
+            "timestamp": TS,
+            "message": {
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "tu-1", "content": "ok"}
+                ]
+            },
+        },
+        [_ev("tool_result", event_key="tool_result:tu-1")],
+    ),
+    Fixture(
+        "user_list_tool_result_without_id",
+        {
+            "type": "user",
+            "timestamp": TS,
+            "message": {"content": [{"type": "tool_result", "content": "ok"}]},
+        },
+        [_ev("tool_result", event_key=None)],
+    ),
+    Fixture(
+        "user_list_text_plus_tool_result",
+        {
+            "type": "user",
+            "timestamp": TS,
+            "message": {
+                "content": [
+                    {"type": "text", "text": "explain"},
+                    {"type": "tool_result", "tool_use_id": "tu-2", "content": "ok"},
+                ]
+            },
+        },
+        [_ev("user_message"), _ev("tool_result", event_key="tool_result:tu-2")],
+    ),
+    Fixture(
+        "user_list_with_only_unknown_blocks",
+        {
+            "type": "user",
+            "timestamp": TS,
+            "message": {"content": [{"type": "image", "source": {}}]},
+        },
+        [_schema_unknown()],
+    ),
+    Fixture(
+        "user_message_not_dict_is_schema_unknown",
+        {"type": "user", "timestamp": TS, "message": "string"},
+        [_schema_unknown()],
+    ),
+    # --- assistant messages ---
+    Fixture(
+        "assistant_text_only",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {"content": [{"type": "text", "text": "answer"}]},
+        },
+        [_ev("assistant_message")],
+    ),
+    Fixture(
+        "assistant_thinking_only",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {"content": [{"type": "thinking", "thinking": "reasoning"}]},
+        },
+        [_ev("assistant_message")],
+    ),
+    Fixture(
+        "assistant_tool_use_read_emits_file_read",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "tu-3", "name": "Read", "input": {}}
+                ]
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:tu-3"),
+            _ev("file_read", event_key="file_read:tu-3"),
+        ],
+    ),
+    Fixture(
+        "assistant_tool_use_write_emits_file_write",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "tu-4", "name": "Write", "input": {}}
+                ]
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:tu-4"),
+            _ev("file_write", event_key="file_write:tu-4"),
+        ],
+    ),
+    Fixture(
+        "assistant_tool_use_edit_emits_file_write",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "tu-5", "name": "Edit", "input": {}}
+                ]
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:tu-5"),
+            _ev("file_write", event_key="file_write:tu-5"),
+        ],
+    ),
+    Fixture(
+        "assistant_tool_use_multiedit_emits_file_write",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "tu-6", "name": "MultiEdit", "input": {}}
+                ]
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:tu-6"),
+            _ev("file_write", event_key="file_write:tu-6"),
+        ],
+    ),
+    Fixture(
+        "assistant_tool_use_bash_emits_command_start",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": "tu-7", "name": "Bash", "input": {}}
+                ]
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:tu-7"),
+            _ev("command_start", event_key="command_start:tu-7"),
+        ],
+    ),
+    Fixture(
+        "assistant_tool_use_apply_patch_emits_patch",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu-8",
+                        "name": "apply_patch",
+                        "input": {},
+                    }
+                ]
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:tu-8"),
+            _ev("patch", event_key="patch:tu-8"),
+        ],
+    ),
+    Fixture(
+        "assistant_tool_use_unknown_name_tool_call_only",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu-9",
+                        "name": "Glob",  # not in READ/WRITE/PATCH/SHELL sets
+                        "input": {},
+                    }
+                ]
+            },
+        },
+        [_ev("tool_call", event_key="tool_call:tu-9")],
+    ),
+    Fixture(
+        "assistant_tool_use_missing_id_has_no_event_key",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {
+                "content": [
+                    {"type": "tool_use", "name": "Read", "input": {}}
+                ]
+            },
+        },
+        [
+            _ev("tool_call", event_key=None),
+            _ev("file_read", event_key=None),
+        ],
+    ),
+    Fixture(
+        "assistant_toolCall_alternate_key_works",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {
+                "content": [
+                    {"type": "toolCall", "id": "tu-10", "name": "Read", "input": {}}
+                ]
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:tu-10"),
+            _ev("file_read", event_key="file_read:tu-10"),
+        ],
+    ),
+    Fixture(
+        "assistant_text_plus_tool_use",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {
+                "content": [
+                    {"type": "text", "text": "reading"},
+                    {"type": "tool_use", "id": "tu-11", "name": "Read", "input": {}},
+                ]
+            },
+        },
+        [
+            _ev("assistant_message"),
+            _ev("tool_call", event_key="tool_call:tu-11"),
+            _ev("file_read", event_key="file_read:tu-11"),
+        ],
+    ),
+    Fixture(
+        "assistant_content_not_list_is_schema_unknown",
+        {
+            "type": "assistant",
+            "timestamp": TS,
+            "message": {"content": "oops"},
+        },
+        [_schema_unknown()],
+    ),
+    # --- misc ---
+    Fixture(
+        "unknown_entry_type_is_schema_unknown",
+        {"type": "summary", "timestamp": TS},
+        [_schema_unknown()],
+    ),
+    Fixture(
+        "missing_timestamp_defaults_confidence_high",
+        {"type": "user", "message": {"content": "hi"}},
+        [_ev("user_message", event_at=None)],
+    ),
+    Fixture(
+        "naive_timestamp_downgrades_confidence",
+        {"type": "user", "timestamp": TS_NAIVE, "message": {"content": "hi"}},
+        [_ev("user_message", event_at=None, confidence="low", lossiness="unknown")],
+    ),
+    # --- defensive / dead branches (not observed in real Claude JSONL) ---
+    Fixture(
+        "compaction_entry_is_defensive",
+        {"type": "compaction", "timestamp": TS, "summary": "compacted"},
+        [_ev("compaction", lossiness="compacted")],
+        realistic=False,
+    ),
+    Fixture(
+        "session_close_entry_is_defensive",
+        {"type": "session_close", "timestamp": TS, "message": {}},
+        [_ev("session_close")],
+        realistic=False,
+    ),
+    Fixture(
+        "approval_request_is_defensive",
+        {"type": "approval_request", "timestamp": TS, "message": {}},
+        [_ev("approval_request")],
+        realistic=False,
+    ),
+    Fixture(
+        "approval_decision_is_defensive",
+        {"type": "approval_decision", "timestamp": TS, "message": {}},
+        [_ev("approval_decision")],
+        realistic=False,
+    ),
+]
+
+# --------------------------------------------------------------------------- #
+# Codex
+# --------------------------------------------------------------------------- #
+
+CODEX_CORPUS: list[Fixture] = [
+    Fixture(
+        "session_meta_emits_session_open_and_records_version",
+        {
+            "type": "session_meta",
+            "timestamp": TS,
+            "payload": {"version": "0.7.1"},
+        },
+        [_ev("session_open")],
+    ),
+    Fixture(
+        "response_item_function_call_shell",
+        {
+            "type": "response_item",
+            "timestamp": TS,
+            "payload": {
+                "type": "function_call",
+                "name": "shell",
+                "call_id": "c-1",
+                "arguments": "{}",
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:c-1"),
+            _ev("command_start", event_key="command_start:c-1"),
+        ],
+    ),
+    Fixture(
+        "response_item_function_call_read_file",
+        {
+            "type": "response_item",
+            "timestamp": TS,
+            "payload": {
+                "type": "function_call",
+                "name": "read_file",
+                "call_id": "c-2",
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:c-2"),
+            _ev("file_read", event_key="file_read:c-2"),
+        ],
+    ),
+    Fixture(
+        "response_item_function_call_unknown_tool",
+        {
+            "type": "response_item",
+            "timestamp": TS,
+            "payload": {
+                "type": "function_call",
+                "name": "mystery_tool",
+                "call_id": "c-3",
+            },
+        },
+        [_ev("tool_call", event_key="tool_call:c-3")],
+    ),
+    Fixture(
+        "response_item_custom_tool_call",
+        {
+            "type": "response_item",
+            "timestamp": TS,
+            "payload": {
+                "type": "custom_tool_call",
+                "name": "read_file",
+                "call_id": "c-4",
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:c-4"),
+            _ev("file_read", event_key="file_read:c-4"),
+        ],
+    ),
+    Fixture(
+        "response_item_function_call_output",
+        {
+            "type": "response_item",
+            "timestamp": TS,
+            "payload": {
+                "type": "function_call_output",
+                "call_id": "c-5",
+                "output": "ok",
+            },
+        },
+        [_ev("tool_result", event_key="tool_result:c-5")],
+    ),
+    Fixture(
+        "response_item_custom_tool_call_output",
+        {
+            "type": "response_item",
+            "timestamp": TS,
+            "payload": {
+                "type": "custom_tool_call_output",
+                "call_id": "c-6",
+                "output": "ok",
+            },
+        },
+        [_ev("tool_result", event_key="tool_result:c-6")],
+    ),
+    Fixture(
+        "response_item_reasoning_is_low_fidelity_assistant_message",
+        {
+            "type": "response_item",
+            "timestamp": TS,
+            "payload": {"type": "reasoning", "summary": "…"},
+        },
+        [_ev("assistant_message", confidence="medium", lossiness="partial")],
+    ),
+    Fixture(
+        "response_item_unknown_payload_is_schema_unknown",
+        {
+            "type": "response_item",
+            "timestamp": TS,
+            "payload": {"type": "made_up_kind"},
+        },
+        [_schema_unknown()],
+    ),
+    Fixture(
+        "event_msg_user_message",
+        {
+            "type": "event_msg",
+            "timestamp": TS,
+            "payload": {"type": "user_message", "message": "hi"},
+        },
+        [_ev("user_message")],
+    ),
+    Fixture(
+        "event_msg_agent_message",
+        {
+            "type": "event_msg",
+            "timestamp": TS,
+            "payload": {"type": "agent_message", "message": "hello"},
+        },
+        [_ev("assistant_message")],
+    ),
+    Fixture(
+        "event_msg_agent_reasoning_is_low_fidelity",
+        {
+            "type": "event_msg",
+            "timestamp": TS,
+            "payload": {"type": "agent_reasoning", "text": "…"},
+        },
+        [_ev("assistant_message", confidence="medium", lossiness="partial")],
+    ),
+    Fixture(
+        "event_msg_token_count_is_schema_unknown",
+        {
+            "type": "event_msg",
+            "timestamp": TS,
+            "payload": {"type": "token_count", "info": {"total": 1}},
+        },
+        [_schema_unknown()],
+    ),
+    Fixture(
+        "turn_context_is_schema_unknown",
+        {"type": "turn_context", "timestamp": TS, "payload": {}},
+        [_schema_unknown()],
+    ),
+    Fixture(
+        "session_close_entry_is_defensive",
+        {"type": "session_close", "timestamp": TS},
+        [_ev("session_close")],
+        realistic=False,
+    ),
+    Fixture(
+        "approval_request_is_defensive",
+        {"type": "approval_request", "timestamp": TS, "payload": {}},
+        [_ev("approval_request")],
+        realistic=False,
+    ),
+    Fixture(
+        "approval_decision_is_defensive",
+        {"type": "approval_decision", "timestamp": TS, "payload": {}},
+        [_ev("approval_decision")],
+        realistic=False,
+    ),
+]
+
+# --------------------------------------------------------------------------- #
+# OpenClaw
+# --------------------------------------------------------------------------- #
+
+OPENCLAW_CORPUS: list[Fixture] = [
+    Fixture(
+        "session_header_emits_session_open",
+        {"type": "session", "timestamp": TS, "cwd": "/x"},
+        [_ev("session_open")],
+    ),
+    Fixture(
+        "compaction_entry",
+        {"type": "compaction", "timestamp": TS},
+        [_ev("compaction", lossiness="compacted")],
+    ),
+    Fixture(
+        "message_user_string_content",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {"role": "user", "content": "hi"},
+        },
+        [_ev("user_message")],
+    ),
+    Fixture(
+        "message_user_list_with_text",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {
+                "role": "user",
+                "content": [{"type": "text", "text": "hi"}],
+            },
+        },
+        [_ev("user_message")],
+    ),
+    Fixture(
+        "message_user_list_without_text_is_schema_unknown",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {"role": "user", "content": [{"type": "image"}]},
+        },
+        [_schema_unknown()],
+    ),
+    Fixture(
+        "message_assistant_text",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "text", "text": "answer"}],
+            },
+        },
+        [_ev("assistant_message")],
+    ),
+    Fixture(
+        "message_assistant_thinking",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "thinking", "thinking": "reasoning"}],
+            },
+        },
+        [_ev("assistant_message")],
+    ),
+    Fixture(
+        "message_assistant_toolcall_read",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "toolCall", "id": "tc-1", "name": "read_file"}
+                ],
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:tc-1"),
+            _ev("file_read", event_key="file_read:tc-1"),
+        ],
+    ),
+    Fixture(
+        "message_assistant_toolcall_write",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "toolCall", "id": "tc-2", "name": "write_file"}],
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:tc-2"),
+            _ev("file_write", event_key="file_write:tc-2"),
+        ],
+    ),
+    Fixture(
+        "message_assistant_toolcall_shell",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "toolCall", "id": "tc-3", "name": "bash"}],
+            },
+        },
+        [
+            _ev("tool_call", event_key="tool_call:tc-3"),
+            _ev("command_start", event_key="command_start:tc-3"),
+        ],
+    ),
+    Fixture(
+        "message_assistant_toolcall_unknown_tool",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "toolCall", "id": "tc-4", "name": "glob"}],
+            },
+        },
+        [_ev("tool_call", event_key="tool_call:tc-4")],
+    ),
+    Fixture(
+        "message_assistant_text_plus_toolcall",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "reading"},
+                    {"type": "toolCall", "id": "tc-5", "name": "read_file"},
+                ],
+            },
+        },
+        [
+            _ev("assistant_message"),
+            _ev("tool_call", event_key="tool_call:tc-5"),
+            _ev("file_read", event_key="file_read:tc-5"),
+        ],
+    ),
+    Fixture(
+        "message_toolresult_with_id",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {"role": "toolResult", "toolCallId": "tc-1"},
+        },
+        [_ev("tool_result", event_key="tool_result:tc-1")],
+    ),
+    Fixture(
+        "message_toolresult_without_id",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {"role": "toolResult"},
+        },
+        [_ev("tool_result", event_key=None)],
+    ),
+    Fixture(
+        "message_bashexecution_full",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {
+                "role": "bashExecution",
+                "command": "ls",
+                "output": "a\nb\n",
+                "exitCode": 0,
+            },
+        },
+        [
+            _ev("command_start"),
+            _ev("stdout_chunk", confidence="low", lossiness="unknown"),
+            _ev("command_exit"),
+        ],
+    ),
+    Fixture(
+        "message_bashexecution_no_output",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {"role": "bashExecution", "command": "ls", "exitCode": 0},
+        },
+        [_ev("command_start"), _ev("command_exit")],
+    ),
+    Fixture(
+        "message_bashexecution_exit_only",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {"role": "bashExecution", "exitCode": 1},
+        },
+        [_ev("command_exit")],
+    ),
+    Fixture(
+        "message_unknown_role_is_schema_unknown",
+        {
+            "type": "message",
+            "timestamp": TS,
+            "message": {"role": "system", "content": "x"},
+        },
+        [_schema_unknown()],
+    ),
+    Fixture(
+        "unknown_entry_type_is_schema_unknown",
+        {"type": "telemetry", "timestamp": TS},
+        [_schema_unknown()],
+    ),
+    Fixture(
+        "session_close_entry_is_defensive",
+        {"type": "session_close", "timestamp": TS},
+        [_ev("session_close")],
+        realistic=False,
+    ),
+    Fixture(
+        "approval_request_is_defensive",
+        {"type": "approval_request", "timestamp": TS},
+        [_ev("approval_request")],
+        realistic=False,
+    ),
+    Fixture(
+        "approval_decision_is_defensive",
+        {"type": "approval_decision", "timestamp": TS},
+        [_ev("approval_decision")],
+        realistic=False,
+    ),
+]
+
+
+ALL_CORPORA: dict[str, list[Fixture]] = {
+    "claude": CLAUDE_CORPUS,
+    "codex": CODEX_CORPUS,
+    "openclaw": OPENCLAW_CORPUS,
+}

--- a/tests/events/test_classify.py
+++ b/tests/events/test_classify.py
@@ -1,0 +1,111 @@
+import pytest
+
+from clawjournal.events.classify import classify_line
+from clawjournal.events.types import (
+    EVENT_TYPE_SET,
+    ClassifiedEvent,
+    validate_classified_event,
+)
+
+
+def test_claude_assistant_tool_use_emits_assistant_and_tool_events():
+    line = {
+        "type": "assistant",
+        "timestamp": "2026-04-20T10:00:00.000Z",
+        "message": {
+            "content": [
+                {"type": "text", "text": "Reading the file."},
+                {
+                    "type": "tool_use",
+                    "id": "tu-1",
+                    "name": "Read",
+                    "input": {"file_path": "/tmp/demo.py"},
+                },
+            ]
+        },
+    }
+
+    events = classify_line("claude", line)
+    assert [event.type for event in events] == [
+        "assistant_message",
+        "tool_call",
+        "file_read",
+    ]
+    assert all(event.type in EVENT_TYPE_SET for event in events)
+
+
+def test_codex_unknown_payload_becomes_schema_unknown():
+    line = {
+        "type": "event_msg",
+        "timestamp": "2026-04-20T10:00:00.000Z",
+        "payload": {"type": "token_count", "info": {"total": 1}},
+    }
+
+    events = classify_line("codex", line)
+    assert len(events) == 1
+    assert events[0].type == "schema_unknown"
+
+
+def test_codex_function_call_output_with_exit_code_emits_command_exit():
+    line = {
+        "type": "response_item",
+        "timestamp": "2026-04-20T10:00:00.000Z",
+        "payload": {
+            "type": "function_call_output",
+            "call_id": "call-x",
+            "output": "Exit code: 0\nWall time: 0 seconds\nOutput:\nfoo.py\n",
+        },
+    }
+
+    events = classify_line("codex", line)
+    assert [event.type for event in events] == ["tool_result", "command_exit"]
+    assert [event.event_key for event in events] == [
+        "tool_result:call-x",
+        "command_exit:call-x",
+    ]
+
+
+def test_openclaw_session_header_is_session_open():
+    line = {
+        "type": "session",
+        "timestamp": "2026-04-20T10:00:00.000Z",
+        "cwd": "/Users/test/repo",
+    }
+
+    events = classify_line("openclaw", line)
+    assert len(events) == 1
+    assert events[0].type == "session_open"
+
+
+def test_validate_classified_event_rejects_unlisted_type():
+    bogus = ClassifiedEvent(
+        type="totally_made_up",
+        event_at=None,
+        event_key=None,
+        confidence="high",
+        lossiness="none",
+    )
+    with pytest.raises(ValueError, match="Unsupported event type"):
+        validate_classified_event(bogus)
+
+
+def test_validate_classified_event_rejects_unlisted_confidence_and_lossiness():
+    bad_confidence = ClassifiedEvent(
+        type="user_message",
+        event_at=None,
+        event_key=None,
+        confidence="certain",
+        lossiness="none",
+    )
+    with pytest.raises(ValueError, match="confidence"):
+        validate_classified_event(bad_confidence)
+
+    bad_lossiness = ClassifiedEvent(
+        type="user_message",
+        event_at=None,
+        event_key=None,
+        confidence="high",
+        lossiness="mangled",
+    )
+    with pytest.raises(ValueError, match="lossiness"):
+        validate_classified_event(bad_lossiness)

--- a/tests/events/test_classify_claude.py
+++ b/tests/events/test_classify_claude.py
@@ -1,0 +1,32 @@
+"""Exact-match classifier tests for the claude event pipeline.
+
+Every branch in clawjournal/events/classify/claude.py has at least one
+fixture in CLAUDE_CORPUS. Each fixture pins the full event sequence
+the classifier emits for that vendor line.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clawjournal.events.classify import classify_line
+
+from ._fixtures import CLAUDE_CORPUS, ExpectedEvent, Fixture
+
+
+@pytest.mark.parametrize(
+    "fixture", CLAUDE_CORPUS, ids=[f.name for f in CLAUDE_CORPUS]
+)
+def test_claude_classifier_emits_expected_event_sequence(fixture: Fixture):
+    events = classify_line("claude", fixture.line)
+    actual = [
+        ExpectedEvent(
+            type=event.type,
+            event_key=event.event_key,
+            event_at=event.event_at,
+            confidence=event.confidence,
+            lossiness=event.lossiness,
+        )
+        for event in events
+    ]
+    assert actual == fixture.expected

--- a/tests/events/test_classify_codex.py
+++ b/tests/events/test_classify_codex.py
@@ -1,0 +1,27 @@
+"""Exact-match classifier tests for the codex event pipeline."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawjournal.events.classify import classify_line
+
+from ._fixtures import CODEX_CORPUS, ExpectedEvent, Fixture
+
+
+@pytest.mark.parametrize(
+    "fixture", CODEX_CORPUS, ids=[f.name for f in CODEX_CORPUS]
+)
+def test_codex_classifier_emits_expected_event_sequence(fixture: Fixture):
+    events = classify_line("codex", fixture.line)
+    actual = [
+        ExpectedEvent(
+            type=event.type,
+            event_key=event.event_key,
+            event_at=event.event_at,
+            confidence=event.confidence,
+            lossiness=event.lossiness,
+        )
+        for event in events
+    ]
+    assert actual == fixture.expected

--- a/tests/events/test_classify_openclaw.py
+++ b/tests/events/test_classify_openclaw.py
@@ -1,0 +1,27 @@
+"""Exact-match classifier tests for the openclaw event pipeline."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawjournal.events.classify import classify_line
+
+from ._fixtures import OPENCLAW_CORPUS, ExpectedEvent, Fixture
+
+
+@pytest.mark.parametrize(
+    "fixture", OPENCLAW_CORPUS, ids=[f.name for f in OPENCLAW_CORPUS]
+)
+def test_openclaw_classifier_emits_expected_event_sequence(fixture: Fixture):
+    events = classify_line("openclaw", fixture.line)
+    actual = [
+        ExpectedEvent(
+            type=event.type,
+            event_key=event.event_key,
+            event_at=event.event_at,
+            confidence=event.confidence,
+            lossiness=event.lossiness,
+        )
+        for event in events
+    ]
+    assert actual == fixture.expected

--- a/tests/events/test_ingest.py
+++ b/tests/events/test_ingest.py
@@ -1,0 +1,481 @@
+import json
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+from clawjournal.capture.cursors import Cursor, ensure_schema, list_cursors, set_cursor
+from clawjournal.events.ingest import EVENT_CONSUMER_ID, ingest_pending
+from clawjournal.events.schema import ensure_schema as ensure_event_schema
+from clawjournal.workbench.index import open_index
+
+
+def _patch_db(monkeypatch, tmp_path):
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+    monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "config")
+    monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / "config")
+
+
+def _patch_sources(monkeypatch, tmp_path):
+    from clawjournal.parsing import parser
+
+    monkeypatch.setattr(parser, "PROJECTS_DIR", tmp_path / "claude" / "projects")
+    monkeypatch.setattr(parser, "CODEX_SESSIONS_DIR", tmp_path / "codex" / "sessions")
+    monkeypatch.setattr(parser, "CODEX_ARCHIVED_DIR", tmp_path / "codex" / "archived_sessions")
+    monkeypatch.setattr(parser, "LOCAL_AGENT_DIR", tmp_path / "local_agent")
+    monkeypatch.setattr(parser, "OPENCLAW_AGENTS_DIR", tmp_path / "openclaw" / "agents")
+
+
+def test_ingest_records_offsets_and_raw_json(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    session_file = tmp_path / "claude" / "projects" / "demo-project" / "sess-1.jsonl"
+    session_file.parent.mkdir(parents=True)
+    line_1 = {
+        "type": "assistant",
+        "timestamp": "2026-04-20T10:00:00.000Z",
+        "version": "1.2.3",
+        "message": {
+            "content": [
+                {"type": "text", "text": "Reading the file."},
+                {
+                    "type": "tool_use",
+                    "id": "tu-1",
+                    "name": "Read",
+                    "input": {"file_path": "/tmp/demo.py"},
+                },
+            ]
+        },
+    }
+    line_2 = {
+        "type": "user",
+        "timestamp": "2026-04-20T10:00:01.000Z",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "tu-1",
+                    "content": "print('demo')",
+                }
+            ]
+        },
+    }
+    session_file.write_text(
+        json.dumps(line_1) + "\n" + json.dumps(line_2) + "\n",
+        encoding="utf-8",
+    )
+
+    conn = open_index()
+    try:
+        now = datetime.fromtimestamp(session_file.stat().st_mtime, tz=timezone.utc)
+        summary = ingest_pending(conn, source_filter="claude", now=now)
+        assert summary.to_dict()["event_rows"] == 4
+
+        rows = conn.execute(
+            """
+            SELECT type, source_offset, seq, raw_json
+              FROM events
+             ORDER BY source_offset, seq
+            """
+        ).fetchall()
+        assert [row["type"] for row in rows] == [
+            "assistant_message",
+            "tool_call",
+            "file_read",
+            "tool_result",
+        ]
+        first_line_offset = 0
+        second_line_offset = len(json.dumps(line_1).encode("utf-8")) + 1
+        assert [row["source_offset"] for row in rows] == [
+            first_line_offset,
+            first_line_offset,
+            first_line_offset,
+            second_line_offset,
+        ]
+        assert [row["seq"] for row in rows] == [0, 1, 2, 0]
+        assert json.loads(rows[0]["raw_json"]) == line_1
+
+        session_row = conn.execute(
+            "SELECT session_key, client, client_version, status FROM event_sessions"
+        ).fetchone()
+        assert session_row["session_key"] == "claude:demo-project:sess-1"
+        assert session_row["client"] == "claude"
+        assert session_row["client_version"] == "1.2.3"
+        assert session_row["status"] == "active"
+    finally:
+        conn.close()
+
+
+def test_ingest_is_idempotent_and_keeps_scanner_cursor(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    session_file = tmp_path / "claude" / "projects" / "demo-project" / "sess-2.jsonl"
+    session_file.parent.mkdir(parents=True)
+    session_file.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "timestamp": "2026-04-20T10:00:00.000Z",
+                "message": {"content": "Hello"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    conn = open_index()
+    try:
+        ensure_schema(conn)
+        set_cursor(
+            conn,
+            Cursor(
+                consumer_id="scanner",
+                source_path=str(session_file),
+                inode=1,
+                last_offset=0,
+                last_modified=0.0,
+                client="claude",
+            ),
+        )
+        conn.commit()
+
+        now = datetime.fromtimestamp(session_file.stat().st_mtime, tz=timezone.utc)
+        ingest_pending(conn, source_filter="claude", now=now)
+        first_count = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+        assert first_count == 1
+
+        ingest_pending(conn, source_filter="claude", now=now)
+        second_count = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+        assert second_count == first_count
+
+        cursors = list_cursors(conn)
+        assert {(cursor.consumer_id, cursor.source_path) for cursor in cursors} == {
+            ("scanner", str(session_file)),
+            (EVENT_CONSUMER_ID, str(session_file)),
+        }
+    finally:
+        conn.close()
+
+
+def test_idle_session_is_marked_ended_on_later_unchanged_poll(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    session_file = tmp_path / "claude" / "projects" / "demo-project" / "sess-idle.jsonl"
+    session_file.parent.mkdir(parents=True)
+    session_file.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "timestamp": "2026-04-20T10:00:00.000Z",
+                "message": {"content": "Hello"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    conn = open_index()
+    try:
+        fresh_now = datetime.fromtimestamp(session_file.stat().st_mtime, tz=timezone.utc)
+        ingest_pending(conn, source_filter="claude", now=fresh_now)
+        status = conn.execute(
+            "SELECT status FROM event_sessions WHERE session_key = 'claude:demo-project:sess-idle'"
+        ).fetchone()[0]
+        assert status == "active"
+
+        stale_now = fresh_now + timedelta(hours=2)
+        ingest_pending(conn, source_filter="claude", now=stale_now)
+        status = conn.execute(
+            "SELECT status FROM event_sessions WHERE session_key = 'claude:demo-project:sess-idle'"
+        ).fetchone()[0]
+        assert status == "ended"
+    finally:
+        conn.close()
+
+
+def test_native_and_local_agent_converge_on_one_event_session(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    native_file = tmp_path / "claude" / "projects" / "-Users-me-ws" / "dup.jsonl"
+    native_file.parent.mkdir(parents=True)
+    native_file.write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "timestamp": "2026-04-20T10:00:00.000Z",
+                "message": {"content": "From native"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    workspace = (
+        tmp_path
+        / "local_agent"
+        / "11111111-2222-3333-4444-555555555555"
+        / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+    )
+    workspace.mkdir(parents=True)
+    wrapper = workspace / "local_dup.json"
+    wrapper.write_text(
+        json.dumps(
+            {
+                "cliSessionId": "dup",
+                "sessionId": "sess-dup",
+                "processName": "demo",
+                "userSelectedFolders": ["/Users/me/ws"],
+            }
+        ),
+        encoding="utf-8",
+    )
+    transcript_dir = wrapper.with_suffix("") / ".claude" / "projects" / "-sessions-demo"
+    transcript_dir.mkdir(parents=True)
+    (transcript_dir / "dup.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "user",
+                "timestamp": "2026-04-20T10:00:01.000Z",
+                "message": {"content": "From local agent"},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    conn = open_index()
+    try:
+        now = datetime.now(timezone.utc)
+        summary = ingest_pending(conn, source_filter="claude", now=now)
+        assert summary.to_dict()["event_rows"] == 2
+
+        session_rows = conn.execute(
+            "SELECT session_key FROM event_sessions ORDER BY session_key"
+        ).fetchall()
+        assert [row["session_key"] for row in session_rows] == [
+            "claude:-Users-me-ws:dup"
+        ]
+        assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 2
+    finally:
+        conn.close()
+
+
+def test_unparseable_line_stored_with_wrapper(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    session_file = tmp_path / "claude" / "projects" / "demo-project" / "junk.jsonl"
+    session_file.parent.mkdir(parents=True)
+    good_line = {
+        "type": "user",
+        "timestamp": "2026-04-20T10:00:00.000Z",
+        "message": {"content": "Hi"},
+    }
+    bad_line = "this is not json at all {{{"
+    session_file.write_bytes(
+        (json.dumps(good_line) + "\n" + bad_line + "\n").encode("utf-8")
+    )
+
+    conn = open_index()
+    try:
+        now = datetime.fromtimestamp(session_file.stat().st_mtime, tz=timezone.utc)
+        ingest_pending(conn, source_filter="claude", now=now)
+
+        rows = conn.execute(
+            """
+            SELECT type, confidence, lossiness, raw_json, seq
+              FROM events
+             ORDER BY source_offset, seq
+            """
+        ).fetchall()
+        assert len(rows) == 2
+        assert rows[0]["type"] == "user_message"
+
+        unparseable = rows[1]
+        assert unparseable["type"] == "schema_unknown"
+        assert unparseable["confidence"] == "low"
+        assert unparseable["lossiness"] == "unknown"
+        assert unparseable["seq"] == 0
+        wrapper = json.loads(unparseable["raw_json"])
+        assert wrapper == {"_unparseable": True, "raw_text": bad_line}
+    finally:
+        conn.close()
+
+
+def test_rooted_subagent_tool_call_lands_on_root_session(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    project_dir = tmp_path / "claude" / "projects" / "demo-project"
+    project_dir.mkdir(parents=True)
+
+    root_uuid = "11111111-2222-3333-4444-555555555555"
+    root_file = project_dir / f"{root_uuid}.jsonl"
+    rooted_subagent_tool_call = {
+        "type": "assistant",
+        "timestamp": "2026-04-20T10:00:00.000Z",
+        "message": {
+            "content": [
+                {
+                    "type": "tool_use",
+                    "id": "tu-rooted",
+                    "name": "Read",
+                    "input": {"file_path": "/tmp/rooted.py"},
+                }
+            ]
+        },
+    }
+    root_file.write_text(json.dumps(rooted_subagent_tool_call) + "\n", encoding="utf-8")
+
+    sidecar = project_dir / root_uuid / "subagents"
+    sidecar.mkdir(parents=True)
+    (sidecar / "agent-1.jsonl").write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-04-20T10:00:01.000Z",
+                "message": {
+                    "content": [{"type": "text", "text": "subagent-only ghost"}]
+                },
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    conn = open_index()
+    try:
+        now = datetime.fromtimestamp(root_file.stat().st_mtime, tz=timezone.utc)
+        ingest_pending(conn, source_filter="claude", now=now)
+
+        session_rows = conn.execute(
+            "SELECT session_key FROM event_sessions ORDER BY session_key"
+        ).fetchall()
+        assert [row["session_key"] for row in session_rows] == [
+            f"claude:demo-project:{root_uuid}"
+        ]
+
+        event_paths = {
+            row["source_path"]
+            for row in conn.execute("SELECT DISTINCT source_path FROM events").fetchall()
+        }
+        assert event_paths == {str(root_file)}
+
+        tool_call_rows = conn.execute(
+            """
+            SELECT events.event_key, event_sessions.session_key
+              FROM events
+              JOIN event_sessions ON event_sessions.id = events.session_id
+             WHERE events.type = 'tool_call'
+            """
+        ).fetchall()
+        assert len(tool_call_rows) == 1
+        assert tool_call_rows[0]["event_key"] == "tool_call:tu-rooted"
+        assert tool_call_rows[0]["session_key"] == f"claude:demo-project:{root_uuid}"
+    finally:
+        conn.close()
+
+
+def test_parent_link_backfills_when_parent_arrives_later(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    child_file = (
+        tmp_path / "claude" / "projects" / "demo-project" / "child" / "subagents" / "agent-1.jsonl"
+    )
+    child_file.parent.mkdir(parents=True)
+    child_file.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-04-20T10:00:00.000Z",
+                "parentSessionId": "parent",
+                "message": {"content": [{"type": "text", "text": "Child trace"}]},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    conn = open_index()
+    try:
+        child_now = datetime.fromtimestamp(child_file.stat().st_mtime, tz=timezone.utc)
+        ingest_pending(conn, source_filter="claude", now=child_now)
+        child_row = conn.execute(
+            """
+            SELECT parent_session_key, parent_session_id
+              FROM event_sessions
+             WHERE session_key = 'claude:demo-project:child'
+            """
+        ).fetchone()
+        assert child_row["parent_session_key"] == "claude:demo-project:parent"
+        assert child_row["parent_session_id"] is None
+
+        parent_file = tmp_path / "claude" / "projects" / "demo-project" / "parent.jsonl"
+        parent_file.write_text(
+            json.dumps(
+                {
+                    "type": "user",
+                    "timestamp": "2026-04-20T10:00:01.000Z",
+                    "message": {"content": "Parent trace"},
+                }
+            )
+            + "\n",
+            encoding="utf-8",
+        )
+        parent_now = datetime.fromtimestamp(parent_file.stat().st_mtime, tz=timezone.utc)
+        ingest_pending(conn, source_filter="claude", now=parent_now)
+
+        child_parent_id = conn.execute(
+            """
+            SELECT child.parent_session_id
+              FROM event_sessions AS child
+             WHERE child.session_key = 'claude:demo-project:child'
+            """
+        ).fetchone()[0]
+        parent_id = conn.execute(
+            """
+            SELECT id
+              FROM event_sessions
+             WHERE session_key = 'claude:demo-project:parent'
+            """
+        ).fetchone()[0]
+        assert child_parent_id == parent_id
+    finally:
+        conn.close()
+
+
+def test_event_schema_migrates_older_event_sessions_table(tmp_path):
+    db_path = tmp_path / "index.db"
+    conn = sqlite3.connect(db_path)
+    try:
+        conn.execute(
+            """
+            CREATE TABLE event_sessions (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_key TEXT NOT NULL UNIQUE,
+                parent_session_id INTEGER,
+                client TEXT NOT NULL,
+                client_version TEXT,
+                started_at TEXT,
+                ended_at TEXT,
+                status TEXT NOT NULL DEFAULT 'active'
+            )
+            """
+        )
+        conn.commit()
+
+        ensure_event_schema(conn)
+
+        columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(event_sessions)")
+        }
+        assert "parent_session_key" in columns
+        indexes = {
+            row[1] for row in conn.execute("PRAGMA index_list(event_sessions)")
+        }
+        assert "idx_event_sessions_parent_key" in indexes
+    finally:
+        conn.close()

--- a/tests/events/test_invariants.py
+++ b/tests/events/test_invariants.py
@@ -1,0 +1,607 @@
+"""Tier-1 invariant tests for the execution recorder.
+
+These tests pin the plan's core guarantees independently of classifier
+branch coverage: raw-JSON round-trip, classifier ↔ capability-matrix
+agreement, summary accuracy vs. the DB, monotonic session upsert,
+multi-batch append idempotency, and byte-accurate per-line offsets
+under multibyte UTF-8.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+from clawjournal.events.capabilities import CAPABILITY_MATRIX
+from clawjournal.events.classify import classify_line
+from clawjournal.events.ingest import ingest_pending
+from clawjournal.workbench.index import open_index
+
+
+# Timestamps chosen so input == normalized output (no trailing zero
+# fractions to be stripped by datetime.isoformat).
+TS0 = "2026-04-20T10:00:00Z"
+TS1 = "2026-04-20T10:00:01Z"
+TS2 = "2026-04-20T10:00:02Z"
+TS3 = "2026-04-20T10:00:03Z"
+
+
+def _patch_db(monkeypatch, tmp_path):
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+    monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "config")
+    monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / "config")
+
+
+def _patch_sources(monkeypatch, tmp_path):
+    from clawjournal.parsing import parser
+
+    monkeypatch.setattr(parser, "PROJECTS_DIR", tmp_path / "claude" / "projects")
+    monkeypatch.setattr(parser, "CODEX_SESSIONS_DIR", tmp_path / "codex" / "sessions")
+    monkeypatch.setattr(
+        parser, "CODEX_ARCHIVED_DIR", tmp_path / "codex" / "archived_sessions"
+    )
+    monkeypatch.setattr(parser, "LOCAL_AGENT_DIR", tmp_path / "local_agent")
+    monkeypatch.setattr(parser, "OPENCLAW_AGENTS_DIR", tmp_path / "openclaw" / "agents")
+
+
+def _write_claude_session(tmp_path, project, name, lines):
+    path = tmp_path / "claude" / "projects" / project / f"{name}.jsonl"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(
+        ("\n".join(json.dumps(line) for line in lines) + "\n").encode("utf-8")
+    )
+    return path
+
+
+def _append_claude_session(path, lines):
+    with path.open("ab") as f:
+        f.write(
+            ("\n".join(json.dumps(line) for line in lines) + "\n").encode("utf-8")
+        )
+
+
+def _now_from(path):
+    return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc)
+
+
+# --------------------------------------------------------------------------- #
+# Raw-JSON round-trip
+# --------------------------------------------------------------------------- #
+
+
+def test_raw_json_roundtrip_preserves_vendor_content(monkeypatch, tmp_path):
+    """For every parseable line, json.loads(raw_json) must equal the
+    original parsed dict — 02 never filters vendor content."""
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    fixtures = [
+        {
+            "type": "assistant",
+            "timestamp": TS0,
+            "version": "1.2.3",
+            "message": {
+                "content": [
+                    {"type": "text", "text": "hello"},
+                    {
+                        "type": "tool_use",
+                        "id": "t-1",
+                        "name": "Read",
+                        "input": {
+                            "path": "/a/b/c",
+                            "meta": {"deep": {"nested": [1, 2, 3], "flag": True}},
+                        },
+                    },
+                ],
+                "extras": {"null_value": None, "false_value": False, "float": 0.5},
+            },
+        },
+        {
+            "type": "user",
+            "timestamp": TS1,
+            "message": {"content": "你好 🙂 مرحبا שלום"},
+        },
+        {
+            "type": "user",
+            "timestamp": TS2,
+            "message": {"content": [], "tags": {}},
+        },
+        {
+            "type": "user",
+            "timestamp": TS3,
+            "message": {
+                "content": "numbers",
+                "big_int": 2**53,
+                "neg_float": -1.5e-10,
+                "unicode_key_é": "ok",
+            },
+        },
+    ]
+
+    path = _write_claude_session(tmp_path, "demo-project", "roundtrip", fixtures)
+
+    conn = open_index()
+    try:
+        ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        rows = conn.execute(
+            """
+            SELECT DISTINCT source_offset, raw_json
+              FROM events
+             ORDER BY source_offset
+            """
+        ).fetchall()
+        assert len(rows) == len(fixtures)
+        for row, fixture in zip(rows, fixtures):
+            assert json.loads(row["raw_json"]) == fixture
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# Classifier ↔ capability-matrix agreement
+# --------------------------------------------------------------------------- #
+
+
+_CLAUDE_CORPUS = [
+    {"type": "user", "timestamp": TS0, "message": {"content": "plain text"}},
+    {
+        "type": "user",
+        "timestamp": TS0,
+        "message": {
+            "content": [
+                {"type": "tool_result", "tool_use_id": "tu-1", "content": "ok"}
+            ]
+        },
+    },
+    {
+        "type": "assistant",
+        "timestamp": TS0,
+        "message": {
+            "content": [
+                {"type": "text", "text": "calling a tool"},
+                {"type": "tool_use", "id": "tu-2", "name": "Read", "input": {}},
+            ]
+        },
+    },
+    {
+        "type": "assistant",
+        "timestamp": TS0,
+        "message": {
+            "content": [
+                {"type": "tool_use", "id": "tu-3", "name": "Write", "input": {}},
+            ]
+        },
+    },
+    {
+        "type": "assistant",
+        "timestamp": TS0,
+        "message": {
+            "content": [
+                {"type": "tool_use", "id": "tu-4", "name": "Bash", "input": {}},
+            ]
+        },
+    },
+    # NOTE: approval_request/decision are in the plan's `type` vocabulary
+    # but no real Claude JSONL line carries them today. Classifier has
+    # defensive branches for them; intentionally not exercised here so
+    # this test pins the realistic-vendor-input surface. If future
+    # fixtures add an approval line and this test fails, either add
+    # (claude, approval_*) to the capability matrix or drop the dead
+    # classifier branch.
+]
+
+_CODEX_CORPUS = [
+    {"type": "session_meta", "timestamp": TS0, "payload": {"version": "0.7"}},
+    {
+        "type": "response_item",
+        "timestamp": TS0,
+        "payload": {
+            "type": "function_call",
+            "name": "shell",
+            "call_id": "c-1",
+            "arguments": "{}",
+        },
+    },
+    {
+        "type": "response_item",
+        "timestamp": TS0,
+        "payload": {
+            "type": "function_call_output",
+            "call_id": "c-1",
+            "output": "ok",
+        },
+    },
+    {
+        "type": "response_item",
+        "timestamp": TS0,
+        "payload": {"type": "reasoning", "summary": "thinking…"},
+    },
+    {
+        "type": "event_msg",
+        "timestamp": TS0,
+        "payload": {"type": "user_message", "message": "hi"},
+    },
+    {
+        "type": "event_msg",
+        "timestamp": TS0,
+        "payload": {"type": "agent_message", "message": "hello"},
+    },
+    {
+        "type": "event_msg",
+        "timestamp": TS0,
+        "payload": {"type": "agent_reasoning", "text": "…"},
+    },
+]
+
+_OPENCLAW_CORPUS = [
+    {"type": "session", "timestamp": TS0, "cwd": "/x/y"},
+    {
+        "type": "message",
+        "timestamp": TS0,
+        "message": {"role": "user", "content": "hi"},
+    },
+    {
+        "type": "message",
+        "timestamp": TS0,
+        "message": {
+            "role": "assistant",
+            "content": [
+                {"type": "text", "text": "response"},
+                {"type": "toolCall", "id": "tc-1", "name": "read_file"},
+            ],
+        },
+    },
+    {
+        "type": "message",
+        "timestamp": TS0,
+        "message": {"role": "toolResult", "toolCallId": "tc-1"},
+    },
+    {
+        "type": "message",
+        "timestamp": TS0,
+        "message": {
+            "role": "bashExecution",
+            "command": "ls",
+            "output": "a\nb\n",
+            "exitCode": 0,
+        },
+    },
+]
+
+
+def test_classifier_never_emits_type_that_matrix_marks_unsupported():
+    """Every (client, type) a classifier emits for a realistic vendor
+    line must appear in CAPABILITY_MATRIX with supported=True. Guards
+    against drift where a classifier path starts emitting a type the
+    matrix doesn't know about."""
+    corpora = {
+        "claude": _CLAUDE_CORPUS,
+        "codex": _CODEX_CORPUS,
+        "openclaw": _OPENCLAW_CORPUS,
+    }
+    drift: list[tuple[str, str, dict]] = []
+    for client, lines in corpora.items():
+        for line in lines:
+            events = classify_line(client, line)
+            for event in events:
+                supported, _reason = CAPABILITY_MATRIX.get(
+                    (client, event.type), (False, "missing")
+                )
+                if not supported:
+                    drift.append((client, event.type, line))
+
+    assert not drift, (
+        "Classifier emitted types the capability matrix marks unsupported: "
+        f"{[(client, event_type) for client, event_type, _ in drift]}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Summary accuracy
+# --------------------------------------------------------------------------- #
+
+
+def test_summary_event_rows_equals_db_count_on_first_ingest(monkeypatch, tmp_path):
+    """summary.event_rows must match COUNT(*) from events after a fresh
+    ingest — if the two ever diverge, observability into the recorder is
+    broken."""
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    fixtures = [
+        {
+            "type": "assistant",
+            "timestamp": TS0,
+            "message": {
+                "content": [
+                    {"type": "text", "text": "calling"},
+                    {"type": "tool_use", "id": "t", "name": "Read", "input": {}},
+                ]
+            },
+        },
+        {"type": "user", "timestamp": TS1, "message": {"content": "hi"}},
+    ]
+    path = _write_claude_session(tmp_path, "demo-project", "summary", fixtures)
+
+    conn = open_index()
+    try:
+        summary = ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        db_count = conn.execute("SELECT COUNT(*) FROM events").fetchone()[0]
+        assert summary.to_dict()["event_rows"] == db_count
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# Monotonic event_sessions upsert
+# --------------------------------------------------------------------------- #
+
+
+def _select_session(conn, session_key):
+    return conn.execute(
+        """
+        SELECT session_key, client_version, started_at, ended_at, status
+          FROM event_sessions WHERE session_key = ?
+        """,
+        (session_key,),
+    ).fetchone()
+
+
+def test_started_at_only_decreases_across_batches(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    path = _write_claude_session(
+        tmp_path,
+        "demo-project",
+        "starts",
+        [{"type": "user", "timestamp": TS3, "message": {"content": "late"}}],
+    )
+
+    conn = open_index()
+    try:
+        ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        first = _select_session(conn, "claude:demo-project:starts")
+        assert first["started_at"] == TS3
+
+        _append_claude_session(
+            path,
+            [{"type": "user", "timestamp": TS1, "message": {"content": "earlier"}}],
+        )
+        ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        second = _select_session(conn, "claude:demo-project:starts")
+        assert second["started_at"] == TS1
+        assert second["ended_at"] == TS3  # unchanged — TS1 < TS3
+    finally:
+        conn.close()
+
+
+def test_ended_at_only_increases_across_batches(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    path = _write_claude_session(
+        tmp_path,
+        "demo-project",
+        "ends",
+        [{"type": "user", "timestamp": TS1, "message": {"content": "early"}}],
+    )
+
+    conn = open_index()
+    try:
+        ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        first = _select_session(conn, "claude:demo-project:ends")
+        assert first["ended_at"] == TS1
+
+        _append_claude_session(
+            path,
+            [{"type": "user", "timestamp": TS3, "message": {"content": "later"}}],
+        )
+        ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        second = _select_session(conn, "claude:demo-project:ends")
+        assert second["ended_at"] == TS3
+        assert second["started_at"] == TS1  # unchanged — TS3 > TS1
+    finally:
+        conn.close()
+
+
+def test_status_never_downgrades_from_ended(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    path = _write_claude_session(
+        tmp_path,
+        "demo-project",
+        "lifecycle",
+        [
+            {"type": "user", "timestamp": TS0, "message": {"content": "hi"}},
+            {"type": "session_close", "timestamp": TS1, "message": {}},
+        ],
+    )
+
+    conn = open_index()
+    try:
+        ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        assert _select_session(conn, "claude:demo-project:lifecycle")["status"] == "ended"
+
+        _append_claude_session(
+            path,
+            [{"type": "user", "timestamp": TS2, "message": {"content": "post-close"}}],
+        )
+        ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        assert (
+            _select_session(conn, "claude:demo-project:lifecycle")["status"] == "ended"
+        )
+    finally:
+        conn.close()
+
+
+def test_client_version_first_non_null_wins(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    # Batch 1: no version
+    path = _write_claude_session(
+        tmp_path,
+        "demo-project",
+        "version",
+        [{"type": "user", "timestamp": TS0, "message": {"content": "hi"}}],
+    )
+    conn = open_index()
+    try:
+        ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        assert (
+            _select_session(conn, "claude:demo-project:version")["client_version"]
+            is None
+        )
+
+        # Batch 2: version appears
+        _append_claude_session(
+            path,
+            [
+                {
+                    "type": "user",
+                    "timestamp": TS1,
+                    "version": "1.0.0",
+                    "message": {"content": "v1"},
+                }
+            ],
+        )
+        ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        assert (
+            _select_session(conn, "claude:demo-project:version")["client_version"]
+            == "1.0.0"
+        )
+
+        # Batch 3: different version — must NOT overwrite
+        _append_claude_session(
+            path,
+            [
+                {
+                    "type": "user",
+                    "timestamp": TS2,
+                    "version": "2.0.0",
+                    "message": {"content": "v2"},
+                }
+            ],
+        )
+        ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        assert (
+            _select_session(conn, "claude:demo-project:version")["client_version"]
+            == "1.0.0"
+        )
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# Multi-batch append
+# --------------------------------------------------------------------------- #
+
+
+def test_multi_batch_append_produces_no_duplicates(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    first_lines = [
+        {"type": "user", "timestamp": TS0, "message": {"content": "one"}},
+        {"type": "user", "timestamp": TS1, "message": {"content": "two"}},
+    ]
+    path = _write_claude_session(tmp_path, "demo-project", "append", first_lines)
+
+    conn = open_index()
+    try:
+        first = ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        assert first.to_dict()["batches"] == 1
+        assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 2
+
+        second_lines = [
+            {"type": "user", "timestamp": TS2, "message": {"content": "three"}},
+            {"type": "user", "timestamp": TS3, "message": {"content": "four"}},
+        ]
+        _append_claude_session(path, second_lines)
+
+        second = ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        assert second.to_dict()["batches"] == 1
+        assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 4
+
+        # Cursor landed at EOF for the events consumer.
+        end_offset, inode_now = path.stat().st_size, path.stat().st_ino
+        cursor_row = conn.execute(
+            "SELECT inode, last_offset FROM capture_cursors "
+            "WHERE consumer_id = 'events' AND source_path = ?",
+            (str(path),),
+        ).fetchone()
+        assert cursor_row["last_offset"] == end_offset
+        assert cursor_row["inode"] == inode_now
+
+        # Offsets form a strictly increasing sequence, one per line.
+        offsets = [
+            row[0]
+            for row in conn.execute(
+                "SELECT DISTINCT source_offset FROM events "
+                "WHERE source_path = ? ORDER BY source_offset",
+                (str(path),),
+            )
+        ]
+        assert offsets == sorted(offsets)
+        assert len(offsets) == 4
+
+        # A third poll with no changes is a no-op.
+        third = ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        assert third.to_dict()["batches"] == 0
+        assert conn.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 4
+    finally:
+        conn.close()
+
+
+# --------------------------------------------------------------------------- #
+# Multibyte UTF-8 offsets
+# --------------------------------------------------------------------------- #
+
+
+def test_source_offsets_are_byte_accurate_under_multibyte_utf8(
+    monkeypatch, tmp_path
+):
+    """Per-line source_offset is a byte offset, not a char offset — a
+    line containing multibyte UTF-8 (CJK + emoji + Arabic) must not
+    throw the following line's offset off."""
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    lines = [
+        {"type": "user", "timestamp": TS0, "message": {"content": "你好 🙂 مرحبا שלום"}},
+        {"type": "user", "timestamp": TS1, "message": {"content": "next line"}},
+        {"type": "user", "timestamp": TS2, "message": {"content": "three"}},
+    ]
+    path = _write_claude_session(tmp_path, "demo-project", "utf8", lines)
+    raw = path.read_bytes()
+    # Expected byte offsets = cumulative sum of "<json>\n" byte lengths.
+    expected_offsets: list[int] = []
+    running = 0
+    for line in lines:
+        expected_offsets.append(running)
+        running += len(json.dumps(line).encode("utf-8")) + 1  # +1 for \n
+    assert running == len(raw)  # fixture sanity
+
+    conn = open_index()
+    try:
+        ingest_pending(conn, source_filter="claude", now=_now_from(path))
+        rows = conn.execute(
+            "SELECT DISTINCT source_offset FROM events "
+            "WHERE source_path = ? ORDER BY source_offset",
+            (str(path),),
+        ).fetchall()
+        actual_offsets = [row["source_offset"] for row in rows]
+        assert actual_offsets == expected_offsets
+
+        # Also round-trip raw_json for the multibyte line — proves the
+        # offset slice aligns with the actual JSON boundary, not a
+        # garbled UTF-8 midpoint.
+        raw_json = conn.execute(
+            "SELECT raw_json FROM events WHERE source_offset = ? LIMIT 1",
+            (expected_offsets[0],),
+        ).fetchone()["raw_json"]
+        assert json.loads(raw_json) == lines[0]
+    finally:
+        conn.close()

--- a/tests/events/test_invariants.py
+++ b/tests/events/test_invariants.py
@@ -17,6 +17,8 @@ from clawjournal.events.classify import classify_line
 from clawjournal.events.ingest import ingest_pending
 from clawjournal.workbench.index import open_index
 
+from ._fixtures import ALL_CORPORA
+
 
 # Timestamps chosen so input == normalized output (no trailing zero
 # fractions to be stripped by datetime.isoformat).
@@ -142,157 +144,30 @@ def test_raw_json_roundtrip_preserves_vendor_content(monkeypatch, tmp_path):
 # --------------------------------------------------------------------------- #
 
 
-_CLAUDE_CORPUS = [
-    {"type": "user", "timestamp": TS0, "message": {"content": "plain text"}},
-    {
-        "type": "user",
-        "timestamp": TS0,
-        "message": {
-            "content": [
-                {"type": "tool_result", "tool_use_id": "tu-1", "content": "ok"}
-            ]
-        },
-    },
-    {
-        "type": "assistant",
-        "timestamp": TS0,
-        "message": {
-            "content": [
-                {"type": "text", "text": "calling a tool"},
-                {"type": "tool_use", "id": "tu-2", "name": "Read", "input": {}},
-            ]
-        },
-    },
-    {
-        "type": "assistant",
-        "timestamp": TS0,
-        "message": {
-            "content": [
-                {"type": "tool_use", "id": "tu-3", "name": "Write", "input": {}},
-            ]
-        },
-    },
-    {
-        "type": "assistant",
-        "timestamp": TS0,
-        "message": {
-            "content": [
-                {"type": "tool_use", "id": "tu-4", "name": "Bash", "input": {}},
-            ]
-        },
-    },
-    # NOTE: approval_request/decision are in the plan's `type` vocabulary
-    # but no real Claude JSONL line carries them today. Classifier has
-    # defensive branches for them; intentionally not exercised here so
-    # this test pins the realistic-vendor-input surface. If future
-    # fixtures add an approval line and this test fails, either add
-    # (claude, approval_*) to the capability matrix or drop the dead
-    # classifier branch.
-]
-
-_CODEX_CORPUS = [
-    {"type": "session_meta", "timestamp": TS0, "payload": {"version": "0.7"}},
-    {
-        "type": "response_item",
-        "timestamp": TS0,
-        "payload": {
-            "type": "function_call",
-            "name": "shell",
-            "call_id": "c-1",
-            "arguments": "{}",
-        },
-    },
-    {
-        "type": "response_item",
-        "timestamp": TS0,
-        "payload": {
-            "type": "function_call_output",
-            "call_id": "c-1",
-            "output": "ok",
-        },
-    },
-    {
-        "type": "response_item",
-        "timestamp": TS0,
-        "payload": {"type": "reasoning", "summary": "thinking…"},
-    },
-    {
-        "type": "event_msg",
-        "timestamp": TS0,
-        "payload": {"type": "user_message", "message": "hi"},
-    },
-    {
-        "type": "event_msg",
-        "timestamp": TS0,
-        "payload": {"type": "agent_message", "message": "hello"},
-    },
-    {
-        "type": "event_msg",
-        "timestamp": TS0,
-        "payload": {"type": "agent_reasoning", "text": "…"},
-    },
-]
-
-_OPENCLAW_CORPUS = [
-    {"type": "session", "timestamp": TS0, "cwd": "/x/y"},
-    {
-        "type": "message",
-        "timestamp": TS0,
-        "message": {"role": "user", "content": "hi"},
-    },
-    {
-        "type": "message",
-        "timestamp": TS0,
-        "message": {
-            "role": "assistant",
-            "content": [
-                {"type": "text", "text": "response"},
-                {"type": "toolCall", "id": "tc-1", "name": "read_file"},
-            ],
-        },
-    },
-    {
-        "type": "message",
-        "timestamp": TS0,
-        "message": {"role": "toolResult", "toolCallId": "tc-1"},
-    },
-    {
-        "type": "message",
-        "timestamp": TS0,
-        "message": {
-            "role": "bashExecution",
-            "command": "ls",
-            "output": "a\nb\n",
-            "exitCode": 0,
-        },
-    },
-]
-
-
 def test_classifier_never_emits_type_that_matrix_marks_unsupported():
     """Every (client, type) a classifier emits for a realistic vendor
-    line must appear in CAPABILITY_MATRIX with supported=True. Guards
-    against drift where a classifier path starts emitting a type the
-    matrix doesn't know about."""
-    corpora = {
-        "claude": _CLAUDE_CORPUS,
-        "codex": _CODEX_CORPUS,
-        "openclaw": _OPENCLAW_CORPUS,
-    }
-    drift: list[tuple[str, str, dict]] = []
-    for client, lines in corpora.items():
-        for line in lines:
-            events = classify_line(client, line)
+    line must appear in CAPABILITY_MATRIX with supported=True. Pulls
+    the full per-client corpora from _fixtures so every new realistic
+    fixture automatically widens the drift tripwire. Fixtures tagged
+    realistic=False (defensive branches for shapes no vendor emits
+    today) are skipped — if future work starts emitting those types,
+    flip them to realistic=True and the matrix will need an entry."""
+    drift: list[tuple[str, str, str]] = []
+    for client, corpus in ALL_CORPORA.items():
+        for fixture in corpus:
+            if not fixture.realistic:
+                continue
+            events = classify_line(client, fixture.line)
             for event in events:
                 supported, _reason = CAPABILITY_MATRIX.get(
                     (client, event.type), (False, "missing")
                 )
                 if not supported:
-                    drift.append((client, event.type, line))
+                    drift.append((client, event.type, fixture.name))
 
     assert not drift, (
         "Classifier emitted types the capability matrix marks unsupported: "
-        f"{[(client, event_type) for client, event_type, _ in drift]}"
+        f"{drift}"
     )
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -977,6 +977,54 @@ class TestWorkbenchSourceChoices:
         assert seen["source"] == "aider"
 
 
+class TestEventsCLI:
+    def test_events_capabilities_outputs_json(self, capsys):
+        with patch.object(sys, "argv", ["clawjournal", "events", "capabilities"]):
+            main()
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["claude"]["tool_call"]["supported"] is True
+        assert payload["codex"]["stdout_chunk"]["supported"] is False
+
+    def test_events_ingest_outputs_summary_json(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+        monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "config")
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / "config")
+
+        from clawjournal.parsing import parser
+
+        monkeypatch.setattr(parser, "PROJECTS_DIR", tmp_path / "claude" / "projects")
+        monkeypatch.setattr(parser, "CODEX_SESSIONS_DIR", tmp_path / "codex" / "sessions")
+        monkeypatch.setattr(parser, "CODEX_ARCHIVED_DIR", tmp_path / "codex" / "archived_sessions")
+        monkeypatch.setattr(parser, "LOCAL_AGENT_DIR", tmp_path / "local_agent")
+        monkeypatch.setattr(parser, "OPENCLAW_AGENTS_DIR", tmp_path / "openclaw" / "agents")
+
+        session_file = tmp_path / "claude" / "projects" / "demo-project" / "cli.jsonl"
+        session_file.parent.mkdir(parents=True)
+        session_file.write_text(
+            json.dumps(
+                {
+                    "type": "user",
+                    "timestamp": "2026-04-20T10:00:00.000Z",
+                    "message": {"content": "Hello from CLI"},
+                }
+            )
+            + "\n"
+        )
+
+        with patch.object(
+            sys,
+            "argv",
+            ["clawjournal", "events", "ingest", "--source", "claude", "--json"],
+        ):
+            main()
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["files_scanned"] == 1
+        assert payload["files_with_changes"] == 1
+        assert payload["event_rows"] == 1
+
+
 class TestShareHelpers:
     def test_share_preview_json_returns_payload(self):
         payload = _share_preview([{"session_id": "s1", "display_title": "hello", "risk_badges": "[]"}], output_json=True)


### PR DESCRIPTION
## Summary

Implements plan 02 — the execution recorder. Consumes the 01 capture adapter's line stream and persists every vendor JSONL line as an `events` row carrying the canonicalized raw JSON plus a small set of indexed columns (type, event_at, event_key, confidence, lossiness). Downstream consumers (04 cost ledger, 05 loop detector, 06 timeline, 07 bundle export) will read `raw_json` and extract fields at query time — the recorder does not normalize payloads.

- New module `clawjournal/events/` with per-client `classify()` + `session_meta()` for claude, codex, openclaw and a shared 17-entry `type` vocabulary.
- New tables `events` + `event_sessions` in `~/.clawjournal/index.db`. Append-only, idempotent via `UNIQUE(source, source_path, source_offset, seq)` + `INSERT OR IGNORE`. Session identity comes straight from 01's `SourceFile.session_key`, so native + local-agent Claude transcripts converge on one `event_sessions` row.
- Subagent-only Claude streams land as their own `event_sessions` row; parent links resolve inline when the parent exists, otherwise a backfill sweep resolves them once the parent ingests.
- `LineBatch` now carries per-line byte offsets so `events.source_offset` is exact without re-reading the file.
- CLI: `clawjournal events ingest` drains pending changes; `clawjournal events capabilities` dumps the `(client, event_type)` matrix as JSON.
- Commit protocol: sink-first (event_sessions upsert → events insert) in one transaction, cursor write in a short second transaction. Events consumer's cursor is independent of the workbench scanner's cursor.

Not wired into the workbench daemon yet — downstream stages (03+) will consume from here.

## Test plan
- [x] `pytest tests/events/` — 14 new tests (classifier pinning, vocabulary validation, per-line offsets, idempotency + scanner-cursor independence, native↔LA convergence, rooted-subagent containment, unparseable-line wrapper shape, subagent parent backfill).
- [x] `pytest tests/capture/test_changes.py` — extended to assert `line_offsets` on first-read, append, and partial-trailing-line cases.
- [x] `pytest tests/test_cli.py::TestEventsCLI` — CLI covers `events capabilities` JSON output and `events ingest --json` summary.
- [x] `pytest` — full suite green (1151 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)