### PR TITLE
feat(events): signal/confidence layer — overrides + canonical view

### DIFF
--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3198,6 +3198,19 @@ def main() -> None:
         "capabilities",
         help="Dump the execution-recorder capability matrix as JSON",
     )
+    events_inspect = events_sub.add_parser(
+        "inspect",
+        help="Inspect a single event, its vendor line, and any override",
+    )
+    events_inspect.add_argument(
+        "event_id",
+        nargs="?",
+        type=int,
+        help="events.id primary key (omit when using --session/--event-key)",
+    )
+    events_inspect.add_argument("--session", help="session_key (with --event-key)")
+    events_inspect.add_argument("--event-key", dest="event_key", help="event_key (with --session)")
+    events_inspect.add_argument("--json", action="store_true", help="Output structured JSON")
 
     # Workbench commands
     serve_parser = sub.add_parser("serve", help="Start the workbench daemon + web UI")
@@ -3867,6 +3880,10 @@ def _run_events(args) -> None:
         print(json.dumps(capabilities_json(), indent=2, sort_keys=True))
         return
 
+    if args.events_command == "inspect":
+        _run_events_inspect(args)
+        return
+
     conn = open_index()
     try:
         summary = ingest_pending(conn, source_filter=args.source)
@@ -3882,6 +3899,236 @@ def _run_events(args) -> None:
         f"{payload['files_with_changes']} changed files "
         f"({payload['lines_read']} lines, {payload['sessions_touched']} sessions)."
     )
+
+
+def _run_events_inspect(args) -> None:
+    from .events import CAPABILITY_MATRIX, ensure_view_schema, fetch_vendor_line
+    from .events.schema import ensure_schema as ensure_events_schema
+    from .workbench.index import open_index
+
+    has_id = args.event_id is not None
+    has_sk_ek = args.session is not None and args.event_key is not None
+    if not (has_id ^ has_sk_ek):
+        print(
+            "inspect requires either <event-id> OR both --session and --event-key",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+    conn = open_index()
+    try:
+        ensure_events_schema(conn)
+        ensure_view_schema(conn)
+        if has_id:
+            payload = _inspect_by_event_id(conn, args.event_id)
+        else:
+            payload = _inspect_by_session_event_key(conn, args.session, args.event_key)
+
+        if payload is None:
+            print("event not found", file=sys.stderr)
+            sys.exit(1)
+
+        payload["capability"] = _capability_reason(
+            CAPABILITY_MATRIX, payload["client"], payload["type"]
+        )
+        if payload.get("raw_ref") is not None:
+            source_path, source_offset, _seq = payload["raw_ref"]
+            payload["vendor_line"] = _resolve_vendor_line_text(
+                conn, source_path, source_offset, payload["raw_ref"][2]
+            )
+        else:
+            payload["vendor_line"] = None
+    finally:
+        conn.close()
+
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True, default=str))
+        return
+
+    _print_inspect_human(payload)
+
+
+def _inspect_by_event_id(conn, event_id: int):
+    row = conn.execute(
+        """
+        SELECT events.*, event_sessions.session_key, event_sessions.client
+          FROM events
+          JOIN event_sessions ON event_sessions.id = events.session_id
+         WHERE events.id = ?
+        """,
+        (event_id,),
+    ).fetchone()
+    if row is None:
+        return None
+    base = dict(row)
+    override = _load_override(conn, base["session_id"], base["event_key"])
+    return _payload_for_base_and_override(base, override)
+
+
+def _inspect_by_session_event_key(conn, session_key: str, event_key: str):
+    session_row = conn.execute(
+        "SELECT id, session_key, client FROM event_sessions WHERE session_key = ?",
+        (session_key,),
+    ).fetchone()
+    if session_row is None:
+        return None
+    session_id = int(session_row["id"])
+    client = session_row["client"]
+
+    # Prefer base row if one exists for this event_key; otherwise hook-only.
+    base_row = conn.execute(
+        """
+        SELECT *
+          FROM events
+         WHERE session_id = ? AND event_key = ?
+         ORDER BY event_at IS NULL, event_at, source_path, source_offset, seq
+         LIMIT 1
+        """,
+        (session_id, event_key),
+    ).fetchone()
+    override = _load_override(conn, session_id, event_key)
+
+    if base_row is None and override is None:
+        return None
+
+    if base_row is None:
+        # hook-only
+        return {
+            "id": None,
+            "session_id": session_id,
+            "session_key": session_key,
+            "client": client,
+            "type": override["type"],
+            "event_key": override["event_key"],
+            "event_at": override["event_at"],
+            "ingested_at": None,
+            "source": override["source"],
+            "confidence": override["confidence"],
+            "lossiness": override["lossiness"],
+            "raw_json": None,
+            "raw_ref": None,
+            "override": _override_payload(override),
+            "hook_only": True,
+        }
+
+    base = dict(base_row)
+    base["session_key"] = session_key
+    base["client"] = client
+    return _payload_for_base_and_override(base, override)
+
+
+def _load_override(conn, session_id: int, event_key):
+    if event_key is None:
+        return None
+    row = conn.execute(
+        """
+        SELECT event_key, type, source, confidence, lossiness,
+               event_at, payload_json, origin, created_at
+          FROM event_overrides
+         WHERE session_id = ? AND event_key = ?
+        """,
+        (session_id, event_key),
+    ).fetchone()
+    return dict(row) if row is not None else None
+
+
+def _override_payload(override: dict) -> dict:
+    return {
+        "source": override["source"],
+        "confidence": override["confidence"],
+        "lossiness": override["lossiness"],
+        "event_at": override["event_at"],
+        "payload_json": override["payload_json"],
+        "origin": override["origin"],
+        "created_at": override["created_at"],
+    }
+
+
+def _payload_for_base_and_override(base: dict, override):
+    payload = {
+        "id": base["id"],
+        "session_id": base["session_id"],
+        "session_key": base["session_key"],
+        "client": base["client"],
+        "type": base["type"],
+        "event_key": base["event_key"],
+        "event_at": base["event_at"],
+        "ingested_at": base["ingested_at"],
+        "source": base["source"],
+        "confidence": base["confidence"],
+        "lossiness": base["lossiness"],
+        "raw_json": base["raw_json"],
+        "raw_ref": [base["source_path"], base["source_offset"], base["seq"]],
+        "override": _override_payload(override) if override is not None else None,
+        "hook_only": False,
+    }
+    return payload
+
+
+def _capability_reason(matrix, client: str, event_type: str) -> str:
+    supported, reason = matrix.get((client, event_type), (False, "missing"))
+    prefix = "emitted" if supported else "NOT emitted"
+    return f"{prefix} by {client} ({reason})"
+
+
+def _resolve_vendor_line_text(conn, source_path: str, source_offset: int, seq: int):
+    # First try a bundle-imported snippet store if it exists; 07 will
+    # own the table, so tolerate the table being absent today.
+    try:
+        row = conn.execute(
+            """
+            SELECT text FROM event_source_snippets
+             WHERE source_path = ? AND source_offset = ? AND seq = ?
+            """,
+            (source_path, source_offset, seq),
+        ).fetchone()
+        if row is not None:
+            return row[0]
+    except Exception:
+        pass
+    from .events import fetch_vendor_line
+    return fetch_vendor_line(source_path, source_offset)
+
+
+def _print_inspect_human(payload: dict) -> None:
+    ev_id = payload["id"]
+    label = f"#{ev_id}" if ev_id is not None else "(hook-only)"
+    print(f"event {label}  type={payload['type']}  event_key={payload['event_key']}")
+    print(f"session    {payload['session_key']} (client={payload['client']})")
+    print(f"source     {payload['source']}")
+    print(f"confidence {payload['confidence']:<10}          lossiness={payload['lossiness']}")
+    event_at = payload["event_at"] or "(none)"
+    ingested_at = payload["ingested_at"] or "(n/a)"
+    print(f"event_at   {event_at:<24} ingested_at={ingested_at}")
+    raw_ref = payload.get("raw_ref")
+    if raw_ref is None:
+        print("raw_ref    (no vendor base — hook-originated)")
+    else:
+        print(f"raw_ref    {raw_ref[0]}:{raw_ref[1]}:{raw_ref[2]}")
+    print()
+
+    override = payload.get("override")
+    if override is None:
+        print("override   (none)")
+    else:
+        print(
+            f"override   source={override['source']} confidence={override['confidence']} "
+            f"origin={override['origin']}"
+        )
+    print(f"capability {payload['capability']}")
+    print()
+
+    if payload.get("hook_only"):
+        print("vendor line:")
+        print("  (no vendor base — hook-originated)")
+        return
+
+    print("vendor line:")
+    vendor_line = payload.get("vendor_line")
+    if vendor_line is None:
+        print("  (source file no longer on disk)")
+    else:
+        print(f"  {vendor_line}")
 
 
 def _generate_pii_findings(file_path: Path, output_path: Path, provider: str, min_confidence: float = 0.0, backend: str = "auto") -> dict[str, Any]:

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3211,6 +3211,14 @@ def main() -> None:
     events_inspect.add_argument("--session", help="session_key (with --event-key)")
     events_inspect.add_argument("--event-key", dest="event_key", help="event_key (with --session)")
     events_inspect.add_argument("--json", action="store_true", help="Output structured JSON")
+    events_inspect.add_argument(
+        "--truncate",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Truncate raw_json / payload_json / vendor line to N chars "
+             "(default: 1024 in human mode, no truncation in --json mode)",
+    )
 
     # Workbench commands
     serve_parser = sub.add_parser("serve", help="Start the workbench daemon + web UI")
