### PR TITLE
feat(events): ADR-001 session_key bridge + backfill

### DIFF
--- a/clawjournal/capture/discovery.py
+++ b/clawjournal/capture/discovery.py
@@ -293,6 +293,9 @@ def _load_local_agent_wrapper(wrapper_path: Path) -> dict | None:
     Returns None for malformed JSON, non-dict payloads, or missing
     `cliSessionId`. The capture adapter and the parser must skip the
     same wrappers, or step-2 Scanner parity regresses.
+
+    Also consumed by `clawjournal.workbench.index` during session_key
+    backfill (ADR-001). Renames must update that call site too.
     """
     try:
         payload = json.loads(wrapper_path.read_text())
@@ -306,6 +309,8 @@ def _load_local_agent_wrapper(wrapper_path: Path) -> dict | None:
 
 
 def _workspace_key_from_wrapper(wrapper: dict, session_dir: Path) -> str:
+    # Also consumed by `clawjournal.workbench.index` during session_key
+    # backfill (ADR-001). Renames must update that call site too.
     user_folders = wrapper.get("userSelectedFolders") or []
     if (
         isinstance(user_folders, list)

--- a/clawjournal/events/ingest.py
+++ b/clawjournal/events/ingest.py
@@ -119,6 +119,7 @@ def ingest_pending(
 ) -> IngestSummary:
     ensure_capture_schema(conn)
     ensure_event_schema(conn)
+    from clawjournal.workbench.index import backfill_session_keys
 
     summary = IngestSummary()
     latest_mtime_by_session_key: dict[str, float] = {}
@@ -138,6 +139,7 @@ def ingest_pending(
         summary._session_keys.add(source.session_key)
         summary.event_rows += _ingest_batch(conn, source, batch, now=now)
     _sweep_idle_sessions(conn, latest_mtime_by_session_key, now=now)
+    backfill_session_keys(conn)
     return summary
 
 

--- a/clawjournal/events/types.py
+++ b/clawjournal/events/types.py
@@ -1,4 +1,60 @@
-"""Shared types and validation for the execution recorder."""
+"""Shared types and validation for the execution recorder.
+
+``session_key`` grammar (per ADR-001, 2026-04-22)
+-------------------------------------------------
+
+``session_key`` is the canonical public session identifier for every phase-1
+feature from 06 onward: timeline-viewer URLs, replay-export bundles, encrypted
+HTML-share metadata, aggregation bucket keys, cross-session FTS results, and
+any external tool (MCP responses, etc.) that needs to reference a session.
+Workbench's legacy ``sessions.session_id`` remains for internal plumbing only.
+
+Current grammar, by ``client``:
+
+- ``claude:<project_dir_name>:<session_uuid>``
+  Native Claude Code (``~/.claude/projects/<project_dir_name>/<uuid>.jsonl``)
+  and the Claude-Desktop local-agent convergence case where the CLI session id
+  matches the native uuid.
+- ``claude:<workspace_key>:<cliSessionId>``
+  Claude-Desktop local-agent path when the CLI session id differs from the
+  native uuid. ``workspace_key`` is derived from the wrapper's
+  ``userSelectedFolders[0]`` (path separators replaced with ``-``) or
+  ``_cowork_<sessionId>`` when no user-selected folder is present.
+- ``codex:<absolute_source_path>``
+- ``openclaw:<absolute_source_path>``
+
+Stability guarantees
+--------------------
+
+The grammar above is the public contract. Any change to the grammar itself
+requires an ADR amendment or a superseding ADR. Do not edit the grammar in
+isolation; the export, URL, and FTS consumers all assume the shapes above.
+
+For a fixed grammar, ``session_key`` values are stable with respect to a
+fixed set of inputs (``project_dir_name``, session UUID, wrapper metadata).
+They are **not** guaranteed stable across input changes — renaming
+``~/Projects/myapp`` → ``~/Projects/my-app`` today produces a new
+``session_key`` because ``project_dir_name`` is part of the claude grammar.
+This is ADR-001's Open Question #1 and is deferred to a follow-up ADR; a
+future grammar may decouple ``project_dir_name`` from the key specifically to
+survive renames.
+
+Consumers that care about durability across renames (bundle export, URL
+bookmarks, encrypted share metadata) should either (a) snapshot the
+``session_key`` at share time and treat it as an opaque handle, or (b) carry
+a bundle ``schema_version`` that can be converted when the grammar changes.
+
+Within a single grammar version:
+
+- Bundles exported on one ``schema_version`` remain resolvable by any later
+  clawjournal version that honors the same ``schema_version``.
+- URLs of the form ``clawjournal://session/<session_key>#event-<id>`` remain
+  resolvable as long as the underlying inputs (path + wrapper) are unchanged.
+- Workbench ``sessions.session_key`` re-derives on upsert — a rescan after an
+  input change will overwrite the stored value with the new derivation. This
+  is the intentional escape hatch for fixing derivation bugs; it is also why
+  renames surface as an Open Question rather than a silent breakage.
+"""
 
 from __future__ import annotations
 

--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -717,6 +717,7 @@ def parse_project_sessions(
             if parsed and parsed["messages"]:
                 parsed["project"] = _build_openclaw_project_name(project_dir_name)
                 parsed["source"] = OPENCLAW_SOURCE
+                parsed["raw_source_path"] = str(session_file)
                 sessions.append(parsed)
         return sessions
 
@@ -764,6 +765,7 @@ def parse_project_sessions(
             if parsed and parsed["messages"]:
                 parsed["project"] = _build_codex_project_name(project_dir_name)
                 parsed["source"] = CODEX_SOURCE
+                parsed["raw_source_path"] = str(session_file)
                 # Derive client_origin from originator field
                 originator = parsed.pop("originator", None) or ""
                 parsed.pop("codex_source", None)

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -782,7 +782,7 @@ def backfill_session_keys(conn: sqlite3.Connection) -> int:
         return 0
 
     with conn:
-        conn.executemany(
+        cursor = conn.executemany(
             """
             UPDATE sessions
                SET session_key = ?
