### PR TITLE
feat(events): cost ledger — token_usage, anomaly detection, incremental replay

### DIFF
--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3220,6 +3220,26 @@ def main() -> None:
              "(default: 1024 in human mode, no truncation in --json mode)",
     )
 
+    events_cost = events_sub.add_parser(
+        "cost",
+        help="Cost ledger commands (token attribution + anomaly detection)",
+    )
+    events_cost_sub = events_cost.add_subparsers(
+        dest="cost_command", required=True
+    )
+    events_cost_ingest = events_cost_sub.add_parser(
+        "ingest",
+        help="Extract token usage from already-recorded events and detect anomalies",
+    )
+    events_cost_ingest.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="Replay the full cost ledger from raw events, bypassing the incremental cursor",
+    )
+    events_cost_ingest.add_argument(
+        "--json", action="store_true", help="Output JSON summary"
+    )
+
     # Workbench commands
     serve_parser = sub.add_parser("serve", help="Start the workbench daemon + web UI")
     serve_parser.add_argument("--port", type=int, default=8384, help="Port (default: 8384)")
@@ -3892,6 +3912,10 @@ def _run_events(args) -> None:
         _run_events_inspect(args)
         return
 
+    if args.events_command == "cost":
+        _run_events_cost(args)
+        return
+
     conn = open_index()
     try:
         summary = ingest_pending(conn, source_filter=args.source)
@@ -3906,6 +3930,32 @@ def _run_events(args) -> None:
         f"Ingested {payload['event_rows']} event rows from "
         f"{payload['files_with_changes']} changed files "
         f"({payload['lines_read']} lines, {payload['sessions_touched']} sessions)."
+    )
+
+
+def _run_events_cost(args) -> None:
+    from .events.cost import ingest_cost_pending
+    from .workbench.index import open_index
+
+    if args.cost_command != "ingest":
+        print(f"Unknown cost command: {args.cost_command}", file=sys.stderr)
+        sys.exit(2)
+
+    conn = open_index()
+    try:
+        summary = ingest_cost_pending(conn, rebuild=args.rebuild)
+    finally:
+        conn.close()
+
+    payload = summary.to_dict()
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    print(
+        f"Cost ledger: scanned {payload['events_scanned']} events, "
+        f"wrote {payload['token_rows_written']} token_usage rows + "
+        f"{payload['anomalies_written']} anomalies "
+        f"across {payload['sessions_touched']} sessions."
     )
 
 

--- a/clawjournal/events/cost/__init__.py
+++ b/clawjournal/events/cost/__init__.py
@@ -1,0 +1,64 @@
+"""Cost ledger for the execution recorder (phase-1 plan 04).
+
+Per-event token + cost accounting on top of the raw event stream from
+02. The ledger reads `events.raw_json`, extracts vendor token-usage
+blocks via per-client extractors, persists a `token_usage` row keyed
+by `event_id`, and runs anomaly detectors (cache_read_collapse,
+input_spike, model_shift, service_tier_shift) into `cost_anomalies`.
+
+Every `token_usage` row records `data_source` (`api` vs `estimated`)
+so anomaly detectors can ignore comparisons that mix vendor-reported
+counts with content-length estimates.
+"""
+
+from __future__ import annotations
+
+from clawjournal.events.cost.anomalies import (
+    ANOMALY_KINDS,
+    AnomalyHit,
+    detect_session_anomalies,
+)
+from clawjournal.events.cost.extract import extract_tokens
+from clawjournal.events.cost.ingest import (
+    COST_CONSUMER_ID,
+    CostIngestSummary,
+    ingest_cost_pending,
+    rebuild_cost_ledger,
+)
+from clawjournal.events.cost.pricing import (
+    PRICING_TABLE,
+    PRICING_TABLE_VERSION,
+    ModelInfo,
+    estimate_cost,
+    normalize_model,
+)
+from clawjournal.events.cost.schema import ensure_cost_schema
+from clawjournal.events.cost.types import (
+    DATA_SOURCE_API,
+    DATA_SOURCE_ESTIMATED,
+    VALID_DATA_SOURCES,
+    CostAnomaly,
+    TokenUsage,
+)
+
+__all__ = [
+    "ANOMALY_KINDS",
+    "AnomalyHit",
+    "COST_CONSUMER_ID",
+    "CostAnomaly",
+    "CostIngestSummary",
+    "DATA_SOURCE_API",
+    "DATA_SOURCE_ESTIMATED",
+    "ModelInfo",
+    "PRICING_TABLE",
+    "PRICING_TABLE_VERSION",
+    "TokenUsage",
+    "VALID_DATA_SOURCES",
+    "detect_session_anomalies",
+    "ensure_cost_schema",
+    "estimate_cost",
+    "extract_tokens",
+    "ingest_cost_pending",
+    "normalize_model",
+    "rebuild_cost_ledger",
+]

--- a/clawjournal/events/cost/anomalies.py
+++ b/clawjournal/events/cost/anomalies.py
@@ -1,0 +1,255 @@
+"""Cost-ledger anomaly detectors.
+
+Four kinds:
+
+- `cache_read_collapse` — cache_read tokens dropped >= 50% between
+  two adjacent assistant turns whose input_tokens are within 25% of
+  each other (so we're not flagging a small turn against a big one).
+  Only fires when both adjacent rows are `data_source='api'`.
+
+- `input_spike` — current `input` exceeds 3x the rolling mean of the
+  prior `INPUT_SPIKE_BASELINE_WINDOW` rows. `data_source='estimated'`
+  rows are skipped entirely (both as the candidate and as part of the
+  baseline window).
+
+- `model_shift` — model id changed between adjacent rows.
+  `data_source` is not consulted: the model id is metadata, not a
+  count, so estimates participate.
+
+- `service_tier_shift` — service_tier changed between adjacent rows
+  with the same model. Surfaced as a separate kind from `model_shift`
+  so consumers can distinguish "same model, different latency tier"
+  (a routing change) from a model swap.
+
+Detection runs against `token_usage` rows for a session, ordered by
+event_at NULLS LAST then event_id. Returns a list of `AnomalyHit`
+objects without writing to the database — the ingest layer commits
+them via `INSERT OR IGNORE` so re-runs are idempotent under the
+`UNIQUE(session_id, kind, turn_event_id)` constraint.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from dataclasses import dataclass, field
+from typing import Any
+
+from clawjournal.events.cost.types import DATA_SOURCE_API
+
+ANOMALY_KINDS = (
+    "cache_read_collapse",
+    "input_spike",
+    "model_shift",
+    "service_tier_shift",
+)
+
+CACHE_READ_COLLAPSE_DROP_RATIO = 0.5     # 50% drop required
+CACHE_READ_COLLAPSE_INPUT_TOLERANCE = 0.25  # adjacent inputs within +/-25%
+INPUT_SPIKE_BASELINE_WINDOW = 5
+INPUT_SPIKE_MULTIPLIER = 3.0
+
+
+@dataclass(frozen=True)
+class AnomalyHit:
+    session_id: int
+    turn_event_id: int
+    kind: str
+    confidence: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+def detect_session_anomalies(
+    conn: sqlite3.Connection, session_id: int
+) -> list[AnomalyHit]:
+    """Run all anomaly detectors against a session's token_usage rows.
+
+    Reads only — never writes. The caller persists the returned hits
+    via `INSERT OR IGNORE` into `cost_anomalies`.
+    """
+    rows = list(
+        conn.execute(
+            """
+            SELECT event_id, model, input, output, cache_read, cache_write,
+                   reasoning, service_tier, data_source, event_at
+              FROM token_usage
+             WHERE session_id = ?
+             ORDER BY event_at IS NULL, event_at, event_id
+            """,
+            (session_id,),
+        )
+    )
+    if not rows:
+        return []
+
+    hits: list[AnomalyHit] = []
+    hits.extend(_detect_cache_read_collapse(session_id, rows))
+    hits.extend(_detect_input_spike(session_id, rows))
+    hits.extend(_detect_model_shift(session_id, rows))
+    hits.extend(_detect_service_tier_shift(session_id, rows))
+    return hits
+
+
+def _detect_cache_read_collapse(
+    session_id: int, rows: list[sqlite3.Row]
+) -> list[AnomalyHit]:
+    hits: list[AnomalyHit] = []
+    prev: sqlite3.Row | None = None
+    for row in rows:
+        if row["data_source"] != DATA_SOURCE_API:
+            # An estimated row breaks the chain — we don't reason
+            # about cache state across an estimate.
+            prev = None
+            continue
+        if prev is None or prev["data_source"] != DATA_SOURCE_API:
+            prev = row
+            continue
+        if not _similar_input(prev["input"], row["input"]):
+            prev = row
+            continue
+        cur_cache = row["cache_read"]
+        prev_cache = prev["cache_read"]
+        if prev_cache is None or cur_cache is None:
+            prev = row
+            continue
+        if prev_cache <= 0:
+            prev = row
+            continue
+        drop = (prev_cache - cur_cache) / prev_cache
+        if drop >= CACHE_READ_COLLAPSE_DROP_RATIO:
+            hits.append(
+                AnomalyHit(
+                    session_id=session_id,
+                    turn_event_id=int(row["event_id"]),
+                    kind="cache_read_collapse",
+                    confidence="high",
+                    evidence={
+                        "previous_cache_read": prev_cache,
+                        "current_cache_read": cur_cache,
+                        "drop_ratio": round(drop, 4),
+                        "previous_input": prev["input"],
+                        "current_input": row["input"],
+                        "previous_event_id": int(prev["event_id"]),
+                        "drop_threshold": CACHE_READ_COLLAPSE_DROP_RATIO,
+                    },
+                )
+            )
+        prev = row
+    return hits
+
+
+def _detect_input_spike(
+    session_id: int, rows: list[sqlite3.Row]
+) -> list[AnomalyHit]:
+    hits: list[AnomalyHit] = []
+    baseline: list[int] = []
+    for row in rows:
+        if row["data_source"] != DATA_SOURCE_API:
+            # Estimated rows participate in neither baseline nor candidate.
+            continue
+        cur = row["input"]
+        if cur is None:
+            continue
+        if len(baseline) >= 1:
+            mean = sum(baseline) / len(baseline)
+            if mean > 0 and cur > mean * INPUT_SPIKE_MULTIPLIER:
+                hits.append(
+                    AnomalyHit(
+                        session_id=session_id,
+                        turn_event_id=int(row["event_id"]),
+                        kind="input_spike",
+                        confidence="high",
+                        evidence={
+                            "current_input": cur,
+                            "baseline_mean": round(mean, 2),
+                            "baseline_window": list(baseline),
+                            "multiplier": INPUT_SPIKE_MULTIPLIER,
+                            "ratio": round(cur / mean, 2),
+                        },
+                    )
+                )
+        baseline.append(cur)
+        if len(baseline) > INPUT_SPIKE_BASELINE_WINDOW:
+            baseline.pop(0)
+    return hits
+
+
+def _detect_model_shift(
+    session_id: int, rows: list[sqlite3.Row]
+) -> list[AnomalyHit]:
+    hits: list[AnomalyHit] = []
+    prev_model: str | None = None
+    prev_event_id: int | None = None
+    for row in rows:
+        cur_model = row["model"]
+        if cur_model is None:
+            continue
+        if prev_model is not None and cur_model != prev_model:
+            hits.append(
+                AnomalyHit(
+                    session_id=session_id,
+                    turn_event_id=int(row["event_id"]),
+                    kind="model_shift",
+                    confidence="high",
+                    evidence={
+                        "previous_model": prev_model,
+                        "current_model": cur_model,
+                        "previous_event_id": prev_event_id,
+                    },
+                )
+            )
+        prev_model = cur_model
+        prev_event_id = int(row["event_id"])
+    return hits
+
+
+def _detect_service_tier_shift(
+    session_id: int, rows: list[sqlite3.Row]
+) -> list[AnomalyHit]:
+    hits: list[AnomalyHit] = []
+    prev_tier: str | None = None
+    prev_model: str | None = None
+    prev_event_id: int | None = None
+    for row in rows:
+        cur_tier = row["service_tier"]
+        cur_model = row["model"]
+        if cur_tier is None:
+            continue
+        if (
+            prev_tier is not None
+            and cur_tier != prev_tier
+            and prev_model is not None
+            and cur_model is not None
+            and cur_model == prev_model
+        ):
+            hits.append(
+                AnomalyHit(
+                    session_id=session_id,
+                    turn_event_id=int(row["event_id"]),
+                    kind="service_tier_shift",
+                    confidence="high",
+                    evidence={
+                        "previous_service_tier": prev_tier,
+                        "current_service_tier": cur_tier,
+                        "model": cur_model,
+                        "previous_event_id": prev_event_id,
+                    },
+                )
+            )
+        prev_tier = cur_tier
+        prev_model = cur_model
+        prev_event_id = int(row["event_id"])
+    return hits
+
+
+def _similar_input(prev_input: int | None, cur_input: int | None) -> bool:
+    """Cache-read collapse only fires when adjacent inputs are
+    comparable in size — otherwise a tiny turn after a huge one
+    naturally has fewer cache reads and we'd false-positive."""
+    if prev_input is None or cur_input is None:
+        return False
+    if prev_input <= 0:
+        return False
+    ratio = cur_input / prev_input
+    lo = 1 - CACHE_READ_COLLAPSE_INPUT_TOLERANCE
+    hi = 1 + CACHE_READ_COLLAPSE_INPUT_TOLERANCE
+    return lo <= ratio <= hi