@@ -3901,8 +3909,11 @@ def _run_events(args) -> None:
     )
 
 
+_INSPECT_HUMAN_DEFAULT_TRUNCATE = 1024
+
+
 def _run_events_inspect(args) -> None:
-    from .events import CAPABILITY_MATRIX, ensure_view_schema, fetch_vendor_line
+    from .events import CAPABILITY_MATRIX, ensure_view_schema
     from .events.schema import ensure_schema as ensure_events_schema
     from .workbench.index import open_index
 
@@ -3941,11 +3952,41 @@ def _run_events_inspect(args) -> None:
     finally:
         conn.close()
 
+    _apply_inspect_truncation(payload, _effective_truncate(args))
+
     if args.json:
         print(json.dumps(payload, indent=2, sort_keys=True, default=str))
         return
 
     _print_inspect_human(payload)
+
+
+def _effective_truncate(args) -> int | None:
+    """Return the truncation limit in chars, or None for unlimited.
+
+    - `--truncate 0` means unlimited (explicit opt-out).
+    - `--truncate N` (N>0) always truncates.
+    - No flag: human mode defaults to 1024; --json defaults to unlimited.
+    """
+    if args.truncate is not None:
+        return None if args.truncate <= 0 else args.truncate
+    return None if args.json else _INSPECT_HUMAN_DEFAULT_TRUNCATE
+
+
+def _apply_inspect_truncation(payload: dict, limit: int | None) -> None:
+    if limit is None:
+        return
+    payload["raw_json"] = _truncate_str(payload.get("raw_json"), limit)
+    override = payload.get("override")
+    if override is not None:
+        override["payload_json"] = _truncate_str(override.get("payload_json"), limit)
+    payload["vendor_line"] = _truncate_str(payload.get("vendor_line"), limit)
+
+
+def _truncate_str(value, limit: int):
+    if not isinstance(value, str) or len(value) <= limit:
+        return value
+    return value[:limit] + f" … [truncated at {limit} of {len(value)} chars]"
 
 
 def _inspect_by_event_id(conn, event_id: int):
@@ -4045,18 +4086,19 @@ def _override_payload(override: dict) -> dict:
 
 
 def _payload_for_base_and_override(base: dict, override):