@@ -791,7 +791,11 @@ def backfill_session_keys(conn: sqlite3.Connection) -> int:
             """,
             updates,
         )
-    return len(updates)
+    # `cursor.rowcount` reflects rows actually affected by the guarded UPDATE
+    # (concurrent backfills can see the same NULL candidates and race; the
+    # `session_key IS NULL` guard keeps the data correct but `len(updates)`
+    # would over-report in that case).
+    return max(cursor.rowcount, 0)
 
 
 def session_matches_excluded_projects(

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -748,7 +748,15 @@ def _lookup_event_session_key(
 
 
 def backfill_session_keys(conn: sqlite3.Connection) -> int:
-    """Populate missing `sessions.session_key` values from events or path derivation."""
+    """Populate missing `sessions.session_key` values from events or path derivation.
+
+    Safe to call on a fresh workbench DB where no ``events ingest`` has run yet —
+    ``event_sessions`` / ``events`` are ensured here, so ``_lookup_event_session_key``
+    degrades to an empty query and the backfill falls through to path derivation.
+    """
+    from clawjournal.events.schema import ensure_schema as ensure_event_schema
+
+    ensure_event_schema(conn)
     rows = conn.execute(
         """
         SELECT session_id, source, raw_source_path

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -21,11 +21,12 @@ from ..pricing import estimate_cost
 INDEX_DB = CONFIG_DIR / "index.db"
 BLOBS_DIR = CONFIG_DIR / "blobs"
 
-# Schema version sentinel. Bumped once for the security refactor (findings,
-# allowlist, hold-state history, per-session security columns). The prior
-# bundles→shares migration uses version 1; the security migration advances
-# PRAGMA user_version to 2 and is gated atomically on that comparison.
+# Schema version sentinels. Version 1 is the bundles→shares migration,
+# version 2 is the security refactor, and version 3 adds the
+# `sessions.session_key` bridge to `event_sessions.session_key`.
 SECURITY_SCHEMA_VERSION = 2