--- a/clawjournal/events/cost/extract/__init__.py
+++ b/clawjournal/events/cost/extract/__init__.py
@@ -1,0 +1,47 @@
+"""Per-client token-usage extractors.
+
+Each extractor takes a parsed JSONL line dict and returns a
+`TokenUsage` populated from the vendor's own usage block, or `None`
+when the line carries no extractable usage. The dispatcher
+`extract_tokens(client, line)` picks the right extractor for the
+client.
+
+Estimation (`data_source='estimated'`) is NOT performed in the
+extractors — that's the ingest layer's call, when no extractor
+returned anything for a turn the user is asking about. Extractors
+only emit `data_source='api'`.
+"""
+
+from __future__ import annotations
+
+from typing import Callable
+
+from clawjournal.events.cost.extract.claude import extract_tokens as _claude
+from clawjournal.events.cost.extract.codex import extract_tokens as _codex
+from clawjournal.events.cost.types import TokenUsage
+
+_EXTRACTORS: dict[str, Callable[[dict], TokenUsage | None]] = {
+    "claude": _claude,
+    "codex": _codex,
+    # OpenClaw mirrors Claude's wire format closely; reuse the same
+    # extractor until the client diverges enough to justify a peer.
+    "openclaw": _claude,
+}
+
+
+def extract_tokens(client: str, line: dict) -> TokenUsage | None:
+    """Dispatch to the appropriate per-client extractor.
+
+    Returns None when the client is unknown or when the line has no
+    usage block to report. Callers MUST treat None as "no API-source
+    data" rather than as zero counts.
+    """
+    extractor = _EXTRACTORS.get(client)
+    if extractor is None:
+        return None
+    if not isinstance(line, dict):
+        return None
+    return extractor(line)
+
+
+__all__ = ["extract_tokens"]

--- a/clawjournal/events/cost/extract/claude.py
+++ b/clawjournal/events/cost/extract/claude.py
@@ -1,0 +1,97 @@
+"""Claude (and OpenClaw) JSONL token-usage extractor.
+
+Anthropic's wire format puts the usage block on assistant messages:
+
+    {
+      "type": "assistant",
+      "message": {
+        "model": "claude-opus-4-6",
+        "usage": {
+          "input_tokens": 3,
+          "output_tokens": 621,
+          "cache_creation_input_tokens": 12263,
+          "cache_read_input_tokens": 11895,
+          "service_tier": "standard",
+          ...
+        }
+      }
+    }
+
+Older client versions used `cache_creation_tokens` / `cache_read_tokens`
+without the `_input` infix. Both spellings are accepted; the canonical
+spelling per current vendor docs is the `_input` form. Reasoning
+tokens are not surfaced separately by Anthropic today (they roll
+into `output_tokens`); we leave `reasoning=None` rather than guess.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawjournal.events.cost.types import DATA_SOURCE_API, TokenUsage
+
+
+def extract_tokens(line: dict) -> TokenUsage | None:
+    if line.get("type") != "assistant":
+        return None
+    message = line.get("message")
+    if not isinstance(message, dict):
+        return None
+    usage = message.get("usage")
+    if not isinstance(usage, dict):
+        return None
+
+    model = _as_str(message.get("model")) or _as_str(line.get("model"))
+    input_tokens = _as_int(usage.get("input_tokens"))
+    output_tokens = _as_int(usage.get("output_tokens"))
+    cache_read = _first_int(
+        usage.get("cache_read_input_tokens"),
+        usage.get("cache_read_tokens"),
+    )
+    cache_write = _first_int(
+        usage.get("cache_creation_input_tokens"),
+        usage.get("cache_creation_tokens"),
+    )
+    reasoning = _as_int(usage.get("reasoning_tokens"))
+    service_tier = _as_str(usage.get("service_tier"))
+
+    if all(
+        v is None
+        for v in (input_tokens, output_tokens, cache_read, cache_write, reasoning)
+    ):
+        return None
+
+    return TokenUsage(
+        model=model,
+        input=input_tokens,
+        output=output_tokens,
+        cache_read=cache_read,
+        cache_write=cache_write,
+        reasoning=reasoning,
+        service_tier=service_tier,
+        data_source=DATA_SOURCE_API,
+    )
+
+
+def _as_int(value: Any) -> int | None:
+    if isinstance(value, bool):  # bool is a subclass of int — reject it
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+def _first_int(*values: Any) -> int | None:
+    for v in values:
+        out = _as_int(v)
+        if out is not None:
+            return out
+    return None
+
+
+def _as_str(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value
+    return None

--- a/clawjournal/events/cost/extract/codex.py
+++ b/clawjournal/events/cost/extract/codex.py
@@ -1,0 +1,95 @@
+"""Codex rollout token-usage extractor.
+
+Codex emits per-turn usage as an `event_msg` of type `token_count`:
+
+    {
+      "type": "event_msg",
+      "payload": {
+        "type": "token_count",
+        "info": {
+          "last_token_usage": {
+            "input_tokens": 3655,
+            "cached_input_tokens": 2048,
+            "output_tokens": 105,
+            "reasoning_output_tokens": 64
+          },
+          "total_token_usage": {...},
+          "model_context_window": 272000
+        }
+      }
+    }
+
+We attribute the per-turn delta (`last_token_usage`) to the row.
+Codex does NOT carry the model id on this event — the model is
+declared earlier in `turn_context`. The ingest layer threads the
+most-recently-seen model into the row; this extractor leaves
+`model=None`.
+
+Codex doesn't currently surface `service_tier`. Kept as None.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from clawjournal.events.cost.types import DATA_SOURCE_API, TokenUsage
+
+
+def extract_tokens(line: dict) -> TokenUsage | None:
+    if line.get("type") != "event_msg":
+        return None
+    payload = line.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    if payload.get("type") != "token_count":
+        return None
+    info = payload.get("info")
+    if not isinstance(info, dict):
+        return None
+
+    # `last_token_usage` is the per-turn delta — what we actually want
+    # to attribute to a single events row. `total_token_usage` is the
+    # session-cumulative figure and would double-count if we used it
+    # across rows.
+    usage = info.get("last_token_usage")
+    if not isinstance(usage, dict):
+        return None
+
+    input_tokens = _as_int(usage.get("input_tokens"))
+    output_tokens = _as_int(usage.get("output_tokens"))
+    cache_read = _as_int(usage.get("cached_input_tokens"))
+    reasoning = _as_int(usage.get("reasoning_output_tokens"))
+    service_tier = _as_str(usage.get("service_tier"))
+
+    if all(
+        v is None
+        for v in (input_tokens, output_tokens, cache_read, reasoning)
+    ):
+        return None
+
+    return TokenUsage(
+        model=None,
+        input=input_tokens,
+        output=output_tokens,
+        cache_read=cache_read,
+        cache_write=None,  # Codex/OpenAI don't bill cache writes today
+        reasoning=reasoning,
+        service_tier=service_tier,
+        data_source=DATA_SOURCE_API,
+    )
+
+
+def _as_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return None
+
+
+def _as_str(value: Any) -> str | None:
+    if isinstance(value, str) and value.strip():
+        return value
+    return None