+    override_applied = override is not None and _override_wins_base(base, override)
     payload = {
         "id": base["id"],
         "session_id": base["session_id"],
         "session_key": base["session_key"],
         "client": base["client"],
-        "type": base["type"],
+        "type": override["type"] if override_applied else base["type"],
         "event_key": base["event_key"],
-        "event_at": base["event_at"],
+        "event_at": override["event_at"] if override_applied else base["event_at"],
         "ingested_at": base["ingested_at"],
-        "source": base["source"],
-        "confidence": base["confidence"],
-        "lossiness": base["lossiness"],
+        "source": override["source"] if override_applied else base["source"],
+        "confidence": override["confidence"] if override_applied else base["confidence"],
+        "lossiness": override["lossiness"] if override_applied else base["lossiness"],
         "raw_json": base["raw_json"],
         "raw_ref": [base["source_path"], base["source_offset"], base["seq"]],
         "override": _override_payload(override) if override is not None else None,
@@ -4065,8 +4107,19 @@ def _payload_for_base_and_override(base: dict, override):
     return payload
 
 
+def _override_wins_base(base: dict, override: dict) -> bool:
+    from .events import CONFIDENCE_RANK
+
+    return (
+        CONFIDENCE_RANK.get(override["confidence"], 0)
+        >= CONFIDENCE_RANK.get(base["confidence"], 0)
+    )
+
+
 def _capability_reason(matrix, client: str, event_type: str) -> str:
-    supported, reason = matrix.get((client, event_type), (False, "missing"))
+    supported, reason = matrix.get(
+        (client, event_type), (False, "not emitted by this client")
+    )
     prefix = "emitted" if supported else "NOT emitted"
     return f"{prefix} by {client} ({reason})"
 
@@ -4074,6 +4127,7 @@ def _capability_reason(matrix, client: str, event_type: str) -> str:
 def _resolve_vendor_line_text(conn, source_path: str, source_offset: int, seq: int):
     # First try a bundle-imported snippet store if it exists; 07 will
     # own the table, so tolerate the table being absent today.
+    import sqlite3 as _sqlite3
     try:
         row = conn.execute(
             """
@@ -4084,7 +4138,8 @@ def _resolve_vendor_line_text(conn, source_path: str, source_offset: int, seq: i
         ).fetchone()
         if row is not None:
             return row[0]
-    except Exception:
+    except _sqlite3.OperationalError:
+        # Table doesn't exist yet (07 owns it); fall through.
         pass
     from .events import fetch_vendor_line
     return fetch_vendor_line(source_path, source_offset)
@@ -4118,6 +4173,17 @@ def _print_inspect_human(payload: dict) -> None:
     print(f"capability {payload['capability']}")
     print()
 
+    raw_json = payload.get("raw_json")
+    if raw_json is not None:
+        print("raw_json:")
+        _print_indented_text(raw_json)
+        print()
+
+    if override is not None:
+        print("override payload:")
+        _print_indented_text(override["payload_json"])
+        print()
+
     if payload.get("hook_only"):
         print("vendor line:")
         print("  (no vendor base — hook-originated)")
@@ -4129,6 +4195,12 @@ def _print_inspect_human(payload: dict) -> None:
         print("  (source file no longer on disk)")
     else:
         print(f"  {vendor_line}")
+
+
+def _print_indented_text(text: str) -> None:
+    lines = str(text).splitlines() or [""]
+    for line in lines:
+        print(f"  {line}")
 
 
 def _generate_pii_findings(file_path: Path, output_path: Path, provider: str, min_confidence: float = 0.0, backend: str = "auto") -> dict[str, Any]:

--- a/clawjournal/events/__init__.py
+++ b/clawjournal/events/__init__.py
@@ -1,22 +1,40 @@
-"""Execution recorder for phase-1 plan 02."""
+"""Execution recorder + signal/confidence layer for phase-1 plans 02 + 03."""
 
 from clawjournal.events.capabilities import CAPABILITY_MATRIX, capabilities_json
 from clawjournal.events.ingest import EVENT_CONSUMER_ID, IngestSummary, ingest_pending
 from clawjournal.events.schema import ensure_schema
 from clawjournal.events.types import (
+    CONFIDENCE_RANK,
     EVENT_TYPES,
     ClassifiedEvent,
     SessionMeta,
 )
+from clawjournal.events.view import (
+    CanonicalEvent,
+    CapabilityState,
+    canonical_events,
+    capability_join,
+    ensure_view_schema,
+    fetch_vendor_line,
+    write_hook_override,
+)
 
 __all__ = [
     "CAPABILITY_MATRIX",
+    "CONFIDENCE_RANK",
+    "CanonicalEvent",
+    "CapabilityState",
     "EVENT_CONSUMER_ID",
     "EVENT_TYPES",
     "ClassifiedEvent",
     "IngestSummary",
     "SessionMeta",
+    "canonical_events",
     "capabilities_json",
+    "capability_join",
     "ensure_schema",
+    "ensure_view_schema",
+    "fetch_vendor_line",
     "ingest_pending",
+    "write_hook_override",
 ]

--- a/clawjournal/events/types.py
+++ b/clawjournal/events/types.py
@@ -36,6 +36,16 @@ VALID_SOURCES = {
 VALID_CONFIDENCE = {"high", "medium", "low", "missing"}
 VALID_LOSSINESS = {"none", "partial", "unknown", "compacted"}
 
+# `missing` is a read-time presentation state (produced by capability_join)
+# and never persisted. Included here with rank 0 so comparisons against
+# hypothetical missing inputs stay well-defined; writers reject it upstream.
+CONFIDENCE_RANK: dict[str, int] = {
+    "high": 3,
+    "medium": 2,
+    "low": 1,
+    "missing": 0,
+}
+
 
 class ClassifiedEvent(NamedTuple):
     type: str

--- a/clawjournal/events/view.py
+++ b/clawjournal/events/view.py
@@ -23,6 +23,7 @@ Exposes:
 
 from __future__ import annotations
 
+import json
 import sqlite3
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -153,6 +154,12 @@ def write_hook_override(
         raise ValueError(f"Unsupported lossiness: {lossiness}")
     if not event_key:
         raise ValueError("event_key is required for overrides")
+    if not isinstance(payload_json, str):
+        raise ValueError("payload_json must be a JSON string")
+    try:
+        json.loads(payload_json)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise ValueError("payload_json must be valid JSON") from exc
 
     session_id = _resolve_session_id(conn, session_key)
     if session_id is None:
@@ -398,8 +405,10 @@ def fetch_vendor_line(source_path: str | Path, source_offset: int) -> str | None
     - no terminating newline exists between source_offset and EOF
       (partial trailing line — matches 01's "skip incomplete lines"
       semantics);
-    - the line would exceed `_MAX_LINE_BYTES` (defends against a
-      corrupted or adversarial file where no newline ever appears).
+    - the line would exceed `_MAX_LINE_BYTES`, whether because no
+      newline appears within the cap or because the terminating
+      newline sits past it (defends against a very long or adversarial
+      line).
 
     Does NOT detect rotation / replacement — the file at source_path may
     have been swapped since the event was ingested. Phase 1 accepts this
@@ -416,15 +425,18 @@ def fetch_vendor_line(source_path: str | Path, source_offset: int) -> str | None
                     return None  # partial line — EOF with no newline
                 newline_pos = block.find(b"\n")
                 if newline_pos >= 0:
-                    chunks.append(block)
                     absolute_newline = total + newline_pos
+                    if absolute_newline > _MAX_LINE_BYTES:
+                        return None  # newline exists, but only after the safety cap
+                    chunks.append(block)
                     complete = b"".join(chunks)[:absolute_newline]
                     if complete.endswith(b"\r"):
                         complete = complete[:-1]
                     return complete.decode("utf-8", errors="replace")
-                total += len(block)
-                if total > _MAX_LINE_BYTES:
+                next_total = total + len(block)
+                if next_total > _MAX_LINE_BYTES:
                     return None  # pathological: no newline within safety cap
+                total = next_total
                 chunks.append(block)
     except (FileNotFoundError, IsADirectoryError):
         return None

--- a/clawjournal/events/view.py
+++ b/clawjournal/events/view.py
@@ -33,7 +33,6 @@ from clawjournal.events.capabilities import CAPABILITY_MATRIX
 from clawjournal.events.types import (
     CONFIDENCE_RANK,
     EVENT_TYPES,
-    VALID_CONFIDENCE,
     VALID_LOSSINESS,
     VALID_SOURCES,
 )
@@ -227,7 +226,11 @@ def canonical_events(
     - Overrides whose event_key never appears on a base row emit as
       hook-only CanonicalEvents (raw_json=None, raw_ref=None).
     - `prefer_source` filters base rows before dedup (e.g.
-      "claude-jsonl" drops LA duplicates).
+      "claude-jsonl" drops LA duplicates). Note: if `prefer_source`
+      filters out a base row that had a matching override, the override
+      will emit as hook-only (no base in scope to merge raw_json against).
+      Callers wanting override-promoted rows across all sources should
+      either leave `prefer_source` unset or accept this asymmetry.
     """
     overrides = {row["event_key"]: dict(row) for row in conn.execute(_OVERRIDE_SELECT, (session_id,))}
 
@@ -383,6 +386,7 @@ def capability_join(conn: sqlite3.Connection, session_id: int) -> list[Capabilit
 
 
 _FETCH_CHUNK = 65_536
+_MAX_LINE_BYTES = 16 * 1024 * 1024  # safety cap — real vendor lines are KB-sized
 
 
 def fetch_vendor_line(source_path: str | Path, source_offset: int) -> str | None:
@@ -393,7 +397,9 @@ def fetch_vendor_line(source_path: str | Path, source_offset: int) -> str | None
     - the offset is past EOF;
     - no terminating newline exists between source_offset and EOF
       (partial trailing line — matches 01's "skip incomplete lines"
-      semantics).
+      semantics);
+    - the line would exceed `_MAX_LINE_BYTES` (defends against a
+      corrupted or adversarial file where no newline ever appears).
 
     Does NOT detect rotation / replacement — the file at source_path may
     have been swapped since the event was ingested. Phase 1 accepts this
@@ -408,15 +414,18 @@ def fetch_vendor_line(source_path: str | Path, source_offset: int) -> str | None
                 block = f.read(_FETCH_CHUNK)
                 if not block:
                     return None  # partial line — EOF with no newline
-                chunks.append(block)
                 newline_pos = block.find(b"\n")
                 if newline_pos >= 0:
+                    chunks.append(block)
                     absolute_newline = total + newline_pos
                     complete = b"".join(chunks)[:absolute_newline]
                     if complete.endswith(b"\r"):
                         complete = complete[:-1]
                     return complete.decode("utf-8", errors="replace")
                 total += len(block)
+                if total > _MAX_LINE_BYTES:
+                    return None  # pathological: no newline within safety cap
+                chunks.append(block)
     except (FileNotFoundError, IsADirectoryError):
         return None
     except OSError:

--- a/clawjournal/events/view.py
+++ b/clawjournal/events/view.py
@@ -1,0 +1,423 @@
+"""Read-time signal/confidence layer for the execution recorder.
+
+Exposes:
+
+- `ensure_view_schema(conn)` — additive migration creating `event_overrides`
+  (named to avoid collision with `events.schema.ensure_schema`).
+- `canonical_events(conn, session_id, *, prefer_source=None)` — deduped,
+  override-promoted event stream. Readers use this rather than reading
+  `events` directly.
+- `capability_join(conn, session_id)` — three-state capability report per
+  event type (present / missing / supported_but_absent), with counts split
+  between base (`events`) and override (`event_overrides`) producers.
+- `fetch_vendor_line(source_path, source_offset)` — best-effort retrieval
+  of the vendor JSONL line an event references. Returns None when the
+  file is gone, the offset is past EOF, or the line is partial. Does NOT
+  detect rotation/replacement (01/02 don't persist inode).
+- `write_hook_override(conn, *, session_key, event_key, event_type, source,
+  confidence, lossiness, event_at, payload_json, origin)` — the one
+  supported path for Beat 3+ hooks to land higher-confidence data.
+
+`events` stays append-only; all overwrite state lives in `event_overrides`.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterator, NamedTuple
+
+from clawjournal.events.capabilities import CAPABILITY_MATRIX
+from clawjournal.events.types import (
+    CONFIDENCE_RANK,
+    EVENT_TYPES,
+    VALID_CONFIDENCE,
+    VALID_LOSSINESS,
+    VALID_SOURCES,
+)
+
+
+# --- schema --------------------------------------------------------------- #
+
+_WRITABLE_CONFIDENCE = {"high", "medium", "low"}  # "missing" is read-time only
+
+
+def _sql_in_list(values) -> str:
+    return "(" + ", ".join(f"'{v}'" for v in sorted(values)) + ")"
+
+
+_SCHEMA_SQL = f"""
+CREATE TABLE IF NOT EXISTS event_overrides (
+    session_id    INTEGER NOT NULL REFERENCES event_sessions(id) ON DELETE CASCADE,
+    event_key     TEXT    NOT NULL,
+    type          TEXT    NOT NULL CHECK (type IN {_sql_in_list(EVENT_TYPES)}),
+    source        TEXT    NOT NULL CHECK (source IN {_sql_in_list(VALID_SOURCES)}),
+    confidence    TEXT    NOT NULL CHECK (confidence IN {_sql_in_list(_WRITABLE_CONFIDENCE)}),
+    lossiness     TEXT    NOT NULL CHECK (lossiness IN {_sql_in_list(VALID_LOSSINESS)}),
+    event_at      TEXT,
+    payload_json  TEXT    NOT NULL,
+    origin        TEXT,
+    created_at    TEXT    NOT NULL,
+    PRIMARY KEY (session_id, event_key)
+);
+CREATE INDEX IF NOT EXISTS idx_event_overrides_session ON event_overrides(session_id);
+"""
+
+
+def ensure_view_schema(conn: sqlite3.Connection) -> None:
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.executescript(_SCHEMA_SQL)
+
+
+# --- types ---------------------------------------------------------------- #
+
+
+@dataclass(frozen=True)
+class CanonicalEvent:
+    type: str
+    event_key: str | None
+    event_at: str | None
+    source: str
+    confidence: str
+    lossiness: str
+    raw_json: str | None
+    payload_json: str | None
+    raw_ref: tuple[str, int, int] | None
+    origin: str | None
+
+
+class CapabilityState(NamedTuple):
+    event_type: str
+    state: str                     # "present" | "missing" | "supported_but_absent"
+    reason: str
+    observed_base_count: int
+    observed_override_count: int
+
+
+# --- hook override writer -------------------------------------------------- #
+
+
+_UPSERT_SQL = """
+INSERT INTO event_overrides (
+    session_id, event_key, type, source, confidence, lossiness,
+    event_at, payload_json, origin, created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(session_id, event_key) DO UPDATE SET
+    type         = excluded.type,
+    source       = excluded.source,
+    confidence   = excluded.confidence,
+    lossiness    = excluded.lossiness,
+    event_at     = excluded.event_at,
+    payload_json = excluded.payload_json,
+    origin       = excluded.origin,
+    created_at   = excluded.created_at
+  WHERE
+    CASE excluded.confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END
+    >
+    CASE event_overrides.confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END
+"""
+
+
+def write_hook_override(
+    conn: sqlite3.Connection,
+    *,
+    session_key: str,
+    event_key: str,
+    event_type: str,
+    source: str,
+    confidence: str,
+    lossiness: str,
+    event_at: str | None,
+    payload_json: str,
+    origin: str | None,
+) -> bool:
+    """Write a hook-originated override. Returns True if the row landed
+    (fresh insert or a strict-greater override replacement), False if the
+    rank guard rejected the write.
+
+    Raises ValueError on invalid enum inputs; KeyError if the session_key
+    doesn't exist in `event_sessions` yet (hooks fire against live
+    sessions that 02's ingest has already created).
+    """
+    if event_type not in EVENT_TYPES:
+        raise ValueError(f"Unsupported event type: {event_type}")
+    if source not in VALID_SOURCES:
+        raise ValueError(f"Unsupported source: {source}")
+    if confidence not in _WRITABLE_CONFIDENCE:
+        raise ValueError(
+            f"Unsupported confidence for write: {confidence} "
+            "(valid: high / medium / low; 'missing' is read-time only)"
+        )
+    if lossiness not in VALID_LOSSINESS:
+        raise ValueError(f"Unsupported lossiness: {lossiness}")
+    if not event_key:
+        raise ValueError("event_key is required for overrides")
+
+    session_id = _resolve_session_id(conn, session_key)
+    if session_id is None:
+        raise KeyError(f"session_key not found in event_sessions: {session_key}")
+
+    created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    with conn:
+        cursor = conn.execute(
+            _UPSERT_SQL,
+            (
+                session_id,
+                event_key,
+                event_type,
+                source,
+                confidence,
+                lossiness,
+                event_at,
+                payload_json,
+                origin,
+                created_at,
+            ),
+        )
+        return cursor.rowcount > 0
+
+
+def _resolve_session_id(conn: sqlite3.Connection, session_key: str) -> int | None:
+    row = conn.execute(
+        "SELECT id FROM event_sessions WHERE session_key = ?",
+        (session_key,),
+    ).fetchone()
+    return None if row is None else int(row[0])
+
+
+# --- canonical reader ----------------------------------------------------- #
+
+
+_BASE_SELECT = """
+SELECT type, event_key, event_at, source, confidence, lossiness,
+       raw_json, source_path, source_offset, seq
+  FROM events
+ WHERE session_id = ?
+"""
+
+_BASE_ORDER = " ORDER BY event_at IS NULL, event_at, source_path, source_offset, seq"
+
+
+_OVERRIDE_SELECT = """
+SELECT event_key, type, source, confidence, lossiness,
+       event_at, payload_json, origin
+  FROM event_overrides
+ WHERE session_id = ?
+ ORDER BY event_at IS NULL, event_at, event_key
+"""
+
+
+def canonical_events(
+    conn: sqlite3.Connection,
+    session_id: int,
+    *,
+    prefer_source: str | None = None,
+) -> Iterator[CanonicalEvent]:
+    """Yield the deduped, override-promoted event stream for a session.
+
+    Rules (summary; full spec in docs/plans/phase-1/03-*):
+    - Base rows with NULL event_key pass through unchanged.
+    - For each event_key, keep the first base row seen in canonical
+      order; skip later duplicates. If an override exists and
+      CONFIDENCE_RANK[override] >= CONFIDENCE_RANK[base], the override
+      wins (takes type/source/confidence/lossiness/event_at/origin/
+      payload_json; base contributes raw_json/raw_ref).
+    - Overrides whose event_key never appears on a base row emit as
+      hook-only CanonicalEvents (raw_json=None, raw_ref=None).
+    - `prefer_source` filters base rows before dedup (e.g.
+      "claude-jsonl" drops LA duplicates).
+    """
+    overrides = {row["event_key"]: dict(row) for row in conn.execute(_OVERRIDE_SELECT, (session_id,))}
+
+    sql = _BASE_SELECT
+    params: list = [session_id]
+    if prefer_source is not None:
+        sql += " AND source = ?"
+        params.append(prefer_source)
+    sql += _BASE_ORDER
+
+    emitted_keys: set[str] = set()
+    for row in conn.execute(sql, params):
+        event_key = row["event_key"]
+        base = dict(row)
+
+        if event_key is None:
+            yield _canonical_from_base(base)
+            continue
+
+        if event_key in emitted_keys:
+            continue  # cross-source duplicate
+
+        emitted_keys.add(event_key)
+        override = overrides.get(event_key)
+        if override is not None and _override_beats_base(override, base):
+            yield _canonical_override_wins(override, base)
+        else:
+            yield _canonical_from_base(base)
+
+    for event_key, override in overrides.items():
+        if event_key in emitted_keys:
+            continue
+        yield _canonical_hook_only(override)
+
+
+def _override_beats_base(override: dict, base: dict) -> bool:
+    return (
+        CONFIDENCE_RANK.get(override["confidence"], 0)
+        >= CONFIDENCE_RANK.get(base["confidence"], 0)
+    )
+
+
+def _canonical_from_base(base: dict) -> CanonicalEvent:
+    return CanonicalEvent(
+        type=base["type"],
+        event_key=base["event_key"],
+        event_at=base["event_at"],
+        source=base["source"],
+        confidence=base["confidence"],
+        lossiness=base["lossiness"],
+        raw_json=base["raw_json"],
+        payload_json=None,
+        raw_ref=(base["source_path"], base["source_offset"], base["seq"]),
+        origin=None,
+    )
+
+
+def _canonical_override_wins(override: dict, base: dict) -> CanonicalEvent:
+    return CanonicalEvent(
+        type=override["type"],
+        event_key=override["event_key"],
+        event_at=override["event_at"],
+        source=override["source"],
+        confidence=override["confidence"],
+        lossiness=override["lossiness"],
+        raw_json=base["raw_json"],
+        payload_json=override["payload_json"],
+        raw_ref=(base["source_path"], base["source_offset"], base["seq"]),
+        origin=override["origin"],
+    )
+
+
+def _canonical_hook_only(override: dict) -> CanonicalEvent:
+    return CanonicalEvent(
+        type=override["type"],
+        event_key=override["event_key"],
+        event_at=override["event_at"],
+        source=override["source"],
+        confidence=override["confidence"],
+        lossiness=override["lossiness"],
+        raw_json=None,
+        payload_json=override["payload_json"],
+        raw_ref=None,
+        origin=override["origin"],
+    )
+
+
+# --- capability join ------------------------------------------------------ #
+
+
+def capability_join(conn: sqlite3.Connection, session_id: int) -> list[CapabilityState]:
+    """Report the per-event-type capability state for a session.
+
+    Uses the session's client (from event_sessions.client) + the static
+    CAPABILITY_MATRIX to classify each of EVENT_TYPES as present,
+    missing, or supported_but_absent — with counts split between base
+    and override producers so consumers can distinguish vendor-observed
+    from hook-synthesized.
+    """
+    row = conn.execute(
+        "SELECT client FROM event_sessions WHERE id = ?", (session_id,)
+    ).fetchone()
+    if row is None:
+        raise KeyError(f"session_id not found: {session_id}")
+    client = row["client"]
+
+    base_counts = {
+        r["type"]: r["n"]
+        for r in conn.execute(
+            "SELECT type, COUNT(*) AS n FROM events WHERE session_id = ? GROUP BY type",
+            (session_id,),
+        )
+    }
+    override_counts = {
+        r["type"]: r["n"]
+        for r in conn.execute(
+            "SELECT type, COUNT(*) AS n FROM event_overrides WHERE session_id = ? GROUP BY type",
+            (session_id,),
+        )
+    }
+
+    states: list[CapabilityState] = []
+    for event_type in EVENT_TYPES:
+        base_n = base_counts.get(event_type, 0)
+        override_n = override_counts.get(event_type, 0)
+        supported, matrix_reason = CAPABILITY_MATRIX.get(
+            (client, event_type), (False, "not emitted by this client")
+        )
+
+        if base_n + override_n > 0:
+            state = "present"
+            reason = "observed in this session"
+        elif supported:
+            state = "supported_but_absent"
+            reason = matrix_reason
+        else:
+            state = "missing"
+            reason = matrix_reason
+
+        states.append(
+            CapabilityState(
+                event_type=event_type,
+                state=state,
+                reason=reason,
+                observed_base_count=base_n,
+                observed_override_count=override_n,
+            )
+        )
+    return states
+
+
+# --- vendor-line fetch ---------------------------------------------------- #
+
+
+_FETCH_CHUNK = 65_536
+
+
+def fetch_vendor_line(source_path: str | Path, source_offset: int) -> str | None:
+    """Best-effort retrieval of the JSONL line at (source_path, source_offset).
+
+    Returns None if:
+    - the file is missing;
+    - the offset is past EOF;
+    - no terminating newline exists between source_offset and EOF
+      (partial trailing line — matches 01's "skip incomplete lines"
+      semantics).
+
+    Does NOT detect rotation / replacement — the file at source_path may
+    have been swapped since the event was ingested. Phase 1 accepts this
+    limit; see docs/plans/phase-1/03-*.
+    """
+    try:
+        with open(source_path, "rb") as f:
+            f.seek(source_offset)
+            chunks: list[bytes] = []
+            total = 0
+            while True:
+                block = f.read(_FETCH_CHUNK)
+                if not block:
+                    return None  # partial line — EOF with no newline
+                chunks.append(block)
+                newline_pos = block.find(b"\n")
+                if newline_pos >= 0:
+                    absolute_newline = total + newline_pos
+                    complete = b"".join(chunks)[:absolute_newline]
+                    if complete.endswith(b"\r"):
+                        complete = complete[:-1]
+                    return complete.decode("utf-8", errors="replace")
+                total += len(block)
+    except (FileNotFoundError, IsADirectoryError):
+        return None
+    except OSError:
+        return None

--- a/tests/events/test_view.py
+++ b/tests/events/test_view.py
@@ -1,0 +1,690 @@
+"""Unit tests for clawjournal.events.view — 03 signal/confidence layer.
+
+Covers:
+- ensure_view_schema idempotency + CHECK constraints
+- write_hook_override validation, rank guards, session lookup
+- canonical_events base-only / override-wins / hook-only / cross-source
+- capability_join present / missing / supported_but_absent + split counts
+- fetch_vendor_line existing / missing / past-EOF / partial-line / CRLF
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from clawjournal.events.schema import ensure_schema as ensure_events_schema
+from clawjournal.events.view import (
+    CanonicalEvent,
+    canonical_events,
+    capability_join,
+    ensure_view_schema,
+    fetch_vendor_line,
+    write_hook_override,
+)
+
+
+TS0 = "2026-04-20T10:00:00Z"
+TS1 = "2026-04-20T10:00:01Z"
+TS2 = "2026-04-20T10:00:02Z"
+
+
+# --------------------------------------------------------------------------- #
+# Fixture helpers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    ensure_events_schema(c)
+    ensure_view_schema(c)
+    return c
+
+
+def _insert_event_session(
+    conn: sqlite3.Connection,
+    *,
+    session_key: str,
+    client: str,
+    status: str = "active",
+) -> int:
+    cursor = conn.execute(
+        "INSERT INTO event_sessions (session_key, client, status) VALUES (?, ?, ?)",
+        (session_key, client, status),
+    )
+    conn.commit()
+    return int(cursor.lastrowid)
+
+
+def _insert_event(
+    conn: sqlite3.Connection,
+    *,
+    session_id: int,
+    type: str = "user_message",
+    event_key: str | None = None,
+    event_at: str | None = TS0,
+    source: str = "claude-jsonl",
+    source_path: str = "/tmp/demo.jsonl",
+    source_offset: int = 0,
+    seq: int = 0,
+    client: str = "claude",
+    confidence: str = "high",
+    lossiness: str = "none",
+    raw_json: str = "{}",
+) -> int:
+    cursor = conn.execute(
+        """
+        INSERT INTO events (
+            session_id, type, event_key, event_at, ingested_at, source,
+            source_path, source_offset, seq, client, confidence, lossiness,
+            raw_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        (
+            session_id, type, event_key, event_at, TS0, source,
+            source_path, source_offset, seq, client, confidence, lossiness,
+            raw_json,
+        ),
+    )
+    conn.commit()
+    return int(cursor.lastrowid)
+
+
+# --------------------------------------------------------------------------- #
+# ensure_view_schema
+# --------------------------------------------------------------------------- #
+
+
+def test_ensure_view_schema_is_idempotent(conn):
+    ensure_view_schema(conn)  # second call must not raise
+    tables = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'"
+    )}
+    assert "event_overrides" in tables
+
+    indexes = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='index'"
+    )}
+    assert "idx_event_overrides_session" in indexes
+
+
+def test_ensure_view_schema_rejects_invalid_source_via_check(conn):
+    sid = _insert_event_session(conn, session_key="s:1", client="claude")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO event_overrides
+              (session_id, event_key, type, source, confidence, lossiness,
+               event_at, payload_json, origin, created_at)
+            VALUES (?, 'tool_call:x', 'tool_call', 'bogus-source', 'high',
+                    'none', NULL, '{}', NULL, ?)
+            """,
+            (sid, TS0),
+        )
+
+
+def test_ensure_view_schema_rejects_missing_confidence_via_check(conn):
+    sid = _insert_event_session(conn, session_key="s:2", client="claude")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            """
+            INSERT INTO event_overrides
+              (session_id, event_key, type, source, confidence, lossiness,
+               event_at, payload_json, origin, created_at)
+            VALUES (?, 'tool_call:x', 'tool_call', 'hook', 'missing',
+                    'none', NULL, '{}', NULL, ?)
+            """,
+            (sid, TS0),
+        )
+
+
+def test_ensure_view_schema_cascades_on_session_delete(conn):
+    sid = _insert_event_session(conn, session_key="s:cascade", client="claude")
+    assert write_hook_override(
+        conn,
+        session_key="s:cascade",
+        event_key="tool_call:x",
+        event_type="tool_call",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS0,
+        payload_json="{}",
+        origin=None,
+    )
+    assert conn.execute("SELECT COUNT(*) FROM event_overrides").fetchone()[0] == 1
+
+    conn.execute("DELETE FROM event_sessions WHERE id = ?", (sid,))
+    conn.commit()
+    assert conn.execute("SELECT COUNT(*) FROM event_overrides").fetchone()[0] == 0
+
+
+# --------------------------------------------------------------------------- #
+# write_hook_override
+# --------------------------------------------------------------------------- #
+
+
+def test_write_hook_override_first_write_lands(conn):
+    _insert_event_session(conn, session_key="s:hook-1", client="claude")
+    result = write_hook_override(
+        conn,
+        session_key="s:hook-1",
+        event_key="tool_call:tu-1",
+        event_type="tool_call",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS0,
+        payload_json='{"precise": true}',
+        origin="hook:pre-tool-use:v1",
+    )
+    assert result is True
+    row = conn.execute("SELECT * FROM event_overrides").fetchone()
+    assert row["event_key"] == "tool_call:tu-1"
+    assert row["origin"] == "hook:pre-tool-use:v1"
+
+
+def test_write_hook_override_strict_greater_guard_rejects_equal_confidence(conn):
+    _insert_event_session(conn, session_key="s:hook-2", client="claude")
+    common = dict(
+        session_key="s:hook-2",
+        event_key="tool_call:tu-2",
+        event_type="tool_call",
+        source="hook",
+        lossiness="none",
+        event_at=TS0,
+        payload_json="{}",
+        origin=None,
+    )
+    assert write_hook_override(conn, confidence="high", **common) is True
+    assert write_hook_override(conn, confidence="high", **common) is False
+    assert conn.execute("SELECT COUNT(*) FROM event_overrides").fetchone()[0] == 1
+
+
+def test_write_hook_override_lower_rank_rejected(conn):
+    _insert_event_session(conn, session_key="s:hook-3", client="claude")
+    common = dict(
+        session_key="s:hook-3",
+        event_key="tool_call:tu-3",
+        event_type="tool_call",
+        source="hook",
+        lossiness="none",
+        event_at=TS0,
+        payload_json="{}",
+        origin=None,
+    )
+    assert write_hook_override(conn, confidence="high", **common) is True
+    assert write_hook_override(conn, confidence="low", **common) is False
+    stored_confidence = conn.execute(
+        "SELECT confidence FROM event_overrides"
+    ).fetchone()[0]
+    assert stored_confidence == "high"
+
+
+def test_write_hook_override_higher_rank_replaces(conn):
+    _insert_event_session(conn, session_key="s:hook-4", client="claude")
+    common = dict(
+        session_key="s:hook-4",
+        event_key="tool_call:tu-4",
+        event_type="tool_call",
+        source="hook",
+        lossiness="none",
+        event_at=TS0,
+        origin=None,
+    )
+    assert write_hook_override(
+        conn, confidence="low", payload_json='{"v": 1}', **common
+    ) is True
+    assert write_hook_override(
+        conn, confidence="high", payload_json='{"v": 2}', **common
+    ) is True
+    row = conn.execute(
+        "SELECT confidence, payload_json FROM event_overrides"
+    ).fetchone()
+    assert row["confidence"] == "high"
+    assert row["payload_json"] == '{"v": 2}'
+
+
+def test_write_hook_override_raises_on_unknown_session(conn):
+    with pytest.raises(KeyError):
+        write_hook_override(
+            conn,
+            session_key="s:nonexistent",
+            event_key="tool_call:x",
+            event_type="tool_call",
+            source="hook",
+            confidence="high",
+            lossiness="none",
+            event_at=TS0,
+            payload_json="{}",
+            origin=None,
+        )
+
+
+@pytest.mark.parametrize(
+    "kwargs,match",
+    [
+        (dict(event_type="not_a_type"), "event type"),
+        (dict(source="bogus"), "source"),
+        (dict(confidence="missing"), "confidence"),
+        (dict(confidence="medium-high"), "confidence"),
+        (dict(lossiness="weird"), "lossiness"),
+        (dict(event_key=""), "event_key"),
+    ],
+)
+def test_write_hook_override_validation(conn, kwargs, match):
+    _insert_event_session(conn, session_key="s:validate", client="claude")
+    base = dict(
+        session_key="s:validate",
+        event_key="tool_call:x",
+        event_type="tool_call",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS0,
+        payload_json="{}",
+        origin=None,
+    )
+    base.update(kwargs)
+    with pytest.raises(ValueError, match=match):
+        write_hook_override(conn, **base)
+
+
+# --------------------------------------------------------------------------- #
+# canonical_events
+# --------------------------------------------------------------------------- #
+
+
+def test_canonical_events_base_only_session(conn):
+    sid = _insert_event_session(conn, session_key="s:base", client="claude")
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="user_message",
+        event_key=None,
+        event_at=TS0,
+        source_offset=0,
+        raw_json='{"type":"user"}',
+    )
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="tool_call",
+        event_key="tool_call:tu-1",
+        event_at=TS1,
+        source_offset=50,
+        raw_json='{"tool":"read"}',
+    )
+
+    events = list(canonical_events(conn, sid))
+    assert [e.type for e in events] == ["user_message", "tool_call"]
+    assert all(e.payload_json is None for e in events)
+    assert all(e.origin is None for e in events)
+    assert events[0].raw_ref == ("/tmp/demo.jsonl", 0, 0)
+    assert events[1].raw_ref == ("/tmp/demo.jsonl", 50, 0)
+
+
+def test_canonical_events_override_wins_preserves_base_raw_json(conn):
+    sid = _insert_event_session(conn, session_key="s:override", client="claude")
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="tool_call",
+        event_key="tool_call:tu-2",
+        confidence="low",
+        raw_json='{"base":"low"}',
+        source_offset=100,
+    )
+    write_hook_override(
+        conn,
+        session_key="s:override",
+        event_key="tool_call:tu-2",
+        event_type="tool_call",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS0,
+        payload_json='{"override":"high"}',
+        origin="hook:test",
+    )
+
+    [event] = list(canonical_events(conn, sid))
+    assert event.confidence == "high"
+    assert event.source == "hook"
+    assert event.origin == "hook:test"
+    assert event.payload_json == '{"override":"high"}'
+    assert event.raw_json == '{"base":"low"}'  # base content preserved
+    assert event.raw_ref == ("/tmp/demo.jsonl", 100, 0)
+
+
+def test_canonical_events_override_rejected_when_lower_confidence(conn):
+    sid = _insert_event_session(conn, session_key="s:reject", client="claude")
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="tool_call",
+        event_key="tool_call:tu-3",
+        confidence="high",
+        raw_json='{"base":"high"}',
+    )
+    write_hook_override(
+        conn,
+        session_key="s:reject",
+        event_key="tool_call:tu-3",
+        event_type="tool_call",
+        source="hook",
+        confidence="low",
+        lossiness="none",
+        event_at=TS0,
+        payload_json='{"override":"low"}',
+        origin="hook:test",
+    )
+
+    [event] = list(canonical_events(conn, sid))
+    assert event.confidence == "high"
+    assert event.source == "claude-jsonl"  # base
+    assert event.payload_json is None
+    assert event.origin is None
+    assert event.raw_json == '{"base":"high"}'
+
+
+def test_canonical_events_equal_rank_override_wins(conn):
+    sid = _insert_event_session(conn, session_key="s:equal", client="claude")
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="tool_call",
+        event_key="tool_call:tu-4",
+        confidence="high",
+        raw_json='{"base":true}',
+    )
+    write_hook_override(
+        conn,
+        session_key="s:equal",
+        event_key="tool_call:tu-4",
+        event_type="tool_call",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS0,
+        payload_json='{"override":true}',
+        origin="hook:test",
+    )
+
+    [event] = list(canonical_events(conn, sid))
+    assert event.source == "hook"
+    assert event.payload_json == '{"override":true}'
+
+
+def test_canonical_events_hook_only_has_no_raw_json(conn):
+    sid = _insert_event_session(conn, session_key="s:hookonly", client="claude")
+    write_hook_override(
+        conn,
+        session_key="s:hookonly",
+        event_key="tool_call:novel",
+        event_type="tool_call",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS0,
+        payload_json='{"hook":true}',
+        origin="hook:test",
+    )
+
+    [event] = list(canonical_events(conn, sid))
+    assert event.type == "tool_call"
+    assert event.event_key == "tool_call:novel"
+    assert event.raw_json is None
+    assert event.raw_ref is None
+    assert event.payload_json == '{"hook":true}'
+    assert event.origin == "hook:test"
+
+
+def test_canonical_events_cross_source_dedup(conn):
+    sid = _insert_event_session(conn, session_key="s:xsrc", client="claude")
+    # Two base rows on different paths sharing an event_key. Canonical
+    # order is (event_at, source_path, source_offset, seq) — so the path
+    # that sorts first lexically wins. Paths chosen so the expected
+    # winner is visible in the assertion.
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="tool_call",
+        event_key="tool_call:shared",
+        event_at=TS0,
+        source="claude-jsonl",
+        source_path="/a_first.jsonl",
+        raw_json='{"from":"first"}',
+    )
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="tool_call",
+        event_key="tool_call:shared",
+        event_at=TS0,
+        source="claude-jsonl",
+        source_path="/b_second.jsonl",
+        raw_json='{"from":"second"}',
+    )
+
+    events = list(canonical_events(conn, sid))
+    assert len(events) == 1
+    assert events[0].raw_ref[0] == "/a_first.jsonl"
+
+
+def test_canonical_events_prefer_source_drives_cross_source_winner(conn):
+    sid = _insert_event_session(conn, session_key="s:xsrc2", client="claude")
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="tool_call",
+        event_key="tool_call:shared",
+        event_at=TS0,
+        source="claude-jsonl",
+        source_path="/x.jsonl",
+        raw_json="{}",
+    )
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="tool_call",
+        event_key="tool_call:shared",
+        event_at=TS0,
+        source="codex-rollout",
+        source_path="/y.jsonl",
+        raw_json="{}",
+    )
+    # Filter to codex-rollout: the claude-jsonl row disappears before dedup.
+    [event] = list(canonical_events(conn, sid, prefer_source="codex-rollout"))
+    assert event.source == "codex-rollout"
+    assert event.raw_ref[0] == "/y.jsonl"
+
+
+def test_canonical_events_prefer_source_filters_base_rows(conn):
+    sid = _insert_event_session(conn, session_key="s:prefer", client="claude")
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="tool_call",
+        event_key="tool_call:A",
+        source_path="/native.jsonl",
+        source="claude-jsonl",
+        raw_json='{"from":"native"}',
+    )
+    # A "codex-rollout" row to exercise filtering — contrived but valid.
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="tool_call",
+        event_key="tool_call:B",
+        source_path="/c.jsonl",
+        source="codex-rollout",
+        raw_json='{"from":"codex"}',
+    )
+
+    [event] = list(canonical_events(conn, sid, prefer_source="claude-jsonl"))
+    assert event.event_key == "tool_call:A"
+
+
+def test_canonical_events_null_event_key_passes_through_every_row(conn):
+    sid = _insert_event_session(conn, session_key="s:null", client="claude")
+    for offset in (0, 20, 40):
+        _insert_event(
+            conn,
+            session_id=sid,
+            type="schema_unknown",
+            event_key=None,
+            source_offset=offset,
+            raw_json=f'{{"offset":{offset}}}',
+        )
+    events = list(canonical_events(conn, sid))
+    assert [e.raw_ref[1] for e in events] == [0, 20, 40]
+
+
+def test_canonical_events_ordering_mixes_base_then_hook_only(conn):
+    sid = _insert_event_session(conn, session_key="s:order", client="claude")
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="tool_call",
+        event_key="tool_call:B1",
+        event_at=TS1,
+        raw_json="{}",
+    )
+    write_hook_override(
+        conn,
+        session_key="s:order",
+        event_key="tool_call:novel",
+        event_type="tool_call",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS0,
+        payload_json="{}",
+        origin=None,
+    )
+
+    events = list(canonical_events(conn, sid))
+    # Base rows emit first (in event_at order), then hook-only overrides.
+    assert [e.event_key for e in events] == ["tool_call:B1", "tool_call:novel"]
+
+
+# --------------------------------------------------------------------------- #
+# capability_join
+# --------------------------------------------------------------------------- #
+
+
+def test_capability_join_present_from_base(conn):
+    sid = _insert_event_session(conn, session_key="s:cap-present", client="claude")
+    _insert_event(
+        conn,
+        session_id=sid,
+        type="tool_call",
+        event_key="tool_call:x",
+        raw_json="{}",
+    )
+    states = {s.event_type: s for s in capability_join(conn, sid)}
+    assert states["tool_call"].state == "present"
+    assert states["tool_call"].observed_base_count == 1
+    assert states["tool_call"].observed_override_count == 0
+
+
+def test_capability_join_missing_for_unsupported_type(conn):
+    sid = _insert_event_session(conn, session_key="s:cap-missing", client="codex")
+    states = {s.event_type: s for s in capability_join(conn, sid)}
+    # codex matrix: stdout_chunk / stderr_chunk / compaction are all False
+    for t in ("stdout_chunk", "stderr_chunk", "compaction"):
+        assert states[t].state == "missing"
+        assert states[t].observed_base_count == 0
+        assert states[t].observed_override_count == 0
+
+
+def test_capability_join_supported_but_absent(conn):
+    sid = _insert_event_session(
+        conn, session_key="s:cap-absent", client="codex"
+    )
+    states = {s.event_type: s for s in capability_join(conn, sid)}
+    # codex matrix: tool_call is supported but we've not inserted any events.
+    assert states["tool_call"].state == "supported_but_absent"
+    assert states["tool_call"].observed_base_count == 0
+
+
+def test_capability_join_override_only_flips_to_present(conn):
+    sid = _insert_event_session(
+        conn, session_key="s:cap-override", client="codex"
+    )
+    # codex doesn't emit stdout_chunk — if a hook writes an override, it flips.
+    write_hook_override(
+        conn,
+        session_key="s:cap-override",
+        event_key="stdout_chunk:c1",
+        event_type="stdout_chunk",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS0,
+        payload_json="{}",
+        origin=None,
+    )
+    states = {s.event_type: s for s in capability_join(conn, sid)}
+    assert states["stdout_chunk"].state == "present"
+    assert states["stdout_chunk"].observed_base_count == 0
+    assert states["stdout_chunk"].observed_override_count == 1
+
+
+def test_capability_join_raises_on_unknown_session(conn):
+    with pytest.raises(KeyError):
+        capability_join(conn, 999_999)
+
+
+# --------------------------------------------------------------------------- #
+# fetch_vendor_line
+# --------------------------------------------------------------------------- #
+
+
+def test_fetch_vendor_line_existing_line(tmp_path):
+    path = tmp_path / "t.jsonl"
+    line1 = b'{"a":1}\n'
+    line2 = b'{"b":2}\n'
+    path.write_bytes(line1 + line2)
+    assert fetch_vendor_line(path, 0) == '{"a":1}'
+    assert fetch_vendor_line(path, len(line1)) == '{"b":2}'
+
+
+def test_fetch_vendor_line_missing_file(tmp_path):
+    assert fetch_vendor_line(tmp_path / "nonexistent.jsonl", 0) is None
+
+
+def test_fetch_vendor_line_past_eof_returns_none(tmp_path):
+    path = tmp_path / "t.jsonl"
+    path.write_bytes(b'{"a":1}\n')
+    assert fetch_vendor_line(path, 9999) is None
+
+
+def test_fetch_vendor_line_partial_trailing_line_returns_none(tmp_path):
+    path = tmp_path / "t.jsonl"
+    path.write_bytes(b'{"a":1}\n{"incomplete":true')
+    # First line still works.
+    assert fetch_vendor_line(path, 0) == '{"a":1}'
+    # Partial line (no newline after offset) → None.
+    assert fetch_vendor_line(path, len(b'{"a":1}\n')) is None
+
+
+def test_fetch_vendor_line_strips_crlf(tmp_path):
+    path = tmp_path / "t.jsonl"
+    path.write_bytes(b'{"a":1}\r\n')
+    assert fetch_vendor_line(path, 0) == '{"a":1}'
+
+
+def test_fetch_vendor_line_handles_utf8(tmp_path):
+    payload = {"msg": "你好 🙂"}
+    line = (json.dumps(payload) + "\n").encode("utf-8")
+    path = tmp_path / "t.jsonl"
+    path.write_bytes(line)
+    result = fetch_vendor_line(path, 0)
+    assert result is not None
+    assert json.loads(result) == payload