+SESSION_IDENTITY_SCHEMA_VERSION = 3
+WORKBENCH_SCHEMA_VERSION = SESSION_IDENTITY_SCHEMA_VERSION
 BACKFILL_WINDOW = 100
 
 # Display-only normalization from the mixed AI/heuristic outcome vocabulary
@@ -87,6 +88,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     reviewed_at        TEXT,
     blob_path          TEXT,
     raw_source_path    TEXT,
+    session_key        TEXT,
     indexed_at         TEXT NOT NULL,
     updated_at         TEXT,
     share_id           TEXT REFERENCES shares(share_id),
@@ -299,6 +301,7 @@ def open_index() -> sqlite3.Connection:
                 raise
 
     _migrate_security_refactor(conn)
+    _migrate_session_identity_bridge(conn)
 
     # Clean up ai_outcome_badge values that the judge wrote before the
     # resolution validator rejected invalid labels. Idempotent: after
@@ -386,6 +389,31 @@ def _migrate_security_refactor(conn: sqlite3.Connection) -> None:
         )
 
         conn.execute(f"PRAGMA user_version = {SECURITY_SCHEMA_VERSION}")
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def _migrate_session_identity_bridge(conn: sqlite3.Connection) -> None:
+    """Add `sessions.session_key` + partial index and advance version 2 → 3."""
+    version_row = conn.execute("PRAGMA user_version").fetchone()
+    version = version_row[0] if version_row else 0
+    if version >= SESSION_IDENTITY_SCHEMA_VERSION:
+        return
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        try:
+            conn.execute("ALTER TABLE sessions ADD COLUMN session_key TEXT")
+        except sqlite3.OperationalError as e:
+            if "duplicate column" not in str(e):
+                raise
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sessions_session_key "
+            "ON sessions(session_key) WHERE session_key IS NOT NULL"
+        )
+        conn.execute(f"PRAGMA user_version = {SESSION_IDENTITY_SCHEMA_VERSION}")
         conn.commit()
     except Exception:
         conn.rollback()
@@ -633,6 +661,129 @@ def _dedupe_strings(values: list[str]) -> list[str]:
         seen.add(cleaned)
         result.append(cleaned)
     return result