--- a/clawjournal/events/cost/ingest.py
+++ b/clawjournal/events/cost/ingest.py
@@ -1,0 +1,349 @@
+"""Drive the cost ledger from already-ingested `events` rows.
+
+Walks new `events` rows since the cost ledger's last successful run,
+runs the per-client extractor against `raw_json`, and persists a row
+(`data_source='api'`) when the vendor surfaced usage. Rows that carry
+no usage block are still marked as examined via the cost-ingest cursor
+so repeated runs do not rescan them forever.
+
+For Codex — where the model id is carried on `turn_context` rather
+than the `token_count` event itself — we backfill the most-recently-
+seen model per session as we walk in canonical order, and seed from
+earlier raw events when a token_count lands in a later batch than its
+preceding turn_context.
+
+This module deliberately does NOT perform content-length estimation.
+The spec leaves the door open for `data_source='estimated'` rows but
+the v0.1 ingest only records what the API actually emitted; the
+extraction layer (`clawjournal/events/cost/extract/`) returns None
+for lines without a usage block. Estimation is tracked as a
+follow-up so that the data we do persist is unambiguously vendor
+truth.
+
+After token_usage rows land for the touched sessions, we run the
+anomaly detectors on those sessions and replace that session's
+`cost_anomalies` rows with the fresh hit set so stale anomalies do not
+linger after late-arriving events change adjacency or baselines.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from clawjournal.events.cost.anomalies import detect_session_anomalies
+from clawjournal.events.cost.extract import extract_tokens
+from clawjournal.events.cost.pricing import (
+    PRICING_TABLE_VERSION,
+    estimate_cost,
+    normalize_model,
+)
+from clawjournal.events.cost.schema import ensure_cost_schema
+from clawjournal.events.schema import ensure_schema as ensure_events_schema
+
+COST_CONSUMER_ID = "cost_ledger"
+
+
+@dataclass
+class CostIngestSummary:
+    events_scanned: int = 0
+    token_rows_written: int = 0
+    anomalies_written: int = 0
+    sessions_touched: set[int] = field(default_factory=set, repr=False)
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "events_scanned": self.events_scanned,
+            "token_rows_written": self.token_rows_written,
+            "anomalies_written": self.anomalies_written,
+            "sessions_touched": len(self.sessions_touched),
+        }
+
+
+_INSERT_TOKEN_USAGE_SQL = """
+INSERT OR REPLACE INTO token_usage (
+    event_id, session_id, model, model_family, model_tier, model_provider,
+    input, output, cache_read, cache_write, reasoning,
+    service_tier, data_source, cost_estimate, pricing_table_version, event_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+_INSERT_ANOMALY_SQL = """
+INSERT INTO cost_anomalies (
+    session_id, turn_event_id, kind, confidence, evidence_json, created_at
+) VALUES (?, ?, ?, ?, ?, ?)
+"""
+
+_SELECT_NEW_EVENTS_SQL = """
+SELECT events.id           AS event_id,
+       events.session_id   AS session_id,
+       events.client       AS client,
+       events.type         AS type,
+       events.event_at     AS event_at,
+       events.raw_json     AS raw_json
+  FROM events
+ WHERE events.id > ?
+ ORDER BY events.session_id, events.event_at IS NULL, events.event_at, events.id
+"""
+
+_SELECT_LAST_EVENT_ID_SQL = """
+SELECT last_event_id
+  FROM cost_ingest_state
+ WHERE consumer_id = ?
+"""
+
+_UPSERT_LAST_EVENT_ID_SQL = """
+INSERT INTO cost_ingest_state (consumer_id, last_event_id)
+VALUES (?, ?)
+ON CONFLICT(consumer_id) DO UPDATE SET
+    last_event_id = excluded.last_event_id
+"""
+
+_DELETE_INGEST_STATE_SQL = """
+DELETE FROM cost_ingest_state
+ WHERE consumer_id = ?
+"""
+
+_DELETE_ALL_TOKEN_USAGE_SQL = """
+DELETE FROM token_usage
+"""
+
+_DELETE_SESSION_ANOMALIES_SQL = """
+DELETE FROM cost_anomalies
+ WHERE session_id = ?
+"""
+
+_DELETE_ALL_ANOMALIES_SQL = """
+DELETE FROM cost_anomalies
+"""
+
+
+def ingest_cost_pending(
+    conn: sqlite3.Connection,
+    *,
+    now: datetime | None = None,
+    rebuild: bool = False,
+) -> CostIngestSummary:
+    """Scan new events, persist usage where the vendor emitted it, and
+    (re)compute anomalies for touched sessions.
+
+    The per-run cursor advances only after the token rows and anomaly
+    refresh commit together, so a crash cannot skip unprocessed
+    events. Re-running with no new events is a no-op.
+
+    With `rebuild=True`, the cost-ledger tables are cleared first and
+    then replayed from `events` id 1 onward. This is the supported path
+    when extractor coverage expands or an operator wants to recompute
+    historical rows from the raw event stream.
+    """
+    ensure_events_schema(conn)
+    ensure_cost_schema(conn)
+
+    summary = CostIngestSummary()
+    created_at = _utc_now_iso(now)
+    last_model_per_session: dict[int, str] = {}
+    last_event_id = 0 if rebuild else _get_last_processed_event_id(conn)
+
+    rows = conn.execute(_SELECT_NEW_EVENTS_SQL, (last_event_id,)).fetchall()
+    pending: list[tuple] = []
+    max_event_id = last_event_id
+    for row in rows:
+        summary.events_scanned += 1
+        event_id = int(row["event_id"])
+        session_id = int(row["session_id"])
+        max_event_id = max(max_event_id, event_id)
+        client = row["client"]
+        try:
+            line = json.loads(row["raw_json"])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(line, dict):
+            continue
+
+        # For Codex, threads the latest model from turn_context onto
+        # later token_count events in the same session.
+        if client == "codex":
+            model_from_turn = _codex_model_from_turn_context(line)
+            if model_from_turn:
+                last_model_per_session[session_id] = model_from_turn
+
+        usage = extract_tokens(client, line)
+        if usage is None:
+            continue
+
+        model = usage.model
+        if model is None and client == "codex":
+            model = last_model_per_session.get(session_id)
+            if model is None:
+                model = _latest_codex_model_before_event(
+                    conn,
+                    session_id=session_id,
+                    event_at=row["event_at"],
+                    event_id=event_id,
+                )
+                if model:
+                    last_model_per_session[session_id] = model
+
+        info = normalize_model(model)
+        cost = estimate_cost(
+            info,
+            input_tokens=usage.input,
+            output_tokens=usage.output,
+            cache_read_tokens=usage.cache_read,
+            cache_write_tokens=usage.cache_write,
+            reasoning_tokens=usage.reasoning,
+        )
+
+        pending.append(
+            (
+                event_id,
+                session_id,
+                model,
+                info.family,
+                info.tier,
+                info.provider,
+                usage.input,
+                usage.output,
+                usage.cache_read,
+                usage.cache_write,
+                usage.reasoning,
+                usage.service_tier,
+                usage.data_source,
+                cost,
+                PRICING_TABLE_VERSION,
+                row["event_at"],
+            )
+        )
+        summary.sessions_touched.add(session_id)
+
+    if summary.events_scanned or rebuild:
+        with conn:
+            if rebuild:
+                _reset_cost_ledger(conn)
+            if pending:
+                conn.executemany(_INSERT_TOKEN_USAGE_SQL, pending)
+                summary.token_rows_written = len(pending)
+
+            # Anomaly detection runs against the post-insert state, so any
+            # session that just received a new token_usage row gets fully
+            # recomputed. Delete-then-insert keeps the table aligned with the
+            # current session view and drops stale hits.
+            for session_id in sorted(summary.sessions_touched):
+                hits = detect_session_anomalies(conn, session_id)
+                conn.execute(_DELETE_SESSION_ANOMALIES_SQL, (session_id,))
+                if not hits:
+                    continue
+                conn.executemany(
+                    _INSERT_ANOMALY_SQL,
+                    [
+                        (
+                            hit.session_id,
+                            hit.turn_event_id,
+                            hit.kind,
+                            hit.confidence,
+                            json.dumps(hit.evidence, sort_keys=True),
+                            created_at,
+                        )
+                        for hit in hits
+                    ],
+                )
+                summary.anomalies_written += len(hits)
+
+            conn.execute(
+                _UPSERT_LAST_EVENT_ID_SQL,
+                (COST_CONSUMER_ID, max_event_id),
+            )
+
+    return summary
+
+
+def rebuild_cost_ledger(
+    conn: sqlite3.Connection,
+    *,
+    now: datetime | None = None,
+) -> CostIngestSummary:
+    """Replay the full cost ledger from raw events."""
+    return ingest_cost_pending(conn, now=now, rebuild=True)
+
+
+def _get_last_processed_event_id(conn: sqlite3.Connection) -> int:
+    row = conn.execute(_SELECT_LAST_EVENT_ID_SQL, (COST_CONSUMER_ID,)).fetchone()
+    if row is None:
+        return 0
+    return int(row["last_event_id"])
+
+
+def _reset_cost_ledger(conn: sqlite3.Connection) -> None:
+    """Clear derived cost-ledger state so the next ingest replays all events."""
+    conn.execute(_DELETE_ALL_ANOMALIES_SQL)
+    conn.execute(_DELETE_ALL_TOKEN_USAGE_SQL)
+    conn.execute(_DELETE_INGEST_STATE_SQL, (COST_CONSUMER_ID,))
+
+
+def _latest_codex_model_before_event(
+    conn: sqlite3.Connection,
+    *,
+    session_id: int,
+    event_at: str | None,
+    event_id: int,
+) -> str | None:
+    """Find the nearest earlier Codex turn_context model for a session.
+
+    Incremental ingest only scans new events, so a token_count row may land in
+    a later run than its preceding turn_context. Query the earlier raw events in
+    canonical order to recover the model rather than depending on re-scans.
+    """
+    rows = conn.execute(
+        """
+        SELECT raw_json
+          FROM events
+         WHERE session_id = ?
+           AND client = 'codex'
+           AND (
+               (? IS NOT NULL AND event_at IS NOT NULL AND
+                   (event_at < ? OR (event_at = ? AND id < ?)))
+               OR
+               (? IS NULL AND (event_at IS NOT NULL OR (event_at IS NULL AND id < ?)))
+           )
+         ORDER BY event_at IS NULL DESC, event_at DESC, id DESC
+        """,
+        (
+            session_id,
+            event_at,
+            event_at,
+            event_at,
+            event_id,
+            event_at,
+            event_id,
+        ),
+    )
+    for row in rows:
+        try:
+            line = json.loads(row["raw_json"])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(line, dict):
+            continue
+        model = _codex_model_from_turn_context(line)
+        if model:
+            return model
+    return None
+
+
+def _codex_model_from_turn_context(line: dict) -> str | None:
+    if line.get("type") != "turn_context":
+        return None
+    payload = line.get("payload")
+    if not isinstance(payload, dict):
+        return None
+    model = payload.get("model")
+    if isinstance(model, str) and model.strip():
+        return model
+    return None
+
+
+def _utc_now_iso(now: datetime | None) -> str:
+    effective = now or datetime.now(timezone.utc)
+    return effective.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/clawjournal/events/cost/pricing.py
+++ b/clawjournal/events/cost/pricing.py
@@ -1,0 +1,200 @@
+"""Model normalization + versioned pricing table for the cost ledger.
+
+`normalize_model(raw)` turns a vendor model id into a
+`ModelInfo(family, tier, provider)` triple suitable for pricing-table
+lookup. Handles Claude (`opus` / `sonnet` / `haiku`), OpenAI
+(`o1`/`o3`/`o4`/`gpt-*`), and Gemini (`flash` / `pro` / `ultra`),
+with an `unknown` fallback that preserves the raw id as the tier so
+debug output stays meaningful.
+
+Pricing is keyed by `(family, tier)` with provider expressed
+explicitly per entry so cross-provider name collisions (e.g. an
+OpenAI vs. a Google model that both happen to be called `flash`)
+cannot accidentally share a row. `cost_estimate` is plainly an
+estimate — never billed truth — and exported bundles carry
+`PRICING_TABLE_VERSION` so off-machine review can pin the table that
+produced the numbers.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+# Bumped whenever a price changes. Persisted on every token_usage row
+# and exported alongside bundles so consumers know which table the
+# cost_estimate column was computed against.
+PRICING_TABLE_VERSION = "2026-04-21"
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    family: str
+    tier: str
+    provider: str
+
+
+@dataclass(frozen=True)
+class PricingEntry:
+    """USD per 1M tokens by token kind. Reasoning is split out per
+    open-question recommendation in 04-cost-ledger.md (vendors bill
+    thinking separately)."""
+
+    input: float
+    output: float
+    cache_read: float = 0.0
+    cache_write: float = 0.0
+    reasoning: float = 0.0
+
+
+# Keyed by `(family, tier)` to avoid cross-provider collisions.
+# Numbers reflect public list prices observed early 2026 and are
+# treated by the rest of the ledger as estimates only — they are not
+# a billing source of truth.
+PRICING_TABLE: dict[tuple[str, str], PricingEntry] = {
+    # --- Anthropic (Claude) ---
+    ("claude", "opus"):   PricingEntry(input=15.00, output=75.00, cache_read=1.50,  cache_write=18.75, reasoning=75.00),
+    ("claude", "sonnet"): PricingEntry(input=3.00,  output=15.00, cache_read=0.30,  cache_write=3.75,  reasoning=15.00),
+    ("claude", "haiku"):  PricingEntry(input=1.00,  output=5.00,  cache_read=0.10,  cache_write=1.25,  reasoning=5.00),
+    # --- OpenAI ---
+    ("gpt", "5.4"):       PricingEntry(input=2.50,  output=15.00, cache_read=0.25,  reasoning=15.00),
+    ("gpt", "5.4-mini"):  PricingEntry(input=0.75,  output=4.50,  cache_read=0.075, reasoning=4.50),
+    ("gpt", "5.4-nano"):  PricingEntry(input=0.20,  output=1.25,  cache_read=0.02,  reasoning=1.25),
+    ("gpt", "5.3-codex"): PricingEntry(input=1.75,  output=14.00, cache_read=0.175, reasoning=14.00),
+    ("gpt", "5.2"):       PricingEntry(input=1.75,  output=14.00, cache_read=0.175, reasoning=14.00),
+    ("gpt", "5.2-codex"): PricingEntry(input=1.75,  output=14.00, cache_read=0.175, reasoning=14.00),
+    ("gpt", "5.1"):       PricingEntry(input=1.25,  output=10.00, cache_read=0.125, reasoning=10.00),
+    ("gpt", "5.1-codex"): PricingEntry(input=1.25,  output=10.00, cache_read=0.125, reasoning=10.00),
+    ("gpt", "5.1-codex-max"): PricingEntry(input=1.25, output=10.00, cache_read=0.125, reasoning=10.00),
+    ("gpt", "5"):         PricingEntry(input=1.25,  output=10.00, cache_read=0.125, reasoning=10.00),
+    ("gpt", "5-codex"):   PricingEntry(input=1.25,  output=10.00, cache_read=0.125, reasoning=10.00),
+    ("gpt", "5-mini"):    PricingEntry(input=0.25,  output=2.00,  cache_read=0.025, reasoning=2.00),
+    ("gpt", "5-nano"):    PricingEntry(input=0.05,  output=0.40,  cache_read=0.005, reasoning=0.40),
+    ("gpt", "5-pro"):     PricingEntry(input=15.00, output=120.00, reasoning=120.00),
+    ("gpt", "4.1"):       PricingEntry(input=2.00,  output=8.00,  cache_read=0.50,  reasoning=8.00),
+    ("gpt", "4.1-mini"):  PricingEntry(input=0.40,  output=1.60, cache_read=0.10,  reasoning=1.60),
+    ("gpt", "4o"):        PricingEntry(input=2.50,  output=10.00, cache_read=1.25, reasoning=10.00),
+    ("gpt", "4o-mini"):   PricingEntry(input=0.15,  output=0.60, cache_read=0.075, reasoning=0.60),
+    ("o", "1"):           PricingEntry(input=15.00, output=60.00, reasoning=60.00),
+    ("o", "1-mini"):      PricingEntry(input=3.00,  output=12.00, reasoning=12.00),
+    ("o", "3"):           PricingEntry(input=2.00,  output=8.00,  reasoning=8.00),
+    ("o", "3-mini"):      PricingEntry(input=1.10,  output=4.40,  reasoning=4.40),
+    ("o", "4-mini"):      PricingEntry(input=1.10,  output=4.40,  reasoning=4.40),
+    # --- Google (Gemini) ---
+    ("gemini", "pro"):    PricingEntry(input=1.25,  output=10.00),
+    ("gemini", "flash"):  PricingEntry(input=0.30,  output=2.50),
+    ("gemini", "ultra"):  PricingEntry(input=7.00,  output=21.00),
+}
+
+
+def normalize_model(raw: str | None) -> ModelInfo:
+    """Map a vendor model id to a `(family, tier, provider)` triple.
+
+    The raw id may include provider prefixes (`anthropic/...`),
+    snapshot dates (`...-20241022`), or marketing suffixes. The
+    normalizer tries to extract `family` (`claude` / `gpt` / `o` /
+    `gemini`) and `tier` (`opus`/`sonnet`/`haiku`/`4o`/`pro`/...)
+    deterministically. Anything it cannot place returns
+    `ModelInfo(family="unknown", tier=<raw>, provider="unknown")` so
+    the original string survives in pricing-table-lookup misses for
+    debugging.
+    """
+    if not raw or not isinstance(raw, str):
+        return ModelInfo(family="unknown", tier="", provider="unknown")
+
+    cleaned = raw.strip()
+    if not cleaned:
+        return ModelInfo(family="unknown", tier="", provider="unknown")
+
+    lowered = cleaned.lower()
+    if "/" in lowered:
+        lowered = lowered.rsplit("/", 1)[-1]
+
+    # --- Anthropic (Claude) ---
+    if "claude" in lowered:
+        for tier in ("opus", "sonnet", "haiku"):
+            if tier in lowered:
+                return ModelInfo(family="claude", tier=tier, provider="anthropic")
+        return ModelInfo(family="claude", tier=lowered, provider="anthropic")
+
+    # --- OpenAI o-series (must check before "gpt" because "o3" et al
+    # do not contain "gpt"). Order matters: longer tiers first so that
+    # `o3-mini` doesn't collapse to `3`.
+    o_tiers = ("4-mini", "3-mini", "1-mini", "4", "3", "1")
+    for tier in o_tiers:
+        prefix = f"o{tier}"
+        if lowered == prefix or lowered.startswith(f"{prefix}-") or lowered.startswith(f"{prefix}_"):
+            return ModelInfo(family="o", tier=tier, provider="openai")
+
+    # --- OpenAI GPT-4-class ---
+    if "gpt" in lowered:
+        # Match longer tiers first so suffixed Codex / mini variants don't
+        # collapse onto shorter parents.
+        for tier in (
+            "5.4-mini",
+            "5.4-nano",
+            "5.4",
+            "5.3-codex",
+            "5.2-codex",
+            "5.2",
+            "5.1-codex-max",
+            "5.1-codex",
+            "5.1",
+            "5-codex",
+            "5-pro",
+            "5-mini",
+            "5-nano",
+            "5",
+            "4.1-mini",
+            "4.1",
+            "4o-mini",
+            "4o",
+            "4-turbo",
+            "4",
+            "3.5",
+        ):
+            prefix = f"gpt-{tier}"
+            if lowered == prefix or lowered.startswith(f"{prefix}-") or lowered.startswith(f"{prefix}_"):
+                return ModelInfo(family="gpt", tier=tier, provider="openai")
+        return ModelInfo(family="gpt", tier=lowered, provider="openai")
+
+    # --- Gemini ---
+    if "gemini" in lowered:
+        for tier in ("flash", "pro", "ultra"):
+            if tier in lowered:
+                return ModelInfo(family="gemini", tier=tier, provider="google")
+        return ModelInfo(family="gemini", tier=lowered, provider="google")
+
+    return ModelInfo(family="unknown", tier=cleaned, provider="unknown")
+
+
+def estimate_cost(
+    model_info: ModelInfo,
+    *,
+    input_tokens: int | None,
+    output_tokens: int | None,
+    cache_read_tokens: int | None = None,
+    cache_write_tokens: int | None = None,
+    reasoning_tokens: int | None = None,
+) -> float | None:
+    """Return USD cost estimate, or None if the model isn't priced.
+
+    `None` token counts are treated as 0 for the cost arithmetic only.
+    Persistence layer keeps them as NULL so confidence semantics
+    survive — this helper is purely the dollars math.
+    """
+    entry = PRICING_TABLE.get((model_info.family, model_info.tier))
+    if entry is None:
+        return None
+    inp = input_tokens or 0
+    out = output_tokens or 0
+    cr = cache_read_tokens or 0
+    cw = cache_write_tokens or 0
+    rs = reasoning_tokens or 0
+    cost = (
+        inp * entry.input
+        + out * entry.output
+        + cr * entry.cache_read
+        + cw * entry.cache_write
+        + rs * entry.reasoning
+    ) / 1_000_000
+    return cost

--- a/clawjournal/events/cost/schema.py
+++ b/clawjournal/events/cost/schema.py
@@ -1,0 +1,82 @@
+"""SQLite schema for the cost ledger (phase-1 plan 04).
+
+Three tables:
+
+- `token_usage` — one row per `events.id` that carried a usage block.
+  Columns mirror the spec, with `data_source` CHECK-constrained to
+  `api` / `estimated`. Numeric columns are nullable so that a vendor
+  field the client doesn't emit can stay NULL (and surface as
+  `confidence=missing` via the 03 layer) rather than being coerced to
+  zero.
+
+- `cost_anomalies` — one row per detected anomaly (cache_read_collapse,
+  input_spike, model_shift, service_tier_shift). `evidence_json`
+  carries the per-anomaly context (e.g. previous + current token
+  counts, threshold used).
+
+- `cost_ingest_state` — lightweight cursor state for the cost-ledger
+  consumer so already-examined non-usage events do not get rescanned on
+  every run.
+
+All tables live in `~/.clawjournal/index.db` alongside 02's
+`events` / `event_sessions`.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+TOKEN_USAGE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS token_usage (
+    event_id              INTEGER PRIMARY KEY REFERENCES events(id) ON DELETE CASCADE,
+    session_id            INTEGER NOT NULL REFERENCES event_sessions(id) ON DELETE CASCADE,
+    model                 TEXT,
+    model_family          TEXT,
+    model_tier            TEXT,
+    model_provider        TEXT,
+    input                 INTEGER,
+    output                INTEGER,
+    cache_read            INTEGER,
+    cache_write           INTEGER,
+    reasoning             INTEGER,
+    service_tier          TEXT,
+    data_source           TEXT    NOT NULL CHECK (data_source IN ('api','estimated')),
+    cost_estimate         REAL,
+    pricing_table_version TEXT,
+    event_at              TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_token_usage_session
+    ON token_usage(session_id, event_at);
+CREATE INDEX IF NOT EXISTS idx_token_usage_data_source
+    ON token_usage(session_id, data_source);
+"""
+
+COST_INGEST_STATE_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS cost_ingest_state (
+    consumer_id   TEXT PRIMARY KEY,
+    last_event_id INTEGER NOT NULL
+);
+"""
+
+COST_ANOMALIES_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS cost_anomalies (
+    id             INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id     INTEGER NOT NULL REFERENCES event_sessions(id) ON DELETE CASCADE,
+    turn_event_id  INTEGER REFERENCES events(id) ON DELETE SET NULL,
+    kind           TEXT    NOT NULL,
+    confidence     TEXT    NOT NULL,
+    evidence_json  TEXT    NOT NULL,
+    created_at     TEXT    NOT NULL,
+    UNIQUE (session_id, kind, turn_event_id)
+);
+CREATE INDEX IF NOT EXISTS idx_cost_anomalies_session
+    ON cost_anomalies(session_id, kind);
+"""
+
+
+def ensure_cost_schema(conn: sqlite3.Connection) -> None:
+    """Create cost-ledger tables if absent. Safe to call repeatedly."""
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.executescript(TOKEN_USAGE_TABLE_SQL)
+    conn.executescript(COST_INGEST_STATE_TABLE_SQL)
+    conn.executescript(COST_ANOMALIES_TABLE_SQL)

--- a/clawjournal/events/cost/types.py
+++ b/clawjournal/events/cost/types.py
@@ -1,0 +1,52 @@
+"""Dataclasses + constants for the cost ledger (phase-1 plan 04)."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+DATA_SOURCE_API = "api"
+DATA_SOURCE_ESTIMATED = "estimated"
+VALID_DATA_SOURCES = {DATA_SOURCE_API, DATA_SOURCE_ESTIMATED}
+
+
+@dataclass(frozen=True)
+class TokenUsage:
+    """Token counts attributable to a single `events` row.
+
+    A `None` count is "the vendor did not emit this field" — it must
+    NOT be coerced to 0, since 03's capability_join needs to surface
+    these as `confidence=missing` rather than as legitimate zero usage.
+
+    `data_source='api'` means the values came verbatim from the
+    vendor's usage block (Anthropic `usage`, OpenAI `token_count`,
+    etc). `data_source='estimated'` means they were inferred from
+    content length and downstream anomaly detectors must skip them.
+    """
+
+    model: str | None
+    input: int | None
+    output: int | None
+    cache_read: int | None
+    cache_write: int | None
+    reasoning: int | None
+    service_tier: str | None
+    data_source: str
+
+    def __post_init__(self) -> None:
+        if self.data_source not in VALID_DATA_SOURCES:
+            raise ValueError(
+                f"Invalid data_source: {self.data_source!r} "
+                f"(valid: {sorted(VALID_DATA_SOURCES)})"
+            )
+
+
+@dataclass(frozen=True)
+class CostAnomaly:
+    """A detected divergence between adjacent token-usage rows."""
+
+    session_id: int
+    turn_event_id: int | None
+    kind: str
+    confidence: str
+    evidence: dict[str, Any] = field(default_factory=dict)

--- a/tests/events/cost/test_extract.py
+++ b/tests/events/cost/test_extract.py
@@ -1,0 +1,173 @@
+"""Per-client token-extractor unit tests."""
+
+from __future__ import annotations
+
+from clawjournal.events.cost import DATA_SOURCE_API, extract_tokens
+from clawjournal.events.cost.extract import extract_tokens as direct_extract
+
+
+def test_claude_assistant_with_full_usage_block():
+    line = {
+        "type": "assistant",
+        "message": {
+            "model": "claude-opus-4-6",
+            "usage": {
+                "input_tokens": 3,
+                "output_tokens": 621,
+                "cache_creation_input_tokens": 12263,
+                "cache_read_input_tokens": 11895,
+                "service_tier": "standard",
+            },
+        },
+    }
+    usage = extract_tokens("claude", line)
+    assert usage is not None
+    assert usage.model == "claude-opus-4-6"
+    assert usage.input == 3
+    assert usage.output == 621
+    assert usage.cache_read == 11895
+    assert usage.cache_write == 12263
+    assert usage.reasoning is None
+    assert usage.service_tier == "standard"
+    assert usage.data_source == DATA_SOURCE_API
+
+
+def test_claude_legacy_field_aliases():
+    """Older client versions emit cache_*_tokens without the
+    `_input` infix — the extractor must accept both spellings."""
+    line = {
+        "type": "assistant",
+        "message": {
+            "model": "claude-sonnet-4",
+            "usage": {
+                "input_tokens": 100,
+                "output_tokens": 50,
+                "cache_creation_tokens": 7,
+                "cache_read_tokens": 3,
+            },
+        },
+    }
+    usage = extract_tokens("claude", line)
+    assert usage is not None
+    assert usage.cache_read == 3
+    assert usage.cache_write == 7
+
+
+def test_claude_canonical_field_takes_precedence_over_legacy():
+    line = {
+        "type": "assistant",
+        "message": {
+            "model": "claude-sonnet-4",
+            "usage": {
+                "input_tokens": 1,
+                "output_tokens": 1,
+                "cache_read_input_tokens": 999,
+                "cache_read_tokens": 1,
+                "cache_creation_input_tokens": 888,
+                "cache_creation_tokens": 1,
+            },
+        },
+    }
+    usage = extract_tokens("claude", line)
+    assert usage.cache_read == 999
+    assert usage.cache_write == 888
+
+
+def test_claude_missing_field_stays_none_not_zero():
+    """A vendor field that wasn't emitted must stay None so the
+    capability layer can surface it as `confidence=missing`."""
+    line = {
+        "type": "assistant",
+        "message": {
+            "model": "claude-opus-4-6",
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 5,
+            },
+        },
+    }
+    usage = extract_tokens("claude", line)
+    assert usage is not None
+    assert usage.input == 10
+    assert usage.cache_read is None
+    assert usage.cache_write is None
+    assert usage.reasoning is None
+
+
+def test_claude_non_assistant_returns_none():
+    assert extract_tokens("claude", {"type": "user"}) is None
+
+
+def test_claude_no_usage_block_returns_none():
+    assert (
+        extract_tokens(
+            "claude", {"type": "assistant", "message": {"model": "x"}}
+        )
+        is None
+    )
+
+
+def test_codex_token_count_event_extracts_last_turn_usage():
+    line = {
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {
+                "last_token_usage": {
+                    "input_tokens": 3655,
+                    "cached_input_tokens": 2048,
+                    "output_tokens": 105,
+                    "reasoning_output_tokens": 64,
+                },
+                "total_token_usage": {
+                    "input_tokens": 9999,
+                    "output_tokens": 999,
+                },
+            },
+        },
+    }
+    usage = extract_tokens("codex", line)
+    assert usage is not None
+    # Per-turn delta wins over cumulative, otherwise we'd double-count.
+    assert usage.input == 3655
+    assert usage.cache_read == 2048
+    assert usage.output == 105
+    assert usage.reasoning == 64
+    assert usage.cache_write is None
+    assert usage.model is None  # threaded in by the ingest layer
+    assert usage.data_source == DATA_SOURCE_API
+
+
+def test_codex_token_count_with_no_info_returns_none():
+    line = {
+        "type": "event_msg",
+        "payload": {"type": "token_count", "info": None},
+    }
+    assert extract_tokens("codex", line) is None
+
+
+def test_codex_unrelated_event_returns_none():
+    line = {"type": "turn_context", "payload": {"model": "gpt-5-codex"}}
+    assert extract_tokens("codex", line) is None
+
+
+def test_dispatcher_unknown_client_returns_none():
+    assert direct_extract("not-a-client", {"type": "assistant"}) is None
+
+
+def test_dispatcher_handles_non_dict_line():
+    assert direct_extract("claude", "not a dict") is None  # type: ignore[arg-type]
+
+
+def test_openclaw_uses_claude_extractor():
+    """OpenClaw mirrors Claude's wire format; sanity-check the alias."""
+    line = {
+        "type": "assistant",
+        "message": {
+            "model": "claude-haiku-4-5",
+            "usage": {"input_tokens": 1, "output_tokens": 2},
+        },
+    }
+    usage = extract_tokens("openclaw", line)
+    assert usage is not None
+    assert usage.model == "claude-haiku-4-5"