--- a/tests/events/test_view.py
+++ b/tests/events/test_view.py
@@ -274,6 +274,9 @@ def test_write_hook_override_raises_on_unknown_session(conn):
         (dict(confidence="medium-high"), "confidence"),
         (dict(lossiness="weird"), "lossiness"),
         (dict(event_key=""), "event_key"),
+        (dict(payload_json="not json at all"), "payload_json"),
+        (dict(payload_json=""), "payload_json"),
+        (dict(payload_json=None), "payload_json must be a JSON string"),
     ],
 )
 def test_write_hook_override_validation(conn, kwargs, match):
@@ -699,6 +702,16 @@ def test_fetch_vendor_line_enforces_safety_cap(tmp_path, monkeypatch):
     path = tmp_path / "huge.jsonl"
     # 32 bytes with no newline — well past the 8-byte cap.
     path.write_bytes(b"x" * 32)
+    assert fetch_vendor_line(path, 0) is None
+
+
+def test_fetch_vendor_line_rejects_newline_beyond_safety_cap(tmp_path, monkeypatch):
+    from clawjournal.events import view as view_module
+
+    monkeypatch.setattr(view_module, "_MAX_LINE_BYTES", 8)
+    monkeypatch.setattr(view_module, "_FETCH_CHUNK", 32)
+    path = tmp_path / "beyond-cap.jsonl"
+    path.write_bytes(b"123456789\n")
     assert fetch_vendor_line(path, 0) is None
 
 

