### PR TITLE
feat(events): loop detector lite — exact-repeat command + tool-call incidents

### DIFF
--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3240,6 +3240,26 @@ def main() -> None:
         "--json", action="store_true", help="Output JSON summary"
     )
 
+    events_incidents = events_sub.add_parser(
+        "incidents",
+        help="Incidents pipeline (loop detector lite, future: more kinds)",
+    )
+    events_incidents_sub = events_incidents.add_subparsers(
+        dest="incidents_command", required=True
+    )
+    events_incidents_detect = events_incidents_sub.add_parser(
+        "detect",
+        help="Detect exact-repeat command/tool-call loops in recorded events",
+    )
+    events_incidents_detect.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="Clear loop incidents + cursor, re-evaluate every session",
+    )
+    events_incidents_detect.add_argument(
+        "--json", action="store_true", help="Output JSON summary"
+    )
+
     # Workbench commands
     serve_parser = sub.add_parser("serve", help="Start the workbench daemon + web UI")
     serve_parser.add_argument("--port", type=int, default=8384, help="Port (default: 8384)")
@@ -3916,6 +3936,10 @@ def _run_events(args) -> None:
         _run_events_cost(args)
         return
 
+    if args.events_command == "incidents":
+        _run_events_incidents(args)
+        return
+
     conn = open_index()
     try:
         summary = ingest_pending(conn, source_filter=args.source)
@@ -3955,6 +3979,32 @@ def _run_events_cost(args) -> None:
         f"Cost ledger: scanned {payload['events_scanned']} events, "
         f"wrote {payload['token_rows_written']} token_usage rows + "
         f"{payload['anomalies_written']} anomalies "
+        f"across {payload['sessions_touched']} sessions."
+    )
+
+
+def _run_events_incidents(args) -> None:
+    from .events.incidents import ingest_loop_incidents
+    from .workbench.index import open_index
+
+    if args.incidents_command != "detect":
+        print(f"Unknown incidents command: {args.incidents_command}", file=sys.stderr)
+        sys.exit(2)
+
+    conn = open_index()
+    try:
+        summary = ingest_loop_incidents(conn, rebuild=args.rebuild)
+    finally:
+        conn.close()
+
+    payload = summary.to_dict()
+    if args.json:
+        print(json.dumps(payload, indent=2, sort_keys=True))
+        return
+    print(
+        f"Loop detector: scanned {payload['events_scanned']} new events, "
+        f"evaluated {payload['sessions_evaluated']} sessions, "
+        f"wrote {payload['incidents_written']} loop incidents "
         f"across {payload['sessions_touched']} sessions."
     )
 

--- a/clawjournal/events/incidents/__init__.py
+++ b/clawjournal/events/incidents/__init__.py
@@ -1,0 +1,56 @@
+"""Incidents pipeline (phase-1 plan 05) — currently the loop detector lite.
+
+Reads `events.raw_json` and emits `incidents` rows when the same
+shell command (3+ in a row) or the same tool call (5+ in a row)
+fires consecutively with the same normalized outcome. Later beats
+add new `incidents.kind` values (unchanged-diff heuristics, novel-args
+ratio, etc.) into the same table.
+
+Public surface:
+
+- `ensure_incidents_schema(conn)` — creates `incidents` +
+  `loop_ingest_state` if absent.
+- `ingest_loop_incidents(conn, *, rebuild=False)` — incremental
+  driver that scans only sessions touched by new events, recomputes
+  loops for each touched session, and replaces that session's
+  `incidents` rows so growing runs update in place.
+- `detect_session_loops(conn, session_id)` — pure read that returns
+  the current set of loop hits for a session without writing.
+- `normalize_outcome_text(text)` — stderr/output normalizer used by
+  the detector (documented ruleset; testable rule-by-rule).
+"""
+
+from __future__ import annotations
+
+from clawjournal.events.incidents.ingest import (
+    LOOP_CONSUMER_ID,
+    LoopIngestSummary,
+    ingest_loop_incidents,
+    rebuild_loop_incidents,
+)
+from clawjournal.events.incidents.loop_detector import (
+    DEFAULT_SHELL_THRESHOLD,
+    DEFAULT_TOOL_CALL_THRESHOLD,
+    IncidentHit,
+    LoopRule,
+    detect_session_loops,
+)
+from clawjournal.events.incidents.normalize import normalize_outcome_text
+from clawjournal.events.incidents.schema import ensure_incidents_schema
+from clawjournal.events.incidents.types import LOOP_INCIDENT_KIND, ValidIncidentKinds
+
+__all__ = [
+    "DEFAULT_SHELL_THRESHOLD",
+    "DEFAULT_TOOL_CALL_THRESHOLD",
+    "IncidentHit",
+    "LOOP_CONSUMER_ID",
+    "LOOP_INCIDENT_KIND",
+    "LoopIngestSummary",
+    "LoopRule",
+    "ValidIncidentKinds",
+    "detect_session_loops",
+    "ensure_incidents_schema",
+    "ingest_loop_incidents",
+    "normalize_outcome_text",
+    "rebuild_loop_incidents",
+]

--- a/clawjournal/events/incidents/ingest.py
+++ b/clawjournal/events/incidents/ingest.py
@@ -3,7 +3,11 @@
 The driver mirrors the cost ledger pattern (`events/cost/ingest.py`):
 
 - A `loop_ingest_state` cursor tracks the highest `events.id` we've
-  evaluated, so re-running with no new events is a no-op.
+  evaluated plus the latest `(event_overrides.created_at, session_id,
+  event_key)` frontier we've seen, so re-running with no new events or
+  overrides is a no-op. The tuple tiebreaker is VACUUM-stable — unlike
+  SQLite's implicit rowid, `session_id` and `event_key` can't be
+  renumbered.
 - Every session that gained a new event since the last run gets its
   full event list re-evaluated by `detect_session_loops`. Recomputing
   the whole session is necessary because a new repeat can extend a
@@ -46,6 +50,7 @@ LOOP_CONSUMER_ID = "loop_detector"
 @dataclass
 class LoopIngestSummary:
     events_scanned: int = 0
+    overrides_scanned: int = 0
     sessions_evaluated: int = 0
     incidents_written: int = 0
     sessions_touched: set[int] = field(default_factory=set, repr=False)
@@ -53,10 +58,19 @@ class LoopIngestSummary:
     def to_dict(self) -> dict[str, int]:
         return {
             "events_scanned": self.events_scanned,
+            "overrides_scanned": self.overrides_scanned,
             "sessions_evaluated": self.sessions_evaluated,
             "incidents_written": self.incidents_written,
             "sessions_touched": len(self.sessions_touched),
         }
+
+
+@dataclass(frozen=True)
+class LoopIngestCursor:
+    last_event_id: int
+    last_override_created_at: str | None = None
+    last_override_session_id: int = 0
+    last_override_event_key: str = ""
 
 
 _SELECT_NEW_EVENT_SESSIONS_SQL = """
@@ -66,18 +80,51 @@ SELECT DISTINCT session_id, COUNT(*) AS new_event_count
  GROUP BY session_id
 """
 
+# Row-value tuple comparison: pick up every override strictly greater
+# than the cursor (created_at, session_id, event_key). `session_id` +
+# `event_key` are VACUUM-stable tiebreakers for same-`created_at`
+# writes.
+_SELECT_NEW_OVERRIDE_SESSIONS_SQL = """
+SELECT DISTINCT session_id, COUNT(*) AS new_override_count
+  FROM event_overrides
+ WHERE (created_at, session_id, event_key) > (?, ?, ?)
+ GROUP BY session_id
+"""
+
 _SELECT_MAX_EVENT_ID_SQL = """
 SELECT COALESCE(MAX(id), 0) AS max_id FROM events
 """
 
-_SELECT_LAST_EVENT_ID_SQL = """
-SELECT last_event_id FROM loop_ingest_state WHERE consumer_id = ?
+_SELECT_MAX_OVERRIDE_CURSOR_SQL = """
+SELECT created_at, session_id, event_key
+  FROM event_overrides
+ ORDER BY created_at DESC, session_id DESC, event_key DESC
+ LIMIT 1
 """
 
-_UPSERT_LAST_EVENT_ID_SQL = """
-INSERT INTO loop_ingest_state (consumer_id, last_event_id)
-VALUES (?, ?)
-ON CONFLICT(consumer_id) DO UPDATE SET last_event_id = excluded.last_event_id
+_SELECT_LAST_CURSOR_SQL = """
+SELECT last_event_id,
+       last_override_created_at,
+       last_override_session_id,
+       last_override_event_key
+  FROM loop_ingest_state
+ WHERE consumer_id = ?
+"""
+
+_UPSERT_CURSOR_SQL = """
+INSERT INTO loop_ingest_state (
+    consumer_id,
+    last_event_id,
+    last_override_created_at,
+    last_override_session_id,
+    last_override_event_key
+)
+VALUES (?, ?, ?, ?, ?)
+ON CONFLICT(consumer_id) DO UPDATE SET
+    last_event_id            = excluded.last_event_id,
+    last_override_created_at = excluded.last_override_created_at,
+    last_override_session_id = excluded.last_override_session_id,
+    last_override_event_key  = excluded.last_override_event_key
 """
 
 _DELETE_LOOP_INCIDENTS_FOR_SESSION_SQL = """
@@ -131,13 +178,37 @@ def ingest_loop_incidents(
     # could leapfrog events that never got evaluated.
     conn.execute("BEGIN IMMEDIATE")
     try:
-        last_event_id = 0 if rebuild else _get_last_processed_event_id(conn)
+        cursor = (
+            LoopIngestCursor(0, None, 0, "")
+            if rebuild
+            else _get_last_processed_cursor(conn)
+        )
+        last_event_id = cursor.last_event_id
+        last_override_created_at = cursor.last_override_created_at
+        last_override_session_id = cursor.last_override_session_id
+        last_override_event_key = cursor.last_override_event_key
 
         new_session_rows = conn.execute(
             _SELECT_NEW_EVENT_SESSIONS_SQL, (last_event_id,)
         ).fetchall()
-        sessions_to_evaluate: list[int] = [int(r["session_id"]) for r in new_session_rows]
+        new_override_rows = conn.execute(
+            _SELECT_NEW_OVERRIDE_SESSIONS_SQL,
+            (
+                last_override_created_at or "",
+                last_override_session_id,
+                last_override_event_key,
+            ),
+        ).fetchall()
+        sessions_to_evaluate = sorted(
+            {
+                *(int(r["session_id"]) for r in new_session_rows),
+                *(int(r["session_id"]) for r in new_override_rows),
+            }
+        )
         summary.events_scanned = sum(int(r["new_event_count"]) for r in new_session_rows)
+        summary.overrides_scanned = sum(
+            int(r["new_override_count"]) for r in new_override_rows
+        )
 
         if rebuild:
             all_sessions = conn.execute(
@@ -147,6 +218,16 @@ def ingest_loop_incidents(
 
         max_event_id_row = conn.execute(_SELECT_MAX_EVENT_ID_SQL).fetchone()
         max_event_id = int(max_event_id_row["max_id"] or 0)
+        max_override_cursor_row = conn.execute(
+            _SELECT_MAX_OVERRIDE_CURSOR_SQL
+        ).fetchone()
+        max_override_created_at = None
+        max_override_session_id = 0
+        max_override_event_key = ""
+        if max_override_cursor_row is not None:
+            max_override_created_at = max_override_cursor_row["created_at"]
+            max_override_session_id = int(max_override_cursor_row["session_id"])
+            max_override_event_key = max_override_cursor_row["event_key"]
 
         if not sessions_to_evaluate and not rebuild:
             conn.commit()
@@ -183,10 +264,22 @@ def ingest_loop_incidents(
             summary.incidents_written += len(hits)
             summary.sessions_touched.add(session_id)
 
-        if max_event_id > last_event_id or rebuild:
+        if (
+            max_event_id > last_event_id
+            or max_override_created_at != last_override_created_at
+            or max_override_session_id != last_override_session_id
+            or max_override_event_key != last_override_event_key
+            or rebuild
+        ):
             conn.execute(
-                _UPSERT_LAST_EVENT_ID_SQL,
-                (LOOP_CONSUMER_ID, max_event_id),
+                _UPSERT_CURSOR_SQL,
+                (
+                    LOOP_CONSUMER_ID,
+                    max_event_id,
+                    max_override_created_at,
+                    max_override_session_id,
+                    max_override_event_key,
+                ),
             )
 
         conn.commit()
@@ -206,11 +299,16 @@ def rebuild_loop_incidents(
     return ingest_loop_incidents(conn, now=now, rebuild=True)
 
 
-def _get_last_processed_event_id(conn: sqlite3.Connection) -> int:
-    row = conn.execute(_SELECT_LAST_EVENT_ID_SQL, (LOOP_CONSUMER_ID,)).fetchone()
+def _get_last_processed_cursor(conn: sqlite3.Connection) -> LoopIngestCursor:
+    row = conn.execute(_SELECT_LAST_CURSOR_SQL, (LOOP_CONSUMER_ID,)).fetchone()
     if row is None:
-        return 0
-    return int(row["last_event_id"])
+        return LoopIngestCursor(0, None, 0, "")
+    return LoopIngestCursor(
+        last_event_id=int(row["last_event_id"]),
+        last_override_created_at=row["last_override_created_at"],
+        last_override_session_id=int(row["last_override_session_id"] or 0),
+        last_override_event_key=row["last_override_event_key"] or "",
+    )
 
 
 def _reset_loop_state(conn: sqlite3.Connection) -> None:

--- a/clawjournal/events/incidents/ingest.py
+++ b/clawjournal/events/incidents/ingest.py
@@ -3,11 +3,10 @@
 The driver mirrors the cost ledger pattern (`events/cost/ingest.py`):
 
 - A `loop_ingest_state` cursor tracks the highest `events.id` we've
-  evaluated plus the latest `(event_overrides.created_at, session_id,
-  event_key)` frontier we've seen, so re-running with no new events or
-  overrides is a no-op. The tuple tiebreaker is VACUUM-stable — unlike
-  SQLite's implicit rowid, `session_id` and `event_key` can't be
-  renumbered.
+  evaluated plus the latest accepted `event_overrides.write_seq` we've
+  seen, so re-running with no new events or overrides is a no-op. The
+  cursor also stores the matching `(created_at, session_id, event_key)`
+  snapshot for debugging / inspection.
 - Every session that gained a new event since the last run gets its
   full event list re-evaluated by `detect_session_loops`. Recomputing
   the whole session is necessary because a new repeat can extend a
@@ -68,6 +67,7 @@ class LoopIngestSummary:
 @dataclass(frozen=True)
 class LoopIngestCursor:
     last_event_id: int
+    last_override_write_seq: int = 0
     last_override_created_at: str | None = None
     last_override_session_id: int = 0
     last_override_event_key: str = ""
@@ -80,14 +80,10 @@ SELECT DISTINCT session_id, COUNT(*) AS new_event_count
  GROUP BY session_id
 """
 
-# Row-value tuple comparison: pick up every override strictly greater
-# than the cursor (created_at, session_id, event_key). `session_id` +
-# `event_key` are VACUUM-stable tiebreakers for same-`created_at`
-# writes.
 _SELECT_NEW_OVERRIDE_SESSIONS_SQL = """
 SELECT DISTINCT session_id, COUNT(*) AS new_override_count
   FROM event_overrides
- WHERE (created_at, session_id, event_key) > (?, ?, ?)
+ WHERE write_seq > ?
  GROUP BY session_id
 """
 
@@ -96,14 +92,15 @@ SELECT COALESCE(MAX(id), 0) AS max_id FROM events
 """
 
 _SELECT_MAX_OVERRIDE_CURSOR_SQL = """
-SELECT created_at, session_id, event_key
+SELECT write_seq, created_at, session_id, event_key
   FROM event_overrides
- ORDER BY created_at DESC, session_id DESC, event_key DESC
+ ORDER BY write_seq DESC
  LIMIT 1
 """
 
 _SELECT_LAST_CURSOR_SQL = """
 SELECT last_event_id,
+       last_override_write_seq,
        last_override_created_at,
        last_override_session_id,
        last_override_event_key
@@ -115,13 +112,15 @@ _UPSERT_CURSOR_SQL = """
 INSERT INTO loop_ingest_state (
     consumer_id,
     last_event_id,
+    last_override_write_seq,
     last_override_created_at,
     last_override_session_id,
     last_override_event_key
 )
-VALUES (?, ?, ?, ?, ?)
+VALUES (?, ?, ?, ?, ?, ?)
 ON CONFLICT(consumer_id) DO UPDATE SET
     last_event_id            = excluded.last_event_id,
+    last_override_write_seq  = excluded.last_override_write_seq,
     last_override_created_at = excluded.last_override_created_at,
     last_override_session_id = excluded.last_override_session_id,
     last_override_event_key  = excluded.last_override_event_key
@@ -179,11 +178,12 @@ def ingest_loop_incidents(
     conn.execute("BEGIN IMMEDIATE")
     try:
         cursor = (
-            LoopIngestCursor(0, None, 0, "")
+            LoopIngestCursor(0, 0, None, 0, "")
             if rebuild
             else _get_last_processed_cursor(conn)
         )
         last_event_id = cursor.last_event_id
+        last_override_write_seq = cursor.last_override_write_seq
         last_override_created_at = cursor.last_override_created_at
         last_override_session_id = cursor.last_override_session_id
         last_override_event_key = cursor.last_override_event_key
@@ -193,11 +193,7 @@ def ingest_loop_incidents(
         ).fetchall()
         new_override_rows = conn.execute(
             _SELECT_NEW_OVERRIDE_SESSIONS_SQL,
-            (
-                last_override_created_at or "",
-                last_override_session_id,
-                last_override_event_key,
-            ),
+            (last_override_write_seq,),
         ).fetchall()
         sessions_to_evaluate = sorted(
             {
@@ -221,10 +217,12 @@ def ingest_loop_incidents(
         max_override_cursor_row = conn.execute(
             _SELECT_MAX_OVERRIDE_CURSOR_SQL
         ).fetchone()
+        max_override_write_seq = 0
         max_override_created_at = None
         max_override_session_id = 0
         max_override_event_key = ""
         if max_override_cursor_row is not None:
+            max_override_write_seq = int(max_override_cursor_row["write_seq"] or 0)
             max_override_created_at = max_override_cursor_row["created_at"]
             max_override_session_id = int(max_override_cursor_row["session_id"])
             max_override_event_key = max_override_cursor_row["event_key"]
@@ -266,6 +264,7 @@ def ingest_loop_incidents(
 
         if (
             max_event_id > last_event_id
+            or max_override_write_seq != last_override_write_seq
             or max_override_created_at != last_override_created_at
             or max_override_session_id != last_override_session_id
             or max_override_event_key != last_override_event_key
@@ -276,6 +275,7 @@ def ingest_loop_incidents(
                 (
                     LOOP_CONSUMER_ID,
                     max_event_id,
+                    max_override_write_seq,
                     max_override_created_at,
                     max_override_session_id,
                     max_override_event_key,
@@ -302,9 +302,10 @@ def rebuild_loop_incidents(
 def _get_last_processed_cursor(conn: sqlite3.Connection) -> LoopIngestCursor:
     row = conn.execute(_SELECT_LAST_CURSOR_SQL, (LOOP_CONSUMER_ID,)).fetchone()
     if row is None:
-        return LoopIngestCursor(0, None, 0, "")
+        return LoopIngestCursor(0, 0, None, 0, "")
     return LoopIngestCursor(
         last_event_id=int(row["last_event_id"]),
+        last_override_write_seq=int(row["last_override_write_seq"] or 0),
         last_override_created_at=row["last_override_created_at"],
         last_override_session_id=int(row["last_override_session_id"] or 0),
         last_override_event_key=row["last_override_event_key"] or "",

--- a/clawjournal/events/incidents/ingest.py
+++ b/clawjournal/events/incidents/ingest.py
@@ -1,0 +1,210 @@
+"""Drive the loop detector incrementally from already-recorded events.
+
+The driver mirrors the cost ledger pattern (`events/cost/ingest.py`):
+
+- A `loop_ingest_state` cursor tracks the highest `events.id` we've
+  evaluated, so re-running with no new events is a no-op.
+- Every session that gained a new event since the last run gets its
+  full event list re-evaluated by `detect_session_loops`. Recomputing
+  the whole session is necessary because a new repeat can extend a
+  pre-existing run — we have to update the prior `incidents` row's
+  `count` / `last_event_id`.
+- Per-session refresh deletes existing `loop_exact_repeat` rows for
+  that session before re-inserting the current hit set, so runs that
+  shrink (because of a re-classification or override) don't leave
+  stale incident rows behind.
+- `--rebuild` clears the entire `incidents` table for `kind =
+  loop_exact_repeat` plus the cursor, then replays from `events.id =
+  0`.
+
+The schema's `UNIQUE (session_id, kind, first_event_id)` is the
+spec's dedupe key; the per-session DELETE keeps it from ever
+firing in normal operation but the constraint stays as defense in
+depth.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+from clawjournal.events.incidents.loop_detector import (
+    DEFAULT_RULES,
+    LoopRule,
+    detect_session_loops,
+)
+from clawjournal.events.incidents.schema import ensure_incidents_schema
+from clawjournal.events.incidents.types import LOOP_INCIDENT_KIND
+from clawjournal.events.schema import ensure_schema as ensure_events_schema
+
+LOOP_CONSUMER_ID = "loop_detector"
+
+
+@dataclass
+class LoopIngestSummary:
+    events_scanned: int = 0
+    sessions_evaluated: int = 0
+    incidents_written: int = 0
+    sessions_touched: set[int] = field(default_factory=set, repr=False)
+
+    def to_dict(self) -> dict[str, int]:
+        return {
+            "events_scanned": self.events_scanned,
+            "sessions_evaluated": self.sessions_evaluated,
+            "incidents_written": self.incidents_written,
+            "sessions_touched": len(self.sessions_touched),
+        }
+
+
+_SELECT_NEW_EVENT_SESSIONS_SQL = """
+SELECT DISTINCT session_id, COUNT(*) AS new_event_count
+  FROM events
+ WHERE id > ?
+ GROUP BY session_id
+"""
+
+_SELECT_MAX_EVENT_ID_SQL = """
+SELECT COALESCE(MAX(id), 0) AS max_id FROM events
+"""
+
+_SELECT_LAST_EVENT_ID_SQL = """
+SELECT last_event_id FROM loop_ingest_state WHERE consumer_id = ?
+"""
+
+_UPSERT_LAST_EVENT_ID_SQL = """
+INSERT INTO loop_ingest_state (consumer_id, last_event_id)
+VALUES (?, ?)
+ON CONFLICT(consumer_id) DO UPDATE SET last_event_id = excluded.last_event_id
+"""
+
+_DELETE_LOOP_INCIDENTS_FOR_SESSION_SQL = """
+DELETE FROM incidents WHERE session_id = ? AND kind = ?
+"""
+
+_DELETE_ALL_LOOP_INCIDENTS_SQL = """
+DELETE FROM incidents WHERE kind = ?
+"""
+
+_DELETE_INGEST_STATE_SQL = """
+DELETE FROM loop_ingest_state WHERE consumer_id = ?
+"""
+
+_INSERT_INCIDENT_SQL = """
+INSERT INTO incidents (
+    session_id, kind, first_event_id, last_event_id,
+    evidence_json, count, confidence, created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(session_id, kind, first_event_id) DO UPDATE SET
+    last_event_id = excluded.last_event_id,
+    evidence_json = excluded.evidence_json,
+    count         = excluded.count,
+    confidence    = excluded.confidence,
+    created_at    = excluded.created_at
+"""
+
+
+def ingest_loop_incidents(
+    conn: sqlite3.Connection,
+    *,
+    now: datetime | None = None,
+    rebuild: bool = False,
+    rules: tuple[LoopRule, ...] = DEFAULT_RULES,
+) -> LoopIngestSummary:
+    """Scan for new events, re-evaluate touched sessions, and refresh
+    `incidents` rows of kind `loop_exact_repeat`.
+
+    With `rebuild=True`, the cursor + all loop incidents are cleared
+    first and every session with at least one event is re-evaluated.
+    """
+    ensure_events_schema(conn)
+    ensure_incidents_schema(conn)
+
+    summary = LoopIngestSummary()
+    created_at = _utc_now_iso(now)
+    last_event_id = 0 if rebuild else _get_last_processed_event_id(conn)
+
+    new_session_rows = conn.execute(
+        _SELECT_NEW_EVENT_SESSIONS_SQL, (last_event_id,)
+    ).fetchall()
+    sessions_to_evaluate: list[int] = [int(r["session_id"]) for r in new_session_rows]
+    summary.events_scanned = sum(int(r["new_event_count"]) for r in new_session_rows)
+
+    if rebuild:
+        all_sessions = conn.execute(
+            "SELECT id FROM event_sessions"
+        ).fetchall()
+        sessions_to_evaluate = [int(r["id"]) for r in all_sessions]
+
+    max_event_id_row = conn.execute(_SELECT_MAX_EVENT_ID_SQL).fetchone()
+    max_event_id = int(max_event_id_row["max_id"] or 0)
+
+    if not sessions_to_evaluate and not rebuild:
+        return summary
+
+    with conn:
+        if rebuild:
+            _reset_loop_state(conn)
+
+        for session_id in sorted(sessions_to_evaluate):
+            summary.sessions_evaluated += 1
+            hits = detect_session_loops(conn, session_id, rules=rules)
+            conn.execute(
+                _DELETE_LOOP_INCIDENTS_FOR_SESSION_SQL,
+                (session_id, LOOP_INCIDENT_KIND),
+            )
+            if not hits:
+                continue
+            conn.executemany(
+                _INSERT_INCIDENT_SQL,
+                [
+                    (
+                        hit.session_id,
+                        hit.kind,
+                        hit.first_event_id,
+                        hit.last_event_id,
+                        json.dumps(hit.evidence, sort_keys=True),
+                        hit.count,
+                        hit.confidence,
+                        created_at,
+                    )
+                    for hit in hits
+                ],
+            )
+            summary.incidents_written += len(hits)
+            summary.sessions_touched.add(session_id)
+
+        if max_event_id > last_event_id or rebuild:
+            conn.execute(
+                _UPSERT_LAST_EVENT_ID_SQL,
+                (LOOP_CONSUMER_ID, max_event_id),
+            )
+
+    return summary
+
+
+def rebuild_loop_incidents(
+    conn: sqlite3.Connection,
+    *,
+    now: datetime | None = None,
+) -> LoopIngestSummary:
+    """Clear loop incidents + cursor and re-evaluate every session."""
+    return ingest_loop_incidents(conn, now=now, rebuild=True)
+
+
+def _get_last_processed_event_id(conn: sqlite3.Connection) -> int:
+    row = conn.execute(_SELECT_LAST_EVENT_ID_SQL, (LOOP_CONSUMER_ID,)).fetchone()
+    if row is None:
+        return 0
+    return int(row["last_event_id"])
+
+
+def _reset_loop_state(conn: sqlite3.Connection) -> None:
+    conn.execute(_DELETE_ALL_LOOP_INCIDENTS_SQL, (LOOP_INCIDENT_KIND,))
+    conn.execute(_DELETE_INGEST_STATE_SQL, (LOOP_CONSUMER_ID,))
+
+
+def _utc_now_iso(now: datetime | None) -> str:
+    effective = now or datetime.now(timezone.utc)
+    return effective.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")