--- a/tests/events/cost/test_ingest.py
+++ b/tests/events/cost/test_ingest.py
@@ -1,0 +1,515 @@
+"""End-to-end tests for ingest_cost_pending + anomaly detection."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from clawjournal.events.cost import (
+    ANOMALY_KINDS,
+    PRICING_TABLE_VERSION,
+    ensure_cost_schema,
+    ingest_cost_pending,
+)
+from clawjournal.events.schema import ensure_schema as ensure_events_schema
+
+
+TS = "2026-04-20T10:00:00Z"
+
+
+# --------------------------------------------------------------------------- #
+# fixture helpers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    ensure_events_schema(c)
+    ensure_cost_schema(c)
+    return c
+
+
+def _insert_session(conn, *, session_key: str, client: str) -> int:
+    cur = conn.execute(
+        "INSERT INTO event_sessions (session_key, client, status) VALUES (?, ?, 'active')",
+        (session_key, client),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def _insert_event(
+    conn,
+    *,
+    session_id: int,
+    client: str,
+    event_type: str,
+    raw: dict,
+    event_at: str | None = TS,
+    source: str | None = None,
+    source_path: str = "/tmp/x.jsonl",
+) -> int:
+    if source is None:
+        source = {"claude": "claude-jsonl", "codex": "codex-rollout", "openclaw": "openclaw-jsonl"}[client]
+    # monotonically increasing offset so ORDER BY source_offset is stable.
+    cur = conn.execute("SELECT COALESCE(MAX(source_offset), -1) + 1 FROM events").fetchone()
+    offset = int(cur[0])
+    cursor = conn.execute(
+        """
+        INSERT INTO events (
+            session_id, type, event_key, event_at, ingested_at, source,
+            source_path, source_offset, seq, client, confidence, lossiness,
+            raw_json
+        ) VALUES (?, ?, NULL, ?, ?, ?, ?, ?, 0, ?, 'high', 'none', ?)
+        """,
+        (
+            session_id, event_type, event_at, TS, source, source_path,
+            offset, client, json.dumps(raw, sort_keys=True),
+        ),
+    )
+    conn.commit()
+    return int(cursor.lastrowid)
+
+
+def _claude_assistant(
+    *,
+    model: str = "claude-opus-4-6",
+    input_tokens: int = 100,
+    output_tokens: int = 50,
+    cache_read: int | None = None,
+    cache_write: int | None = None,
+    service_tier: str | None = None,
+) -> dict:
+    usage: dict = {"input_tokens": input_tokens, "output_tokens": output_tokens}
+    if cache_read is not None:
+        usage["cache_read_input_tokens"] = cache_read
+    if cache_write is not None:
+        usage["cache_creation_input_tokens"] = cache_write
+    if service_tier is not None:
+        usage["service_tier"] = service_tier
+    return {
+        "type": "assistant",
+        "message": {"model": model, "usage": usage},
+    }
+
+
+# --------------------------------------------------------------------------- #
+# basic ingest
+# --------------------------------------------------------------------------- #
+
+
+def test_ingest_writes_token_usage_for_claude_assistant(conn):
+    sid = _insert_session(conn, session_key="s:claude", client="claude")
+    eid = _insert_event(
+        conn,
+        session_id=sid,
+        client="claude",
+        event_type="assistant_message",
+        raw=_claude_assistant(input_tokens=10, output_tokens=5, cache_read=200),
+    )
+
+    summary = ingest_cost_pending(conn)
+    assert summary.token_rows_written == 1
+    assert summary.sessions_touched == {sid}
+
+    row = conn.execute("SELECT * FROM token_usage WHERE event_id = ?", (eid,)).fetchone()
+    assert row is not None
+    assert row["model"] == "claude-opus-4-6"
+    assert row["model_family"] == "claude"
+    assert row["model_tier"] == "opus"
+    assert row["input"] == 10
+    assert row["output"] == 5
+    assert row["cache_read"] == 200
+    assert row["cache_write"] is None  # never emitted → stays NULL, not zero
+    assert row["data_source"] == "api"
+    assert row["pricing_table_version"] == PRICING_TABLE_VERSION
+    assert row["cost_estimate"] is not None and row["cost_estimate"] > 0
+
+
+def test_ingest_is_idempotent(conn):
+    sid = _insert_session(conn, session_key="s:idem", client="claude")
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(),
+    )
+
+    first = ingest_cost_pending(conn)
+    second = ingest_cost_pending(conn)
+
+    assert first.token_rows_written == 1
+    # Re-running picks no new events because token_usage already covers them.
+    assert second.events_scanned == 0
+    assert second.token_rows_written == 0
+    assert second.anomalies_written == 0
+
+
+def test_ingest_skips_unparseable_raw_json(conn):
+    sid = _insert_session(conn, session_key="s:bad", client="claude")
+    # Manually insert a row whose raw_json isn't valid JSON.
+    conn.execute(
+        """
+        INSERT INTO events (
+            session_id, type, event_key, event_at, ingested_at, source,
+            source_path, source_offset, seq, client, confidence, lossiness,
+            raw_json
+        ) VALUES (?, 'schema_unknown', NULL, ?, ?, 'claude-jsonl',
+                  '/tmp/x.jsonl', 0, 0, 'claude', 'low', 'unknown', ?)
+        """,
+        (sid, TS, TS, "{not json"),
+    )
+    conn.commit()
+
+    summary = ingest_cost_pending(conn)
+    assert summary.token_rows_written == 0
+
+
+def test_ingest_does_not_record_estimated_rows_today(conn):
+    """v0.1 ingest only persists vendor-emitted (api) usage. A turn
+    with no usage block produces no token_usage row."""
+    sid = _insert_session(conn, session_key="s:noapi", client="claude")
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw={"type": "assistant", "message": {"model": "claude-opus-4-6"}},  # no usage
+    )
+    summary = ingest_cost_pending(conn)
+    assert summary.token_rows_written == 0
+
+
+def test_ingest_advances_past_examined_non_usage_rows(conn):
+    sid = _insert_session(conn, session_key="s:examined", client="claude")
+    eid = _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw={"type": "assistant", "message": {"model": "claude-opus-4-6"}},
+    )
+
+    first = ingest_cost_pending(conn)
+    second = ingest_cost_pending(conn)
+
+    assert first.events_scanned == 1
+    assert first.token_rows_written == 0
+    assert second.events_scanned == 0
+    assert second.token_rows_written == 0
+
+    # Historical backfill is still possible via explicit rebuild.
+    conn.execute(
+        "UPDATE events SET raw_json = ? WHERE id = ?",
+        (json.dumps(_claude_assistant(input_tokens=10, output_tokens=5), sort_keys=True), eid),
+    )
+    conn.commit()
+
+    third = ingest_cost_pending(conn)
+    rebuilt = ingest_cost_pending(conn, rebuild=True)
+
+    assert third.events_scanned == 0
+    assert rebuilt.events_scanned == 1
+    assert rebuilt.token_rows_written == 1
+    row = conn.execute("SELECT * FROM token_usage WHERE event_id = ?", (eid,)).fetchone()
+    assert row is not None
+    assert row["input"] == 10
+    assert row["output"] == 5
+
+
+# --------------------------------------------------------------------------- #
+# Codex model threading
+# --------------------------------------------------------------------------- #
+
+
+def _codex_token_count(
+    *,
+    input_tokens: int,
+    output_tokens: int = 10,
+    cached: int | None = None,
+    reasoning: int | None = None,
+) -> dict:
+    last: dict = {"input_tokens": input_tokens, "output_tokens": output_tokens}
+    if cached is not None:
+        last["cached_input_tokens"] = cached
+    if reasoning is not None:
+        last["reasoning_output_tokens"] = reasoning
+    return {
+        "type": "event_msg",
+        "payload": {
+            "type": "token_count",
+            "info": {"last_token_usage": last},
+        },
+    }
+
+
+def test_ingest_threads_codex_model_from_turn_context(conn):
+    sid = _insert_session(conn, session_key="s:codex", client="codex")
+    _insert_event(
+        conn, session_id=sid, client="codex", event_type="schema_unknown",
+        raw={"type": "turn_context", "payload": {"model": "gpt-5-codex"}},
+        event_at="2026-04-20T10:00:00Z",
+    )
+    eid = _insert_event(
+        conn, session_id=sid, client="codex", event_type="schema_unknown",
+        raw=_codex_token_count(input_tokens=3655, cached=2048, reasoning=64),
+        event_at="2026-04-20T10:00:01Z",
+    )
+
+    ingest_cost_pending(conn)
+    row = conn.execute("SELECT * FROM token_usage WHERE event_id = ?", (eid,)).fetchone()
+    assert row is not None
+    assert row["model"] == "gpt-5-codex"
+    assert row["input"] == 3655
+    assert row["cache_read"] == 2048
+    assert row["reasoning"] == 64
+    assert row["data_source"] == "api"
+    assert row["cost_estimate"] is not None and row["cost_estimate"] > 0
+
+
+def test_ingest_threads_codex_model_from_prior_run_turn_context(conn):
+    sid = _insert_session(conn, session_key="s:codex-prior", client="codex")
+    _insert_event(
+        conn, session_id=sid, client="codex", event_type="schema_unknown",
+        raw={"type": "turn_context", "payload": {"model": "gpt-5.3-codex"}},
+        event_at="2026-04-20T10:00:00Z",
+    )
+    first = ingest_cost_pending(conn)
+    assert first.events_scanned == 1
+    assert first.token_rows_written == 0
+
+    eid = _insert_event(
+        conn, session_id=sid, client="codex", event_type="schema_unknown",
+        raw=_codex_token_count(input_tokens=3655, cached=2048, reasoning=64),
+        event_at="2026-04-20T10:00:01Z",
+    )
+
+    second = ingest_cost_pending(conn)
+    row = conn.execute("SELECT * FROM token_usage WHERE event_id = ?", (eid,)).fetchone()
+    assert second.events_scanned == 1
+    assert second.token_rows_written == 1
+    assert row is not None
+    assert row["model"] == "gpt-5.3-codex"
+    assert row["model_tier"] == "5.3-codex"
+    assert row["cost_estimate"] is not None and row["cost_estimate"] > 0
+
+
+# --------------------------------------------------------------------------- #
+# anomaly detectors — acceptance criteria from 04-cost-ledger.md
+# --------------------------------------------------------------------------- #
+
+
+def test_cache_read_collapse_flagged_on_warm_to_cold_transition(conn):
+    sid = _insert_session(conn, session_key="s:collapse", client="claude")
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(input_tokens=1000, cache_read=10_000),
+        event_at="2026-04-20T10:00:00Z",
+    )
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(input_tokens=1000, cache_read=100),
+        event_at="2026-04-20T10:00:01Z",
+    )
+
+    ingest_cost_pending(conn)
+    anomalies = conn.execute(
+        "SELECT kind, evidence_json FROM cost_anomalies WHERE session_id = ?",
+        (sid,),
+    ).fetchall()
+    kinds = [a["kind"] for a in anomalies]
+    assert "cache_read_collapse" in kinds
+    evidence = json.loads(
+        next(a["evidence_json"] for a in anomalies if a["kind"] == "cache_read_collapse")
+    )
+    assert evidence["previous_cache_read"] == 10_000
+    assert evidence["current_cache_read"] == 100
+    assert evidence["drop_ratio"] >= 0.5
+
+
+def test_cache_read_collapse_skipped_when_estimated_row_present(conn):
+    """Anomaly detectors must not compare api against estimated.
+
+    We simulate this by manually marking one row as estimated.
+    """
+    sid = _insert_session(conn, session_key="s:est", client="claude")
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(input_tokens=1000, cache_read=10_000),
+        event_at="2026-04-20T10:00:00Z",
+    )
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(input_tokens=1000, cache_read=100),
+        event_at="2026-04-20T10:00:01Z",
+    )
+
+    ingest_cost_pending(conn)
+    # Demote the second row to estimated and re-run anomaly detection.
+    conn.execute(
+        "UPDATE token_usage SET data_source = 'estimated' "
+        "WHERE event_at = '2026-04-20T10:00:01Z'"
+    )
+    conn.execute("DELETE FROM cost_anomalies")
+    conn.commit()
+
+    from clawjournal.events.cost.anomalies import detect_session_anomalies
+
+    hits = detect_session_anomalies(conn, sid)
+    cache_hits = [h for h in hits if h.kind == "cache_read_collapse"]
+    assert cache_hits == []  # estimated row breaks the comparison chain
+
+
+def test_input_spike_flagged_against_rolling_baseline(conn):
+    sid = _insert_session(conn, session_key="s:spike", client="claude")
+    # Five baseline turns at 100 input tokens, then one at 1000.
+    for i in range(5):
+        _insert_event(
+            conn, session_id=sid, client="claude", event_type="assistant_message",
+            raw=_claude_assistant(input_tokens=100, output_tokens=10),
+            event_at=f"2026-04-20T10:00:0{i}Z",
+        )
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(input_tokens=1000, output_tokens=10),
+        event_at="2026-04-20T10:00:05Z",
+    )
+
+    ingest_cost_pending(conn)
+    spikes = [
+        a for a in conn.execute(
+            "SELECT kind, evidence_json FROM cost_anomalies WHERE session_id = ?",
+            (sid,),
+        )
+        if a["kind"] == "input_spike"
+    ]
+    assert len(spikes) == 1
+    evidence = json.loads(spikes[0]["evidence_json"])
+    assert evidence["current_input"] == 1000
+    assert evidence["baseline_mean"] == pytest.approx(100)
+    assert evidence["ratio"] >= 3.0
+
+
+def test_model_shift_detected_within_session(conn):
+    sid = _insert_session(conn, session_key="s:shift", client="claude")
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(model="claude-opus-4-6", input_tokens=10),
+        event_at="2026-04-20T10:00:00Z",
+    )
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(model="claude-sonnet-4-6", input_tokens=10),
+        event_at="2026-04-20T10:00:01Z",
+    )
+
+    ingest_cost_pending(conn)
+    kinds = {
+        a["kind"]
+        for a in conn.execute(
+            "SELECT kind FROM cost_anomalies WHERE session_id = ?", (sid,)
+        )
+    }
+    assert "model_shift" in kinds
+
+
+def test_service_tier_shift_distinct_from_model_shift(conn):
+    sid = _insert_session(conn, session_key="s:tier", client="claude")
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(input_tokens=10, service_tier="standard"),
+        event_at="2026-04-20T10:00:00Z",
+    )
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(input_tokens=10, service_tier="priority"),
+        event_at="2026-04-20T10:00:01Z",
+    )
+
+    ingest_cost_pending(conn)
+    rows = list(conn.execute(
+        "SELECT kind FROM cost_anomalies WHERE session_id = ?", (sid,)
+    ))
+    kinds = [r["kind"] for r in rows]
+    assert "service_tier_shift" in kinds
+    # Model didn't change → no model_shift recorded.
+    assert "model_shift" not in kinds
+
+
+def test_anomaly_recompute_drops_stale_rows(conn):
+    sid = _insert_session(conn, session_key="s:stale", client="claude")
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(input_tokens=1000, cache_read=10_000),
+        event_at="2026-04-20T10:00:00Z",
+    )
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(input_tokens=1000, cache_read=100),
+        event_at="2026-04-20T10:00:02Z",
+    )
+
+    first = ingest_cost_pending(conn)
+    assert first.anomalies_written == 1
+
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(input_tokens=10, cache_read=50),
+        event_at="2026-04-20T10:00:01Z",
+    )
+    second = ingest_cost_pending(conn)
+
+    assert second.anomalies_written == 0
+    rows = list(
+        conn.execute(
+            "SELECT kind FROM cost_anomalies WHERE session_id = ?",
+            (sid,),
+        )
+    )
+    assert rows == []
+
+
+def test_anomalies_unique_constraint_idempotent(conn):
+    sid = _insert_session(conn, session_key="s:dup", client="claude")
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(model="claude-opus-4-6", input_tokens=10),
+        event_at="2026-04-20T10:00:00Z",
+    )
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw=_claude_assistant(model="claude-sonnet-4-6", input_tokens=10),
+        event_at="2026-04-20T10:00:01Z",
+    )
+    ingest_cost_pending(conn)
+    n1 = conn.execute("SELECT COUNT(*) FROM cost_anomalies").fetchone()[0]
+
+    # Force the anomaly detectors to run again by clearing the
+    # token_usage cache hint and re-ingesting; rows already covered
+    # by a token_usage entry are skipped, but anomaly INSERT OR IGNORE
+    # should suppress duplicates either way.
+    from clawjournal.events.cost.anomalies import detect_session_anomalies
+    hits = detect_session_anomalies(conn, sid)
+    with conn:
+        conn.executemany(
+            "INSERT OR IGNORE INTO cost_anomalies "
+            "(session_id, turn_event_id, kind, confidence, evidence_json, created_at) "
+            "VALUES (?, ?, ?, ?, ?, ?)",
+            [
+                (h.session_id, h.turn_event_id, h.kind, h.confidence,
+                 json.dumps(h.evidence, sort_keys=True), TS)
+                for h in hits
+            ],
+        )
+    n2 = conn.execute("SELECT COUNT(*) FROM cost_anomalies").fetchone()[0]
+    assert n1 == n2  # dedup held
+
+
+# --------------------------------------------------------------------------- #
+# constants / api surface
+# --------------------------------------------------------------------------- #
+
+
+def test_anomaly_kinds_set_matches_spec():
+    assert set(ANOMALY_KINDS) == {
+        "cache_read_collapse",
+        "input_spike",
+        "model_shift",
+        "service_tier_shift",
+    }

--- a/tests/events/cost/test_pricing.py
+++ b/tests/events/cost/test_pricing.py
@@ -1,0 +1,123 @@
+"""Golden-file tests for the model normalizer + pricing-table lookups."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawjournal.events.cost import (
+    PRICING_TABLE,
+    PRICING_TABLE_VERSION,
+    ModelInfo,
+    estimate_cost,
+    normalize_model,
+)
+
+
+@pytest.mark.parametrize(
+    "raw,expected",
+    [
+        # --- Anthropic ---
+        ("claude-3-5-sonnet-20241022", ModelInfo("claude", "sonnet", "anthropic")),
+        ("claude-opus-4-6", ModelInfo("claude", "opus", "anthropic")),
+        ("claude-haiku-4-5-20251001", ModelInfo("claude", "haiku", "anthropic")),
+        ("anthropic/claude-haiku-4-5", ModelInfo("claude", "haiku", "anthropic")),
+        # --- OpenAI o-series ---
+        ("o1", ModelInfo("o", "1", "openai")),
+        ("o1-mini", ModelInfo("o", "1-mini", "openai")),
+        ("o3", ModelInfo("o", "3", "openai")),
+        ("o3-mini-2025-01-31", ModelInfo("o", "3-mini", "openai")),
+        ("o4-mini", ModelInfo("o", "4-mini", "openai")),
+        # --- OpenAI GPT ---
+        ("gpt-4o", ModelInfo("gpt", "4o", "openai")),
+        ("gpt-4o-mini", ModelInfo("gpt", "4o-mini", "openai")),
+        ("gpt-4.1", ModelInfo("gpt", "4.1", "openai")),
+        ("gpt-4.1-mini", ModelInfo("gpt", "4.1-mini", "openai")),
+        ("gpt-5-codex", ModelInfo("gpt", "5-codex", "openai")),
+        ("gpt-5.3-codex", ModelInfo("gpt", "5.3-codex", "openai")),
+        ("gpt-5.4", ModelInfo("gpt", "5.4", "openai")),
+        ("gpt-5.4-mini", ModelInfo("gpt", "5.4-mini", "openai")),
+        ("openai/gpt-4o", ModelInfo("gpt", "4o", "openai")),
+        # --- Gemini ---
+        ("gemini-2.5-flash", ModelInfo("gemini", "flash", "google")),
+        ("gemini-2.5-pro", ModelInfo("gemini", "pro", "google")),
+        ("gemini-ultra", ModelInfo("gemini", "ultra", "google")),
+        # --- fallback ---
+        ("some-novel-frontier-model", ModelInfo("unknown", "some-novel-frontier-model", "unknown")),
+        ("", ModelInfo("unknown", "", "unknown")),
+        (None, ModelInfo("unknown", "", "unknown")),
+    ],
+)
+def test_normalize_model_golden(raw, expected):
+    assert normalize_model(raw) == expected
+
+
+def test_pricing_table_version_is_a_string():
+    assert isinstance(PRICING_TABLE_VERSION, str)
+    assert PRICING_TABLE_VERSION  # non-empty
+
+
+def test_pricing_table_covers_canonical_families():
+    assert ("claude", "opus") in PRICING_TABLE
+    assert ("claude", "sonnet") in PRICING_TABLE
+    assert ("claude", "haiku") in PRICING_TABLE
+    assert ("o", "3") in PRICING_TABLE
+    assert ("gpt", "4o") in PRICING_TABLE
+    assert ("gpt", "5-codex") in PRICING_TABLE
+    assert ("gpt", "5.3-codex") in PRICING_TABLE
+    assert ("gemini", "flash") in PRICING_TABLE
+
+
+def test_estimate_cost_known_model():
+    info = normalize_model("claude-sonnet-4-6")
+    cost = estimate_cost(
+        info,
+        input_tokens=1_000_000,
+        output_tokens=1_000_000,
+    )
+    # Sonnet is $3 input + $15 output per 1M.
+    assert cost == pytest.approx(3.00 + 15.00)
+
+
+def test_estimate_cost_returns_none_for_unknown_model():
+    info = normalize_model("future-model-xyz")
+    assert (
+        estimate_cost(info, input_tokens=1, output_tokens=1) is None
+    )
+
+
+def test_estimate_cost_treats_none_counts_as_zero():
+    info = normalize_model("claude-haiku-4-5")
+    cost = estimate_cost(
+        info,
+        input_tokens=None,
+        output_tokens=None,
+        cache_read_tokens=None,
+        cache_write_tokens=None,
+        reasoning_tokens=None,
+    )
+    assert cost == 0.0
+
+
+def test_estimate_cost_includes_cache_read_and_write():
+    info = normalize_model("claude-opus-4-6")
+    entry = PRICING_TABLE[("claude", "opus")]
+    cost = estimate_cost(
+        info,
+        input_tokens=0,
+        output_tokens=0,
+        cache_read_tokens=1_000_000,
+        cache_write_tokens=1_000_000,
+    )
+    assert cost == pytest.approx(entry.cache_read + entry.cache_write)
+
+
+def test_estimate_cost_includes_reasoning_for_gpt_codex():
+    info = normalize_model("gpt-5.3-codex")
+    entry = PRICING_TABLE[("gpt", "5.3-codex")]
+    cost = estimate_cost(
+        info,
+        input_tokens=0,
+        output_tokens=0,
+        reasoning_tokens=1_000_000,
+    )
+    assert cost == pytest.approx(entry.reasoning)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1380,6 +1380,40 @@ class TestEventsInspectCLI:
         assert "truncated at 1024" in out
 
 