+
+
+def _derive_session_key_from_source(
+    source: Any, raw_source_path: Any
+) -> str | None:
+    """Best-effort `event_sessions.session_key` derivation from workbench provenance."""
+    if not isinstance(source, str) or not isinstance(raw_source_path, str):
+        return None
+    if not raw_source_path.strip():
+        return None
+
+    path = Path(raw_source_path)
+    if source == "codex":
+        return f"codex:{path}"
+    if source == "openclaw":
+        return f"openclaw:{path}"
+    if source != "claude":
+        return None
+
+    if ".claude" in path.parts and path.suffix == ".jsonl":
+        la_key = _derive_local_agent_claude_session_key(path)
+        if la_key is not None:
+            return la_key
+        # Real native paths (~/.claude/projects/<proj>/<uuid>.jsonl) also
+        # contain `.claude`; when the local-agent wrapper probe fails, fall
+        # through to the stem-based native derivation below.
+
+    if path.suffix == ".jsonl":
+        project_dir_name = path.parent.name
+        session_id = path.stem
+    else:
+        project_dir_name = path.parent.name
+        session_id = path.name
+
+    if not project_dir_name or not session_id:
+        return None
+    return f"claude:{project_dir_name}:{session_id}"
+
+
+def _derive_local_agent_claude_session_key(path: Path) -> str | None:
+    """Recover the Claude local-agent session key from a nested transcript path."""
+    try:
+        session_dir = path.parents[3]
+    except IndexError:
+        return None
+
+    wrapper_path = session_dir.with_suffix(".json")
+    if not wrapper_path.is_file():
+        return None
+
+    # Deferred import to avoid a workbench↔capture cycle. We reach into two
+    # private helpers in `clawjournal.capture.discovery` so the workbench
+    # backfill derives exactly the same `session_key` the events-layer
+    # capture adapter writes. If those helpers are renamed, update this
+    # call site in lockstep or the derivation silently diverges.
+    from clawjournal.capture import discovery
+
+    wrapper = discovery._load_local_agent_wrapper(wrapper_path)
+    if wrapper is None:
+        return None
+    cli_session_id = wrapper.get("cliSessionId")
+    if not isinstance(cli_session_id, str) or cli_session_id != path.stem:
+        return None
+    workspace_key = discovery._workspace_key_from_wrapper(wrapper, session_dir)
+    return f"claude:{workspace_key}:{cli_session_id}"
+
+
+def _lookup_event_session_key(
+    conn: sqlite3.Connection, raw_source_path: Any
+) -> str | None:
+    if not isinstance(raw_source_path, str) or not raw_source_path.strip():
+        return None
+    row = conn.execute(
+        """
+        SELECT event_sessions.session_key
+          FROM event_sessions
+          JOIN events ON events.session_id = event_sessions.id
+         WHERE events.source_path = ?
+         ORDER BY events.id
+         LIMIT 1
+        """,
+        (raw_source_path,),
+    ).fetchone()
+    return None if row is None else str(row["session_key"])
+
+
+def backfill_session_keys(conn: sqlite3.Connection) -> int:
+    """Populate missing `sessions.session_key` values from events or path derivation."""
+    rows = conn.execute(
+        """
+        SELECT session_id, source, raw_source_path
+          FROM sessions
+         WHERE session_key IS NULL
+           AND source IN ('claude', 'codex', 'openclaw')
+        """
+    ).fetchall()
+    if not rows:
+        return 0
+
+    updates: list[tuple[str, str]] = []
+    for row in rows:
+        session_key = _lookup_event_session_key(
+            conn, row["raw_source_path"]
+        ) or _derive_session_key_from_source(
+            row["source"], row["raw_source_path"]
+        )
+        if session_key is not None:
+            updates.append((session_key, row["session_id"]))
+
+    if not updates:
+        return 0
+
+    with conn:
+        conn.executemany(
+            """
+            UPDATE sessions
+               SET session_key = ?
+             WHERE session_id = ?
+               AND session_key IS NULL
+            """,
+            updates,
+        )
+    return len(updates)
 
 
 def session_matches_excluded_projects(
@@ -1254,6 +1405,9 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
         if not project or not source:
             continue
 
+        session_key = _derive_session_key_from_source(
+            source, session.get("raw_source_path")
+        )
         stats = session.get("stats", {})
         duration = _compute_duration(session)
 
@@ -1281,7 +1435,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
             "ai_display_title, ai_task_type, ai_outcome_badge, "
             "ai_value_badges, ai_risk_badges, "
             "ai_effort_estimate, ai_summary, "
-            "share_id, parent_session_id, subagent_session_ids, "
+            "share_id, session_key, parent_session_id, subagent_session_ids, "
             "estimated_cost_usd, end_time "
             "FROM sessions WHERE session_id = ?",
             (session_id,),
@@ -1318,6 +1472,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
         preserved_ai_effort = existing["ai_effort_estimate"] if not is_new else None
         preserved_ai_summary = existing["ai_summary"] if not is_new else None
         preserved_share_id = existing["share_id"] if not is_new else None
+        preserved_session_key = existing["session_key"] if not is_new else None
         preserved_parent_session_id = existing["parent_session_id"] if not is_new else None
         preserved_subagent_session_ids = existing["subagent_session_ids"] if not is_new else None
 
@@ -1357,6 +1512,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 sensitivity_score, task_type,
                 files_touched, commands_run,
                 blob_path, raw_source_path,
+                session_key,
                 indexed_at, updated_at,
                 review_status,
                 selection_reason, reviewer_notes, reviewed_at,
@@ -1386,7 +1542,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 ?, ?,
                 ?, ?,
                 ?,
-                ?, ?, ?,
+                ?, ?, ?, ?,
                 ?, ?, ?,
                 ?, ?, ?,
                 ?, ?,
@@ -1426,6 +1582,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 commands_run = excluded.commands_run,
                 blob_path = excluded.blob_path,
                 raw_source_path = excluded.raw_source_path,
+                session_key = COALESCE(excluded.session_key, session_key),
                 updated_at = excluded.updated_at,
                 parent_session_id = COALESCE(excluded.parent_session_id, parent_session_id),
                 segment_index = excluded.segment_index,
@@ -1460,6 +1617,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 json.dumps(commands),
                 str(blob_path),
                 session.get("raw_source_path"),
+                session_key or preserved_session_key,
                 preserved_indexed_at,
                 now,
                 preserved_status,

--- a/tests/events/test_ingest.py
+++ b/tests/events/test_ingest.py
@@ -262,6 +262,54 @@ def test_native_and_local_agent_converge_on_one_event_session(monkeypatch, tmp_p
         conn.close()
 
 
+def test_ingest_backfills_workbench_session_key_from_subagent_directory(monkeypatch, tmp_path):
+    _patch_db(monkeypatch, tmp_path)
+    _patch_sources(monkeypatch, tmp_path)
+
+    session_dir = tmp_path / "claude" / "projects" / "demo-project" / "child"
+    child_file = session_dir / "subagents" / "agent-1.jsonl"
+    child_file.parent.mkdir(parents=True)
+    child_file.write_text(
+        json.dumps(
+            {
+                "type": "assistant",
+                "timestamp": "2026-04-20T10:00:00.000Z",
+                "message": {"content": [{"type": "text", "text": "Child trace"}]},
+            }
+        )
+        + "\n",
+        encoding="utf-8",
+    )
+
+    conn = open_index()
+    try:
+        conn.execute(
+            """
+            INSERT INTO sessions (
+                session_id, project, source, raw_source_path, indexed_at
+            ) VALUES (?, ?, ?, ?, ?)
+            """,
+            (
+                "legacy-child",
+                "claude:demo-project",
+                "claude",
+                str(session_dir),
+                "2026-04-20T09:59:00Z",
+            ),
+        )
+        conn.commit()
+
+        now = datetime.fromtimestamp(child_file.stat().st_mtime, tz=timezone.utc)
+        ingest_pending(conn, source_filter="claude", now=now)
+
+        row = conn.execute(
+            "SELECT session_key FROM sessions WHERE session_id = 'legacy-child'"
+        ).fetchone()
+        assert row["session_key"] == "claude:demo-project:child"
+    finally:
+        conn.close()
+
+
 def test_unparseable_line_stored_with_wrapper(monkeypatch, tmp_path):
     _patch_db(monkeypatch, tmp_path)
     _patch_sources(monkeypatch, tmp_path)

--- a/tests/parsing/test_parser.py
+++ b/tests/parsing/test_parser.py
@@ -768,6 +768,7 @@ class TestDiscoverProjects:
         assert sessions[0]["messages"][0]["role"] == "user"
         assert sessions[0]["messages"][1]["role"] == "assistant"
         assert sessions[0]["messages"][1]["tool_uses"][0]["tool"] == "exec_command"
+        assert sessions[0]["raw_source_path"] == str(session_file)
 
     def test_codex_thinking_not_duplicated(self, tmp_path, monkeypatch, mock_anonymizer):
         """Reasoning from response_item and agent_reasoning event_msg should not duplicate."""
@@ -1834,6 +1835,7 @@ class TestDiscoverOpenclawProjects:
         assert sessions[0]["source"] == "openclaw"
         assert sessions[0]["project"] == "openclaw:myapp"
         assert sessions[0]["messages"][0]["content"] == "Hello"
+        assert sessions[0]["raw_source_path"] == str(sessions_dir / "sess-1.jsonl")
 
     def test_multiple_agents_same_cwd(self, tmp_path, monkeypatch, mock_anonymizer):
         """Sessions from different agents but same cwd should be grouped."""

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -8,6 +8,7 @@ import pytest
 from clawjournal.workbench.index import (
     _migrate_bundles_to_shares,
     add_policy,
+    backfill_session_keys,
     create_share,
     get_effective_share_settings,
     get_dashboard_analytics,
@@ -246,6 +247,26 @@ class TestUpsertSessions:
             "SELECT session_key FROM sessions WHERE session_id = 'sess-1'"
         ).fetchone()
         assert row["session_key"] == expected
+
+    def test_backfill_session_keys_on_fresh_db_without_events_ingest(self, index_conn):
+        """Calling backfill before any events ingest must not crash on missing
+        `event_sessions` / `events` tables — it should ensure them and fall
+        through to path derivation.
+        """
+        index_conn.execute(
+            "INSERT INTO sessions (session_id, project, source, raw_source_path, indexed_at) "
+            "VALUES ('legacy', 'p', 'claude', "
+            "'/home/u/.claude/projects/p/uuid1.jsonl', '2026-01-01T00:00:00Z')"
+        )
+        index_conn.commit()
+
+        updated = backfill_session_keys(index_conn)
+        assert updated == 1
+
+        row = index_conn.execute(
+            "SELECT session_key FROM sessions WHERE session_id = 'legacy'"
+        ).fetchone()
+        assert row["session_key"] == "claude:p:uuid1"
 
     def test_upsert_derives_local_agent_session_key_from_wrapper(self, index_conn, tmp_path):
         workspace_dir = (

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -213,13 +213,71 @@ class TestUpsertSessions:
         """Sessions without provenance fields should have NULL values."""
         upsert_sessions(index_conn, [_make_session()])
         row = index_conn.execute(
-            "SELECT raw_source_path, client_origin, runtime_channel, outer_session_id "
+            "SELECT raw_source_path, session_key, client_origin, runtime_channel, outer_session_id "
             "FROM sessions WHERE session_id = 'sess-1'"
         ).fetchone()
         assert row["raw_source_path"] is None
+        assert row["session_key"] is None
         assert row["client_origin"] is None
         assert row["runtime_channel"] is None
         assert row["outer_session_id"] is None
+
+    @pytest.mark.parametrize(
+        ("source", "raw_source_path", "expected"),
+        [
+            ("claude", "/tmp/claude/projects/demo-project/sess-1.jsonl", "claude:demo-project:sess-1"),
+            ("claude", "/tmp/claude/projects/demo-project/subagent-only", "claude:demo-project:subagent-only"),
+            # Real production native path: ~/.claude/projects/<proj>/<uuid>.jsonl.
+            # `.claude` is in path.parts but no local-agent wrapper exists at
+            # parents[3].json — must fall through to native stem derivation.
+            ("claude", "/Users/alice/.claude/projects/demo-project/sess-1.jsonl", "claude:demo-project:sess-1"),
+            ("codex", "/tmp/codex/sessions/2025/01/02/run.jsonl", "codex:/tmp/codex/sessions/2025/01/02/run.jsonl"),
+            ("openclaw", "/tmp/openclaw/agents/a/sessions/demo.jsonl", "openclaw:/tmp/openclaw/agents/a/sessions/demo.jsonl"),
+        ],
+    )
+    def test_upsert_derives_session_key_from_provenance(
+        self, index_conn, source, raw_source_path, expected
+    ):
+        session = _make_session(source=source, project=f"{source}:demo")
+        session["raw_source_path"] = raw_source_path
+        upsert_sessions(index_conn, [session])
+
+        row = index_conn.execute(
+            "SELECT session_key FROM sessions WHERE session_id = 'sess-1'"
+        ).fetchone()
+        assert row["session_key"] == expected
+
+    def test_upsert_derives_local_agent_session_key_from_wrapper(self, index_conn, tmp_path):
+        workspace_dir = (
+            tmp_path
+            / "local_agent"
+            / "11111111-2222-3333-4444-555555555555"
+            / "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+        )
+        workspace_dir.mkdir(parents=True)
+        wrapper = workspace_dir / "local_demo.json"
+        wrapper.write_text(
+            json.dumps(
+                {
+                    "cliSessionId": "cli-42",
+                    "sessionId": "sess-42",
+                    "processName": "demo",
+                    "userSelectedFolders": ["/Users/me/ws"],
+                }
+            )
+        )
+        transcript = wrapper.with_suffix("") / ".claude" / "projects" / "-sessions-demo" / "cli-42.jsonl"
+        transcript.parent.mkdir(parents=True)
+        transcript.write_text("{}\n")
+
+        session = _make_session(project="claude:ws")
+        session["raw_source_path"] = str(transcript)
+        upsert_sessions(index_conn, [session])
+
+        row = index_conn.execute(
+            "SELECT session_key FROM sessions WHERE session_id = 'sess-1'"
+        ).fetchone()
+        assert row["session_key"] == "claude:-Users-me-ws:cli-42"
 
     def test_link_subagent_hierarchy_skips_conflicting_existing_parent(self, index_conn):
         parent_one = _make_session(

--- a/tests/workbench/test_security_migration.py
+++ b/tests/workbench/test_security_migration.py
@@ -16,7 +16,7 @@ from clawjournal.paths import (
 )
 from clawjournal.workbench.index import (
     BACKFILL_WINDOW,
-    SECURITY_SCHEMA_VERSION,
+    WORKBENCH_SCHEMA_VERSION,
     open_index,
     upsert_sessions,
 )
@@ -76,11 +76,21 @@ class TestFreshInstall:
         finally:
             conn.close()
 
+    def test_adds_session_key_bridge_column_and_index(self, fresh_db):
+        conn = open_index()
+        try:
+            cols = _columns(conn, "sessions")
+            assert "session_key" in cols
+            indexes = _indexes(conn, "sessions")
+            assert "idx_sessions_session_key" in indexes
+        finally:
+            conn.close()
+
     def test_advances_schema_version(self, fresh_db):
         conn = open_index()
         try:
             version = conn.execute("PRAGMA user_version").fetchone()[0]
-            assert version == SECURITY_SCHEMA_VERSION
+            assert version == WORKBENCH_SCHEMA_VERSION
         finally:
             conn.close()
 
@@ -183,7 +193,7 @@ class TestUpsertHoldState:
 
 
 class TestLegacyMigration:
-    """Exercise the v1 → v2 migration path on a pre-security-refactor DB."""
+    """Exercise the v1 → v3 migration path on a pre-security-refactor DB."""
 
     def _build_v1_db(self, db_path, session_rows):
         """Create a minimal pre-security-refactor DB at PRAGMA user_version=1.
@@ -282,7 +292,80 @@ class TestLegacyMigration:
             ).fetchone()[0]
             assert history_count == 1
             version = conn2.execute("PRAGMA user_version").fetchone()[0]
-            assert version == SECURITY_SCHEMA_VERSION
+            assert version == WORKBENCH_SCHEMA_VERSION
+        finally:
+            conn2.close()
+
+
+class TestSessionIdentityBridgeMigration:
+    def _build_v2_db(self, db_path):
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                session_id         TEXT PRIMARY KEY,
+                project            TEXT NOT NULL,
+                source             TEXT NOT NULL,
+                start_time         TEXT,
+                end_time           TEXT,
+                review_status      TEXT DEFAULT 'new',
+                indexed_at         TEXT NOT NULL,
+                hold_state         TEXT DEFAULT 'auto_redacted',
+                embargo_until      TEXT,
+                findings_revision  TEXT,
+                findings_backfill_needed INTEGER
+            );
+            CREATE TABLE session_hold_history (
+                history_id     TEXT PRIMARY KEY,
+                session_id     TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+                from_state     TEXT,
+                to_state       TEXT NOT NULL,
+                embargo_until  TEXT,
+                changed_by     TEXT NOT NULL,
+                changed_at     TEXT NOT NULL,
+                reason         TEXT
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions (session_id, project, source, indexed_at) "
+            "VALUES ('s1', 'p', 'claude', '2025-01-01T00:00:00+00:00')"
+        )
+        conn.execute("PRAGMA user_version = 2")
+        conn.commit()
+        conn.close()
+
+    def test_v2_db_gains_session_key_bridge(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "index.db"
+        self._build_v2_db(db_path)
+        monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", db_path)
+        monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+
+        conn = open_index()
+        try:
+            cols = _columns(conn, "sessions")
+            assert "session_key" in cols
+            indexes = _indexes(conn, "sessions")
+            assert "idx_sessions_session_key" in indexes
+            version = conn.execute("PRAGMA user_version").fetchone()[0]
+            assert version == WORKBENCH_SCHEMA_VERSION
+        finally:
+            conn.close()
+
+    def test_v2_bridge_migration_is_idempotent(self, tmp_path, monkeypatch):
+        db_path = tmp_path / "index.db"
+        self._build_v2_db(db_path)
+        monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", db_path)
+        monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+
+        conn1 = open_index()
+        conn1.close()
+        conn2 = open_index()
+        try:
+            indexes = _indexes(conn2, "sessions")
+            assert "idx_sessions_session_key" in indexes
+            version = conn2.execute("PRAGMA user_version").fetchone()[0]
+            assert version == WORKBENCH_SCHEMA_VERSION
         finally:
             conn2.close()
 


### PR DESCRIPTION
## Summary

- Lands [ADR-001](docs/plans/phase-1/ADR-001-session-identity.md) Step 1 + Step 2: adds `sessions.session_key` (gated v2→v3 migration, partial index) and backfills it from `raw_source_path` on every `events ingest`.
- Documents the `session_key` grammar and stability contract in `clawjournal/events/types.py` so the contract lives next to the code that validates events, including the ADR-001 Open Question #1 rename caveat.
- Unblocks phase-1 tickets 06 (timeline viewer), 07 (replay export), 09 (encrypted HTML share), 10 (aggregation), and 11 (cross-session FTS) — all of which reference `event_sessions.session_key` as the canonical public session identifier.

Workbench legacy `sessions.session_id` is untouched; the new `session_key` column is an additive bridge. No existing workbench flow (review, findings, share, hold-state) changes behavior.

## Notable bits

- **Native-claude derivation fix**: `.claude` appears in both local-agent and native paths. The local-agent wrapper probe returns `None` for native paths; the derivation now falls through to stem-based native derivation instead of returning `None`. Test coverage added for `/Users/<user>/.claude/projects/...`.
- **Parser change**: codex and openclaw sessions now carry `raw_source_path` (previously only claude did), so the workbench can derive a `session_key` for all three sources.
- **Cross-module coupling**: `workbench.index` reaches into two private helpers in `capture.discovery` (`_load_local_agent_wrapper`, `_workspace_key_from_wrapper`) to derive the exact same key the capture adapter writes. Comments added at both ends so renames update both sites.

## Test plan

- [x] `pytest tests/workbench/test_security_migration.py tests/workbench/test_index.py tests/events/test_ingest.py tests/parsing/test_parser.py` — covers migration idempotency, v1→v3 and v2→v3 paths, derivation for all four sources (including the new native-claude fallthrough case), and subagent-directory backfill via the events join.
- [x] Full suite (`pytest --ignore=tests/workbench/test_trace_note_*.py`) — 1392 passed. The three `test_trace_note_*` collection errors pre-exist on `main` and are unrelated to this change.

## Follow-ups (not in scope)

- 06 session timeline viewer — fresh PR on top of this one.
- ADR-001 Step 4 (formal FK on `sessions.session_key`) — deferred until backfill completeness is observed in real corpora.
- ADR-001 Open Question #1 — grammar change to decouple `project_dir_name` from the claude key so renames don't mint a new key. Requires a follow-up ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)