### PR TITLE
fix(events): null-ts codex priors only feed null-ts candidates

### DIFF
--- a/clawjournal/events/cost/ingest.py
+++ b/clawjournal/events/cost/ingest.py
@@ -296,7 +296,7 @@ def _latest_codex_model_before_event(
     canonical order to recover the model rather than depending on re-scans.
     """
     if event_at is not None:
-        model = _latest_codex_model_from_rows(
+        return _latest_codex_model_from_rows(
             conn.execute(
                 """
                 SELECT raw_json
@@ -310,12 +310,9 @@ def _latest_codex_model_before_event(
                 (session_id, event_at, event_at, event_id),
             )
         )
-        if model:
-            return model
 
-    # Fallback for earlier rows that carried no vendor timestamp. This keeps
-    # replay robust when an older turn_context predates a later token_count by
-    # source order / id but not by event_at presence.
+    # Null-timestamp rows sort after all timestamped rows in canonical order,
+    # so only a null-timestamp candidate can inherit from earlier null rows.
     model = _latest_codex_model_from_rows(
         conn.execute(
             """
@@ -333,24 +330,20 @@ def _latest_codex_model_before_event(
     if model:
         return model
 
-    if event_at is None:
-        model = _latest_codex_model_from_rows(
-            conn.execute(
-                """
-                SELECT raw_json
-                  FROM events
-                 WHERE session_id = ?
-                   AND client = 'codex'
-                   AND event_at IS NOT NULL
-                   AND id < ?
-                 ORDER BY event_at DESC, id DESC
-                """,
-                (session_id, event_id),
-            )
+    return _latest_codex_model_from_rows(
+        conn.execute(
+            """
+            SELECT raw_json
+              FROM events
+             WHERE session_id = ?
+               AND client = 'codex'
+               AND event_at IS NOT NULL
+               AND id < ?
+             ORDER BY event_at DESC, id DESC
+            """,
+            (session_id, event_id),
         )
-        if model:
-            return model
-    return None
+    )
 
 
 def _latest_codex_model_from_rows(rows) -> str | None:

--- a/tests/events/cost/test_ingest.py
+++ b/tests/events/cost/test_ingest.py
@@ -290,24 +290,78 @@ def test_ingest_threads_codex_model_from_prior_run_turn_context(conn):
     assert row["cost_estimate"] is not None and row["cost_estimate"] > 0
 
 
-def test_ingest_threads_codex_model_from_null_timestamp_turn_context(conn):
+def test_ingest_threads_codex_model_from_prior_null_timestamp_turn_context(conn):
     sid = _insert_session(conn, session_key="s:codex-null-ts", client="codex")
     _insert_event(
         conn, session_id=sid, client="codex", event_type="schema_unknown",
         raw={"type": "turn_context", "payload": {"model": "gpt-5-codex"}},
         event_at=None,
     )
+    first = ingest_cost_pending(conn)
+    assert first.events_scanned == 1
+    assert first.token_rows_written == 0
+
     eid = _insert_event(
+        conn, session_id=sid, client="codex", event_type="schema_unknown",
+        raw=_codex_token_count(input_tokens=3655, cached=2048, reasoning=64),
+        event_at=None,
+    )
+
+    second = ingest_cost_pending(conn)
+    row = conn.execute("SELECT * FROM token_usage WHERE event_id = ?", (eid,)).fetchone()
+    assert second.events_scanned == 1
+    assert second.token_rows_written == 1
+    assert row is not None
+    assert row["model"] == "gpt-5-codex"
+    assert row["cost_estimate"] is not None and row["cost_estimate"] > 0
+
+
+def test_ingest_does_not_emit_false_model_shift_from_null_timestamp_backfill(conn):
+    sid = _insert_session(conn, session_key="s:codex-null-false-shift", client="codex")
+    _insert_event(
+        conn, session_id=sid, client="codex", event_type="schema_unknown",
+        raw={"type": "turn_context", "payload": {"model": "gpt-5-codex"}},
+        event_at=None,
+    )
+    first_eid = _insert_event(
         conn, session_id=sid, client="codex", event_type="schema_unknown",
         raw=_codex_token_count(input_tokens=3655, cached=2048, reasoning=64),
         event_at="2026-04-20T10:00:01Z",
     )
+    _insert_event(
+        conn, session_id=sid, client="codex", event_type="schema_unknown",
+        raw={"type": "turn_context", "payload": {"model": "gpt-5.3-codex"}},
+        event_at="2026-04-20T10:00:02Z",
+    )
+    second_eid = _insert_event(
+        conn, session_id=sid, client="codex", event_type="schema_unknown",
+        raw=_codex_token_count(input_tokens=4000, cached=1024, reasoning=32),
+        event_at="2026-04-20T10:00:03Z",
+    )
 
     ingest_cost_pending(conn)
-    row = conn.execute("SELECT * FROM token_usage WHERE event_id = ?", (eid,)).fetchone()
-    assert row is not None
-    assert row["model"] == "gpt-5-codex"
-    assert row["cost_estimate"] is not None and row["cost_estimate"] > 0
+
+    first_row = conn.execute(
+        "SELECT model FROM token_usage WHERE event_id = ?",
+        (first_eid,),
+    ).fetchone()
+    second_row = conn.execute(
+        "SELECT model FROM token_usage WHERE event_id = ?",
+        (second_eid,),
+    ).fetchone()
+    kinds = [
+        row["kind"]
+        for row in conn.execute(
+            "SELECT kind FROM cost_anomalies WHERE session_id = ?",
+            (sid,),
+        )
+    ]
+
+    assert first_row is not None
+    assert first_row["model"] is None
+    assert second_row is not None
+    assert second_row["model"] == "gpt-5.3-codex"
+    assert "model_shift" not in kinds
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Summary

Follow-up to #18 that closes a subtle hole in `_latest_codex_model_before_event`.

The three-pass fallback merged in #18 allowed a **null-`event_at` turn_context** to thread its model into an **`event_at`-bearing token_count** (via the second pass, which queried null-`event_at` priors by id regardless of the candidate's timestamp). That's wrong in canonical order: null-timestamp rows sort *after* all timestamped rows, so a null-ts turn_context cannot be a legitimate prior for a timestamped candidate — it represents a future (unstamped) run whose model hasn't been established yet.

### Observable consequences in the prior code

- Timestamped `token_count` rows could pick up a stale/speculative model from a null-ts `turn_context` belonging to a later ingest.
- A later real (timestamped) `turn_context` carrying a different model would then fire a **spurious `model_shift` anomaly** against the falsely-threaded prior model.

## What this changes

Restructures the function into two branches keyed on the candidate's `event_at`:

- **Timestamped candidate** → only timestamped priors. Returns `None` if none exist (no null-ts fallback).
- **Null-ts candidate** → null-ts priors first (id-ordered), then timestamped priors by id as a secondary fallback.

## Tests

- `test_ingest_threads_codex_model_from_null_timestamp_turn_context` renamed to `..._from_prior_null_timestamp_turn_context`. Tightened so **both** the `turn_context` and the `token_count` are null-ts (the legitimate case). Also exercises the two-pass ingest (turn_context scanned first; token_count written on the second pass) to pin the incremental behavior.
- **New** `test_ingest_does_not_emit_false_model_shift_from_null_timestamp_backfill` — a timestamped `token_count` following a null-ts `turn_context` now records `model = None` rather than inheriting; a subsequent real `turn_context` + `token_count` records its own model and no `model_shift` anomaly fires.

## Test plan

- [x] `pytest tests/events/cost/ -q` — 61 passed
- [ ] Full suite green in CI

## Behavior change worth flagging

Existing users with Codex sessions that had null-ts `turn_context` rows preceding timestamped `token_count` rows will see those `token_count` rows now record `model = None` (previously incorrectly inherited). Any downstream `cost_estimate` on those rows will be absent until a real (timestamped) `turn_context` is threaded. This is a correctness fix — the prior behavior was fabricating model attribution.

🤖 Generated with [Claude Code](https://claude.com/claude-code)