+class TestEventsCostCLI:
+    def test_ingest_rebuild_forwards_flag(self, monkeypatch, capsys):
+        summary = MagicMock()
+        summary.to_dict.return_value = {
+            "events_scanned": 3,
+            "token_rows_written": 1,
+            "anomalies_written": 0,
+            "sessions_touched": 1,
+        }
+        captured: dict[str, object] = {}
+
+        def fake_ingest(conn, *, rebuild=False):
+            captured["conn"] = conn
+            captured["rebuild"] = rebuild
+            return summary
+
+        conn = MagicMock()
+        monkeypatch.setattr("clawjournal.events.cost.ingest_cost_pending", fake_ingest)
+        monkeypatch.setattr("clawjournal.workbench.index.open_index", lambda: conn)
+
+        with patch.object(
+            sys,
+            "argv",
+            ["clawjournal", "events", "cost", "ingest", "--rebuild", "--json"],
+        ):
+            main()
+
+        assert captured["conn"] is conn
+        assert captured["rebuild"] is True
+        conn.close.assert_called_once()
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["events_scanned"] == 3
+
+
 class TestShareHelpers:
     def test_share_preview_json_returns_payload(self):
         payload = _share_preview([{"session_id": "s1", "display_title": "hello", "risk_badges": "[]"}], output_json=True)