--- a/tests/events/test_view.py
+++ b/tests/events/test_view.py
@@ -688,3 +688,24 @@ def test_fetch_vendor_line_handles_utf8(tmp_path):
     result = fetch_vendor_line(path, 0)
     assert result is not None
     assert json.loads(result) == payload
+
+
+def test_fetch_vendor_line_enforces_safety_cap(tmp_path, monkeypatch):
+    """A file with no newline within the safety cap returns None rather
+    than reading the whole blob into memory."""
+    from clawjournal.events import view as view_module
+
+    monkeypatch.setattr(view_module, "_MAX_LINE_BYTES", 8)
+    path = tmp_path / "huge.jsonl"
+    # 32 bytes with no newline — well past the 8-byte cap.
+    path.write_bytes(b"x" * 32)
+    assert fetch_vendor_line(path, 0) is None
+
+
+def test_fetch_vendor_line_short_line_under_cap_still_works(tmp_path, monkeypatch):
+    from clawjournal.events import view as view_module
+
+    monkeypatch.setattr(view_module, "_MAX_LINE_BYTES", 1024)
+    path = tmp_path / "small.jsonl"
+    path.write_bytes(b'{"ok":1}\n')
+    assert fetch_vendor_line(path, 0) == '{"ok":1}'

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1071,6 +1071,70 @@ class TestEventsInspectCLI:
             conn.close()
         return event_id, session_key, session_file
 