--- a/clawjournal/events/incidents/ingest.py
+++ b/clawjournal/events/incidents/ingest.py
@@ -38,6 +38,7 @@ from clawjournal.events.incidents.loop_detector import (
 from clawjournal.events.incidents.schema import ensure_incidents_schema
 from clawjournal.events.incidents.types import LOOP_INCIDENT_KIND
 from clawjournal.events.schema import ensure_schema as ensure_events_schema
+from clawjournal.events.view import ensure_view_schema
 
 LOOP_CONSUMER_ID = "loop_detector"
 
@@ -100,8 +101,7 @@ ON CONFLICT(session_id, kind, first_event_id) DO UPDATE SET
     last_event_id = excluded.last_event_id,
     evidence_json = excluded.evidence_json,
     count         = excluded.count,
-    confidence    = excluded.confidence,
-    created_at    = excluded.created_at
+    confidence    = excluded.confidence
 """
 
 
@@ -120,30 +120,38 @@ def ingest_loop_incidents(
     """
     ensure_events_schema(conn)
     ensure_incidents_schema(conn)
+    ensure_view_schema(conn)
 
     summary = LoopIngestSummary()
     created_at = _utc_now_iso(now)
-    last_event_id = 0 if rebuild else _get_last_processed_event_id(conn)
 
-    new_session_rows = conn.execute(
-        _SELECT_NEW_EVENT_SESSIONS_SQL, (last_event_id,)
-    ).fetchall()
-    sessions_to_evaluate: list[int] = [int(r["session_id"]) for r in new_session_rows]
-    summary.events_scanned = sum(int(r["new_event_count"]) for r in new_session_rows)
+    # All reads + writes run inside a single BEGIN IMMEDIATE so a
+    # concurrent writer can't land new events between "pick sessions
+    # to evaluate" and "advance the cursor" — otherwise the cursor
+    # could leapfrog events that never got evaluated.
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        last_event_id = 0 if rebuild else _get_last_processed_event_id(conn)
 
-    if rebuild:
-        all_sessions = conn.execute(
-            "SELECT id FROM event_sessions"
+        new_session_rows = conn.execute(
+            _SELECT_NEW_EVENT_SESSIONS_SQL, (last_event_id,)
         ).fetchall()
-        sessions_to_evaluate = [int(r["id"]) for r in all_sessions]
+        sessions_to_evaluate: list[int] = [int(r["session_id"]) for r in new_session_rows]
+        summary.events_scanned = sum(int(r["new_event_count"]) for r in new_session_rows)
 
-    max_event_id_row = conn.execute(_SELECT_MAX_EVENT_ID_SQL).fetchone()
-    max_event_id = int(max_event_id_row["max_id"] or 0)
+        if rebuild:
+            all_sessions = conn.execute(
+                "SELECT id FROM event_sessions"
+            ).fetchall()
+            sessions_to_evaluate = [int(r["id"]) for r in all_sessions]
 
-    if not sessions_to_evaluate and not rebuild:
-        return summary
+        max_event_id_row = conn.execute(_SELECT_MAX_EVENT_ID_SQL).fetchone()
+        max_event_id = int(max_event_id_row["max_id"] or 0)
 
-    with conn:
+        if not sessions_to_evaluate and not rebuild:
+            conn.commit()
+            return summary
+
         if rebuild:
             _reset_loop_state(conn)
 
@@ -180,6 +188,11 @@ def ingest_loop_incidents(
                 _UPSERT_LAST_EVENT_ID_SQL,
                 (LOOP_CONSUMER_ID, max_event_id),
             )
+
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
 
     return summary
 

--- a/clawjournal/events/incidents/loop_detector.py
+++ b/clawjournal/events/incidents/loop_detector.py
@@ -13,11 +13,11 @@ Per-rule thresholds (spec):
   need **5** repeats.
 
 The "outcome" portion of the fingerprint is the normalized result
-text from the paired `tool_result` row (see `normalize.py`). If a
-tool_call has no paired result (e.g. mid-execution), the outcome is
-the empty string — two such events still match each other but the
-detector treats the run as `confidence='medium'` since we can't see
-whether the result diverged.
+text from the paired `tool_result` row (see `normalize.py`), plus an
+availability bit so a missing result doesn't collapse with a real
+empty-string result. If a tool_call has no paired result (e.g.
+mid-execution), the detector treats the run as `confidence='medium'`
+since we can't see whether the result diverged.
 
 Cross-session matching is not done. Cross-event-key matching is
 strict: a `tool_call` and a `tool_result` are paired only by the
@@ -83,6 +83,8 @@ _RUN_BREAKERS = frozenset({"user_message", "compaction"})
 # model-narrated or ergonomic and would otherwise hide loops whenever
 # those fields drift between identical retries.
 _SHELL_FINGERPRINT_FIELDS = frozenset({"command", "cmd", "workdir", "cwd"})
+_OUTCOME_PRESENT = "present"
+_OUTCOME_MISSING = "missing"
 
 
 @dataclass
@@ -98,6 +100,7 @@ class _SessionEvent:
     event_id: int | None
     event_type: str
     event_key: str | None
+    event_at: str | None
     raw_json: str | None
     payload_json: str | None
 
@@ -176,11 +179,12 @@ def _load_canonical_session_events(
                 event_id=event_id,
                 event_type=event.type,
                 event_key=event.event_key,
+                event_at=event.event_at,
                 raw_json=event.raw_json,
                 payload_json=event.payload_json,
             )
         )
-    return stream
+    return _restore_hook_only_breaker_order(stream)
 
 
 def _has_event_overrides_table(conn: sqlite3.Connection) -> bool:
@@ -200,7 +204,7 @@ def _load_base_session_events(
 ) -> list[_SessionEvent]:
     rows = conn.execute(
         """
-        SELECT id, type, event_key, raw_json
+        SELECT id, type, event_key, event_at, raw_json
           FROM events
          WHERE session_id = ?
          ORDER BY event_at IS NULL, event_at, source_path, source_offset, seq
@@ -220,11 +224,42 @@ def _load_base_session_events(
                 event_id=int(row["id"]),
                 event_type=row["type"],
                 event_key=event_key,
+                event_at=row["event_at"],
                 raw_json=row["raw_json"],
                 payload_json=None,
             )
         )
     return stream
+
+
+def _restore_hook_only_breaker_order(
+    stream: list[_SessionEvent],
+) -> list[_SessionEvent]:
+    ordered: list[_SessionEvent] = []
+    for event in stream:
+        if not _is_hook_only_breaker(event):
+            ordered.append(event)
+            continue
+        insert_at = len(ordered)
+        event_key = _session_event_sort_key(event)
+        for idx, existing in enumerate(ordered):
+            if _session_event_sort_key(existing) > event_key:
+                insert_at = idx
+                break
+        ordered.insert(insert_at, event)
+    return ordered
+
+
+def _is_hook_only_breaker(event: _SessionEvent) -> bool:
+    return (
+        event.event_id is None
+        and event.event_type in _RUN_BREAKERS
+        and event.event_at is not None
+    )
+
+
+def _session_event_sort_key(event: _SessionEvent) -> tuple[bool, str | None]:
+    return (event.event_at is None, event.event_at)
 
 
 def _collect_result_texts(rows, *, client: str) -> dict[str, str]:
@@ -358,10 +393,7 @@ def _emit_runs_for_rule(
         if not run or cur_fingerprint is None or len(run) < rule.threshold:
             run = []
             return None
-        # The fingerprint's last element is the (normalized) outcome
-        # text; an empty string means we couldn't read it, so the
-        # run's confidence drops.
-        confidence = "high" if cur_fingerprint[-1] != "" else "medium"
+        confidence = "high" if _fingerprint_has_observed_outcome(cur_fingerprint) else "medium"
         hit = IncidentHit(
             session_id=session_id,
             kind=rule.kind,
@@ -421,10 +453,15 @@ def _fingerprint_for(
     event does.
     """
     tool_id = _tool_id_from_event_key(event_key)
-    outcome = results.get(tool_id, "") if tool_id is not None else ""
+    outcome_state = _OUTCOME_MISSING
+    outcome = ""
     inline_outcome = _inline_outcome_for_client(client, event_type, parsed)
     if inline_outcome is not None:
+        outcome_state = _OUTCOME_PRESENT
         outcome = normalize_outcome_text(inline_outcome)
+    elif tool_id is not None and tool_id in results:
+        outcome_state = _OUTCOME_PRESENT
+        outcome = results[tool_id]
 
     if event_type == "command_start":
         command, args_key = _command_signature_for_client(
@@ -434,7 +471,7 @@ def _fingerprint_for(
         )
         if not command:
             return None
-        return ("command_start", command, args_key, outcome)
+        return ("command_start", command, args_key, outcome_state, outcome)
     if event_type == "tool_call":
         name, args_key = _tool_call_signature_for_client(
             client,
@@ -449,7 +486,7 @@ def _fingerprint_for(
         # threshold.
         if _is_shell_tool_name(name):
             return None
-        return ("tool_call", name, args_key, outcome)
+        return ("tool_call", name, args_key, outcome_state, outcome)
     return None
 
 
@@ -457,9 +494,10 @@ def _serialize_fingerprint(fingerprint: tuple) -> list:
     """Project an in-memory fingerprint tuple into the form stored in
     `incidents.evidence_json`.
 
-    The live fingerprint carries the normalized paired-`tool_result`
-    text as its last element so run-grouping can compare outcomes. That
-    text is derived from `events.raw_json` and has NOT been through the
+    The live fingerprint carries an outcome-availability marker plus
+    the normalized paired-`tool_result` text as its last element so
+    run-grouping can compare both availability and content. That text
+    is derived from `events.raw_json` and has NOT been through the
     workbench regex/PII redaction pipeline — persisting it verbatim in
     `evidence_json` would smuggle secrets past any consumer that reads
     incidents without re-redacting. We replace the outcome with a
@@ -470,14 +508,25 @@ def _serialize_fingerprint(fingerprint: tuple) -> list:
     if not fingerprint:
         return []
     out = list(fingerprint)
+    availability = _fingerprint_outcome_state(fingerprint)
     outcome = out[-1]
     if isinstance(outcome, str):
-        if outcome == "":
+        if availability == _OUTCOME_MISSING:
             out[-1] = ""  # preserve the "no outcome available" signal
         else:
             digest = hashlib.sha256(outcome.encode("utf-8")).hexdigest()[:16]
             out[-1] = f"sha256:{digest}"
     return out
+
+
+def _fingerprint_has_observed_outcome(fingerprint: tuple) -> bool:
+    return _fingerprint_outcome_state(fingerprint) == _OUTCOME_PRESENT
+
+
+def _fingerprint_outcome_state(fingerprint: tuple) -> str:
+    if len(fingerprint) >= 2 and fingerprint[-2] in {_OUTCOME_PRESENT, _OUTCOME_MISSING}:
+        return fingerprint[-2]
+    return _OUTCOME_MISSING
 
 
 def _tool_id_from_event_key(event_key: str | None) -> str | None:
@@ -683,6 +732,14 @@ def _result_text_for_client(
             try:
                 wrapped = json.loads(out)
             except json.JSONDecodeError:
+                # If the raw text carries a codex `Exit code:` / `Wall
+                # time:` / `Output:` preamble, let the parser own the
+                # answer even when the `Output:` marker is missing —
+                # that case returns None, which propagates out as
+                # "missing outcome" so the run scores confidence=medium
+                # rather than collapsing into a spurious empty match.
+                if _is_codex_metadata_format(out):
+                    return _parse_codex_plain_text_output(out)
                 return out
             if isinstance(wrapped, dict):
                 inner = wrapped.get("output")
@@ -691,7 +748,12 @@ def _result_text_for_client(
                 return json.dumps(wrapped, sort_keys=True)
             return out
         if isinstance(out, list):
-            return _flatten_text(out)
+            text = _flatten_text(out)
+            if text is None:
+                return None
+            if _is_codex_metadata_format(text):
+                return _parse_codex_plain_text_output(text)
+            return text
         return None
     return None
 
@@ -732,6 +794,61 @@ def _flatten_text(value: object) -> str | None:
         if chunks:
             return "\n".join(chunks)
     return None
+
+
+def _is_codex_metadata_format(text: str) -> bool:
+    """True when `text` carries a codex `Exit code:` / `Wall time:` /
+    `Output:` preamble. Scan only the first few lines so unrelated
+    output that happens to embed one of those phrases later doesn't
+    misclassify."""
+    for line in text.splitlines()[:5]:
+        if (
+            line.startswith("Exit code: ")
+            or line.startswith("Wall time: ")
+            or line == "Output:"
+        ):
+            return True
+    return False
+
+
+def _parse_codex_plain_text_output(text: str) -> str | None:
+    """Extract the post-`Output:` payload from a codex plain-text result.
+
+    Returns:
+    - The stripped output text when a well-formed `Exit code` /
+      `Wall time` / `Output:` preamble is present.
+    - `None` when no codex metadata prefix is recognized (fall back to
+      the raw text) OR when metadata is present but the `Output:`
+      marker never arrives (truncated rollout — indistinguishable from
+      "no observable outcome"; the caller treats `None` as missing so
+      the run is scored `confidence="medium"` instead of collapsing
+      into a spurious empty-outcome match).
+
+    Prefix detection is gated on `saw_output_marker` so that `Exit
+    code:` / `Wall time:` lines embedded inside the real output (e.g.
+    a shell log echoing its child's exit status) are preserved
+    verbatim instead of being silently dropped.
+    """
+    saw_metadata = False
+    saw_output_marker = False
+    output_lines: list[str] = []
+    for line in text.splitlines():
+        if not saw_output_marker:
+            if line.startswith("Exit code: "):
+                saw_metadata = True
+                continue
+            if line.startswith("Wall time: "):
+                saw_metadata = True
+                continue
+            if line == "Output:":
+                saw_metadata = True
+                saw_output_marker = True
+                continue
+        else:
+            output_lines.append(line)
+    if not saw_metadata or not saw_output_marker:
+        return None
+    return "\n".join(output_lines).strip()
 
 
 def _matching_tool_call_block(

--- a/clawjournal/events/incidents/loop_detector.py
+++ b/clawjournal/events/incidents/loop_detector.py
@@ -1,7 +1,8 @@
 """Loop detector (lite) — flag exact-repeat command and tool-call runs.
 
 The detector walks a session's events in canonical order and computes
-a per-event "fingerprint" from `events.raw_json` plus the matching
+a per-event "fingerprint" from the canonical payload (override
+`payload_json` when present, else base `raw_json`) plus the matching
 `tool_result` row. Consecutive events sharing a fingerprint are
 grouped into a run; runs meeting the per-rule threshold become
 `incidents` rows of kind `loop_exact_repeat`.
@@ -81,7 +82,7 @@ _RUN_BREAKERS = frozenset({"user_message", "compaction"})
 # Claude Bash's `description`, `timeout`, `run_in_background`) are
 # model-narrated or ergonomic and would otherwise hide loops whenever
 # those fields drift between identical retries.
-_SHELL_FINGERPRINT_FIELDS = frozenset({"command", "workdir", "cwd"})
+_SHELL_FINGERPRINT_FIELDS = frozenset({"command", "cmd", "workdir", "cwd"})
 
 
 @dataclass
@@ -98,6 +99,7 @@ class _SessionEvent:
     event_type: str
     event_key: str | None
     raw_json: str | None
+    payload_json: str | None
 
 
 def detect_session_loops(
@@ -175,6 +177,7 @@ def _load_canonical_session_events(
                 event_type=event.type,
                 event_key=event.event_key,
                 raw_json=event.raw_json,
+                payload_json=event.payload_json,
             )
         )
     return stream
@@ -218,6 +221,7 @@ def _load_base_session_events(
                 event_type=row["type"],
                 event_key=event_key,
                 raw_json=row["raw_json"],
+                payload_json=None,
             )
         )
     return stream
@@ -230,21 +234,21 @@ def _collect_result_texts(rows, *, client: str) -> dict[str, str]:
     duplicates have been removed before pairing."""
     out: dict[str, str] = {}
     for row in rows:
-        if row.event_type != "tool_result" or row.raw_json is None:
+        payload_json = _effective_payload_json(row)
+        if row.event_type != "tool_result" or payload_json is None:
             continue
-        event_key = row.event_key
-        if not event_key or not event_key.startswith("tool_result:"):
+        tool_id = _tool_result_id_from_event_key(row.event_key)
+        if tool_id is None:
             continue
-        tool_id = event_key[len("tool_result:") :]
         if tool_id in out:
             continue  # first one wins
         try:
-            parsed = json.loads(row.raw_json)
+            parsed = json.loads(payload_json)
         except (TypeError, json.JSONDecodeError):
             continue
         if not isinstance(parsed, dict):
             continue
-        text = _result_text_for_client(client, parsed)
+        text = _result_text_for_client(client, parsed, tool_id=tool_id)
         if text is None:
             continue
         out[tool_id] = normalize_outcome_text(text)
@@ -274,7 +278,8 @@ def _build_rule_candidates(
             # surrounding real events remain adjacent.
             if row.event_id is None:
                 continue
-            if row.raw_json is None:
+            payload_json = _effective_payload_json(row)
+            if payload_json is None:
                 candidates.append(
                     _CandidateRow(
                         event_id=int(row.event_id),
@@ -285,7 +290,7 @@ def _build_rule_candidates(
                 )
                 continue
             try:
-                parsed = json.loads(row.raw_json)
+                parsed = json.loads(payload_json)
             except (TypeError, json.JSONDecodeError):
                 # Eligible row whose payload won't parse: include it
                 # with fingerprint=None so it breaks the run rather
@@ -417,14 +422,25 @@ def _fingerprint_for(
     """
     tool_id = _tool_id_from_event_key(event_key)
     outcome = results.get(tool_id, "") if tool_id is not None else ""
+    inline_outcome = _inline_outcome_for_client(client, event_type, parsed)
+    if inline_outcome is not None:
+        outcome = normalize_outcome_text(inline_outcome)
 
     if event_type == "command_start":
-        command, args_key = _command_signature_for_client(client, parsed)
+        command, args_key = _command_signature_for_client(
+            client,
+            parsed,
+            tool_id=tool_id,
+        )
         if not command:
             return None
         return ("command_start", command, args_key, outcome)
     if event_type == "tool_call":
-        name, args_key = _tool_call_signature_for_client(client, parsed)
+        name, args_key = _tool_call_signature_for_client(
+            client,
+            parsed,
+            tool_id=tool_id,
+        )
         if not name:
             return None
         # Shell tool calls already get a `command_start` companion
@@ -465,16 +481,27 @@ def _serialize_fingerprint(fingerprint: tuple) -> list:
 
 
 def _tool_id_from_event_key(event_key: str | None) -> str | None:
+    return _event_key_suffix(event_key, "command_start:", "tool_call:")
+
+
+def _tool_result_id_from_event_key(event_key: str | None) -> str | None:
+    return _event_key_suffix(event_key, "tool_result:")
+
+
+def _event_key_suffix(event_key: str | None, *prefixes: str) -> str | None:
     if not event_key:
         return None
-    for prefix in ("command_start:", "tool_call:"):
+    for prefix in prefixes:
         if event_key.startswith(prefix):
             return event_key[len(prefix) :]
     return None
 
 
 def _command_signature_for_client(
-    client: str, parsed: dict
+    client: str,
+    parsed: dict,
+    *,
+    tool_id: str | None,
 ) -> tuple[str | None, str]:
     if client in ("claude", "openclaw"):
         # Either a Bash tool_use carrying input.command, or a
@@ -485,18 +512,14 @@ def _command_signature_for_client(
                 command = message.get("command")
                 if isinstance(command, str) and command.strip():
                     return command, _canonical_args({"command": command})
-            content = message.get("content")
-            if isinstance(content, list):
-                for block in content:
-                    if not isinstance(block, dict):
-                        continue
-                    if block.get("type") not in ("tool_use", "toolCall"):
-                        continue
-                    name = block.get("name")
-                    if not _is_shell_tool_name(name):
-                        continue
-                    args = block.get("input") if "input" in block else block.get("arguments")
-                    return _command_signature_from_args(args)
+            block = _matching_tool_call_block(message, expected_tool_id=tool_id)
+            if block is None:
+                return None, ""
+            name = block.get("name")
+            if not _is_shell_tool_name(name):
+                return None, ""
+            args = block.get("input") if "input" in block else block.get("arguments")
+            return _command_signature_from_args(args)
         return None, ""
     if client == "codex":
         payload = parsed.get("payload")
@@ -523,16 +546,7 @@ def _command_signature_for_client(
 
 def _command_signature_from_args(args: object) -> tuple[str | None, str]:
     args_key = _shell_fingerprint_key(args)
-    if not isinstance(args, dict):
-        return None, args_key
-    cmd = args.get("command")
-    if isinstance(cmd, list):
-        joined = " ".join(str(part) for part in cmd).strip()
-        return (joined or None), args_key
-    if isinstance(cmd, str):
-        stripped = cmd.strip()
-        return (stripped or None), args_key
-    return None, args_key
+    return _shell_command_from_args(args), args_key
 
 
 def _shell_fingerprint_key(args: object) -> str:
@@ -549,27 +563,44 @@ def _shell_fingerprint_key(args: object) -> str:
     return _canonical_args(filtered)
 
 
+def _shell_command_from_args(args: object) -> str | None:
+    if not isinstance(args, dict):
+        return None
+    for key in ("command", "cmd"):
+        command = _command_value_to_string(args.get(key))
+        if command is not None:
+            return command
+    return None
+
+
+def _command_value_to_string(value: object) -> str | None:
+    if isinstance(value, list):
+        joined = " ".join(str(part) for part in value).strip()
+        return joined or None
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    return None
+
+
 def _tool_call_signature_for_client(
-    client: str, parsed: dict
+    client: str,
+    parsed: dict,
+    *,
+    tool_id: str | None,
 ) -> tuple[str | None, str]:
     if client in ("claude", "openclaw"):
         message = parsed.get("message")
         if not isinstance(message, dict):
             return None, ""
-        content = message.get("content")
-        if not isinstance(content, list):
+        block = _matching_tool_call_block(message, expected_tool_id=tool_id)
+        if block is None:
             return None, ""
-        for block in content:
-            if not isinstance(block, dict):
-                continue
-            if block.get("type") not in ("tool_use", "toolCall"):
-                continue
-            name = block.get("name")
-            if not isinstance(name, str):
-                continue
-            args = block.get("input") if "input" in block else block.get("arguments")
-            return name, _canonical_args(args)
-        return None, ""
+        name = block.get("name")
+        if not isinstance(name, str):
+            return None, ""
+        args = block.get("input") if "input" in block else block.get("arguments")
+        return name, _canonical_args(args)
     if client == "codex":
         payload = parsed.get("payload")
         if not isinstance(payload, dict):
@@ -604,7 +635,12 @@ def _is_shell_tool_name(name: object) -> bool:
     )
 
 
-def _result_text_for_client(client: str, parsed: dict) -> str | None:
+def _result_text_for_client(
+    client: str,
+    parsed: dict,
+    *,
+    tool_id: str | None,
+) -> str | None:
     """Pull the human-readable result text from a tool_result row.
 
     Falls back to a stable JSON dump if the wire format puts the
@@ -614,20 +650,24 @@ def _result_text_for_client(client: str, parsed: dict) -> str | None:
         message = parsed.get("message")
         if isinstance(message, dict):
             if client == "openclaw" and message.get("role") == "toolResult":
+                message_tool_id = _tool_result_message_id(message)
+                if (
+                    tool_id is not None
+                    and message_tool_id is not None
+                    and message_tool_id != tool_id
+                ):
+                    return None
                 text = _flatten_text(message.get("content"))
                 if text is not None:
                     return text
-            content = message.get("content")
-            if isinstance(content, list):
-                for block in content:
-                    if not isinstance(block, dict):
-                        continue
-                    if block.get("type") != "tool_result":
-                        continue
-                    inner = block.get("content")
-                    text = _flatten_text(inner)
-                    if text is not None:
-                        return text
+            block = _matching_tool_result_block(
+                message,
+                expected_tool_id=tool_id,
+            )
+            if block is not None:
+                text = _flatten_text(block.get("content"))
+                if text is not None:
+                    return text
         return None
     if client == "codex":
         payload = parsed.get("payload")
@@ -656,6 +696,27 @@ def _result_text_for_client(client: str, parsed: dict) -> str | None:
     return None
 
 
+def _effective_payload_json(row: _SessionEvent) -> str | None:
+    return row.payload_json if row.payload_json is not None else row.raw_json
+
+
+def _inline_outcome_for_client(
+    client: str,
+    event_type: str,
+    parsed: dict,
+) -> str | None:
+    if event_type != "command_start":
+        return None
+    if client not in ("claude", "openclaw"):
+        return None
+    message = parsed.get("message")
+    if not isinstance(message, dict):
+        return None
+    if message.get("role") != "bashExecution":
+        return None
+    return _flatten_text(message.get("output"))
+
+
 def _flatten_text(value: object) -> str | None:
     if isinstance(value, str):
         return value
@@ -670,4 +731,68 @@ def _flatten_text(value: object) -> str | None:
                     chunks.append(text)
         if chunks:
             return "\n".join(chunks)
+    return None
+
+
+def _matching_tool_call_block(
+    message: dict,
+    *,
+    expected_tool_id: str | None,
+) -> dict | None:
+    content = message.get("content")
+    if not isinstance(content, list):
+        return None
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") not in ("tool_use", "toolCall"):
+            continue
+        if expected_tool_id is None:
+            return block
+        if _tool_call_block_id(block) == expected_tool_id:
+            return block
+    return None
+
+
+def _tool_call_block_id(block: dict) -> str | None:
+    for key in ("id", "toolUseId", "toolCallId"):
+        value = block.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _matching_tool_result_block(
+    message: dict,
+    *,
+    expected_tool_id: str | None,
+) -> dict | None:
+    content = message.get("content")
+    if not isinstance(content, list):
+        return None
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "tool_result":
+            continue
+        if expected_tool_id is None:
+            return block
+        if _tool_result_block_id(block) == expected_tool_id:
+            return block
+    return None
+
+
+def _tool_result_block_id(block: dict) -> str | None:
+    for key in ("tool_use_id", "toolUseId", "tool_call_id", "toolCallId", "id"):
+        value = block.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
+    return None
+
+
+def _tool_result_message_id(message: dict) -> str | None:
+    for key in ("toolCallId", "toolUseId", "tool_call_id", "tool_use_id"):
+        value = message.get(key)
+        if isinstance(value, str) and value.strip():
+            return value
     return None

--- a/clawjournal/events/incidents/loop_detector.py
+++ b/clawjournal/events/incidents/loop_detector.py
@@ -26,6 +26,7 @@ which 02 already populates.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import sqlite3
 from dataclasses import dataclass, field
@@ -365,7 +366,7 @@ def _emit_runs_for_rule(
             confidence=confidence,
             evidence={
                 "event_type": rule.event_type,
-                "fingerprint": list(cur_fingerprint),
+                "fingerprint": _serialize_fingerprint(cur_fingerprint),
                 "threshold": rule.threshold,
                 "first_event_id": run[0].event_id,
                 "last_event_id": run[-1].event_id,
@@ -434,6 +435,33 @@ def _fingerprint_for(
             return None
         return ("tool_call", name, args_key, outcome)
     return None
+
+
+def _serialize_fingerprint(fingerprint: tuple) -> list:
+    """Project an in-memory fingerprint tuple into the form stored in
+    `incidents.evidence_json`.
+
+    The live fingerprint carries the normalized paired-`tool_result`
+    text as its last element so run-grouping can compare outcomes. That
+    text is derived from `events.raw_json` and has NOT been through the
+    workbench regex/PII redaction pipeline — persisting it verbatim in
+    `evidence_json` would smuggle secrets past any consumer that reads
+    incidents without re-redacting. We replace the outcome with a
+    truncated sha256 so grouping + audit still work without leaking the
+    payload; the full text remains reachable via `first_event_id` /
+    `last_event_id` through the normal redaction paths.
+    """
+    if not fingerprint:
+        return []
+    out = list(fingerprint)
+    outcome = out[-1]
+    if isinstance(outcome, str):
+        if outcome == "":
+            out[-1] = ""  # preserve the "no outcome available" signal
+        else:
+            digest = hashlib.sha256(outcome.encode("utf-8")).hexdigest()[:16]
+            out[-1] = f"sha256:{digest}"
+    return out
 
 
 def _tool_id_from_event_key(event_key: str | None) -> str | None:

--- a/clawjournal/events/incidents/loop_detector.py
+++ b/clawjournal/events/incidents/loop_detector.py
@@ -31,8 +31,10 @@ import sqlite3
 from dataclasses import dataclass, field
 from typing import Any
 
+from clawjournal.events.classify.common import is_shell_tool
 from clawjournal.events.incidents.normalize import normalize_outcome_text
 from clawjournal.events.incidents.types import LOOP_INCIDENT_KIND
+from clawjournal.events.view import canonical_events
 
 DEFAULT_SHELL_THRESHOLD = 3
 DEFAULT_TOOL_CALL_THRESHOLD = 5
@@ -73,14 +75,28 @@ class IncidentHit:
 # auto-retries wouldn't register as a loop.
 _RUN_BREAKERS = frozenset({"user_message", "compaction"})
 
+# Shell-command fingerprint fields. Only these keys from a Bash/shell
+# tool's args contribute to the run-identity key — other fields (e.g.
+# Claude Bash's `description`, `timeout`, `run_in_background`) are
+# model-narrated or ergonomic and would otherwise hide loops whenever
+# those fields drift between identical retries.
+_SHELL_FINGERPRINT_FIELDS = frozenset({"command", "workdir", "cwd"})
+
 
 @dataclass
 class _CandidateRow:
     event_id: int
     event_type: str
     event_key: str | None
-    raw: dict
     fingerprint: tuple | None  # None = unparseable eligible row
+
+
+@dataclass(frozen=True)
+class _SessionEvent:
+    event_id: int | None
+    event_type: str
+    event_key: str | None
+    raw_json: str | None
 
 
 def detect_session_loops(
@@ -99,23 +115,28 @@ def detect_session_loops(
     or `compaction` event resets adjacency — the next attempt is then
     a response to new context, not a blind retry.
     """
-    rows = conn.execute(
-        """
-        SELECT id, type, event_key, client, raw_json, source_path, source_offset, seq
-          FROM events
-         WHERE session_id = ?
-         ORDER BY event_at IS NULL, event_at, source_path, source_offset, seq
-        """,
+    row = conn.execute(
+        "SELECT client FROM event_sessions WHERE id = ?",
         (session_id,),
-    ).fetchall()
+    ).fetchone()
+    if row is None:
+        return []
+    client = row["client"]
+
+    rows = _load_canonical_session_events(conn, session_id)
     if not rows:
         return []
 
-    result_text_by_tool_id = _collect_result_texts(rows)
+    result_text_by_tool_id = _collect_result_texts(rows, client=client)
 
     hits: list[IncidentHit] = []
     for rule in rules:
-        candidates = _build_rule_candidates(rows, rule, result_text_by_tool_id)
+        candidates = _build_rule_candidates(
+            rows,
+            rule,
+            result_text_by_tool_id,
+            client=client,
+        )
         hits.extend(_emit_runs_for_rule(session_id, candidates, rule))
     return hits
 
@@ -123,30 +144,106 @@ def detect_session_loops(
 # --- candidate construction ----------------------------------------------- #
 
 
-def _collect_result_texts(rows) -> dict[str, str]:
+def _load_canonical_session_events(
+    conn: sqlite3.Connection,
+    session_id: int,
+) -> list[_SessionEvent]:
+    if not _has_event_overrides_table(conn):
+        return _load_base_session_events(conn, session_id)
+
+    event_id_by_raw_ref = {
+        (row["source_path"], int(row["source_offset"]), int(row["seq"])): int(row["id"])
+        for row in conn.execute(
+            """
+            SELECT id, source_path, source_offset, seq
+              FROM events
+             WHERE session_id = ?
+            """,
+            (session_id,),
+        )
+    }
+
+    stream: list[_SessionEvent] = []
+    for event in canonical_events(conn, session_id):
+        event_id = None
+        if event.raw_ref is not None:
+            event_id = event_id_by_raw_ref.get(event.raw_ref)
+        stream.append(
+            _SessionEvent(
+                event_id=event_id,
+                event_type=event.type,
+                event_key=event.event_key,
+                raw_json=event.raw_json,
+            )
+        )
+    return stream
+
+
+def _has_event_overrides_table(conn: sqlite3.Connection) -> bool:
+    row = conn.execute(
+        """
+        SELECT 1
+          FROM sqlite_master
+         WHERE type = 'table' AND name = 'event_overrides'
+        """
+    ).fetchone()
+    return row is not None
+
+
+def _load_base_session_events(
+    conn: sqlite3.Connection,
+    session_id: int,
+) -> list[_SessionEvent]:
+    rows = conn.execute(
+        """
+        SELECT id, type, event_key, raw_json
+          FROM events
+         WHERE session_id = ?
+         ORDER BY event_at IS NULL, event_at, source_path, source_offset, seq
+        """,
+        (session_id,),
+    ).fetchall()
+    emitted_keys: set[str] = set()
+    stream: list[_SessionEvent] = []
+    for row in rows:
+        event_key = row["event_key"]
+        if event_key is not None:
+            if event_key in emitted_keys:
+                continue
+            emitted_keys.add(event_key)
+        stream.append(
+            _SessionEvent(
+                event_id=int(row["id"]),
+                event_type=row["type"],
+                event_key=event_key,
+                raw_json=row["raw_json"],
+            )
+        )
+    return stream
+
+
+def _collect_result_texts(rows, *, client: str) -> dict[str, str]:
     """Map `tool_id -> normalized result text` for paired lookup.
 
-    Only the *latest* tool_result wins if there are duplicates across
-    sources (native + LA emit the same logical event); cross-source
-    dedup happens at the read layer via 03's canonical_events for
-    consumers that need it, but for fingerprint comparison we just
-    pick whichever lands first — they should produce identical
-    normalized text by construction."""
+    Rows already come from `canonical_events`, so cross-source
+    duplicates have been removed before pairing."""
     out: dict[str, str] = {}
     for row in rows:
-        if row["type"] != "tool_result":
+        if row.event_type != "tool_result" or row.raw_json is None:
             continue
-        event_key = row["event_key"]
+        event_key = row.event_key
         if not event_key or not event_key.startswith("tool_result:"):
             continue
         tool_id = event_key[len("tool_result:") :]
         if tool_id in out:
             continue  # first one wins
         try:
-            parsed = json.loads(row["raw_json"])
+            parsed = json.loads(row.raw_json)
         except (TypeError, json.JSONDecodeError):
             continue
-        text = _result_text_for_client(row["client"], parsed)
+        if not isinstance(parsed, dict):
+            continue
+        text = _result_text_for_client(client, parsed)
         if text is None:
             continue
         out[tool_id] = normalize_outcome_text(text)
@@ -154,7 +251,11 @@ def _collect_result_texts(rows) -> dict[str, str]:
 
 
 def _build_rule_candidates(
-    rows, rule: LoopRule, results: dict[str, str]
+    rows,
+    rule: LoopRule,
+    results: dict[str, str],
+    *,
+    client: str,
 ) -> list[_CandidateRow]:
     """For a single rule, project the canonical stream down to (a)
     eligible-type rows and (b) breaker rows that reset adjacency.
@@ -165,47 +266,72 @@ def _build_rule_candidates(
     """
     candidates: list[_CandidateRow] = []
     for row in rows:
-        event_type = row["type"]
+        event_type = row.event_type
         if event_type == rule.event_type:
+            # Hook-only synthetic events have no `events.id` to cite
+            # in an incident row. Treat them as transparent — the
+            # surrounding real events remain adjacent.
+            if row.event_id is None:
+                continue
+            if row.raw_json is None:
+                candidates.append(
+                    _CandidateRow(
+                        event_id=int(row.event_id),
+                        event_type=event_type,
+                        event_key=row.event_key,
+                        fingerprint=None,
+                    )
+                )
+                continue
             try:
-                parsed = json.loads(row["raw_json"])
+                parsed = json.loads(row.raw_json)
             except (TypeError, json.JSONDecodeError):
                 # Eligible row whose payload won't parse: include it
                 # with fingerprint=None so it breaks the run rather
                 # than silently extending it.
                 candidates.append(
                     _CandidateRow(
-                        event_id=int(row["id"]),
+                        event_id=int(row.event_id),
                         event_type=event_type,
-                        event_key=row["event_key"],
-                        raw={},
+                        event_key=row.event_key,
+                        fingerprint=None,
+                    )
+                )
+                continue
+            if not isinstance(parsed, dict):
+                candidates.append(
+                    _CandidateRow(
+                        event_id=int(row.event_id),
+                        event_type=event_type,
+                        event_key=row.event_key,
                         fingerprint=None,
                     )
                 )
                 continue
             fingerprint = _fingerprint_for(
-                client=row["client"],
+                client=client,
                 event_type=event_type,
-                event_key=row["event_key"],
+                event_key=row.event_key,
                 parsed=parsed,
                 results=results,
             )
             candidates.append(
                 _CandidateRow(
-                    event_id=int(row["id"]),
+                    event_id=int(row.event_id),
                     event_type=event_type,
-                    event_key=row["event_key"],
-                    raw=parsed,
+                    event_key=row.event_key,
                     fingerprint=fingerprint,
                 )
             )
         elif event_type in _RUN_BREAKERS:
+            # Breakers never cite an event_id in the incident row, but
+            # hook-only overrides may have raw_ref=None → no id. Use 0
+            # as a harmless sentinel; it's never read back.
             candidates.append(
                 _CandidateRow(
-                    event_id=int(row["id"]),
+                    event_id=int(row.event_id) if row.event_id is not None else 0,
                     event_type=event_type,
-                    event_key=row["event_key"],
-                    raw={},
+                    event_key=row.event_key,
                     fingerprint=None,
                 )
             )
@@ -292,10 +418,10 @@ def _fingerprint_for(
     outcome = results.get(tool_id, "") if tool_id is not None else ""
 
     if event_type == "command_start":
-        command = _command_string_for_client(client, parsed)
+        command, args_key = _command_signature_for_client(client, parsed)
         if not command:
             return None
-        return ("command_start", command, outcome)
+        return ("command_start", command, args_key, outcome)
     if event_type == "tool_call":
         name, args_key = _tool_call_signature_for_client(client, parsed)
         if not name:
@@ -319,7 +445,9 @@ def _tool_id_from_event_key(event_key: str | None) -> str | None:
     return None
 
 
-def _command_string_for_client(client: str, parsed: dict) -> str | None:
+def _command_signature_for_client(
+    client: str, parsed: dict
+) -> tuple[str | None, str]:
     if client in ("claude", "openclaw"):
         # Either a Bash tool_use carrying input.command, or a
         # bashExecution role carrying a top-level command string.
@@ -328,7 +456,7 @@ def _command_string_for_client(client: str, parsed: dict) -> str | None:
             if message.get("role") == "bashExecution":
                 command = message.get("command")
                 if isinstance(command, str) and command.strip():
-                    return command
+                    return command, _canonical_args({"command": command})
             content = message.get("content")
             if isinstance(content, list):
                 for block in content:
@@ -339,38 +467,58 @@ def _command_string_for_client(client: str, parsed: dict) -> str | None:
                     name = block.get("name")
                     if not _is_shell_tool_name(name):
                         continue
-                    inp = block.get("input")
-                    if isinstance(inp, dict):
-                        cmd = inp.get("command")
-                        if isinstance(cmd, str) and cmd.strip():
-                            return cmd
-                    return None
-        return None
+                    args = block.get("input") if "input" in block else block.get("arguments")
+                    return _command_signature_from_args(args)
+        return None, ""
     if client == "codex":
         payload = parsed.get("payload")
         if not isinstance(payload, dict):
-            return None
+            return None, ""
         if payload.get("type") not in ("function_call", "custom_tool_call"):
-            return None
+            return None, ""
         if not _is_shell_tool_name(payload.get("name")):
-            return None
+            return None, ""
         args = payload.get("arguments")
         if isinstance(args, str):
             try:
                 args_obj = json.loads(args)
             except json.JSONDecodeError:
-                return args.strip() or None
+                stripped = args.strip()
+                return (stripped or None), stripped
         elif isinstance(args, dict):
             args_obj = args
         else:
-            return None
-        cmd = args_obj.get("command") if isinstance(args_obj, dict) else None
-        if isinstance(cmd, list):
-            return " ".join(str(p) for p in cmd)
-        if isinstance(cmd, str) and cmd.strip():
-            return cmd
-        return None
-    return None
+            return None, ""
+        return _command_signature_from_args(args_obj)
+    return None, ""
+
+
+def _command_signature_from_args(args: object) -> tuple[str | None, str]:
+    args_key = _shell_fingerprint_key(args)
+    if not isinstance(args, dict):
+        return None, args_key
+    cmd = args.get("command")
+    if isinstance(cmd, list):
+        joined = " ".join(str(part) for part in cmd).strip()
+        return (joined or None), args_key
+    if isinstance(cmd, str):
+        stripped = cmd.strip()
+        return (stripped or None), args_key
+    return None, args_key
+
+
+def _shell_fingerprint_key(args: object) -> str:
+    """Canonicalize *only* the shell-identity fields of `args`.
+
+    Prevents Claude Bash's `description`/`timeout`/`run_in_background`
+    drift from hiding otherwise-identical retries.
+    """
+    if not isinstance(args, dict):
+        return _canonical_args(args)
+    filtered = {
+        k: args[k] for k in _SHELL_FINGERPRINT_FIELDS if k in args
+    }
+    return _canonical_args(filtered)
 
 
 def _tool_call_signature_for_client(
@@ -423,10 +571,9 @@ def _canonical_args(args: object) -> str:
 
 
 def _is_shell_tool_name(name: object) -> bool:
-    if not isinstance(name, str):
-        return False
-    lowered = name.lower()
-    return lowered in {"bash", "shell", "sh", "zsh"}
+    return is_shell_tool(name) or (
+        isinstance(name, str) and name.strip().lower() in {"sh", "zsh"}
+    )
 
 
 def _result_text_for_client(client: str, parsed: dict) -> str | None:
@@ -438,6 +585,10 @@ def _result_text_for_client(client: str, parsed: dict) -> str | None:
     if client in ("claude", "openclaw"):
         message = parsed.get("message")
         if isinstance(message, dict):
+            if client == "openclaw" and message.get("role") == "toolResult":
+                text = _flatten_text(message.get("content"))
+                if text is not None:
+                    return text
             content = message.get("content")
             if isinstance(content, list):
                 for block in content:

--- a/clawjournal/events/incidents/loop_detector.py
+++ b/clawjournal/events/incidents/loop_detector.py
@@ -1,0 +1,494 @@
+"""Loop detector (lite) — flag exact-repeat command and tool-call runs.
+
+The detector walks a session's events in canonical order and computes
+a per-event "fingerprint" from `events.raw_json` plus the matching
+`tool_result` row. Consecutive events sharing a fingerprint are
+grouped into a run; runs meeting the per-rule threshold become
+`incidents` rows of kind `loop_exact_repeat`.
+
+Per-rule thresholds (spec):
+- shell command runs (`command_start` events) need **3** repeats.
+- generic tool-call runs (`tool_call` events that are NOT shell)
+  need **5** repeats.
+
+The "outcome" portion of the fingerprint is the normalized result
+text from the paired `tool_result` row (see `normalize.py`). If a
+tool_call has no paired result (e.g. mid-execution), the outcome is
+the empty string — two such events still match each other but the
+detector treats the run as `confidence='medium'` since we can't see
+whether the result diverged.
+
+Cross-session matching is not done. Cross-event-key matching is
+strict: a `tool_call` and a `tool_result` are paired only by the
+suffix of their `event_key` (`tool_call:<id>` ↔ `tool_result:<id>`),
+which 02 already populates.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from typing import Any
+
+from clawjournal.events.incidents.normalize import normalize_outcome_text
+from clawjournal.events.incidents.types import LOOP_INCIDENT_KIND
+
+DEFAULT_SHELL_THRESHOLD = 3
+DEFAULT_TOOL_CALL_THRESHOLD = 5
+
+
+@dataclass(frozen=True)
+class LoopRule:
+    """A per-event-type loop rule. `kind` is the resulting incident
+    kind (always `loop_exact_repeat` today; the field exists so
+    future rules can subclass within the same table)."""
+
+    event_type: str
+    threshold: int
+    kind: str = LOOP_INCIDENT_KIND
+
+
+DEFAULT_RULES: tuple[LoopRule, ...] = (
+    LoopRule(event_type="command_start", threshold=DEFAULT_SHELL_THRESHOLD),
+    LoopRule(event_type="tool_call", threshold=DEFAULT_TOOL_CALL_THRESHOLD),
+)
+
+
+@dataclass(frozen=True)
+class IncidentHit:
+    session_id: int
+    kind: str
+    first_event_id: int
+    last_event_id: int
+    count: int
+    confidence: str
+    evidence: dict[str, Any] = field(default_factory=dict)
+
+
+# Run breakers: events that signal genuine new external input or
+# context resets between two same-typed actions. `user_message` is the
+# only one today — the assistant's own reasoning + tool-result
+# bookkeeping are NOT breakers, since otherwise back-to-back
+# auto-retries wouldn't register as a loop.
+_RUN_BREAKERS = frozenset({"user_message", "compaction"})
+
+
+@dataclass
+class _CandidateRow:
+    event_id: int
+    event_type: str
+    event_key: str | None
+    raw: dict
+    fingerprint: tuple | None  # None = unparseable eligible row
+
+
+def detect_session_loops(
+    conn: sqlite3.Connection,
+    session_id: int,
+    *,
+    rules: tuple[LoopRule, ...] = DEFAULT_RULES,
+) -> list[IncidentHit]:
+    """Pure read — return the current loop hits for a session.
+
+    Each rule is evaluated independently against the events of its
+    own eligible type. Adjacency is measured in the canonical event
+    stream: events of other types are transparent (a `tool_result`
+    between two `command_start`s does NOT break the run, since it's
+    the bookkeeping side of the first command), but a `user_message`
+    or `compaction` event resets adjacency — the next attempt is then
+    a response to new context, not a blind retry.
+    """
+    rows = conn.execute(
+        """
+        SELECT id, type, event_key, client, raw_json, source_path, source_offset, seq
+          FROM events
+         WHERE session_id = ?
+         ORDER BY event_at IS NULL, event_at, source_path, source_offset, seq
+        """,
+        (session_id,),
+    ).fetchall()
+    if not rows:
+        return []
+
+    result_text_by_tool_id = _collect_result_texts(rows)
+
+    hits: list[IncidentHit] = []
+    for rule in rules:
+        candidates = _build_rule_candidates(rows, rule, result_text_by_tool_id)
+        hits.extend(_emit_runs_for_rule(session_id, candidates, rule))
+    return hits
+
+
+# --- candidate construction ----------------------------------------------- #
+
+
+def _collect_result_texts(rows) -> dict[str, str]:
+    """Map `tool_id -> normalized result text` for paired lookup.
+
+    Only the *latest* tool_result wins if there are duplicates across
+    sources (native + LA emit the same logical event); cross-source
+    dedup happens at the read layer via 03's canonical_events for
+    consumers that need it, but for fingerprint comparison we just
+    pick whichever lands first — they should produce identical
+    normalized text by construction."""
+    out: dict[str, str] = {}
+    for row in rows:
+        if row["type"] != "tool_result":
+            continue
+        event_key = row["event_key"]
+        if not event_key or not event_key.startswith("tool_result:"):
+            continue
+        tool_id = event_key[len("tool_result:") :]
+        if tool_id in out:
+            continue  # first one wins
+        try:
+            parsed = json.loads(row["raw_json"])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        text = _result_text_for_client(row["client"], parsed)
+        if text is None:
+            continue
+        out[tool_id] = normalize_outcome_text(text)
+    return out
+
+
+def _build_rule_candidates(
+    rows, rule: LoopRule, results: dict[str, str]
+) -> list[_CandidateRow]:
+    """For a single rule, project the canonical stream down to (a)
+    eligible-type rows and (b) breaker rows that reset adjacency.
+
+    Other event types are transparent — they don't appear in the
+    candidate list, so two `command_start`s with a `tool_result`
+    between them stay adjacent for the run-grouping pass.
+    """
+    candidates: list[_CandidateRow] = []
+    for row in rows:
+        event_type = row["type"]
+        if event_type == rule.event_type:
+            try:
+                parsed = json.loads(row["raw_json"])
+            except (TypeError, json.JSONDecodeError):
+                # Eligible row whose payload won't parse: include it
+                # with fingerprint=None so it breaks the run rather
+                # than silently extending it.
+                candidates.append(
+                    _CandidateRow(
+                        event_id=int(row["id"]),
+                        event_type=event_type,
+                        event_key=row["event_key"],
+                        raw={},
+                        fingerprint=None,
+                    )
+                )
+                continue
+            fingerprint = _fingerprint_for(
+                client=row["client"],
+                event_type=event_type,
+                event_key=row["event_key"],
+                parsed=parsed,
+                results=results,
+            )
+            candidates.append(
+                _CandidateRow(
+                    event_id=int(row["id"]),
+                    event_type=event_type,
+                    event_key=row["event_key"],
+                    raw=parsed,
+                    fingerprint=fingerprint,
+                )
+            )
+        elif event_type in _RUN_BREAKERS:
+            candidates.append(
+                _CandidateRow(
+                    event_id=int(row["id"]),
+                    event_type=event_type,
+                    event_key=row["event_key"],
+                    raw={},
+                    fingerprint=None,
+                )
+            )
+        # Other types are transparent — drop them.
+    return candidates
+
+
+def _emit_runs_for_rule(
+    session_id: int,
+    candidates: list[_CandidateRow],
+    rule: LoopRule,
+):
+    run: list[_CandidateRow] = []
+    cur_fingerprint: tuple | None = None
+
+    def maybe_emit():
+        nonlocal run, cur_fingerprint
+        if not run or cur_fingerprint is None or len(run) < rule.threshold:
+            run = []
+            return None
+        # The fingerprint's last element is the (normalized) outcome
+        # text; an empty string means we couldn't read it, so the
+        # run's confidence drops.
+        confidence = "high" if cur_fingerprint[-1] != "" else "medium"
+        hit = IncidentHit(
+            session_id=session_id,
+            kind=rule.kind,
+            first_event_id=run[0].event_id,
+            last_event_id=run[-1].event_id,
+            count=len(run),
+            confidence=confidence,
+            evidence={
+                "event_type": rule.event_type,
+                "fingerprint": list(cur_fingerprint),
+                "threshold": rule.threshold,
+                "first_event_id": run[0].event_id,
+                "last_event_id": run[-1].event_id,
+                "event_ids": [c.event_id for c in run],
+            },
+        )
+        run = []
+        return hit
+
+    for cand in candidates:
+        if cand.fingerprint is None:
+            hit = maybe_emit()
+            if hit is not None:
+                yield hit
+            cur_fingerprint = None
+            continue
+        if cand.fingerprint != cur_fingerprint:
+            hit = maybe_emit()
+            if hit is not None:
+                yield hit
+            cur_fingerprint = cand.fingerprint
+            run = [cand]
+        else:
+            run.append(cand)
+
+    hit = maybe_emit()
+    if hit is not None:
+        yield hit
+
+
+# --- per-client fingerprint extraction ------------------------------------ #
+
+
+def _fingerprint_for(
+    *,
+    client: str,
+    event_type: str,
+    event_key: str | None,
+    parsed: dict,
+    results: dict[str, str],
+) -> tuple | None:
+    """Compute the comparison key for an eligible event.
+
+    Returns `None` when the event is eligible by type but lacks the
+    fields needed to compare (e.g. an unparseable payload). A None
+    fingerprint breaks adjacent runs the same way a non-eligible
+    event does.
+    """
+    tool_id = _tool_id_from_event_key(event_key)
+    outcome = results.get(tool_id, "") if tool_id is not None else ""
+
+    if event_type == "command_start":
+        command = _command_string_for_client(client, parsed)
+        if not command:
+            return None
+        return ("command_start", command, outcome)
+    if event_type == "tool_call":
+        name, args_key = _tool_call_signature_for_client(client, parsed)
+        if not name:
+            return None
+        # Shell tool calls already get a `command_start` companion
+        # event with the more meaningful (command, outcome) signature
+        # — skip them here to avoid double-counting against a lower
+        # threshold.
+        if _is_shell_tool_name(name):
+            return None
+        return ("tool_call", name, args_key, outcome)
+    return None
+
+
+def _tool_id_from_event_key(event_key: str | None) -> str | None:
+    if not event_key:
+        return None
+    for prefix in ("command_start:", "tool_call:"):
+        if event_key.startswith(prefix):
+            return event_key[len(prefix) :]
+    return None
+
+
+def _command_string_for_client(client: str, parsed: dict) -> str | None:
+    if client in ("claude", "openclaw"):
+        # Either a Bash tool_use carrying input.command, or a
+        # bashExecution role carrying a top-level command string.
+        message = parsed.get("message")
+        if isinstance(message, dict):
+            if message.get("role") == "bashExecution":
+                command = message.get("command")
+                if isinstance(command, str) and command.strip():
+                    return command
+            content = message.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") not in ("tool_use", "toolCall"):
+                        continue
+                    name = block.get("name")
+                    if not _is_shell_tool_name(name):
+                        continue
+                    inp = block.get("input")
+                    if isinstance(inp, dict):
+                        cmd = inp.get("command")
+                        if isinstance(cmd, str) and cmd.strip():
+                            return cmd
+                    return None
+        return None
+    if client == "codex":
+        payload = parsed.get("payload")
+        if not isinstance(payload, dict):
+            return None
+        if payload.get("type") not in ("function_call", "custom_tool_call"):
+            return None
+        if not _is_shell_tool_name(payload.get("name")):
+            return None
+        args = payload.get("arguments")
+        if isinstance(args, str):
+            try:
+                args_obj = json.loads(args)
+            except json.JSONDecodeError:
+                return args.strip() or None
+        elif isinstance(args, dict):
+            args_obj = args
+        else:
+            return None
+        cmd = args_obj.get("command") if isinstance(args_obj, dict) else None
+        if isinstance(cmd, list):
+            return " ".join(str(p) for p in cmd)
+        if isinstance(cmd, str) and cmd.strip():
+            return cmd
+        return None
+    return None
+
+
+def _tool_call_signature_for_client(
+    client: str, parsed: dict
+) -> tuple[str | None, str]:
+    if client in ("claude", "openclaw"):
+        message = parsed.get("message")
+        if not isinstance(message, dict):
+            return None, ""
+        content = message.get("content")
+        if not isinstance(content, list):
+            return None, ""
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            if block.get("type") not in ("tool_use", "toolCall"):
+                continue
+            name = block.get("name")
+            if not isinstance(name, str):
+                continue
+            args = block.get("input") if "input" in block else block.get("arguments")
+            return name, _canonical_args(args)
+        return None, ""
+    if client == "codex":
+        payload = parsed.get("payload")
+        if not isinstance(payload, dict):
+            return None, ""
+        if payload.get("type") not in ("function_call", "custom_tool_call"):
+            return None, ""
+        name = payload.get("name") if isinstance(payload.get("name"), str) else None
+        args = payload.get("arguments")
+        if isinstance(args, str):
+            try:
+                args_obj = json.loads(args)
+            except json.JSONDecodeError:
+                return name, args.strip()
+            return name, _canonical_args(args_obj)
+        return name, _canonical_args(args)
+    return None, ""
+
+
+def _canonical_args(args: object) -> str:
+    """Return a stable string representation of a tool's args."""
+    if args is None:
+        return ""
+    try:
+        return json.dumps(args, sort_keys=True)
+    except (TypeError, ValueError):
+        return str(args)
+
+
+def _is_shell_tool_name(name: object) -> bool:
+    if not isinstance(name, str):
+        return False
+    lowered = name.lower()
+    return lowered in {"bash", "shell", "sh", "zsh"}
+
+
+def _result_text_for_client(client: str, parsed: dict) -> str | None:
+    """Pull the human-readable result text from a tool_result row.
+
+    Falls back to a stable JSON dump if the wire format puts the
+    payload somewhere unexpected — better to compare structured
+    fallback than to lose the comparison entirely."""
+    if client in ("claude", "openclaw"):
+        message = parsed.get("message")
+        if isinstance(message, dict):
+            content = message.get("content")
+            if isinstance(content, list):
+                for block in content:
+                    if not isinstance(block, dict):
+                        continue
+                    if block.get("type") != "tool_result":
+                        continue
+                    inner = block.get("content")
+                    text = _flatten_text(inner)
+                    if text is not None:
+                        return text
+        return None
+    if client == "codex":
+        payload = parsed.get("payload")
+        if not isinstance(payload, dict):
+            return None
+        if payload.get("type") not in (
+            "function_call_output",
+            "custom_tool_call_output",
+        ):
+            return None
+        out = payload.get("output")
+        if isinstance(out, str):
+            try:
+                wrapped = json.loads(out)
+            except json.JSONDecodeError:
+                return out
+            if isinstance(wrapped, dict):
+                inner = wrapped.get("output")
+                if isinstance(inner, str):
+                    return inner
+                return json.dumps(wrapped, sort_keys=True)
+            return out
+        if isinstance(out, list):
+            return _flatten_text(out)
+        return None
+    return None
+
+
+def _flatten_text(value: object) -> str | None:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, list):
+        chunks: list[str] = []
+        for block in value:
+            if isinstance(block, str):
+                chunks.append(block)
+            elif isinstance(block, dict):
+                text = block.get("text")
+                if isinstance(text, str):
+                    chunks.append(text)
+        if chunks:
+            return "\n".join(chunks)
+    return None

--- a/clawjournal/events/incidents/loop_detector.py
+++ b/clawjournal/events/incidents/loop_detector.py
@@ -76,6 +76,9 @@ class IncidentHit:
 # bookkeeping are NOT breakers, since otherwise back-to-back
 # auto-retries wouldn't register as a loop.
 _RUN_BREAKERS = frozenset({"user_message", "compaction"})
+_ADJACENCY_SENSITIVE_TYPES = _RUN_BREAKERS.union(
+    rule.event_type for rule in DEFAULT_RULES
+)
 
 # Shell-command fingerprint fields. Only these keys from a Bash/shell
 # tool's args contribute to the run-identity key — other fields (e.g.
@@ -184,7 +187,7 @@ def _load_canonical_session_events(
                 payload_json=event.payload_json,
             )
         )
-    return _restore_hook_only_breaker_order(stream)
+    return _restore_hook_only_adjacency_order(stream)
 
 
 def _has_event_overrides_table(conn: sqlite3.Connection) -> bool:
@@ -232,12 +235,12 @@ def _load_base_session_events(
     return stream
 
 
-def _restore_hook_only_breaker_order(
+def _restore_hook_only_adjacency_order(
     stream: list[_SessionEvent],
 ) -> list[_SessionEvent]:
     ordered: list[_SessionEvent] = []
     for event in stream:
-        if not _is_hook_only_breaker(event):
+        if not _is_hook_only_adjacency_event(event):
             ordered.append(event)
             continue
         insert_at = len(ordered)
@@ -250,10 +253,10 @@ def _restore_hook_only_breaker_order(
     return ordered
 
 
-def _is_hook_only_breaker(event: _SessionEvent) -> bool:
+def _is_hook_only_adjacency_event(event: _SessionEvent) -> bool:
     return (
         event.event_id is None
-        and event.event_type in _RUN_BREAKERS
+        and event.event_type in _ADJACENCY_SENSITIVE_TYPES
         and event.event_at is not None
     )
 
@@ -269,20 +272,16 @@ def _collect_result_texts(rows, *, client: str) -> dict[str, str]:
     duplicates have been removed before pairing."""
     out: dict[str, str] = {}
     for row in rows:
-        payload_json = _effective_payload_json(row)
-        if row.event_type != "tool_result" or payload_json is None:
+        if row.event_type != "tool_result":
+            continue
+        parsed = _effective_parsed_payload(row, client=client)
+        if parsed is None:
             continue
         tool_id = _tool_result_id_from_event_key(row.event_key)
         if tool_id is None:
             continue
         if tool_id in out:
             continue  # first one wins
-        try:
-            parsed = json.loads(payload_json)
-        except (TypeError, json.JSONDecodeError):
-            continue
-        if not isinstance(parsed, dict):
-            continue
         text = _result_text_for_client(client, parsed, tool_id=tool_id)
         if text is None:
             continue
@@ -308,38 +307,23 @@ def _build_rule_candidates(
     for row in rows:
         event_type = row.event_type
         if event_type == rule.event_type:
-            # Hook-only synthetic events have no `events.id` to cite
-            # in an incident row. Treat them as transparent — the
-            # surrounding real events remain adjacent.
+            # Hook-only synthetic actions have no `events.id` to cite
+            # in an incident row, so they cannot anchor an emitted hit.
+            # They DO still interrupt adjacency: a novel hook-derived
+            # command/tool call between two identical base attempts
+            # means the run was not uninterrupted.
             if row.event_id is None:
-                continue
-            payload_json = _effective_payload_json(row)
-            if payload_json is None:
                 candidates.append(
                     _CandidateRow(
-                        event_id=int(row.event_id),
+                        event_id=0,
                         event_type=event_type,
                         event_key=row.event_key,
                         fingerprint=None,
                     )
                 )
                 continue
-            try:
-                parsed = json.loads(payload_json)
-            except (TypeError, json.JSONDecodeError):
-                # Eligible row whose payload won't parse: include it
-                # with fingerprint=None so it breaks the run rather
-                # than silently extending it.
-                candidates.append(
-                    _CandidateRow(
-                        event_id=int(row.event_id),
-                        event_type=event_type,
-                        event_key=row.event_key,
-                        fingerprint=None,
-                    )
-                )
-                continue
-            if not isinstance(parsed, dict):
+            parsed = _effective_parsed_payload(row, client=client)
+            if parsed is None:
                 candidates.append(
                     _CandidateRow(
                         event_id=int(row.event_id),
@@ -772,8 +756,64 @@ def _result_text_for_client(
     return None
 
 
-def _effective_payload_json(row: _SessionEvent) -> str | None:
-    return row.payload_json if row.payload_json is not None else row.raw_json
+def _effective_parsed_payload(
+    row: _SessionEvent,
+    *,
+    client: str,
+) -> dict | None:
+    fallback: dict | None = None
+    for payload_json in (row.payload_json, row.raw_json):
+        if payload_json is None:
+            continue
+        try:
+            parsed = json.loads(payload_json)
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(parsed, dict):
+            continue
+        if fallback is None:
+            fallback = parsed
+        if _payload_supports_event(
+            client=client,
+            event_type=row.event_type,
+            event_key=row.event_key,
+            parsed=parsed,
+        ):
+            return parsed
+    return fallback
+
+
+def _payload_supports_event(
+    *,
+    client: str,
+    event_type: str,
+    event_key: str | None,
+    parsed: dict,
+) -> bool:
+    if event_type == "command_start":
+        command, _ = _command_signature_for_client(
+            client,
+            parsed,
+            tool_id=_tool_id_from_event_key(event_key),
+        )
+        return command is not None
+    if event_type == "tool_call":
+        name, _ = _tool_call_signature_for_client(
+            client,
+            parsed,
+            tool_id=_tool_id_from_event_key(event_key),
+        )
+        return name is not None
+    if event_type == "tool_result":
+        return (
+            _result_text_for_client(
+                client,
+                parsed,
+                tool_id=_tool_result_id_from_event_key(event_key),
+            )
+            is not None
+        )
+    return True
 
 
 def _inline_outcome_for_client(

--- a/clawjournal/events/incidents/loop_detector.py
+++ b/clawjournal/events/incidents/loop_detector.py
@@ -494,29 +494,43 @@ def _serialize_fingerprint(fingerprint: tuple) -> list:
     """Project an in-memory fingerprint tuple into the form stored in
     `incidents.evidence_json`.
 
-    The live fingerprint carries an outcome-availability marker plus
-    the normalized paired-`tool_result` text as its last element so
-    run-grouping can compare both availability and content. That text
-    is derived from `events.raw_json` and has NOT been through the
-    workbench regex/PII redaction pipeline — persisting it verbatim in
-    `evidence_json` would smuggle secrets past any consumer that reads
-    incidents without re-redacting. We replace the outcome with a
-    truncated sha256 so grouping + audit still work without leaking the
-    payload; the full text remains reachable via `first_event_id` /
-    `last_event_id` through the normal redaction paths.
+    The live fingerprint carries raw command / tool args plus the
+    normalized paired-`tool_result` text. None of those slots have been
+    through the workbench redaction pipeline, so persisting them
+    verbatim in `evidence_json` would leak sensitive input or output to
+    any consumer that reads incidents directly. We keep only the
+    structural markers (`event_type`, outcome availability) in cleartext
+    and replace every comparison slot with a truncated sha256 so audit +
+    grouping remain possible without storing raw payloads; the original
+    text stays reachable via `first_event_id` / `last_event_id` through
+    the normal redaction paths.
     """
     if not fingerprint:
         return []
-    out = list(fingerprint)
+    out: list[Any] = [fingerprint[0]]
     availability = _fingerprint_outcome_state(fingerprint)
-    outcome = out[-1]
-    if isinstance(outcome, str):
-        if availability == _OUTCOME_MISSING:
-            out[-1] = ""  # preserve the "no outcome available" signal
-        else:
-            digest = hashlib.sha256(outcome.encode("utf-8")).hexdigest()[:16]
-            out[-1] = f"sha256:{digest}"
+    state_index = len(fingerprint) - 2
+    outcome_index = len(fingerprint) - 1
+    for index, value in enumerate(fingerprint[1:], start=1):
+        if index == state_index:
+            out.append(value)
+            continue
+        if index == outcome_index and availability == _OUTCOME_MISSING:
+            out.append("")  # preserve the "no outcome available" signal
+            continue
+        out.append(_hashed_fingerprint_slot(value))
     return out
+
+
+def _hashed_fingerprint_slot(value: object) -> str:
+    if value == "":
+        return ""
+    if isinstance(value, str):
+        text = value
+    else:
+        text = _canonical_args(value)
+    digest = hashlib.sha256(text.encode("utf-8")).hexdigest()[:16]
+    return f"sha256:{digest}"
 
 
 def _fingerprint_has_observed_outcome(fingerprint: tuple) -> bool:

--- a/clawjournal/events/incidents/normalize.py
+++ b/clawjournal/events/incidents/normalize.py
@@ -35,10 +35,16 @@ _ISO_TIMESTAMP = re.compile(
     r"(?:Z|[+-]\d{2}:?\d{2})?\b"
 )
 
-# 2. Absolute paths under user-rooted prefixes. Matches the leading slash
-# and continues until whitespace, quote, or terminating punctuation.
+# 2. Absolute paths under user-rooted prefixes. Handles the common
+# unquoted case plus quoted paths whose segments contain spaces.
+_PATH_PLAIN_SEGMENT = r"[^/\s\"'<>(){}\[\],;]+"
+_PATH_SPACED_SEGMENT = rf"{_PATH_PLAIN_SEGMENT}(?: {_PATH_PLAIN_SEGMENT})*"
 _HOME_ROOTED_PATH = re.compile(
-    r"/(?:Users|home|var|private|tmp)/[^\s\"'<>(){}\[\],;]+"
+    rf"(?:"
+    rf"(?<=[\"'`])/(?:Users|home|var|private|tmp)/[^\"'`]+(?=[\"'`])"
+    rf"|"
+    rf"/(?:Users|home|var|private|tmp)/(?:{_PATH_SPACED_SEGMENT}/)*{_PATH_PLAIN_SEGMENT}"
+    rf")"
 )
 
 # 3a. `pid 12345`, `PID: 12345`, `process 12345`

--- a/clawjournal/events/incidents/normalize.py
+++ b/clawjournal/events/incidents/normalize.py
@@ -1,0 +1,70 @@
+"""Outcome-text normalization for the loop detector.
+
+Two failures of the same command rarely produce byte-identical
+output: timestamps differ, PIDs rotate, absolute paths embed the
+user's home, whitespace gets reflowed by the terminal. The detector
+compares *normalized* text instead, with a small explicit ruleset:
+
+1. **Strip ISO-8601 timestamps.** Matches `2026-04-21T10:00:00`,
+   optionally followed by `.<frac>` and `Z` / `+00:00` / `-08:00`.
+2. **Strip absolute paths.** macOS (`/Users/...`, `/var/...`,
+   `/private/...`, `/tmp/...`) and Linux (`/home/...`) home-rooted
+   paths get replaced with `<PATH>`. The replacement preserves the
+   leading slash so a literal `/usr/bin/foo` style binary path
+   doesn't collapse with a user-rooted path.
+3. **Strip PIDs.** `pid 12345`, `[12345]`, and `process 12345`
+   patterns become `pid <PID>` / `[<PID>]` / `process <PID>`.
+4. **Collapse whitespace runs** (including the run lengths produced
+   by stripping bigger tokens out) to a single space.
+5. **Strip leading/trailing whitespace.**
+
+Each rule is a module-level regex so tests can pin them
+individually. The order matters: timestamps and PIDs must be
+stripped before whitespace collapse, otherwise the surrounding
+spaces tilt the comparison.
+"""
+
+from __future__ import annotations
+
+import re
+
+# 1. ISO-8601 timestamps: 2026-04-21T10:00:00(.fff)?(Z|+00:00|-08:00)?
+_ISO_TIMESTAMP = re.compile(
+    r"\b\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}"
+    r"(?:\.\d+)?"
+    r"(?:Z|[+-]\d{2}:?\d{2})?\b"
+)
+
+# 2. Absolute paths under user-rooted prefixes. Matches the leading slash
+# and continues until whitespace, quote, or terminating punctuation.
+_HOME_ROOTED_PATH = re.compile(
+    r"/(?:Users|home|var|private|tmp)/[^\s\"'<>(){}\[\],;]+"
+)
+
+# 3a. `pid 12345`, `PID: 12345`, `process 12345`
+_PID_INLINE = re.compile(r"\b(pid|process)\s*[:=]?\s*\d+\b", re.IGNORECASE)
+# 3b. Bare `[12345]` style. Limited digit count to avoid eating GUIDs.
+_PID_BRACKETED = re.compile(r"\[(\d{2,7})\]")
+
+# 4. Runs of whitespace.
+_WHITESPACE_RUN = re.compile(r"[ \t\r\f\v]+")
+
+PATH_PLACEHOLDER = "<PATH>"
+PID_PLACEHOLDER = "<PID>"
+TIMESTAMP_PLACEHOLDER = "<TS>"
+
+
+def normalize_outcome_text(text: str | None) -> str:
+    """Apply the documented ruleset and return the normalized form.
+
+    Returns the empty string for `None` / non-string input so callers
+    can compare safely.
+    """
+    if not isinstance(text, str):
+        return ""
+    out = _ISO_TIMESTAMP.sub(TIMESTAMP_PLACEHOLDER, text)
+    out = _HOME_ROOTED_PATH.sub(PATH_PLACEHOLDER, out)
+    out = _PID_INLINE.sub(lambda m: f"{m.group(1)} {PID_PLACEHOLDER}", out)
+    out = _PID_BRACKETED.sub(f"[{PID_PLACEHOLDER}]", out)
+    out = _WHITESPACE_RUN.sub(" ", out)
+    return out.strip()

--- a/clawjournal/events/incidents/normalize.py
+++ b/clawjournal/events/incidents/normalize.py
@@ -46,8 +46,8 @@ _PID_INLINE = re.compile(r"\b(pid|process)\s*[:=]?\s*\d+\b", re.IGNORECASE)
 # 3b. Bare `[12345]` style. Limited digit count to avoid eating GUIDs.
 _PID_BRACKETED = re.compile(r"\[(\d{2,7})\]")
 
-# 4. Runs of whitespace.
-_WHITESPACE_RUN = re.compile(r"[ \t\r\f\v]+")
+# 4. Runs of whitespace, including newline-only terminal reflow.
+_WHITESPACE_RUN = re.compile(r"\s+")
 
 PATH_PLACEHOLDER = "<PATH>"
 PID_PLACEHOLDER = "<PID>"

--- a/clawjournal/events/incidents/schema.py
+++ b/clawjournal/events/incidents/schema.py
@@ -1,0 +1,49 @@
+"""SQLite schema for the incidents pipeline (phase-1 plan 05).
+
+Two tables, both alongside 02's `events` / `event_sessions` in
+`~/.clawjournal/index.db`:
+
+- `incidents` — one row per detected incident. Shared by all
+  incident kinds (loop_exact_repeat today; later beats add more).
+  `UNIQUE (session_id, kind, first_event_id)` is the spec's dedupe
+  key — re-running ingest updates the same row's `count` /
+  `last_event_id` / `evidence_json` rather than inserting again.
+- `loop_ingest_state` — per-consumer cursor (consumer_id PK,
+  last_event_id) so the loop detector can advance only after the
+  events it needs to evaluate have actually been ingested by 02.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+INCIDENTS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS incidents (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    session_id      INTEGER NOT NULL REFERENCES event_sessions(id) ON DELETE CASCADE,
+    kind            TEXT    NOT NULL,
+    first_event_id  INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    last_event_id   INTEGER NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    evidence_json   TEXT    NOT NULL,
+    count           INTEGER NOT NULL,
+    confidence      TEXT    NOT NULL,
+    created_at      TEXT    NOT NULL,
+    UNIQUE (session_id, kind, first_event_id)
+);
+CREATE INDEX IF NOT EXISTS idx_incidents_session
+    ON incidents(session_id, kind);
+"""
+
+LOOP_INGEST_STATE_SQL = """
+CREATE TABLE IF NOT EXISTS loop_ingest_state (
+    consumer_id   TEXT PRIMARY KEY,
+    last_event_id INTEGER NOT NULL
+);
+"""
+
+
+def ensure_incidents_schema(conn: sqlite3.Connection) -> None:
+    """Create the incidents tables if absent. Safe to call repeatedly."""
+    conn.execute("PRAGMA foreign_keys=ON")
+    conn.executescript(INCIDENTS_TABLE_SQL)
+    conn.executescript(LOOP_INGEST_STATE_SQL)

--- a/clawjournal/events/incidents/schema.py
+++ b/clawjournal/events/incidents/schema.py
@@ -9,8 +9,12 @@ Two tables, both alongside 02's `events` / `event_sessions` in
   key — re-running ingest updates the same row's `count` /
   `last_event_id` / `evidence_json` rather than inserting again.
 - `loop_ingest_state` — per-consumer cursor (consumer_id PK,
-  last_event_id) so the loop detector can advance only after the
-  events it needs to evaluate have actually been ingested by 02.
+  `last_event_id`, plus the `(created_at, session_id, event_key)`
+  frontier of `event_overrides` we've processed) so the loop detector
+  can advance only after the events and override writes it needs to
+  evaluate have actually landed. `session_id` + `event_key` break
+  `created_at` ties without relying on SQLite's implicit rowid (which
+  VACUUM may renumber).
 """
 
 from __future__ import annotations
@@ -36,8 +40,11 @@ CREATE INDEX IF NOT EXISTS idx_incidents_session
 
 LOOP_INGEST_STATE_SQL = """
 CREATE TABLE IF NOT EXISTS loop_ingest_state (
-    consumer_id   TEXT PRIMARY KEY,
-    last_event_id INTEGER NOT NULL
+    consumer_id                TEXT PRIMARY KEY,
+    last_event_id              INTEGER NOT NULL,
+    last_override_created_at   TEXT,
+    last_override_session_id   INTEGER NOT NULL DEFAULT 0,
+    last_override_event_key    TEXT    NOT NULL DEFAULT ''
 );
 """
 
@@ -47,3 +54,21 @@ def ensure_incidents_schema(conn: sqlite3.Connection) -> None:
     conn.execute("PRAGMA foreign_keys=ON")
     conn.executescript(INCIDENTS_TABLE_SQL)
     conn.executescript(LOOP_INGEST_STATE_SQL)
+
+    existing = {
+        row[1] for row in conn.execute("PRAGMA table_info(loop_ingest_state)")
+    }
+    if "last_override_created_at" not in existing:
+        conn.execute(
+            "ALTER TABLE loop_ingest_state ADD COLUMN last_override_created_at TEXT"
+        )
+    if "last_override_session_id" not in existing:
+        conn.execute(
+            "ALTER TABLE loop_ingest_state "
+            "ADD COLUMN last_override_session_id INTEGER NOT NULL DEFAULT 0"
+        )
+    if "last_override_event_key" not in existing:
+        conn.execute(
+            "ALTER TABLE loop_ingest_state "
+            "ADD COLUMN last_override_event_key TEXT NOT NULL DEFAULT ''"
+        )

--- a/clawjournal/events/incidents/schema.py
+++ b/clawjournal/events/incidents/schema.py
@@ -9,12 +9,11 @@ Two tables, both alongside 02's `events` / `event_sessions` in
   key — re-running ingest updates the same row's `count` /
   `last_event_id` / `evidence_json` rather than inserting again.
 - `loop_ingest_state` — per-consumer cursor (consumer_id PK,
-  `last_event_id`, plus the `(created_at, session_id, event_key)`
-  frontier of `event_overrides` we've processed) so the loop detector
-  can advance only after the events and override writes it needs to
-  evaluate have actually landed. `session_id` + `event_key` break
-  `created_at` ties without relying on SQLite's implicit rowid (which
-  VACUUM may renumber).
+  `last_event_id`, plus the latest override write frontier we've
+  processed) so the loop detector can advance only after the events
+  and override writes it needs to evaluate have actually landed. The
+  cursor stores both the latest `write_seq` and the matching
+  `(created_at, session_id, event_key)` snapshot for debugging.
 """
 
 from __future__ import annotations
@@ -42,6 +41,7 @@ LOOP_INGEST_STATE_SQL = """
 CREATE TABLE IF NOT EXISTS loop_ingest_state (
     consumer_id                TEXT PRIMARY KEY,
     last_event_id              INTEGER NOT NULL,
+    last_override_write_seq    INTEGER NOT NULL DEFAULT 0,
     last_override_created_at   TEXT,
     last_override_session_id   INTEGER NOT NULL DEFAULT 0,
     last_override_event_key    TEXT    NOT NULL DEFAULT ''
@@ -58,6 +58,11 @@ def ensure_incidents_schema(conn: sqlite3.Connection) -> None:
     existing = {
         row[1] for row in conn.execute("PRAGMA table_info(loop_ingest_state)")
     }
+    if "last_override_write_seq" not in existing:
+        conn.execute(
+            "ALTER TABLE loop_ingest_state "
+            "ADD COLUMN last_override_write_seq INTEGER NOT NULL DEFAULT 0"
+        )
     if "last_override_created_at" not in existing:
         conn.execute(
             "ALTER TABLE loop_ingest_state ADD COLUMN last_override_created_at TEXT"

--- a/clawjournal/events/incidents/types.py
+++ b/clawjournal/events/incidents/types.py
@@ -1,0 +1,10 @@
+"""Constants and lightweight types for the incidents pipeline."""
+
+from __future__ import annotations
+
+LOOP_INCIDENT_KIND = "loop_exact_repeat"
+
+# Future beats add entries here as they introduce new kinds. Keeping
+# the set explicit lets the schema CHECK / read-time validators stay
+# in sync with the producer code.
+ValidIncidentKinds = frozenset({LOOP_INCIDENT_KIND})

--- a/clawjournal/events/view.py
+++ b/clawjournal/events/view.py
@@ -99,7 +99,7 @@ class CapabilityState(NamedTuple):
 # --- hook override writer -------------------------------------------------- #
 
 
-_UPSERT_SQL = """
+_UPSERT_OVERRIDE_SQL = """
 INSERT INTO event_overrides (
     session_id, event_key, type, source, confidence, lossiness,
     event_at, payload_json, origin, created_at
@@ -166,9 +166,13 @@ def write_hook_override(
         raise KeyError(f"session_key not found in event_sessions: {session_key}")
 
     created_at = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
+    # Single-statement UPSERT is atomic under SQLite's default
+    # isolation — the rank-guard and the `created_at` bump both live
+    # inside the ON CONFLICT clause, so two concurrent writers can't
+    # race between a pre-check and the write.
     with conn:
         cursor = conn.execute(
-            _UPSERT_SQL,
+            _UPSERT_OVERRIDE_SQL,
             (
                 session_id,
                 event_key,

--- a/clawjournal/events/view.py
+++ b/clawjournal/events/view.py
@@ -60,6 +60,7 @@ CREATE TABLE IF NOT EXISTS event_overrides (
     payload_json  TEXT    NOT NULL,
     origin        TEXT,
     created_at    TEXT    NOT NULL,
+    write_seq     INTEGER NOT NULL DEFAULT 0,
     PRIMARY KEY (session_id, event_key)
 );
 CREATE INDEX IF NOT EXISTS idx_event_overrides_session ON event_overrides(session_id);
@@ -69,6 +70,19 @@ CREATE INDEX IF NOT EXISTS idx_event_overrides_session ON event_overrides(sessio
 def ensure_view_schema(conn: sqlite3.Connection) -> None:
     conn.execute("PRAGMA foreign_keys=ON")
     conn.executescript(_SCHEMA_SQL)
+    existing = {
+        row[1] for row in conn.execute("PRAGMA table_info(event_overrides)")
+    }
+    if "write_seq" not in existing:
+        conn.execute(
+            "ALTER TABLE event_overrides "
+            "ADD COLUMN write_seq INTEGER NOT NULL DEFAULT 0"
+        )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_event_overrides_write_seq "
+        "ON event_overrides(write_seq)"
+    )
+    _backfill_override_write_seq(conn)
 
 
 # --- types ---------------------------------------------------------------- #
@@ -102,8 +116,9 @@ class CapabilityState(NamedTuple):
 _UPSERT_OVERRIDE_SQL = """
 INSERT INTO event_overrides (
     session_id, event_key, type, source, confidence, lossiness,
-    event_at, payload_json, origin, created_at
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    event_at, payload_json, origin, created_at, write_seq
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+          (SELECT COALESCE(MAX(write_seq), 0) + 1 FROM event_overrides))
 ON CONFLICT(session_id, event_key) DO UPDATE SET
     type         = excluded.type,
     source       = excluded.source,
@@ -112,7 +127,8 @@ ON CONFLICT(session_id, event_key) DO UPDATE SET
     event_at     = excluded.event_at,
     payload_json = excluded.payload_json,
     origin       = excluded.origin,
-    created_at   = excluded.created_at
+    created_at   = excluded.created_at,
+    write_seq    = excluded.write_seq
   WHERE
     CASE excluded.confidence WHEN 'high' THEN 3 WHEN 'medium' THEN 2 WHEN 'low' THEN 1 ELSE 0 END
     >
@@ -195,6 +211,33 @@ def _resolve_session_id(conn: sqlite3.Connection, session_key: str) -> int | Non
         (session_key,),
     ).fetchone()
     return None if row is None else int(row[0])
+
+
+def _backfill_override_write_seq(conn: sqlite3.Connection) -> None:
+    """Assign stable non-zero write order to pre-migration rows."""
+    conn.execute(
+        """
+        WITH max_seq AS (
+            SELECT COALESCE(MAX(write_seq), 0) AS base
+              FROM event_overrides
+        ),
+        ordered AS (
+            SELECT rowid AS rid,
+                   (SELECT base FROM max_seq)
+                   + ROW_NUMBER() OVER (
+                         ORDER BY created_at IS NULL, created_at, session_id, event_key
+                     ) AS seq
+              FROM event_overrides
+             WHERE write_seq = 0
+        )
+        UPDATE event_overrides
+           SET write_seq = (
+               SELECT seq FROM ordered WHERE ordered.rid = event_overrides.rowid
+           )
+         WHERE rowid IN (SELECT rid FROM ordered)
+           AND write_seq = 0
+        """
+    )
 
 
 # --- canonical reader ----------------------------------------------------- #

--- a/tests/events/incidents/test_loop_detector.py
+++ b/tests/events/incidents/test_loop_detector.py
@@ -315,6 +315,52 @@ def test_unrelated_event_between_repeats_breaks_the_run(conn):
     assert n == 0
 
 
+def test_transparent_event_between_repeats_does_not_break_the_run(conn):
+    """Only `user_message` / `compaction` reset adjacency. An
+    `assistant_message` between two `command_start`s is bookkeeping,
+    not new external input, and must NOT break the run."""
+    sid = _insert_session(conn, session_key="s:transparent", client="claude")
+    for i in range(2):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"a-{i}",
+            command="npm test", output="FAIL same",
+        )
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="assistant_message",
+        raw={"type": "assistant", "message": {"content": "let me try again"}},
+    )
+    _claude_bash_pair(
+        conn, session_id=sid, tool_id="a-2",
+        command="npm test", output="FAIL same",
+    )
+    ingest_loop_incidents(conn)
+    rows = conn.execute("SELECT count FROM incidents").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["count"] == 3
+
+
+def test_compaction_event_breaks_the_run(conn):
+    """A `compaction` event means the conversation was summarized and
+    the next attempt is against refreshed context — it must break
+    adjacency just like a `user_message` does."""
+    sid = _insert_session(conn, session_key="s:compaction", client="claude")
+    for i in range(2):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"a-{i}",
+            command="npm test", output="FAIL same",
+        )
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="compaction",
+        raw={"type": "system", "subtype": "compact_boundary"},
+    )
+    _claude_bash_pair(
+        conn, session_id=sid, tool_id="a-2",
+        command="npm test", output="FAIL same",
+    )
+    ingest_loop_incidents(conn)
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
 def test_distinct_outputs_do_not_count_as_a_loop(conn):
     """Same command with materially different output is NOT a loop —
     progress is being made."""
@@ -413,6 +459,51 @@ def test_tool_call_below_threshold_does_not_emit(conn):
         )
     ingest_loop_incidents(conn)
     assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
+def test_shell_tool_call_events_do_not_double_emit(conn):
+    """A shell `tool_call` event (e.g. name=`Bash`) has a paired
+    `command_start` event carrying the more meaningful (command,
+    outcome) fingerprint. If the `tool_call` rule also matched, 5
+    identical Bash calls would produce TWO incidents — one under the
+    command-threshold=3 rule, one under the tool-call-threshold=5 rule.
+    `_fingerprint_for` drops shell-named tool_calls for exactly this
+    reason."""
+    sid = _insert_session(conn, session_key="s:shell-tc", client="claude")
+    for i in range(DEFAULT_TOOL_CALL_THRESHOLD):
+        tool_id = f"tc-{i}"
+        # Emit BOTH a command_start (what the shell rule sees) and a
+        # tool_call with name=Bash (what the tool-call rule would see
+        # if the dedup guard regressed).
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=tool_id,
+            command="npm test", output="FAIL",
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="tool_call",
+            event_key=f"tool_call:{tool_id}-tc",
+            raw={
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": f"{tool_id}-tc",
+                            "name": "Bash",
+                            "input": {"command": "npm test"},
+                        }
+                    ]
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    rows = conn.execute("SELECT count, evidence_json FROM incidents").fetchall()
+    assert len(rows) == 1  # ONE incident, not two
+    assert json.loads(rows[0]["evidence_json"])["event_type"] == "command_start"
 
 
 # --------------------------------------------------------------------------- #
@@ -751,6 +842,35 @@ def test_unparseable_raw_json_breaks_run_safely(conn):
     summary = ingest_loop_incidents(conn)
     # The bad row breaks the run; we only have 2 and then 2 → no loop.
     assert summary.incidents_written == 0
+
+
+def test_evidence_json_hashes_outcome_text_instead_of_storing_it(conn):
+    """`incidents.evidence_json` must NOT carry the paired tool_result
+    text verbatim — otherwise secrets that survived the normalizer
+    (anything outside the five fingerprint-normalization rules) would
+    be written into the DB and surface through any consumer that
+    doesn't re-run redaction. The fingerprint's outcome slot is stored
+    as a `sha256:<prefix>` token; the real text stays reachable via
+    `first_event_id` / `last_event_id` through the normal paths."""
+    sid = _insert_session(conn, session_key="s:secret-outcome", client="claude")
+    # Construct an output whose "secret" portion survives the
+    # normalizer (no timestamps / home paths / PIDs / whitespace).
+    secret_output = "ERROR: invalid token AKIA1234567890ABCDEF please check config"
+    for i in range(3):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"tu-{i}",
+            command="deploy", output=secret_output,
+        )
+    ingest_loop_incidents(conn)
+    row = conn.execute(
+        "SELECT evidence_json FROM incidents WHERE session_id = ?", (sid,)
+    ).fetchone()
+    evidence_text = row["evidence_json"]
+    assert "AKIA1234567890ABCDEF" not in evidence_text
+    evidence = json.loads(evidence_text)
+    outcome_token = evidence["fingerprint"][-1]
+    assert outcome_token.startswith("sha256:")
+    assert len(outcome_token) == len("sha256:") + 16
 
 
 def test_claude_bash_description_and_timeout_drift_still_count_as_loop(conn):

--- a/tests/events/incidents/test_loop_detector.py
+++ b/tests/events/incidents/test_loop_detector.py
@@ -435,6 +435,88 @@ def test_hook_only_breaker_override_is_reinserted_chronologically(conn):
     assert detect_session_loops(conn, sid) == []
 
 
+def test_hook_only_command_override_breaks_run_chronologically(conn):
+    sid = _insert_session(conn, session_key="s:hook-command-break", client="claude")
+    for idx, event_at in enumerate(
+        (
+            "2026-04-21T10:00:00Z",
+            "2026-04-21T10:00:02Z",
+            "2026-04-21T10:00:04Z",
+        )
+    ):
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="command_start",
+            event_key=f"command_start:tu-{idx}",
+            event_at=event_at,
+            raw={
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": f"tu-{idx}",
+                            "name": "Bash",
+                            "input": {"command": "npm test"},
+                        }
+                    ]
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="tool_result",
+            event_key=f"tool_result:tu-{idx}",
+            event_at=event_at,
+            raw={
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": f"tu-{idx}",
+                            "content": [{"type": "text", "text": "FAIL same"}],
+                        }
+                    ]
+                },
+            },
+        )
+
+    assert write_hook_override(
+        conn,
+        session_key="s:hook-command-break",
+        event_key="command_start:hook-1",
+        event_type="command_start",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at="2026-04-21T10:00:03Z",
+        payload_json=json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "hook-1",
+                            "name": "Bash",
+                            "input": {"command": "npm run lint"},
+                        }
+                    ]
+                },
+            },
+            sort_keys=True,
+        ),
+        origin="test",
+    )
+
+    assert detect_session_loops(conn, sid) == []
+
+
 def test_distinct_outputs_do_not_count_as_a_loop(conn):
     """Same command with materially different output is NOT a loop —
     progress is being made."""
@@ -1415,6 +1497,74 @@ def test_detect_session_loops_uses_command_start_override_payload(conn):
     )
 
     assert detect_session_loops(conn, sid) == []
+
+
+def test_detect_session_loops_falls_back_to_base_raw_json_for_opaque_command_override(
+    conn,
+):
+    sid = _insert_session(conn, session_key="s:opaque-command-override", client="claude")
+    for i in range(3):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-{i}",
+            command="npm test",
+            output="FAIL identical",
+        )
+
+    assert write_hook_override(
+        conn,
+        session_key="s:opaque-command-override",
+        event_key="command_start:tu-1",
+        event_type="command_start",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS,
+        payload_json=json.dumps(
+            {"tool": "Bash", "args": {"command": "npm test"}},
+            sort_keys=True,
+        ),
+        origin="test",
+    )
+
+    hits = detect_session_loops(conn, sid)
+    assert len(hits) == 1
+    assert hits[0].count == 3
+
+
+def test_detect_session_loops_falls_back_to_base_raw_json_for_opaque_tool_result_override(
+    conn,
+):
+    sid = _insert_session(conn, session_key="s:opaque-tool-result-override", client="claude")
+    for i in range(3):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-{i}",
+            command="npm test",
+            output="FAIL identical",
+        )
+
+    assert write_hook_override(
+        conn,
+        session_key="s:opaque-tool-result-override",
+        event_key="tool_result:tu-1",
+        event_type="tool_result",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS,
+        payload_json=json.dumps(
+            {"tool": "Bash", "result": "FAIL identical"},
+            sort_keys=True,
+        ),
+        origin="test",
+    )
+
+    hits = detect_session_loops(conn, sid)
+    assert len(hits) == 1
+    assert hits[0].count == 3
 
 
 def test_unparseable_raw_json_breaks_run_safely(conn):

--- a/tests/events/incidents/test_loop_detector.py
+++ b/tests/events/incidents/test_loop_detector.py
@@ -29,6 +29,7 @@ from clawjournal.events.incidents import (
     rebuild_loop_incidents,
 )
 from clawjournal.events.schema import ensure_schema as ensure_events_schema
+from clawjournal.events.view import ensure_view_schema
 
 
 TS = "2026-04-21T10:00:00Z"
@@ -45,6 +46,7 @@ def conn() -> sqlite3.Connection:
     c.row_factory = sqlite3.Row
     ensure_events_schema(c)
     ensure_incidents_schema(c)
+    ensure_view_schema(c)
     return c
 
 
@@ -327,6 +329,63 @@ def test_distinct_outputs_do_not_count_as_a_loop(conn):
     assert n == 0
 
 
+def test_cross_source_duplicates_do_not_false_positive_a_shell_loop(conn):
+    sid = _insert_session(conn, session_key="s:xsrc-loop", client="claude")
+    for tool_id, path in (("tu-0", "/a.jsonl"), ("tu-1", "/c.jsonl")):
+        command_raw = {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": tool_id,
+                        "name": "Bash",
+                        "input": {"command": "npm test"},
+                    }
+                ]
+            },
+        }
+        result_raw = {
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_id,
+                        "content": [{"type": "text", "text": "FAIL identical"}],
+                    }
+                ]
+            },
+        }
+        for source, source_path in (
+            ("claude-jsonl", path),
+            ("hook", path.replace(".jsonl", "-dup.jsonl")),
+        ):
+            _insert_event(
+                conn,
+                session_id=sid,
+                client="claude",
+                event_type="command_start",
+                event_key=f"command_start:{tool_id}",
+                raw=command_raw,
+                source=source,
+                source_path=source_path,
+            )
+            _insert_event(
+                conn,
+                session_id=sid,
+                client="claude",
+                event_type="tool_result",
+                event_key=f"tool_result:{tool_id}",
+                raw=result_raw,
+                source=source,
+                source_path=source_path,
+            )
+
+    ingest_loop_incidents(conn)
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
 def test_tool_call_threshold_is_five(conn):
     sid = _insert_session(conn, session_key="s:tools", client="claude")
     # 5 identical Read tool calls.
@@ -459,9 +518,94 @@ def test_codex_shell_loop_detected(conn):
     assert rows[0]["count"] == 3
 
 
+def test_codex_shell_command_loop_detected(conn):
+    sid = _insert_session(conn, session_key="s:codex-shell-command", client="codex")
+    for i in range(3):
+        tool_id = f"call_{i}"
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="codex",
+            event_type="command_start",
+            event_key=f"command_start:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "shell_command",
+                    "call_id": tool_id,
+                    "arguments": json.dumps(
+                        {"command": "npm test", "workdir": "/repo"}
+                    ),
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="codex",
+            event_type="tool_result",
+            event_key=f"tool_result:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": tool_id,
+                    "output": json.dumps({"output": "FAIL identical"}),
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    rows = conn.execute("SELECT count FROM incidents").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["count"] == 3
+
+
+def test_codex_shell_args_are_part_of_the_fingerprint(conn):
+    sid = _insert_session(conn, session_key="s:codex-shell-args", client="codex")
+    for i in range(3):
+        tool_id = f"call_{i}"
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="codex",
+            event_type="command_start",
+            event_key=f"command_start:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "shell_command",
+                    "call_id": tool_id,
+                    "arguments": json.dumps(
+                        {"command": "npm test", "workdir": f"/repo/{i}"}
+                    ),
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="codex",
+            event_type="tool_result",
+            event_key=f"tool_result:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": tool_id,
+                    "output": json.dumps({"output": "FAIL identical"}),
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
 def test_openclaw_tool_loop_detected(conn):
     sid = _insert_session(conn, session_key="s:opc", client="openclaw")
-    # OpenClaw mirrors Claude's wire format.
     for i in range(DEFAULT_TOOL_CALL_THRESHOLD):
         tool_id = f"oc-{i}"
         _insert_event(
@@ -497,6 +641,51 @@ def test_openclaw_tool_loop_detected(conn):
     assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 1
 
 
+def test_openclaw_distinct_results_do_not_count_as_a_loop(conn):
+    sid = _insert_session(conn, session_key="s:opc-distinct", client="openclaw")
+    for i in range(DEFAULT_TOOL_CALL_THRESHOLD):
+        tool_id = f"oc-{i}"
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="openclaw",
+            event_type="tool_call",
+            event_key=f"tool_call:{tool_id}",
+            raw={
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "toolCall",
+                            "id": tool_id,
+                            "name": "read_file",
+                            "input": {"path": "/etc/hosts"},
+                        }
+                    ],
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="openclaw",
+            event_type="tool_result",
+            event_key=f"tool_result:{tool_id}",
+            raw={
+                "type": "message",
+                "message": {
+                    "role": "toolResult",
+                    "toolCallId": tool_id,
+                    "content": [{"type": "text", "text": f"result {i}"}],
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
 def test_pure_read_helper_does_not_write(conn):
     sid = _insert_session(conn, session_key="s:pure", client="claude")
     for i in range(3):
@@ -509,6 +698,27 @@ def test_pure_read_helper_does_not_write(conn):
     assert hits[0].count == 3
     # detect_session_loops must not write anything.
     assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
+def test_pure_read_helper_works_without_view_schema():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_events_schema(conn)
+    ensure_incidents_schema(conn)
+    sid = _insert_session(conn, session_key="s:no-view", client="claude")
+    for i in range(3):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-{i}",
+            command="npm test",
+            output="FAIL",
+        )
+
+    hits = detect_session_loops(conn, sid)
+
+    assert len(hits) == 1
+    assert hits[0].count == 3
 
 
 def test_unparseable_raw_json_breaks_run_safely(conn):
@@ -541,3 +751,127 @@ def test_unparseable_raw_json_breaks_run_safely(conn):
     summary = ingest_loop_incidents(conn)
     # The bad row breaks the run; we only have 2 and then 2 → no loop.
     assert summary.incidents_written == 0
+
+
+def test_claude_bash_description_and_timeout_drift_still_count_as_loop(conn):
+    """Claude's Bash `input` carries `description`, `timeout`, and
+    `run_in_background` alongside `command`. Those fields drift between
+    retries (model-narrated text, ergonomic knobs) and must NOT hide an
+    otherwise-identical loop."""
+    sid = _insert_session(conn, session_key="s:bash-drift", client="claude")
+    for i, description in enumerate(("running tests", "retrying after fix", "one more time")):
+        tool_id = f"tu-{i}"
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="command_start",
+            event_key=f"command_start:{tool_id}",
+            raw={
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": tool_id,
+                            "name": "Bash",
+                            "input": {
+                                "command": "npm test",
+                                "description": description,
+                                "timeout": 5000 + i * 100,
+                                "run_in_background": False,
+                            },
+                        }
+                    ]
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="tool_result",
+            event_key=f"tool_result:{tool_id}",
+            raw={
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_id,
+                            "content": [{"type": "text", "text": "FAIL identical"}],
+                        }
+                    ]
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    rows = conn.execute("SELECT count FROM incidents").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["count"] == 3
+
+
+def test_cursor_advances_correctly_across_mid_run_boundary(conn):
+    """Cursor stops mid-run, a later ingest picks up the rest — the
+    session ends up with one incident whose count reflects the whole
+    run, not two separate rows."""
+    sid = _insert_session(conn, session_key="s:mid-run", client="claude")
+    # First ingest sees only the first 3 of an eventual 5-run.
+    for i in range(3):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"a-{i}",
+            command="npm test", output="FAIL same",
+        )
+    first = ingest_loop_incidents(conn)
+    assert first.incidents_written == 1
+    assert conn.execute(
+        "SELECT count FROM incidents WHERE session_id = ?", (sid,)
+    ).fetchone()["count"] == 3
+
+    # Two more identical failures arrive — the run extends to 5.
+    for i in range(2):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"b-{i}",
+            command="npm test", output="FAIL same",
+        )
+    second = ingest_loop_incidents(conn)
+
+    rows = conn.execute(
+        "SELECT count FROM incidents WHERE session_id = ?", (sid,)
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["count"] == 5
+    assert second.sessions_evaluated == 1
+
+
+def test_rebuild_preserves_non_loop_incident_kinds(conn):
+    """The incidents table is shared across kinds; `--rebuild` must
+    only touch `loop_exact_repeat` rows."""
+    sid = _insert_session(conn, session_key="s:shared-kinds", client="claude")
+    for i in range(3):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"tu-{i}",
+            command="npm test", output="FAIL",
+        )
+    ingest_loop_incidents(conn)
+    # Inject a row of a different kind (as some future detector would).
+    conn.execute(
+        """
+        INSERT INTO incidents (
+            session_id, kind, first_event_id, last_event_id,
+            evidence_json, count, confidence, created_at
+        ) VALUES (?, 'other_kind', 1, 1, '{}', 1, 'high', ?)
+        """,
+        (sid, TS),
+    )
+    conn.commit()
+
+    rebuild_loop_incidents(conn)
+
+    kinds = {
+        row["kind"]
+        for row in conn.execute("SELECT kind FROM incidents WHERE session_id = ?", (sid,))
+    }
+    assert "other_kind" in kinds
+    assert LOOP_INCIDENT_KIND in kinds

--- a/tests/events/incidents/test_loop_detector.py
+++ b/tests/events/incidents/test_loop_detector.py
@@ -361,6 +361,80 @@ def test_compaction_event_breaks_the_run(conn):
     assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
 
 
+def test_hook_only_breaker_override_is_reinserted_chronologically(conn):
+    sid = _insert_session(conn, session_key="s:hook-breaker", client="claude")
+    for idx, event_at in enumerate(
+        (
+            "2026-04-21T10:00:00Z",
+            "2026-04-21T10:00:02Z",
+            "2026-04-21T10:00:04Z",
+        )
+    ):
+        tool_id = f"tu-{idx}"
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="command_start",
+            event_key=f"command_start:{tool_id}",
+            event_at=event_at,
+            raw={
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": tool_id,
+                            "name": "Bash",
+                            "input": {"command": "npm test"},
+                        }
+                    ]
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="tool_result",
+            event_key=f"tool_result:{tool_id}",
+            event_at=event_at,
+            raw={
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": tool_id,
+                            "content": [{"type": "text", "text": "FAIL same"}],
+                        }
+                    ]
+                },
+            },
+        )
+
+    assert write_hook_override(
+        conn,
+        session_key="s:hook-breaker",
+        event_key="user_message:hook-1",
+        event_type="user_message",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at="2026-04-21T10:00:03Z",
+        payload_json=json.dumps(
+            {
+                "type": "user",
+                "message": {"content": "please stop retrying"},
+            },
+            sort_keys=True,
+        ),
+        origin="test",
+    )
+
+    assert detect_session_loops(conn, sid) == []
+
+
 def test_distinct_outputs_do_not_count_as_a_loop(conn):
     """Same command with materially different output is NOT a loop —
     progress is being made."""
@@ -775,6 +849,54 @@ def test_codex_shell_command_loop_detected(conn):
     assert rows[0]["count"] == 3
 
 
+def test_codex_plain_text_shell_outputs_ignore_wall_time(conn):
+    sid = _insert_session(conn, session_key="s:codex-plain-shell-output", client="codex")
+    for i in range(3):
+        tool_id = f"call_{i}"
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="codex",
+            event_type="command_start",
+            event_key=f"command_start:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "shell_command",
+                    "call_id": tool_id,
+                    "arguments": json.dumps({"command": "npm test", "workdir": "/repo"}),
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="codex",
+            event_type="tool_result",
+            event_key=f"tool_result:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": tool_id,
+                    "output": (
+                        "Exit code: 1\n"
+                        f"Wall time: {i} seconds\n"
+                        "Output:\n"
+                        "FAIL identical\n"
+                    ),
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    rows = conn.execute("SELECT count, confidence FROM incidents").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["count"] == 3
+    assert rows[0]["confidence"] == "high"
+
+
 def test_codex_exec_command_cmd_loop_detected(conn):
     sid = _insert_session(conn, session_key="s:codex-exec-command", client="codex")
     for i in range(3):
@@ -1010,6 +1132,206 @@ def test_claude_bash_execution_distinct_inline_outputs_do_not_count_as_loop(conn
                     "command": "npm test",
                     "output": f"FAIL iteration {i}",
                     "exitCode": 1,
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
+def test_empty_tool_results_keep_high_confidence(conn):
+    sid = _insert_session(conn, session_key="s:empty-output", client="claude")
+    for i in range(3):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-{i}",
+            command="true",
+            output="",
+        )
+
+    ingest_loop_incidents(conn)
+    row = conn.execute(
+        "SELECT count, confidence FROM incidents WHERE session_id = ?",
+        (sid,),
+    ).fetchone()
+    assert row["count"] == 3
+    assert row["confidence"] == "high"
+
+
+def test_missing_tool_result_does_not_merge_with_empty_output(conn):
+    sid = _insert_session(conn, session_key="s:missing-vs-empty", client="claude")
+    for i in range(2):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-empty-{i}",
+            command="true",
+            output="",
+        )
+    _insert_event(
+        conn,
+        session_id=sid,
+        client="claude",
+        event_type="command_start",
+        event_key="command_start:tu-missing",
+        raw={
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "tu-missing",
+                        "name": "Bash",
+                        "input": {"command": "true"},
+                    }
+                ]
+            },
+        },
+    )
+
+    ingest_loop_incidents(conn)
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
+def test_three_missing_results_emit_medium_confidence_incident(conn):
+    """Three consecutive `command_start`s with NO paired `tool_result`
+    rows must emit a single incident with `confidence="medium"`. The
+    fingerprint's outcome-availability marker is "missing", runs of
+    missing-marker rows DO group (same command + same state), and the
+    confidence is dropped because we can't observe whether the results
+    diverged."""
+    sid = _insert_session(conn, session_key="s:all-missing", client="claude")
+    for i in range(3):
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="command_start",
+            event_key=f"command_start:tu-miss-{i}",
+            raw={
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": f"tu-miss-{i}",
+                            "name": "Bash",
+                            "input": {"command": "npm test"},
+                        }
+                    ]
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    row = conn.execute(
+        "SELECT count, confidence FROM incidents WHERE session_id = ?",
+        (sid,),
+    ).fetchone()
+    assert row["count"] == 3
+    assert row["confidence"] == "medium"
+
+
+def test_codex_plain_text_metadata_without_output_marker_is_treated_as_missing(conn):
+    """A codex rollout that carries `Exit code:` / `Wall time:` but no
+    `Output:` marker (truncated log, partial capture) must NOT collapse
+    into a high-confidence empty-output loop — the absence of an output
+    section is indistinguishable from "no observable outcome"."""
+    sid = _insert_session(conn, session_key="s:codex-no-output-marker", client="codex")
+    for i in range(3):
+        tool_id = f"call_{i}"
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="codex",
+            event_type="command_start",
+            event_key=f"command_start:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "shell_command",
+                    "call_id": tool_id,
+                    "arguments": json.dumps({"command": "npm test", "workdir": "/repo"}),
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="codex",
+            event_type="tool_result",
+            event_key=f"tool_result:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": tool_id,
+                    # Metadata present, no `Output:` marker (truncated).
+                    "output": (
+                        "Exit code: 1\n"
+                        f"Wall time: {i} seconds\n"
+                    ),
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    row = conn.execute(
+        "SELECT count, confidence FROM incidents WHERE session_id = ?",
+        (sid,),
+    ).fetchone()
+    assert row["count"] == 3
+    assert row["confidence"] == "medium"
+
+
+def test_codex_plain_text_preserves_exit_code_lines_inside_actual_output(conn):
+    """If the real shell output itself contains a line starting with
+    `Exit code: ` or `Wall time: ` (e.g. a shell log echoing a child
+    process's exit), those lines must be preserved verbatim in the
+    fingerprinted outcome — not dropped by the metadata-prefix match.
+    Three commands whose only observable difference lives on such lines
+    must NOT collapse into a loop."""
+    sid = _insert_session(conn, session_key="s:codex-nested-exit", client="codex")
+    for i in range(3):
+        tool_id = f"call_{i}"
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="codex",
+            event_type="command_start",
+            event_key=f"command_start:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "shell_command",
+                    "call_id": tool_id,
+                    "arguments": json.dumps({"command": "bash run.sh", "workdir": "/repo"}),
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="codex",
+            event_type="tool_result",
+            event_key=f"tool_result:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": tool_id,
+                    "output": (
+                        "Exit code: 0\n"
+                        "Wall time: 0.1 seconds\n"
+                        "Output:\n"
+                        "starting job\n"
+                        # Embedded "Exit code:" line varies per run — must survive.
+                        f"Exit code: {i}\n"
+                    ),
                 },
             },
         )
@@ -1396,6 +1718,104 @@ def test_override_cursor_tiebreaker_handles_same_timestamp_writes(conn):
     assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
 
 
+def test_override_cursor_handles_same_row_rewrite_with_same_timestamp(conn):
+    sid = _insert_session(conn, session_key="s:override-same-row", client="claude")
+    fixed_created_at = "2026-04-21T10:00:00.123456Z"
+    for i in range(3):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-{i}",
+            command="npm test",
+            output="FAIL identical",
+        )
+
+    ingest_loop_incidents(conn)
+
+    assert write_hook_override(
+        conn,
+        session_key="s:override-same-row",
+        event_key="tool_result:tu-1",
+        event_type="tool_result",
+        source="hook",
+        confidence="medium",
+        lossiness="none",
+        event_at=TS,
+        payload_json=json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu-1",
+                            "content": [{"type": "text", "text": "FAIL identical"}],
+                        }
+                    ]
+                },
+            },
+            sort_keys=True,
+        ),
+        origin="test",
+    )
+    conn.execute(
+        """
+        UPDATE event_overrides
+           SET created_at = ?
+         WHERE session_id = ? AND event_key = ?
+        """,
+        (fixed_created_at, sid, "tool_result:tu-1"),
+    )
+    conn.commit()
+
+    first = ingest_loop_incidents(conn)
+    assert first.overrides_scanned == 1
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 1
+
+    assert write_hook_override(
+        conn,
+        session_key="s:override-same-row",
+        event_key="tool_result:tu-1",
+        event_type="tool_result",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS,
+        payload_json=json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu-1",
+                            "content": [{"type": "text", "text": "FAIL changed"}],
+                        }
+                    ]
+                },
+            },
+            sort_keys=True,
+        ),
+        origin="test",
+    )
+    conn.execute(
+        """
+        UPDATE event_overrides
+           SET created_at = ?
+         WHERE session_id = ? AND event_key = ?
+        """,
+        (fixed_created_at, sid, "tool_result:tu-1"),
+    )
+    conn.commit()
+
+    second = ingest_loop_incidents(conn)
+
+    assert second.events_scanned == 0
+    assert second.overrides_scanned == 1
+    assert second.sessions_evaluated == 1
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
 def test_rebuild_preserves_non_loop_incident_kinds(conn):
     """The incidents table is shared across kinds; `--rebuild` must
     only touch `loop_exact_repeat` rows."""
@@ -1456,6 +1876,7 @@ def test_legacy_loop_ingest_state_is_migrated_in_place():
     # dropping the stored cursor value.
     ensure_incidents_schema(conn)
     columns = {row[1] for row in conn.execute("PRAGMA table_info(loop_ingest_state)")}
+    assert "last_override_write_seq" in columns
     assert "last_override_created_at" in columns
     assert "last_override_session_id" in columns
     assert "last_override_event_key" in columns
@@ -1464,6 +1885,7 @@ def test_legacy_loop_ingest_state_is_migrated_in_place():
         "SELECT * FROM loop_ingest_state WHERE consumer_id = 'loop_detector'"
     ).fetchone()
     assert row["last_event_id"] == 0
+    assert row["last_override_write_seq"] == 0
     assert row["last_override_created_at"] is None
     assert row["last_override_session_id"] == 0
     assert row["last_override_event_key"] == ""

--- a/tests/events/incidents/test_loop_detector.py
+++ b/tests/events/incidents/test_loop_detector.py
@@ -1478,6 +1478,56 @@ def test_evidence_json_hashes_outcome_text_instead_of_storing_it(conn):
     assert len(outcome_token) == len("sha256:") + 16
 
 
+def test_evidence_json_hashes_command_and_args_slots(conn):
+    sid = _insert_session(conn, session_key="s:secret-command", client="claude")
+    secret = "Bearer sk-live-secret-token"
+    for i in range(3):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-{i}",
+            command=f"curl -H 'Authorization: {secret}' https://example.test",
+            output="HTTP 401",
+        )
+
+    ingest_loop_incidents(conn)
+    row = conn.execute(
+        "SELECT evidence_json FROM incidents WHERE session_id = ?", (sid,)
+    ).fetchone()
+    evidence_text = row["evidence_json"]
+    assert secret not in evidence_text
+    evidence = json.loads(evidence_text)
+    assert evidence["fingerprint"][1].startswith("sha256:")
+    assert evidence["fingerprint"][2].startswith("sha256:")
+
+
+def test_evidence_json_hashes_tool_call_identity_slots(conn):
+    sid = _insert_session(conn, session_key="s:secret-tool-args", client="claude")
+    secret = "sk-live-write-file"
+    for i in range(DEFAULT_TOOL_CALL_THRESHOLD):
+        _claude_tool_call(
+            conn,
+            session_id=sid,
+            tool_id=f"tc-{i}",
+            name="write_file",
+            args={
+                "path": "/tmp/out.txt",
+                "content": f"token={secret}",
+            },
+            result="ok",
+        )
+
+    ingest_loop_incidents(conn)
+    row = conn.execute(
+        "SELECT evidence_json FROM incidents WHERE session_id = ?", (sid,)
+    ).fetchone()
+    evidence_text = row["evidence_json"]
+    assert secret not in evidence_text
+    evidence = json.loads(evidence_text)
+    assert evidence["fingerprint"][1].startswith("sha256:")
+    assert evidence["fingerprint"][2].startswith("sha256:")
+
+
 def test_claude_bash_description_and_timeout_drift_still_count_as_loop(conn):
     """Claude's Bash `input` carries `description`, `timeout`, and
     `run_in_background` alongside `command`. Those fields drift between

--- a/tests/events/incidents/test_loop_detector.py
+++ b/tests/events/incidents/test_loop_detector.py
@@ -1,0 +1,543 @@
+"""End-to-end tests for the loop detector lite.
+
+Covers the spec's three acceptance criteria:
+
+1. Three identical npm test failures → one incident with count=3.
+2. Re-running ingestion does not duplicate incidents (dedupe key is
+   (session_id, kind, first_event_id)).
+3. Per-rule thresholds: 3 for shell, 5 for tool calls; sub-threshold
+   runs do not emit.
+
+Plus per-client fingerprint coverage for claude / codex / openclaw
+and the "non-eligible event breaks the run" semantics.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from clawjournal.events.incidents import (
+    DEFAULT_SHELL_THRESHOLD,
+    DEFAULT_TOOL_CALL_THRESHOLD,
+    LOOP_INCIDENT_KIND,
+    detect_session_loops,
+    ensure_incidents_schema,
+    ingest_loop_incidents,
+    rebuild_loop_incidents,
+)
+from clawjournal.events.schema import ensure_schema as ensure_events_schema
+
+
+TS = "2026-04-21T10:00:00Z"
+
+
+# --------------------------------------------------------------------------- #
+# fixture helpers
+# --------------------------------------------------------------------------- #
+
+
+@pytest.fixture
+def conn() -> sqlite3.Connection:
+    c = sqlite3.connect(":memory:")
+    c.row_factory = sqlite3.Row
+    ensure_events_schema(c)
+    ensure_incidents_schema(c)
+    return c
+
+
+def _insert_session(conn, *, session_key: str, client: str = "claude") -> int:
+    cur = conn.execute(
+        "INSERT INTO event_sessions (session_key, client, status) VALUES (?, ?, 'active')",
+        (session_key, client),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def _insert_event(
+    conn,
+    *,
+    session_id: int,
+    client: str,
+    event_type: str,
+    raw: dict,
+    event_key: str | None = None,
+    event_at: str | None = TS,
+    source: str | None = None,
+    source_path: str = "/tmp/x.jsonl",
+) -> int:
+    if source is None:
+        source = {"claude": "claude-jsonl", "codex": "codex-rollout", "openclaw": "openclaw-jsonl"}[client]
+    offset = int(
+        conn.execute(
+            "SELECT COALESCE(MAX(source_offset), -1) + 1 FROM events"
+        ).fetchone()[0]
+    )
+    cur = conn.execute(
+        """
+        INSERT INTO events (
+            session_id, type, event_key, event_at, ingested_at, source,
+            source_path, source_offset, seq, client, confidence, lossiness,
+            raw_json
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, 0, ?, 'high', 'none', ?)
+        """,
+        (
+            session_id, event_type, event_key, event_at, TS, source, source_path,
+            offset, client, json.dumps(raw, sort_keys=True),
+        ),
+    )
+    conn.commit()
+    return int(cur.lastrowid)
+
+
+def _claude_bash_pair(conn, *, session_id: int, tool_id: str, command: str, output: str):
+    """Insert a paired Claude (assistant tool_call + user tool_result)
+    pair so the loop detector can compute a complete fingerprint."""
+    _insert_event(
+        conn,
+        session_id=session_id,
+        client="claude",
+        event_type="command_start",
+        event_key=f"command_start:{tool_id}",
+        raw={
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": tool_id,
+                        "name": "Bash",
+                        "input": {"command": command},
+                    }
+                ]
+            },
+        },
+    )
+    _insert_event(
+        conn,
+        session_id=session_id,
+        client="claude",
+        event_type="tool_result",
+        event_key=f"tool_result:{tool_id}",
+        raw={
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_id,
+                        "content": [{"type": "text", "text": output}],
+                    }
+                ]
+            },
+        },
+    )
+
+
+def _claude_tool_call(conn, *, session_id: int, tool_id: str, name: str, args: dict, result: str):
+    _insert_event(
+        conn,
+        session_id=session_id,
+        client="claude",
+        event_type="tool_call",
+        event_key=f"tool_call:{tool_id}",
+        raw={
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {"type": "tool_use", "id": tool_id, "name": name, "input": args}
+                ]
+            },
+        },
+    )
+    _insert_event(
+        conn,
+        session_id=session_id,
+        client="claude",
+        event_type="tool_result",
+        event_key=f"tool_result:{tool_id}",
+        raw={
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_id,
+                        "content": [{"type": "text", "text": result}],
+                    }
+                ]
+            },
+        },
+    )
+
+
+# --------------------------------------------------------------------------- #
+# acceptance criteria
+# --------------------------------------------------------------------------- #
+
+
+def test_three_identical_npm_test_failures_produce_one_incident_with_count_3(conn):
+    sid = _insert_session(conn, session_key="s:npm", client="claude")
+    failure_text = (
+        "FAIL src/auth.test.ts\n"
+        "  ✕ login redirects on success (12 ms)\n"
+        "Tests:       1 failed, 0 passed\n"
+    )
+    for i in range(3):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-npm-{i}",
+            command="npm test",
+            # Different timestamp / pid each run; normalization makes them equal.
+            output=f"[{1000 + i}] start at 2026-04-21T10:00:0{i}Z\n{failure_text}",
+        )
+
+    summary = ingest_loop_incidents(conn)
+    incidents = conn.execute(
+        "SELECT * FROM incidents WHERE session_id = ?", (sid,)
+    ).fetchall()
+
+    assert summary.incidents_written == 1
+    assert len(incidents) == 1
+    incident = incidents[0]
+    assert incident["kind"] == LOOP_INCIDENT_KIND
+    assert incident["count"] == 3
+    assert incident["confidence"] == "high"
+    evidence = json.loads(incident["evidence_json"])
+    assert evidence["event_type"] == "command_start"
+    assert evidence["threshold"] == DEFAULT_SHELL_THRESHOLD
+    assert len(evidence["event_ids"]) == 3
+
+
+def test_two_failures_do_not_meet_shell_threshold(conn):
+    sid = _insert_session(conn, session_key="s:two", client="claude")
+    for i in range(2):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-{i}",
+            command="npm test",
+            output="FAIL same output every time",
+        )
+    ingest_loop_incidents(conn)
+    n = conn.execute(
+        "SELECT COUNT(*) FROM incidents WHERE session_id = ?", (sid,)
+    ).fetchone()[0]
+    assert n == 0
+
+
+def test_re_running_does_not_duplicate_incidents(conn):
+    sid = _insert_session(conn, session_key="s:idem", client="claude")
+    for i in range(3):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-{i}",
+            command="npm test",
+            output="FAIL identical",
+        )
+
+    first = ingest_loop_incidents(conn)
+    second = ingest_loop_incidents(conn)
+    assert first.incidents_written == 1
+    # Re-running with no new events is a true no-op: nothing scanned,
+    # nothing evaluated, nothing rewritten.
+    assert second.events_scanned == 0
+    assert second.sessions_evaluated == 0
+    assert second.incidents_written == 0
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 1
+
+
+def test_growing_run_updates_count_without_duplicating(conn):
+    """When a run grows past its first incarnation, the session
+    still has exactly one incident row — the count is the new
+    length. The driver achieves this by deleting + re-inserting
+    the session's loop rows; the spec requires "no duplicates"
+    keyed by (session_id, kind, first_event_id), not that the
+    integer id is stable across runs."""
+    sid = _insert_session(conn, session_key="s:grow", client="claude")
+    # First batch: three identical failures.
+    for i in range(3):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"a-{i}",
+            command="npm test", output="FAIL same",
+        )
+    ingest_loop_incidents(conn)
+    first_first_event_id = conn.execute(
+        "SELECT first_event_id FROM incidents WHERE session_id = ?", (sid,)
+    ).fetchone()[0]
+
+    # Append two more identical failures. Run grows to 5.
+    for i in range(2):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"b-{i}",
+            command="npm test", output="FAIL same",
+        )
+    summary = ingest_loop_incidents(conn)
+
+    rows = conn.execute(
+        "SELECT first_event_id, count FROM incidents WHERE session_id = ?", (sid,)
+    ).fetchall()
+    assert len(rows) == 1
+    assert rows[0]["first_event_id"] == first_first_event_id  # same logical run
+    assert rows[0]["count"] == 5
+    assert summary.sessions_evaluated == 1
+
+
+def test_unrelated_event_between_repeats_breaks_the_run(conn):
+    """A non-eligible event in the middle prevents grouping."""
+    sid = _insert_session(conn, session_key="s:break", client="claude")
+    _claude_bash_pair(
+        conn, session_id=sid, tool_id="a-0",
+        command="npm test", output="FAIL same",
+    )
+    _claude_bash_pair(
+        conn, session_id=sid, tool_id="a-1",
+        command="npm test", output="FAIL same",
+    )
+    # Inject a user message between the second and third failure.
+    _insert_event(
+        conn, session_id=sid, client="claude", event_type="user_message",
+        raw={"type": "user", "message": {"content": "hmm let me think"}},
+    )
+    _claude_bash_pair(
+        conn, session_id=sid, tool_id="a-2",
+        command="npm test", output="FAIL same",
+    )
+    ingest_loop_incidents(conn)
+    n = conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0]
+    assert n == 0
+
+
+def test_distinct_outputs_do_not_count_as_a_loop(conn):
+    """Same command with materially different output is NOT a loop —
+    progress is being made."""
+    sid = _insert_session(conn, session_key="s:progress", client="claude")
+    for i, outcome in enumerate(("first", "second", "third")):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"tu-{i}",
+            command="npm test", output=f"FAIL on iteration {outcome}",
+        )
+    ingest_loop_incidents(conn)
+    n = conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0]
+    assert n == 0
+
+
+def test_tool_call_threshold_is_five(conn):
+    sid = _insert_session(conn, session_key="s:tools", client="claude")
+    # 5 identical Read tool calls.
+    for i in range(DEFAULT_TOOL_CALL_THRESHOLD):
+        _claude_tool_call(
+            conn, session_id=sid, tool_id=f"tc-{i}",
+            name="Read", args={"file_path": "/etc/hosts"},
+            result="127.0.0.1 localhost",
+        )
+
+    ingest_loop_incidents(conn)
+    rows = conn.execute("SELECT count, evidence_json FROM incidents").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["count"] == 5
+    assert json.loads(rows[0]["evidence_json"])["event_type"] == "tool_call"
+
+
+def test_tool_call_below_threshold_does_not_emit(conn):
+    sid = _insert_session(conn, session_key="s:tool-sub", client="claude")
+    for i in range(DEFAULT_TOOL_CALL_THRESHOLD - 1):
+        _claude_tool_call(
+            conn, session_id=sid, tool_id=f"tc-{i}",
+            name="Read", args={"file_path": "/etc/hosts"},
+            result="127.0.0.1 localhost",
+        )
+    ingest_loop_incidents(conn)
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
+# --------------------------------------------------------------------------- #
+# rebuild + cursor
+# --------------------------------------------------------------------------- #
+
+
+def test_rebuild_clears_and_replays(conn):
+    sid = _insert_session(conn, session_key="s:rebuild", client="claude")
+    for i in range(3):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"tu-{i}",
+            command="npm test", output="FAIL",
+        )
+    ingest_loop_incidents(conn)
+    n_first = conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0]
+    assert n_first == 1
+
+    # Forge a stale row so we can prove rebuild deletes-and-replaces.
+    conn.execute(
+        "UPDATE incidents SET count = 999 WHERE session_id = ?", (sid,)
+    )
+    conn.commit()
+
+    summary = rebuild_loop_incidents(conn)
+    assert summary.sessions_evaluated == 1
+    row = conn.execute("SELECT count FROM incidents WHERE session_id = ?", (sid,)).fetchone()
+    assert row["count"] == 3  # forged value gone, real value back
+
+
+def test_cursor_advances_only_after_evaluation(conn):
+    sid = _insert_session(conn, session_key="s:cursor", client="claude")
+    for i in range(3):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"a-{i}",
+            command="npm test", output="FAIL",
+        )
+    ingest_loop_incidents(conn)
+    first_cursor = conn.execute(
+        "SELECT last_event_id FROM loop_ingest_state WHERE consumer_id = 'loop_detector'"
+    ).fetchone()["last_event_id"]
+    assert first_cursor > 0
+
+    # Append two more events — cursor should advance again.
+    _claude_bash_pair(
+        conn, session_id=sid, tool_id="b-0",
+        command="npm test", output="FAIL",
+    )
+    ingest_loop_incidents(conn)
+    second_cursor = conn.execute(
+        "SELECT last_event_id FROM loop_ingest_state WHERE consumer_id = 'loop_detector'"
+    ).fetchone()["last_event_id"]
+    assert second_cursor > first_cursor
+
+
+# --------------------------------------------------------------------------- #
+# per-client fingerprint coverage
+# --------------------------------------------------------------------------- #
+
+
+def test_codex_shell_loop_detected(conn):
+    sid = _insert_session(conn, session_key="s:codex-shell", client="codex")
+    for i in range(3):
+        tool_id = f"call_{i}"
+        _insert_event(
+            conn, session_id=sid, client="codex",
+            event_type="command_start",
+            event_key=f"command_start:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "shell",
+                    "call_id": tool_id,
+                    "arguments": json.dumps(
+                        {"command": ["bash", "-lc", "npm test"], "workdir": "/x"}
+                    ),
+                },
+            },
+        )
+        _insert_event(
+            conn, session_id=sid, client="codex",
+            event_type="tool_result",
+            event_key=f"tool_result:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": tool_id,
+                    "output": json.dumps(
+                        {
+                            "output": "FAIL identical",
+                            "metadata": {"exit_code": 1, "duration_seconds": 0.5 + i * 0.01},
+                        }
+                    ),
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    rows = conn.execute("SELECT count FROM incidents").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["count"] == 3
+
+
+def test_openclaw_tool_loop_detected(conn):
+    sid = _insert_session(conn, session_key="s:opc", client="openclaw")
+    # OpenClaw mirrors Claude's wire format.
+    for i in range(DEFAULT_TOOL_CALL_THRESHOLD):
+        tool_id = f"oc-{i}"
+        _insert_event(
+            conn, session_id=sid, client="openclaw",
+            event_type="tool_call",
+            event_key=f"tool_call:{tool_id}",
+            raw={
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {"type": "toolCall", "id": tool_id, "name": "read_file",
+                         "input": {"path": "/etc/hosts"}}
+                    ],
+                },
+            },
+        )
+        _insert_event(
+            conn, session_id=sid, client="openclaw",
+            event_type="tool_result",
+            event_key=f"tool_result:{tool_id}",
+            raw={
+                "type": "message",
+                "message": {
+                    "role": "toolResult",
+                    "toolCallId": tool_id,
+                    "content": [{"type": "text", "text": "127.0.0.1 localhost"}],
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 1
+
+
+def test_pure_read_helper_does_not_write(conn):
+    sid = _insert_session(conn, session_key="s:pure", client="claude")
+    for i in range(3):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"tu-{i}",
+            command="npm test", output="FAIL",
+        )
+    hits = detect_session_loops(conn, sid)
+    assert len(hits) == 1
+    assert hits[0].count == 3
+    # detect_session_loops must not write anything.
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
+def test_unparseable_raw_json_breaks_run_safely(conn):
+    sid = _insert_session(conn, session_key="s:bad", client="claude")
+    _claude_bash_pair(
+        conn, session_id=sid, tool_id="a-0",
+        command="npm test", output="FAIL",
+    )
+    # Manually inject a row whose raw_json is broken — must not crash.
+    conn.execute(
+        """
+        INSERT INTO events (
+            session_id, type, event_key, event_at, ingested_at, source,
+            source_path, source_offset, seq, client, confidence, lossiness,
+            raw_json
+        ) VALUES (?, 'command_start', ?, ?, ?, 'claude-jsonl',
+                  '/tmp/x.jsonl', 9999, 0, 'claude', 'low', 'unknown', ?)
+        """,
+        (sid, "command_start:bad", TS, TS, "{not json"),
+    )
+    conn.commit()
+    _claude_bash_pair(
+        conn, session_id=sid, tool_id="a-2",
+        command="npm test", output="FAIL",
+    )
+    _claude_bash_pair(
+        conn, session_id=sid, tool_id="a-3",
+        command="npm test", output="FAIL",
+    )
+    summary = ingest_loop_incidents(conn)
+    # The bad row breaks the run; we only have 2 and then 2 → no loop.
+    assert summary.incidents_written == 0

--- a/tests/events/incidents/test_loop_detector.py
+++ b/tests/events/incidents/test_loop_detector.py
@@ -29,7 +29,7 @@ from clawjournal.events.incidents import (
     rebuild_loop_incidents,
 )
 from clawjournal.events.schema import ensure_schema as ensure_events_schema
-from clawjournal.events.view import ensure_view_schema
+from clawjournal.events.view import ensure_view_schema, write_hook_override
 
 
 TS = "2026-04-21T10:00:00Z"
@@ -375,6 +375,128 @@ def test_distinct_outputs_do_not_count_as_a_loop(conn):
     assert n == 0
 
 
+def test_claude_batched_shell_blocks_match_current_event_key(conn):
+    sid = _insert_session(conn, session_key="s:claude-batched-shell", client="claude")
+    for i in range(3):
+        target_id = f"target-{i}"
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="command_start",
+            event_key=f"command_start:{target_id}",
+            raw={
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": f"other-{i}",
+                            "name": "Bash",
+                            "input": {"command": f"echo {i}"},
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": target_id,
+                            "name": "Bash",
+                            "input": {"command": "npm test"},
+                        },
+                    ]
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="tool_result",
+            event_key=f"tool_result:{target_id}",
+            raw={
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": f"other-{i}",
+                            "content": [{"type": "text", "text": f"other {i}"}],
+                        },
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": target_id,
+                            "content": [{"type": "text", "text": "FAIL identical"}],
+                        },
+                    ]
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    rows = conn.execute("SELECT count FROM incidents").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["count"] == 3
+
+
+def test_claude_batched_tool_results_do_not_use_first_block_output(conn):
+    sid = _insert_session(conn, session_key="s:claude-batched-results", client="claude")
+    for i in range(3):
+        target_id = f"target-{i}"
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="command_start",
+            event_key=f"command_start:{target_id}",
+            raw={
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": f"other-{i}",
+                            "name": "Bash",
+                            "input": {"command": "echo shared"},
+                        },
+                        {
+                            "type": "tool_use",
+                            "id": target_id,
+                            "name": "Bash",
+                            "input": {"command": "npm test"},
+                        },
+                    ]
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="tool_result",
+            event_key=f"tool_result:{target_id}",
+            raw={
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": f"other-{i}",
+                            "content": [{"type": "text", "text": "shared"}],
+                        },
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": target_id,
+                            "content": [
+                                {"type": "text", "text": f"FAIL iteration {i}"}
+                            ],
+                        },
+                    ]
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
 def test_cross_source_duplicates_do_not_false_positive_a_shell_loop(conn):
     sid = _insert_session(conn, session_key="s:xsrc-loop", client="claude")
     for tool_id, path in (("tu-0", "/a.jsonl"), ("tu-1", "/c.jsonl")):
@@ -653,6 +775,48 @@ def test_codex_shell_command_loop_detected(conn):
     assert rows[0]["count"] == 3
 
 
+def test_codex_exec_command_cmd_loop_detected(conn):
+    sid = _insert_session(conn, session_key="s:codex-exec-command", client="codex")
+    for i in range(3):
+        tool_id = f"call_{i}"
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="codex",
+            event_type="command_start",
+            event_key=f"command_start:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "exec_command",
+                    "call_id": tool_id,
+                    "arguments": json.dumps({"cmd": "npm test", "cwd": "/repo"}),
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="codex",
+            event_type="tool_result",
+            event_key=f"tool_result:{tool_id}",
+            raw={
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call_output",
+                    "call_id": tool_id,
+                    "output": json.dumps({"output": "FAIL identical"}),
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    rows = conn.execute("SELECT count FROM incidents").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["count"] == 3
+
+
 def test_codex_shell_args_are_part_of_the_fingerprint(conn):
     sid = _insert_session(conn, session_key="s:codex-shell-args", client="codex")
     for i in range(3):
@@ -777,6 +941,83 @@ def test_openclaw_distinct_results_do_not_count_as_a_loop(conn):
     assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
 
 
+def test_openclaw_batched_tool_calls_match_current_event_key(conn):
+    sid = _insert_session(conn, session_key="s:openclaw-batched-tools", client="openclaw")
+    for i in range(DEFAULT_TOOL_CALL_THRESHOLD):
+        target_id = f"target-{i}"
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="openclaw",
+            event_type="tool_call",
+            event_key=f"tool_call:{target_id}",
+            raw={
+                "type": "message",
+                "message": {
+                    "role": "assistant",
+                    "content": [
+                        {
+                            "type": "toolCall",
+                            "id": f"other-{i}",
+                            "name": "read_file",
+                            "input": {"path": f"/tmp/{i}"},
+                        },
+                        {
+                            "type": "toolCall",
+                            "id": target_id,
+                            "name": "read_file",
+                            "input": {"path": "/etc/hosts"},
+                        },
+                    ],
+                },
+            },
+        )
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="openclaw",
+            event_type="tool_result",
+            event_key=f"tool_result:{target_id}",
+            raw={
+                "type": "message",
+                "message": {
+                    "role": "toolResult",
+                    "toolCallId": target_id,
+                    "content": [{"type": "text", "text": "127.0.0.1 localhost"}],
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    rows = conn.execute("SELECT count, evidence_json FROM incidents").fetchall()
+    assert len(rows) == 1
+    assert rows[0]["count"] == DEFAULT_TOOL_CALL_THRESHOLD
+    assert json.loads(rows[0]["evidence_json"])["event_type"] == "tool_call"
+
+
+def test_claude_bash_execution_distinct_inline_outputs_do_not_count_as_loop(conn):
+    sid = _insert_session(conn, session_key="s:claude-bashexec", client="claude")
+    for i in range(3):
+        _insert_event(
+            conn,
+            session_id=sid,
+            client="claude",
+            event_type="command_start",
+            raw={
+                "type": "message",
+                "message": {
+                    "role": "bashExecution",
+                    "command": "npm test",
+                    "output": f"FAIL iteration {i}",
+                    "exitCode": 1,
+                },
+            },
+        )
+
+    ingest_loop_incidents(conn)
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
 def test_pure_read_helper_does_not_write(conn):
     sid = _insert_session(conn, session_key="s:pure", client="claude")
     for i in range(3):
@@ -810,6 +1051,48 @@ def test_pure_read_helper_works_without_view_schema():
 
     assert len(hits) == 1
     assert hits[0].count == 3
+
+
+def test_detect_session_loops_uses_command_start_override_payload(conn):
+    sid = _insert_session(conn, session_key="s:override-command", client="claude")
+    for i in range(3):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-{i}",
+            command="npm test",
+            output="FAIL identical",
+        )
+
+    assert write_hook_override(
+        conn,
+        session_key="s:override-command",
+        event_key="command_start:tu-1",
+        event_type="command_start",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS,
+        payload_json=json.dumps(
+            {
+                "type": "assistant",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_use",
+                            "id": "tu-1",
+                            "name": "Bash",
+                            "input": {"command": "npm run lint"},
+                        }
+                    ]
+                },
+            },
+            sort_keys=True,
+        ),
+        origin="test",
+    )
+
+    assert detect_session_loops(conn, sid) == []
 
 
 def test_unparseable_raw_json_breaks_run_safely(conn):
@@ -965,6 +1248,154 @@ def test_cursor_advances_correctly_across_mid_run_boundary(conn):
     assert second.sessions_evaluated == 1
 
 
+def test_override_only_tool_result_change_reingests_session(conn):
+    sid = _insert_session(conn, session_key="s:override-ingest", client="claude")
+    for i in range(3):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-{i}",
+            command="npm test",
+            output="FAIL identical",
+        )
+
+    first = ingest_loop_incidents(conn)
+    assert first.incidents_written == 1
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 1
+
+    assert write_hook_override(
+        conn,
+        session_key="s:override-ingest",
+        event_key="tool_result:tu-1",
+        event_type="tool_result",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS,
+        payload_json=json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu-1",
+                            "content": [{"type": "text", "text": "FAIL changed"}],
+                        }
+                    ]
+                },
+            },
+            sort_keys=True,
+        ),
+        origin="test",
+    )
+
+    second = ingest_loop_incidents(conn)
+
+    assert second.events_scanned == 0
+    assert second.overrides_scanned == 1
+    assert second.sessions_evaluated == 1
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
+def test_override_cursor_tiebreaker_handles_same_timestamp_writes(conn):
+    sid = _insert_session(conn, session_key="s:override-cursor-tie", client="claude")
+    fixed_created_at = "2026-04-21T10:00:00.123456Z"
+    for i in range(3):
+        _claude_bash_pair(
+            conn,
+            session_id=sid,
+            tool_id=f"tu-{i}",
+            command="npm test",
+            output="FAIL identical",
+        )
+
+    ingest_loop_incidents(conn)
+
+    assert write_hook_override(
+        conn,
+        session_key="s:override-cursor-tie",
+        event_key="tool_result:tu-0",
+        event_type="tool_result",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS,
+        payload_json=json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu-0",
+                            "content": [{"type": "text", "text": "FAIL identical"}],
+                        }
+                    ]
+                },
+            },
+            sort_keys=True,
+        ),
+        origin="test",
+    )
+    conn.execute(
+        """
+        UPDATE event_overrides
+           SET created_at = ?
+         WHERE session_id = ? AND event_key = ?
+        """,
+        (fixed_created_at, sid, "tool_result:tu-0"),
+    )
+    conn.commit()
+
+    first = ingest_loop_incidents(conn)
+    assert first.overrides_scanned == 1
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 1
+
+    assert write_hook_override(
+        conn,
+        session_key="s:override-cursor-tie",
+        event_key="tool_result:tu-1",
+        event_type="tool_result",
+        source="hook",
+        confidence="high",
+        lossiness="none",
+        event_at=TS,
+        payload_json=json.dumps(
+            {
+                "type": "user",
+                "message": {
+                    "content": [
+                        {
+                            "type": "tool_result",
+                            "tool_use_id": "tu-1",
+                            "content": [{"type": "text", "text": "FAIL changed"}],
+                        }
+                    ]
+                },
+            },
+            sort_keys=True,
+        ),
+        origin="test",
+    )
+    conn.execute(
+        """
+        UPDATE event_overrides
+           SET created_at = ?
+         WHERE session_id = ? AND event_key = ?
+        """,
+        (fixed_created_at, sid, "tool_result:tu-1"),
+    )
+    conn.commit()
+
+    second = ingest_loop_incidents(conn)
+
+    assert second.events_scanned == 0
+    assert second.overrides_scanned == 1
+    assert second.sessions_evaluated == 1
+    assert conn.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 0
+
+
 def test_rebuild_preserves_non_loop_incident_kinds(conn):
     """The incidents table is shared across kinds; `--rebuild` must
     only touch `loop_exact_repeat` rows."""
@@ -995,3 +1426,55 @@ def test_rebuild_preserves_non_loop_incident_kinds(conn):
     }
     assert "other_kind" in kinds
     assert LOOP_INCIDENT_KIND in kinds
+
+
+def test_legacy_loop_ingest_state_is_migrated_in_place():
+    """A DB whose `loop_ingest_state` predates the override-cursor
+    columns must migrate cleanly: `ensure_incidents_schema` ALTERs the
+    missing columns in place, old cursor values survive, and
+    `ingest_loop_incidents` runs without touching the legacy row's
+    `last_event_id`."""
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_events_schema(conn)
+    ensure_view_schema(conn)
+
+    # Forge the legacy schema (pre-override-cursor) with a cursor of 0.
+    conn.executescript(
+        """
+        CREATE TABLE loop_ingest_state (
+            consumer_id   TEXT PRIMARY KEY,
+            last_event_id INTEGER NOT NULL
+        );
+        INSERT INTO loop_ingest_state (consumer_id, last_event_id)
+          VALUES ('loop_detector', 0);
+        """
+    )
+    conn.commit()
+
+    # ensure_incidents_schema must ADD the missing columns without
+    # dropping the stored cursor value.
+    ensure_incidents_schema(conn)
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(loop_ingest_state)")}
+    assert "last_override_created_at" in columns
+    assert "last_override_session_id" in columns
+    assert "last_override_event_key" in columns
+
+    row = conn.execute(
+        "SELECT * FROM loop_ingest_state WHERE consumer_id = 'loop_detector'"
+    ).fetchone()
+    assert row["last_event_id"] == 0
+    assert row["last_override_created_at"] is None
+    assert row["last_override_session_id"] == 0
+    assert row["last_override_event_key"] == ""
+
+    # Driving an ingest afterwards must not crash on the migrated row
+    # and must correctly pick up the new events.
+    sid = _insert_session(conn, session_key="s:migrated", client="claude")
+    for i in range(3):
+        _claude_bash_pair(
+            conn, session_id=sid, tool_id=f"tu-{i}",
+            command="npm test", output="FAIL same",
+        )
+    summary = ingest_loop_incidents(conn)
+    assert summary.incidents_written == 1

--- a/tests/events/incidents/test_normalize.py
+++ b/tests/events/incidents/test_normalize.py
@@ -1,0 +1,104 @@
+"""Per-rule unit tests for the loop-detector outcome-text normalizer.
+
+Each rule from `clawjournal.events.incidents.normalize` gets its own
+test so a regression in one rule isn't masked by the others firing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from clawjournal.events.incidents.normalize import normalize_outcome_text
+
+
+def test_normalize_handles_none_and_non_string():
+    assert normalize_outcome_text(None) == ""
+    assert normalize_outcome_text(42) == ""  # type: ignore[arg-type]
+    assert normalize_outcome_text({"oops": True}) == ""  # type: ignore[arg-type]
+
+
+def test_strips_iso8601_with_z():
+    out = normalize_outcome_text("Failed at 2026-04-21T10:00:00Z please retry")
+    assert "2026-04-21T10:00:00Z" not in out
+    assert "<TS>" in out
+
+
+def test_strips_iso8601_with_fractional_seconds_and_offset():
+    out = normalize_outcome_text(
+        "Failed at 2026-04-21T10:00:00.123456-08:00 please retry"
+    )
+    assert "<TS>" in out
+    assert "2026" not in out
+
+
+def test_strips_user_rooted_path():
+    out = normalize_outcome_text("ENOENT: no such file '/Users/kai/llm/foo.py'")
+    assert "/Users/kai/llm/foo.py" not in out
+    assert "<PATH>" in out
+
+
+def test_strips_linux_home_and_tmp_paths():
+    out = normalize_outcome_text(
+        "wrote /home/alice/x.log and /tmp/scratch/output"
+    )
+    assert "/home/alice/x.log" not in out
+    assert "/tmp/scratch/output" not in out
+    assert out.count("<PATH>") == 2
+
+
+def test_does_not_strip_system_binary_paths():
+    """A literal /usr/bin/foo isn't user-rooted; leave it alone so we
+    can still tell different binaries apart."""
+    out = normalize_outcome_text("ran /usr/bin/python3 ok")
+    assert "/usr/bin/python3" in out
+
+
+def test_strips_pid_inline_variants():
+    for raw in ("pid 12345", "PID: 67890", "process 4242"):
+        out = normalize_outcome_text(f"crashed: {raw}")
+        assert "12345" not in out and "67890" not in out and "4242" not in out
+        assert "<PID>" in out
+
+
+def test_strips_bracketed_pid():
+    out = normalize_outcome_text("[12345] error: oh no")
+    assert "[<PID>]" in out
+    assert "12345" not in out
+
+
+def test_does_not_eat_long_digit_strings_as_pids():
+    """[123456789012345] is a GUID-shaped number; the bracketed-PID
+    rule caps at 7 digits to avoid swallowing those."""
+    out = normalize_outcome_text("trace_id=[123456789012345]")
+    assert "123456789012345" in out
+
+
+def test_collapses_whitespace_after_substitutions():
+    out = normalize_outcome_text(
+        "ts=2026-04-21T10:00:00Z   pid 1   in   /Users/kai/x.py"
+    )
+    assert "  " not in out  # no double spaces survive
+    assert out.startswith("ts=<TS>")
+
+
+def test_strips_leading_and_trailing_whitespace():
+    assert normalize_outcome_text("  hello  ") == "hello"
+
+
+@pytest.mark.parametrize(
+    "first,second",
+    [
+        # Two failures of the same command at different times produce
+        # the same normalized form — that's the whole point.
+        (
+            "[12345] ENOENT at 2026-04-21T10:00:00Z in /Users/kai/x.py",
+            "[67890] ENOENT at 2026-04-21T10:01:00Z in /Users/kai/x.py",
+        ),
+        (
+            "Connection refused; pid 4242 in /Users/kai/proj/x.py",
+            "Connection refused; pid 9999 in /Users/kai/proj/x.py",
+        ),
+    ],
+)
+def test_two_distinct_failures_normalize_to_same_text(first, second):
+    assert normalize_outcome_text(first) == normalize_outcome_text(second)

--- a/tests/events/incidents/test_normalize.py
+++ b/tests/events/incidents/test_normalize.py
@@ -37,6 +37,22 @@ def test_strips_user_rooted_path():
     assert "<PATH>" in out
 
 
+def test_strips_user_rooted_path_with_spaces_inside_quotes():
+    out = normalize_outcome_text(
+        "ENOENT: no such file '/Users/kai/My Project/build/output.log'"
+    )
+    assert "/Users/kai/My Project/build/output.log" not in out
+    assert "<PATH>" in out
+
+
+def test_strips_user_rooted_path_with_spaces_in_intermediate_segments():
+    out = normalize_outcome_text(
+        "cannot read /Users/kai/Library/Application Support/Claude/logs.json"
+    )
+    assert "/Users/kai/Library/Application Support/Claude/logs.json" not in out
+    assert "<PATH>" in out
+
+
 def test_strips_linux_home_and_tmp_paths():
     out = normalize_outcome_text(
         "wrote /home/alice/x.log and /tmp/scratch/output"

--- a/tests/events/incidents/test_normalize.py
+++ b/tests/events/incidents/test_normalize.py
@@ -85,6 +85,10 @@ def test_strips_leading_and_trailing_whitespace():
     assert normalize_outcome_text("  hello  ") == "hello"
 
 
+def test_collapses_newline_only_reflow():
+    assert normalize_outcome_text("foo bar") == normalize_outcome_text("foo\nbar")
+
+
 @pytest.mark.parametrize(
     "first,second",
     [

--- a/tests/events/test_view.py
+++ b/tests/events/test_view.py
@@ -111,6 +111,57 @@ def test_ensure_view_schema_is_idempotent(conn):
         "SELECT name FROM sqlite_master WHERE type='index'"
     )}
     assert "idx_event_overrides_session" in indexes
+    assert "idx_event_overrides_write_seq" in indexes
+
+
+def test_ensure_view_schema_migrates_write_seq_in_place():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    ensure_events_schema(conn)
+    conn.executescript(
+        """
+        CREATE TABLE event_overrides (
+            session_id    INTEGER NOT NULL REFERENCES event_sessions(id) ON DELETE CASCADE,
+            event_key     TEXT    NOT NULL,
+            type          TEXT    NOT NULL,
+            source        TEXT    NOT NULL,
+            confidence    TEXT    NOT NULL,
+            lossiness     TEXT    NOT NULL,
+            event_at      TEXT,
+            payload_json  TEXT    NOT NULL,
+            origin        TEXT,
+            created_at    TEXT    NOT NULL,
+            PRIMARY KEY (session_id, event_key)
+        );
+        """
+    )
+    conn.execute(
+        "INSERT INTO event_sessions (session_key, client, status) VALUES (?, ?, ?)",
+        ("s:legacy-view", "claude", "active"),
+    )
+    conn.executemany(
+        """
+        INSERT INTO event_overrides (
+            session_id, event_key, type, source, confidence, lossiness,
+            event_at, payload_json, origin, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+        """,
+        [
+            (1, "tool_call:a", "tool_call", "hook", "high", "none", TS0, "{}", None, TS0),
+            (1, "tool_call:b", "tool_call", "hook", "high", "none", TS1, "{}", None, TS1),
+        ],
+    )
+    conn.commit()
+
+    ensure_view_schema(conn)
+
+    columns = {row[1] for row in conn.execute("PRAGMA table_info(event_overrides)")}
+    assert "write_seq" in columns
+    rows = conn.execute(
+        "SELECT event_key, write_seq FROM event_overrides ORDER BY write_seq"
+    ).fetchall()
+    assert [row["event_key"] for row in rows] == ["tool_call:a", "tool_call:b"]
+    assert [row["write_seq"] for row in rows] == [1, 2]
 
 
 def test_ensure_view_schema_rejects_invalid_source_via_check(conn):
@@ -240,9 +291,11 @@ def test_write_hook_override_higher_rank_replaces(conn):
     assert write_hook_override(
         conn, confidence="low", payload_json='{"v": 1}', **common
     ) is True
-    first_created_at = conn.execute(
-        "SELECT created_at FROM event_overrides"
-    ).fetchone()[0]
+    first_row = conn.execute(
+        "SELECT created_at, write_seq FROM event_overrides"
+    ).fetchone()
+    first_created_at = first_row["created_at"]
+    first_write_seq = first_row["write_seq"]
     # Ensure the second write's wall-clock `created_at` is strictly
     # greater — microsecond-precision ISO timestamps need a brief
     # pause for the string to sort ahead of the first one.
@@ -251,13 +304,14 @@ def test_write_hook_override_higher_rank_replaces(conn):
         conn, confidence="high", payload_json='{"v": 2}', **common
     ) is True
     row = conn.execute(
-        "SELECT confidence, payload_json, created_at FROM event_overrides"
+        "SELECT confidence, payload_json, created_at, write_seq FROM event_overrides"
     ).fetchone()
     assert row["confidence"] == "high"
     assert row["payload_json"] == '{"v": 2}'
     # `created_at` must bump on a rank-winning overwrite so the loop-
     # detector cursor picks up the upgraded override as "new."
     assert row["created_at"] > first_created_at
+    assert row["write_seq"] > first_write_seq
 
 
 def test_write_hook_override_concurrent_writers_do_not_corrupt_state(tmp_path):

--- a/tests/events/test_view.py
+++ b/tests/events/test_view.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import time
 
 import pytest
 
@@ -239,14 +240,93 @@ def test_write_hook_override_higher_rank_replaces(conn):
     assert write_hook_override(
         conn, confidence="low", payload_json='{"v": 1}', **common
     ) is True
+    first_created_at = conn.execute(
+        "SELECT created_at FROM event_overrides"
+    ).fetchone()[0]
+    # Ensure the second write's wall-clock `created_at` is strictly
+    # greater — microsecond-precision ISO timestamps need a brief
+    # pause for the string to sort ahead of the first one.
+    time.sleep(0.01)
     assert write_hook_override(
         conn, confidence="high", payload_json='{"v": 2}', **common
     ) is True
     row = conn.execute(
-        "SELECT confidence, payload_json FROM event_overrides"
+        "SELECT confidence, payload_json, created_at FROM event_overrides"
     ).fetchone()
     assert row["confidence"] == "high"
     assert row["payload_json"] == '{"v": 2}'
+    # `created_at` must bump on a rank-winning overwrite so the loop-
+    # detector cursor picks up the upgraded override as "new."
+    assert row["created_at"] > first_created_at
+
+
+def test_write_hook_override_concurrent_writers_do_not_corrupt_state(tmp_path):
+    """Two processes racing to upgrade the same override must not
+    produce a duplicate-PK IntegrityError, a stale rank-guard bypass,
+    or a partial row. The single-statement UPSERT is atomic under
+    SQLite's default isolation — this test pins that guarantee."""
+    import threading
+
+    db_path = tmp_path / "race.db"
+
+    def _open() -> sqlite3.Connection:
+        c = sqlite3.connect(str(db_path), timeout=5.0)
+        c.row_factory = sqlite3.Row
+        return c
+
+    setup = _open()
+    ensure_events_schema(setup)
+    ensure_view_schema(setup)
+    _insert_event_session(setup, session_key="s:race", client="claude")
+    setup.close()
+
+    common = dict(
+        session_key="s:race",
+        event_key="tool_call:tu-race",
+        event_type="tool_call",
+        source="hook",
+        lossiness="none",
+        event_at=TS0,
+        origin=None,
+    )
+    errors: list[Exception] = []
+
+    def worker(confidence: str, payload: str):
+        conn = _open()
+        try:
+            for _ in range(20):
+                try:
+                    write_hook_override(
+                        conn,
+                        confidence=confidence,
+                        payload_json=payload,
+                        **common,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    errors.append(exc)
+                    return
+        finally:
+            conn.close()
+
+    threads = [
+        threading.Thread(target=worker, args=("high", '{"who": "A"}')),
+        threading.Thread(target=worker, args=("high", '{"who": "B"}')),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+
+    verify = _open()
+    rows = verify.execute(
+        "SELECT confidence, payload_json FROM event_overrides"
+    ).fetchall()
+    verify.close()
+    assert len(rows) == 1  # exactly one winner, no duplicates
+    assert rows[0]["confidence"] == "high"
+    assert rows[0]["payload_json"] in ('{"who": "A"}', '{"who": "B"}')
 
 
 def test_write_hook_override_raises_on_unknown_session(conn):


### PR DESCRIPTION
## Summary

Phase-1 plan 05. Reads `events.raw_json` and emits `incidents` rows of kind `loop_exact_repeat` when a session contains 3+ consecutive identical shell commands or 5+ consecutive identical tool calls. \"Identical\" = same (command/args + normalized outcome text from the paired `tool_result`).

- **New module** \`clawjournal/events/incidents/\`:
  - \`schema.py\` — shared \`incidents\` table (\`UNIQUE(session_id, kind, first_event_id)\` is the spec's dedupe key) + \`loop_ingest_state\` cursor. Table is shared by all future incident kinds.
  - \`normalize.py\` — five-rule documented stderr/output normalizer (ISO-8601 timestamps, user-rooted absolute paths, PIDs, whitespace collapse, trim). Each rule individually pinned by a test.
  - \`loop_detector.py\` — per-rule fingerprint extraction across claude/codex/openclaw + run-grouping. A \`tool_result\` between two \`command_start\`s is **transparent** (it's bookkeeping for the prior command); only \`user_message\` and \`compaction\` reset adjacency. Confidence = \`high\` when paired result text was reachable, \`medium\` otherwise.
  - \`ingest.py\` — incremental driver mirroring the cost-ledger pattern. \`loop_ingest_state\` cursor; per-session DELETE+INSERT keeps growing runs current. \`--rebuild\` clears all loop incidents + cursor.
- **CLI**: \`clawjournal events incidents detect [--rebuild] [--json]\`.
- **Tests**: 27 new tests in \`tests/events/incidents/\` covering all three spec acceptance criteria + per-client coverage + unparseable-payload safety + cursor advancement + rebuild.

## Spec acceptance

- [x] Three identical \`npm test\` failures → **one** incident with \`count=3\` (\`test_three_identical_npm_test_failures_produce_one_incident_with_count_3\`).
- [x] Re-running ingestion does not duplicate incidents (\`test_re_running_does_not_duplicate_incidents\`, \`test_growing_run_updates_count_without_duplicating\`).
- [x] stderr normalization ruleset documented + per-rule fixture tests (\`tests/events/incidents/test_normalize.py\`).

## Resolved decisions (per Open questions in 05-loop-detector-lite.md)

- **Outcome source**: paired \`tool_result\` normalized text. \`normalize_outcome_text\` is the single seam to swap when Beat 2b's Error Normalizer ships.
- **Args matching**: canonical-JSON sort-keys (\`json.dumps(args, sort_keys=True)\`).
- **Run breakers**: \`user_message\` and \`compaction\` only. Tool results / command exits / stdout chunks / assistant_message events are transparent.

## Test plan

- [x] \`pytest tests/events/incidents/\` — 27 passed
- [x] \`pytest\` (full suite) — 1368 passed (was 1343 before this PR)
- [ ] CI green