### PR TITLE
fix(events): tighten cost-ledger input-spike baseline + codex model fallback

### DIFF
--- a/clawjournal/events/cost/anomalies.py
+++ b/clawjournal/events/cost/anomalies.py
@@ -149,7 +149,7 @@ def _detect_input_spike(
         cur = row["input"]
         if cur is None:
             continue
-        if len(baseline) >= 1:
+        if len(baseline) >= INPUT_SPIKE_BASELINE_WINDOW:
             mean = sum(baseline) / len(baseline)
             if mean > 0 and cur > mean * INPUT_SPIKE_MULTIPLIER:
                 hits.append(

--- a/clawjournal/events/cost/ingest.py
+++ b/clawjournal/events/cost/ingest.py
@@ -295,30 +295,65 @@ def _latest_codex_model_before_event(
     a later run than its preceding turn_context. Query the earlier raw events in
     canonical order to recover the model rather than depending on re-scans.
     """
-    rows = conn.execute(
-        """
-        SELECT raw_json
-          FROM events
-         WHERE session_id = ?
-           AND client = 'codex'
-           AND (
-               (? IS NOT NULL AND event_at IS NOT NULL AND
-                   (event_at < ? OR (event_at = ? AND id < ?)))
-               OR
-               (? IS NULL AND (event_at IS NOT NULL OR (event_at IS NULL AND id < ?)))
-           )
-         ORDER BY event_at IS NULL DESC, event_at DESC, id DESC
-        """,
-        (
-            session_id,
-            event_at,
-            event_at,
-            event_at,
-            event_id,
-            event_at,
-            event_id,
-        ),
+    if event_at is not None:
+        model = _latest_codex_model_from_rows(
+            conn.execute(
+                """
+                SELECT raw_json
+                  FROM events
+                 WHERE session_id = ?
+                   AND client = 'codex'
+                   AND event_at IS NOT NULL
+                   AND (event_at < ? OR (event_at = ? AND id < ?))
+                 ORDER BY event_at DESC, id DESC
+                """,
+                (session_id, event_at, event_at, event_id),
+            )
+        )
+        if model:
+            return model
+
+    # Fallback for earlier rows that carried no vendor timestamp. This keeps
+    # replay robust when an older turn_context predates a later token_count by
+    # source order / id but not by event_at presence.
+    model = _latest_codex_model_from_rows(
+        conn.execute(
+            """
+            SELECT raw_json
+              FROM events
+             WHERE session_id = ?
+               AND client = 'codex'
+               AND event_at IS NULL
+               AND id < ?
+             ORDER BY id DESC
+            """,
+            (session_id, event_id),
+        )
     )
+    if model:
+        return model
+
+    if event_at is None:
+        model = _latest_codex_model_from_rows(
+            conn.execute(
+                """
+                SELECT raw_json
+                  FROM events
+                 WHERE session_id = ?
+                   AND client = 'codex'
+                   AND event_at IS NOT NULL
+                   AND id < ?
+                 ORDER BY event_at DESC, id DESC
+                """,
+                (session_id, event_id),
+            )
+        )
+        if model:
+            return model
+    return None
+
+
+def _latest_codex_model_from_rows(rows) -> str | None:
     for row in rows:
         try:
             line = json.loads(row["raw_json"])

--- a/tests/events/cost/test_ingest.py
+++ b/tests/events/cost/test_ingest.py
@@ -290,6 +290,26 @@ def test_ingest_threads_codex_model_from_prior_run_turn_context(conn):
     assert row["cost_estimate"] is not None and row["cost_estimate"] > 0
 
 
+def test_ingest_threads_codex_model_from_null_timestamp_turn_context(conn):
+    sid = _insert_session(conn, session_key="s:codex-null-ts", client="codex")
+    _insert_event(
+        conn, session_id=sid, client="codex", event_type="schema_unknown",
+        raw={"type": "turn_context", "payload": {"model": "gpt-5-codex"}},
+        event_at=None,
+    )
+    eid = _insert_event(
+        conn, session_id=sid, client="codex", event_type="schema_unknown",
+        raw=_codex_token_count(input_tokens=3655, cached=2048, reasoning=64),
+        event_at="2026-04-20T10:00:01Z",
+    )
+
+    ingest_cost_pending(conn)
+    row = conn.execute("SELECT * FROM token_usage WHERE event_id = ?", (eid,)).fetchone()
+    assert row is not None
+    assert row["model"] == "gpt-5-codex"
+    assert row["cost_estimate"] is not None and row["cost_estimate"] > 0
+
+
 # --------------------------------------------------------------------------- #
 # anomaly detectors — acceptance criteria from 04-cost-ledger.md
 # --------------------------------------------------------------------------- #
@@ -384,6 +404,26 @@ def test_input_spike_flagged_against_rolling_baseline(conn):
     assert evidence["current_input"] == 1000
     assert evidence["baseline_mean"] == pytest.approx(100)
     assert evidence["ratio"] >= 3.0
+
+
+def test_input_spike_requires_full_baseline_window(conn):
+    sid = _insert_session(conn, session_key="s:spike-short", client="claude")
+    for i, input_tokens in enumerate((100, 400)):
+        _insert_event(
+            conn, session_id=sid, client="claude", event_type="assistant_message",
+            raw=_claude_assistant(input_tokens=input_tokens, output_tokens=10),
+            event_at=f"2026-04-20T10:00:0{i}Z",
+        )
+
+    ingest_cost_pending(conn)
+    kinds = [
+        a["kind"]
+        for a in conn.execute(
+            "SELECT kind FROM cost_anomalies WHERE session_id = ?",
+            (sid,),
+        )
+    ]
+    assert "input_spike" not in kinds
 
 
 def test_model_shift_detected_within_session(conn):


### PR DESCRIPTION
## Summary

Three follow-ups to #17 that close gaps surfaced during PR review:

- **Input-spike baseline now actually requires 5 prior rows.** The merged version fired at `len(baseline) >= 1`, which made the second turn jumpy and contradicted both the spec's resolved-decisions row and the Status section of `docs/plans/phase-1/04-cost-ledger.md` ("rolling baseline of 5 prior api rows"). One-line fix in `_detect_input_spike`.
- **Codex model fallback refactored** from one conditional SQL into three explicit ordered passes (event_at-bearing prior; null-event_at prior; for null-candidate token_count rows, event_at-bearing prior by id). Cleaner to reason about, and now covers the null-candidate path that the original `OR`-combined query missed.
- **Two pinning tests** so neither regression can come back silently:
  - `test_input_spike_requires_full_baseline_window`
  - `test_ingest_threads_codex_model_from_null_timestamp_turn_context`

## Behavior change worth flagging

After this lands, existing users will see **fewer (and later) `input_spike` anomalies** — only after a session has accumulated 5 api-source token-usage rows. That's the intended behavior per `docs/plans/phase-1/04-cost-ledger.md`, but worth calling out in case anyone has dashboards built against the prior (jumpier) signal.

## Test plan

- [x] `pytest tests/events/cost/` — 60 passed
- [x] `pytest` (full suite) — 1343 passed
- [ ] CI green