+    def _seed_override_case(self, tmp_path, monkeypatch):
+        self._setup_db(tmp_path, monkeypatch)
+
+        vendor_file = tmp_path / "vendor.jsonl"
+        vendor_file.write_text('{"vendor":"line"}\n', encoding="utf-8")
+
+        from clawjournal.events import ensure_view_schema, write_hook_override
+        from clawjournal.events.schema import ensure_schema as ensure_events_schema
+        from clawjournal.workbench.index import open_index
+
+        session_key = "claude:demo-proj:sess-override"
+        conn = open_index()
+        try:
+            ensure_events_schema(conn)
+            ensure_view_schema(conn)
+            session_id = conn.execute(
+                """
+                INSERT INTO event_sessions (session_key, client, status)
+                VALUES (?, ?, ?)
+                """,
+                (session_key, "claude", "active"),
+            ).lastrowid
+            event_id = conn.execute(
+                """
+                INSERT INTO events (
+                    session_id, type, event_key, event_at, ingested_at, source,
+                    source_path, source_offset, seq, client, confidence, lossiness,
+                    raw_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    session_id,
+                    "tool_call",
+                    "tool_call:override",
+                    "2026-04-20T10:00:00Z",
+                    "2026-04-20T10:00:01Z",
+                    "claude-jsonl",
+                    str(vendor_file),
+                    0,
+                    0,
+                    "claude",
+                    "low",
+                    "none",
+                    '{"base":true}',
+                ),
+            ).lastrowid
+            conn.commit()
+            write_hook_override(
+                conn,
+                session_key=session_key,
+                event_key="tool_call:override",
+                event_type="tool_call",
+                source="hook",
+                confidence="high",
+                lossiness="none",
+                event_at="2026-04-20T10:00:02Z",
+                payload_json='{"override":true}',
+                origin="hook:test:v1",
+            )
+        finally:
+            conn.close()
+
+        return int(event_id), session_key, vendor_file
+
     def test_inspect_by_event_id_emits_json(self, tmp_path, monkeypatch, capsys):
         self._setup_db(tmp_path, monkeypatch)
         event_id, _, _ = self._ingest_one_user_line(tmp_path, monkeypatch)
@@ -1087,6 +1151,26 @@ class TestEventsInspectCLI:
         assert payload["override"] is None
         assert payload["raw_ref"][0].endswith("sess.jsonl")
         assert payload["vendor_line"] is not None
+
+    def test_inspect_by_event_id_prefers_canonical_override_fields(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        event_id, _, _ = self._seed_override_case(tmp_path, monkeypatch)
+
+        with patch.object(
+            sys, "argv", ["clawjournal", "events", "inspect", str(event_id), "--json"]
+        ):
+            main()
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["id"] == event_id
+        assert payload["type"] == "tool_call"
+        assert payload["source"] == "hook"
+        assert payload["confidence"] == "high"
+        assert payload["event_at"] == "2026-04-20T10:00:02Z"
+        assert payload["raw_json"] == '{"base":true}'
+        assert payload["override"]["payload_json"] == '{"override":true}'
+        assert payload["vendor_line"] == '{"vendor":"line"}'
 
     def test_inspect_missing_vendor_file_falls_back_to_placeholder(
         self, tmp_path, monkeypatch, capsys
@@ -1151,6 +1235,50 @@ class TestEventsInspectCLI:
         assert payload["raw_ref"] is None
         assert payload["override"]["origin"] == "hook:test:v1"
 
+    def test_inspect_by_session_and_event_key_prefers_canonical_override_fields(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        event_id, session_key, vendor_file = self._seed_override_case(
+            tmp_path, monkeypatch
+        )
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "clawjournal", "events", "inspect",
+                "--session", session_key,
+                "--event-key", "tool_call:override",
+                "--json",
+            ],
+        ):
+            main()
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["id"] == event_id
+        assert payload["type"] == "tool_call"
+        assert payload["source"] == "hook"
+        assert payload["confidence"] == "high"
+        assert payload["event_at"] == "2026-04-20T10:00:02Z"
+        assert payload["raw_ref"][0] == str(vendor_file)
+        assert payload["override"]["origin"] == "hook:test:v1"
+
+    def test_inspect_human_output_includes_raw_and_override_payloads(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        event_id, _, _ = self._seed_override_case(tmp_path, monkeypatch)
+
+        with patch.object(
+            sys, "argv", ["clawjournal", "events", "inspect", str(event_id)]
+        ):
+            main()
+
+        out = capsys.readouterr().out
+        assert "raw_json:" in out
+        assert '{"base":true}' in out
+        assert "override payload:" in out
+        assert '{"override":true}' in out
+
     def test_inspect_rejects_nonexistent_event_id(
         self, tmp_path, monkeypatch, capsys
     ):
@@ -1176,6 +1304,80 @@ class TestEventsInspectCLI:
             assert exc_info.value.code == 2
         err = capsys.readouterr().err
         assert "requires either" in err
+
+    def test_inspect_truncate_flag_shortens_raw_json(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        self._setup_db(tmp_path, monkeypatch)
+        payload = {
+            "type": "user",
+            "timestamp": "2026-04-20T10:00:00Z",
+            "message": {"content": "x" * 2000},
+        }
+        event_id, _, _ = self._ingest_one_user_line(
+            tmp_path, monkeypatch, vendor_line_payload=payload
+        )
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "clawjournal", "events", "inspect", str(event_id),
+                "--json", "--truncate", "64",
+            ],
+        ):
+            main()
+
+        out = json.loads(capsys.readouterr().out)
+        assert out["raw_json"].endswith("chars]")
+        assert "truncated at 64" in out["raw_json"]
+
+    def test_inspect_truncate_zero_disables_truncation(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        self._setup_db(tmp_path, monkeypatch)
+        payload = {
+            "type": "user",
+            "timestamp": "2026-04-20T10:00:00Z",
+            "message": {"content": "x" * 3000},
+        }
+        event_id, _, _ = self._ingest_one_user_line(
+            tmp_path, monkeypatch, vendor_line_payload=payload
+        )
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "clawjournal", "events", "inspect", str(event_id),
+                "--json", "--truncate", "0",
+            ],
+        ):
+            main()
+
+        out = json.loads(capsys.readouterr().out)
+        assert "truncated at" not in out["raw_json"]
+        assert len(out["raw_json"]) > 2000
+
+    def test_inspect_human_mode_default_truncates(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        self._setup_db(tmp_path, monkeypatch)
+        payload = {
+            "type": "user",
+            "timestamp": "2026-04-20T10:00:00Z",
+            "message": {"content": "x" * 3000},
+        }
+        event_id, _, _ = self._ingest_one_user_line(
+            tmp_path, monkeypatch, vendor_line_payload=payload
+        )
+
+        with patch.object(
+            sys, "argv", ["clawjournal", "events", "inspect", str(event_id)]
+        ):
+            main()
+        out = capsys.readouterr().out
+        assert "truncated at 1024" in out
 
 
 class TestShareHelpers:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1025,6 +1025,159 @@ class TestEventsCLI:
         assert payload["event_rows"] == 1
 
 
+class TestEventsInspectCLI:
+    def _setup_db(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db"
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.CONFIG_DIR", tmp_path / "config"
+        )
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / "config")
+
+    def _ingest_one_user_line(self, tmp_path, monkeypatch, vendor_line_payload=None):
+        """Drive real ingest to populate events + event_sessions from a
+        fabricated vendor JSONL file. Returns the ingested events.id."""
+        from clawjournal.parsing import parser
+
+        monkeypatch.setattr(parser, "PROJECTS_DIR", tmp_path / "claude" / "projects")
+        monkeypatch.setattr(parser, "CODEX_SESSIONS_DIR", tmp_path / "codex" / "sessions")
+        monkeypatch.setattr(
+            parser, "CODEX_ARCHIVED_DIR", tmp_path / "codex" / "archived_sessions"
+        )
+        monkeypatch.setattr(parser, "LOCAL_AGENT_DIR", tmp_path / "local_agent")
+        monkeypatch.setattr(parser, "OPENCLAW_AGENTS_DIR", tmp_path / "openclaw" / "agents")
+
+        session_file = tmp_path / "claude" / "projects" / "demo-proj" / "sess.jsonl"
+        session_file.parent.mkdir(parents=True)
+        payload = vendor_line_payload or {
+            "type": "user",
+            "timestamp": "2026-04-20T10:00:00Z",
+            "message": {"content": "hi"},
+        }
+        session_file.write_text(json.dumps(payload) + "\n", encoding="utf-8")
+
+        from clawjournal.events import ingest_pending
+        from clawjournal.workbench.index import open_index
+
+        conn = open_index()
+        try:
+            ingest_pending(conn, source_filter="claude")
+            event_id = conn.execute("SELECT id FROM events LIMIT 1").fetchone()[0]
+            session_key = conn.execute(
+                "SELECT session_key FROM event_sessions LIMIT 1"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        return event_id, session_key, session_file
+
+    def test_inspect_by_event_id_emits_json(self, tmp_path, monkeypatch, capsys):
+        self._setup_db(tmp_path, monkeypatch)
+        event_id, _, _ = self._ingest_one_user_line(tmp_path, monkeypatch)
+
+        with patch.object(
+            sys, "argv", ["clawjournal", "events", "inspect", str(event_id), "--json"]
+        ):
+            main()
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["id"] == event_id
+        assert payload["type"] == "user_message"
+        assert payload["client"] == "claude"
+        assert payload["override"] is None
+        assert payload["raw_ref"][0].endswith("sess.jsonl")
+        assert payload["vendor_line"] is not None
+
+    def test_inspect_missing_vendor_file_falls_back_to_placeholder(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        self._setup_db(tmp_path, monkeypatch)
+        event_id, _, session_file = self._ingest_one_user_line(tmp_path, monkeypatch)
+        session_file.unlink()
+
+        with patch.object(
+            sys, "argv", ["clawjournal", "events", "inspect", str(event_id)]
+        ):
+            main()
+
+        out = capsys.readouterr().out
+        assert "(source file no longer on disk)" in out
+
+    def test_inspect_by_session_and_event_key_hook_only(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A hook-only event (override with no matching base) must be
+        reachable via --session --event-key and marked hook_only."""
+        self._setup_db(tmp_path, monkeypatch)
+        _, session_key, _ = self._ingest_one_user_line(tmp_path, monkeypatch)
+
+        from clawjournal.events import ensure_view_schema, write_hook_override
+        from clawjournal.workbench.index import open_index
+
+        conn = open_index()
+        try:
+            ensure_view_schema(conn)
+            write_hook_override(
+                conn,
+                session_key=session_key,
+                event_key="tool_call:hook-only",
+                event_type="tool_call",
+                source="hook",
+                confidence="high",
+                lossiness="none",
+                event_at="2026-04-20T10:00:05Z",
+                payload_json='{"hook":true}',
+                origin="hook:test:v1",
+            )
+        finally:
+            conn.close()
+
+        with patch.object(
+            sys,
+            "argv",
+            [
+                "clawjournal", "events", "inspect",
+                "--session", session_key,
+                "--event-key", "tool_call:hook-only",
+                "--json",
+            ],
+        ):
+            main()
+
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["id"] is None
+        assert payload["hook_only"] is True
+        assert payload["raw_json"] is None
+        assert payload["raw_ref"] is None
+        assert payload["override"]["origin"] == "hook:test:v1"
+
+    def test_inspect_rejects_nonexistent_event_id(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        self._setup_db(tmp_path, monkeypatch)
+        self._ingest_one_user_line(tmp_path, monkeypatch)
+
+        with patch.object(
+            sys, "argv", ["clawjournal", "events", "inspect", "999999"]
+        ):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 1
+        err = capsys.readouterr().err
+        assert "event not found" in err
+
+    def test_inspect_requires_id_xor_session_event_key(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        self._setup_db(tmp_path, monkeypatch)
+        with patch.object(sys, "argv", ["clawjournal", "events", "inspect"]):
+            with pytest.raises(SystemExit) as exc_info:
+                main()
+            assert exc_info.value.code == 2
+        err = capsys.readouterr().err
+        assert "requires either" in err
+
+
 class TestShareHelpers:
     def test_share_preview_json_returns_payload(self):
         payload = _share_preview([{"session_id": "s1", "display_title": "hello", "risk_badges": "[]"}], output_json=True)


### PR DESCRIPTION
## Summary

Implements plan 03. 02 shipped the provenance fields (`source`, `confidence`, `lossiness`, `event_key`) on `events` rows already; this PR adds the overwrite table + read-time contract on top.

- New module `clawjournal/events/view.py`:
  - `ensure_view_schema` — `event_overrides` table with CHECK constraints + cascade-on-session-delete. `PRIMARY KEY (session_id, event_key)`.
  - `write_hook_override` — the one supported entry point for Beat 3+ hooks. Rank guard strictly greater on override-vs-override (SQL `CASE`-encoded so it survives multi-process writers).
  - `canonical_events` — deduped stream. For each event_key: first base row wins unless `rank(override) >= rank(base)`, in which case the override contributes metadata + `payload_json` and the base contributes `raw_json` + `raw_ref`. Hook-only overrides emit after the base stream with `raw_json=None` / `raw_ref=None`.
  - `capability_join` — three-state report (`present` / `missing` / `supported_but_absent`) with `observed_base_count` + `observed_override_count` split so consumers can distinguish client-emitted from hook-synthesized events.
  - `fetch_vendor_line` — best-effort retrieval of the vendor JSONL line. Returns `None` on missing file, past-EOF, or partial trailing line. Strips trailing `\r`. Does NOT detect rotation (documented Phase-1 limit; needs inode persistence in 01/02).
- New CLI `clawjournal events inspect <event-id> | --session <k> --event-key <k>` with `--json` mode. Human output matches the plan's rendering; hook-only events are reachable only via `--session --event-key`. Consults a future 07-owned `event_source_snippets` table before `fetch_vendor_line()`, tolerating its absence today.
- `CONFIDENCE_RANK = {"high":3,"medium":2,"low":1,"missing":0}` added to `events/types.py`.

## Design notes

- Hooks guard against override-vs-override drift with strict `>` at write time. The reader guards against override-vs-base with `>=` at read time. Both are documented on the plan's decisions table; this PR wires them.
- `missing` is a read-time state only. Writers reject it; CHECK constraints exclude it from `event_overrides.confidence`.
- `event_overrides.type` is required at write time so hook-only events can populate `CanonicalEvent.type` without needing a base row. (Minor plan deviation — noted in the implementation.)

## Test plan
- [x] `pytest tests/events/test_view.py` — 36 cases covering schema, rank guards, canonical stream, capability join, and vendor-line fetch edge cases.
- [x] `pytest tests/test_cli.py::TestEventsInspectCLI` — 5 cases covering lookup modes, hook-only handling, error paths.
- [x] `pytest` — full suite: 1270 passed.

Downstream stages (04 / 05 / 06 / 07) can now consume `canonical_events()` instead of querying `events` directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)