### PR DESCRIPTION
## Summary

Implements phase-1 plan 04 (Cost Ledger). Per-turn token accounting with cache-read / cache-write / reasoning / service-tier columns and four rule-based anomaly detectors, sitting on top of the raw events stream from #15 (02) and the confidence layer from #16 (03).

- **Three new tables** in \`~/.clawjournal/index.db\`: \`token_usage\` (PK \`event_id\`, \`data_source\` CHECK-constrained to \`api\`/\`estimated\`), \`cost_anomalies\` (UNIQUE on \`(session_id, kind, turn_event_id)\`), \`cost_ingest_state\` (incremental replay cursor).
- **New module** at \`clawjournal/events/cost/\` — \`schema\`, \`types\`, \`pricing\`, \`extract/{claude,codex}\`, \`anomalies\`, \`ingest\`.
- **CLI**: \`clawjournal events cost ingest [--rebuild] [--json]\` (sibling of \`events ingest\` / \`events inspect\`).
- **Four anomaly detectors**: \`cache_read_collapse\` (≥50% drop with adjacent inputs within ±25%, api↔api only), \`input_spike\` (3× rolling baseline of prior api rows), \`model_shift\` (within-session), \`service_tier_shift\` (separate kind; only when model is unchanged).

## Key invariants (as shipped)

- \`data_source='estimated'\` rows never trigger anomalies — extractors skip them and detectors gate on \`data_source == DATA_SOURCE_API\`.
- Pricing via a versioned \`PRICING_TABLE\` keyed by \`(family, tier)\` with per-provider entries; \`PRICING_TABLE_VERSION\` persisted on every row so exported bundles (07) can re-cost against a newer table.
- Claude extractor accepts legacy field names (\`cache_read_input_tokens\` / \`cache_read_tokens\`, \`cache_creation_input_tokens\` / \`cache_creation_tokens\`).
- Codex extractor prefers \`last_token_usage\` (per-turn delta) over \`total_token_usage\` — picking the running total would double-count every turn after the first.
- \`turn_context.model\` is threaded onto Codex token-count events (with prior-batch fallback) so \`model_shift\` has a model to compare against.
- Full-session replacement of \`cost_anomalies\` per ingest means stale hits from outdated schemas don't linger; \`--rebuild\` clears derived rows + cursor and replays all raw events.
- \`model_normalize()\` returns \`{family, tier, provider}\` with Claude (opus/sonnet/haiku), OpenAI (\`o1\`/\`o3\`/\`o4\`/\`gpt-*\`/\`gpt-5-codex\`), Gemini (flash/pro/ultra), fallback \`{unknown, <raw>, unknown}\`.

## Test plan

- [x] \`pytest tests/events/cost/\` → 58 passed (pricing goldens, extract legacy aliases, ingest idempotency + rebuild replay, four anomaly detectors + estimated-row exclusion)
- [x] \`pytest tests/test_cli.py::TestEventsCostCLI\` → 1 passed (\`--rebuild\` flag forwarded through the CLI)
- [x] \`pytest -q\` (full suite) → **1341 passed in 40.67s** — no regressions in 01/02/03 or the existing workbench paths
- [ ] Manual smoke: \`clawjournal events cost ingest\` on a real session DB with mixed Claude + Codex events
- [ ] \`clawjournal events cost ingest --rebuild --json\` on a session with pre-existing \`token_usage\` rows to confirm the reset path

## Follow-up items from code review

A proactive bug review surfaced two design-nuance items worth addressing (not blockers; tests pass, behavior is coherent on the happy path):

1. **\`input_spike\` baseline tolerance** (\`anomalies.py:152\`). The gate is \`if len(baseline) >= 1:\`, so a fresh session whose 2nd api turn exceeds 3× its 1st turn will flag \`input_spike\`. The plan says "rolling baseline of 5 prior api rows" — the intent is plausibly to wait for a full window. Two reasonable resolutions: (a) tighten to \`>= INPUT_SPIKE_BASELINE_WINDOW\` for fewer false positives on short sessions, or (b) keep as-is and document the early-session behavior as intentional (anomalies are observability, not gating). Worth a one-line decision either way.
2. **\`_latest_codex_model_before_event\` timestamp OR-clause gap** (\`ingest.py\`). When the current event has a non-NULL \`event_at\` but all prior events have NULL \`event_at\`, neither branch of the OR matches and the fallback returns no prior \`turn_context.model\`. Edge case (Codex consistently emits timestamps in practice) but worth either simplifying the WHERE or adding a branch.
3. **Plan-doc drift** (\`docs/plans/phase-1/04-cost-ledger.md §Data model\`): text still says \`turn_id\`, shipped schema uses \`turn_event_id\` and adds \`created_at\`. Doc-only; not in this PR (plans live under gitignored \`docs/\`).

No boundary tests yet for: exactly 50% cache drop, exactly ±25% input tolerance, exactly 3× spike, single-event session, zero-usage event, Codex token-count arriving before any \`turn_context\` (should yield \`model=None\` gracefully, not crash). Recommend a follow-up PR adding these; each is a 5-10 line fixture.

## Related

- Phase-1 plan: \`docs/plans/phase-1/04-cost-ledger.md\`
- Depends on: #15 (02 execution recorder), #16 (03 signal/confidence layer)
- Enables: 06 timeline viewer (cost badges), 07 replay export (\`token_usage\` + \`pricing_table_version\` travel with the bundle), 10 aggregation (\`clawjournal events cost aggregate --by model\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)