### PR TITLE
feat(workbench): session timeline viewer on /timeline/<session_key>

### DIFF
--- a/clawjournal/events/view.py
+++ b/clawjournal/events/view.py
@@ -100,6 +100,9 @@ class CanonicalEvent:
     payload_json: str | None
     raw_ref: tuple[str, int, int] | None
     origin: str | None
+    event_id: int | None = None
+    session_id: int | None = None
+    ingested_at: str | None = None
 
 
 class CapabilityState(NamedTuple):
@@ -244,8 +247,8 @@ def _backfill_override_write_seq(conn: sqlite3.Connection) -> None:
 
 
 _BASE_SELECT = """
-SELECT type, event_key, event_at, source, confidence, lossiness,
-       raw_json, source_path, source_offset, seq
+SELECT id, session_id, type, event_key, event_at, ingested_at,
+       source, confidence, lossiness, raw_json, source_path, source_offset, seq
   FROM events
  WHERE session_id = ?
 """
@@ -254,7 +257,7 @@ _BASE_ORDER = " ORDER BY event_at IS NULL, event_at, source_path, source_offset,
 
 
 _OVERRIDE_SELECT = """
-SELECT event_key, type, source, confidence, lossiness,
+SELECT session_id, event_key, type, source, confidence, lossiness,
        event_at, payload_json, origin
   FROM event_overrides
  WHERE session_id = ?
@@ -339,6 +342,9 @@ def _canonical_from_base(base: dict) -> CanonicalEvent:
         payload_json=None,
         raw_ref=(base["source_path"], base["source_offset"], base["seq"]),
         origin=None,
+        event_id=base["id"],
+        session_id=base["session_id"],
+        ingested_at=base["ingested_at"],
     )
 
 
@@ -354,6 +360,9 @@ def _canonical_override_wins(override: dict, base: dict) -> CanonicalEvent:
         payload_json=override["payload_json"],
         raw_ref=(base["source_path"], base["source_offset"], base["seq"]),
         origin=override["origin"],
+        event_id=base["id"],
+        session_id=base["session_id"],
+        ingested_at=base["ingested_at"],
     )
 
 
@@ -369,6 +378,9 @@ def _canonical_hook_only(override: dict) -> CanonicalEvent:
         payload_json=override["payload_json"],
         raw_ref=None,
         origin=override["origin"],
+        event_id=None,
+        session_id=override["session_id"],
+        ingested_at=None,
     )
 
 

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -20,7 +20,7 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qs, urlparse
+from urllib.parse import parse_qs, unquote, urlparse
 
 from .. import __version__
 from ..redaction.anonymizer import Anonymizer
@@ -52,6 +52,12 @@ from .index import (
     search_fts,
     update_session,
     upsert_sessions,
+)
+from .timeline import (
+    canonical_session_path,
+    load_timeline_page,
+    render_not_found_html,
+    render_timeline_html,
 )
 from ..parsing.parser import (
     AIDER_SOURCE,
@@ -966,6 +972,11 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             self._handle_list_allowlist()
         elif path == "/api/findings/allowlist":
             self._handle_list_findings_allowlist()
+        elif path.startswith("/timeline/"):
+            if self._handle_session_timeline(path):
+                return
+            self._serve_static(parsed.path)
+            return
         else:
             self._serve_static(parsed.path)
 
@@ -2067,6 +2078,67 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             self.wfile.write(data)
         except OSError:
             self.send_error(404)
+
+    def _handle_session_timeline(self, path: str) -> bool:
+        requested = unquote(path[len("/timeline/"):])
+        if not requested:
+            return False
+
+        conn = open_index()
+        try:
+            legacy_row = conn.execute(
+                "SELECT session_key FROM sessions WHERE session_id = ? LIMIT 1",
+                (requested,),
+            ).fetchone()
+            if legacy_row is not None:
+                session_key = legacy_row["session_key"]
+                if session_key:
+                    self._redirect(canonical_session_path(str(session_key)))
+                    return True
+                # Legacy workbench row exists but has no `session_key`
+                # yet — most likely a pre-ADR-001 session that hasn't been
+                # re-scanned through `events ingest`. Surface the
+                # pending-ingest page with a 404 rather than falling
+                # through to the SPA shell (the SPA has no /timeline/
+                # route).
+                body = render_not_found_html(requested).encode("utf-8")
+                self.send_response(404)
+                self.send_header("Content-Type", "text/html; charset=utf-8")
+                self.send_header("Content-Length", str(len(body)))
+                self.end_headers()
+                self.wfile.write(body)
+                return True
+
+            page = load_timeline_page(conn, requested)
+        finally:
+            conn.close()
+
+        if page.root is None and page.workbench_row is None:
+            body = render_not_found_html(requested).encode("utf-8")
+            self.send_response(404)
+            self.send_header("Content-Type", "text/html; charset=utf-8")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+            return True
+
+        if page.redirect_session_key:
+            self._redirect(canonical_session_path(page.redirect_session_key))
+            return True
+
+        body = render_timeline_html(page).encode("utf-8")
+        self.send_response(200)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+        return True
+
+    def _redirect(self, location: str) -> None:
+        self.send_response(302)
+        self.send_header("Location", location)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
 
     def _inject_api_token(self, data: bytes) -> bytes:
         # Inject the per-install API token so same-origin frontend fetches

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -303,12 +303,51 @@ class Scanner:
 _LOCALHOST_ORIGINS = re.compile(r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$")
 
 
+_API_TOKEN_COOKIE_NAME = "clawjournal_token"
+
+
 def _cors_origin(handler: BaseHTTPRequestHandler) -> str | None:
     """Return the request Origin if it's a localhost address, else None."""
     origin = handler.headers.get("Origin", "")
     if _LOCALHOST_ORIGINS.match(origin):
         return origin
     return None
+
+
+def _parse_cookie_token(cookie_header: str | None) -> str | None:
+    """Extract the per-install api_token from the `Cookie` request header.
+
+    Returns None when the header is absent, unparseable, or does not
+    include the expected cookie. Never raises — malformed cookies just
+    fall through to the 401 path.
+    """
+    if not cookie_header:
+        return None
+    try:
+        from http.cookies import SimpleCookie
+
+        jar = SimpleCookie()
+        jar.load(cookie_header)
+    except Exception:
+        return None
+    morsel = jar.get(_API_TOKEN_COOKIE_NAME)
+    if morsel is None:
+        return None
+    return morsel.value or None
+
+
+def _api_token_cookie_header(token: str) -> str:
+    """Build the `Set-Cookie` value that carries the api_token.
+
+    HttpOnly prevents XSS from reading the token (stricter than the
+    existing `window.__CLAWJOURNAL_API_TOKEN__` injection, which we keep
+    for the SPA's fetch-based API access). SameSite=Strict prevents
+    cross-site navigation from leaking the cookie. No Secure flag — the
+    daemon is loopback HTTP only.
+    """
+    return (
+        f"{_API_TOKEN_COOKIE_NAME}={token}; Path=/; HttpOnly; SameSite=Strict"
+    )
 
 
 def _json_response(handler: BaseHTTPRequestHandler, data: Any, status: int = 200) -> None:
@@ -837,11 +876,11 @@ def upload_share(
 class WorkbenchHandler(BaseHTTPRequestHandler):
     """HTTP request handler for the workbench API + static files.
 
-    Auth: every `/api/*` request requires an `Authorization: Bearer <token>`
-    header where `<token>` matches `~/.clawjournal/api_token`. Missing or
-    wrong tokens get a 401 with an empty body — no hint about what was
-    wrong. Non-`/api/*` paths (static files, health checks) bypass auth.
-    See docs/security-refactor.md §Daemon API surface.
+    Auth: every `/api/*` and `/timeline/*` request requires an
+    `Authorization: Bearer <token>` header where `<token>` matches
+    `~/.clawjournal/api_token`. Missing or wrong tokens get a 401 with
+    an empty body — no hint about what was wrong. Static/SPA shell paths
+    bypass auth. See docs/security-refactor.md §Daemon API surface.
 
     Access logs go to `logger.debug` and receive only the format string
     plus the request line; bodies, query strings, and the `Authorization`
@@ -855,18 +894,26 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         logger.debug(format, *args)
 
     def _check_api_auth(self) -> bool:
-        """Return True if the request is authorized for the API.
+        """Return True if the request is authorized for protected routes.
 
-        Non-`/api/*` routes bypass the check entirely (static files,
-        SPA fallback). Otherwise compare the bearer token against the
-        per-install `api_token`. Uses `secrets.compare_digest` to keep
-        the comparison constant-time.
+        Static assets and the SPA shell bypass auth. Transcript-bearing
+        routes under `/api/*` and `/timeline/*` require the per-install
+        `api_token`, supplied via either the `Authorization: Bearer`
+        header (programmatic clients) or a `clawjournal_token` cookie
+        (browser navigations). The cookie is set by `_serve_static` on
+        every SPA HTML response so a user who has opened the workbench
+        can follow `/timeline/*` links with no extra handling. Uses
+        `secrets.compare_digest` for constant-time comparison.
         """
         from pathlib import Path as _Path
         import secrets as _secrets
 
         parsed = urlparse(self.path)
-        if not parsed.path.startswith("/api/"):
+        if not (
+            parsed.path.startswith("/api/")
+            or parsed.path == "/timeline"
+            or parsed.path.startswith("/timeline/")
+        ):
             return True
 
         try:
@@ -878,10 +925,18 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             return False
 
         header = self.headers.get("Authorization") or ""
-        if not header.startswith("Bearer "):
-            return False
-        supplied = header[len("Bearer "):].strip()
-        return _secrets.compare_digest(supplied, expected)
+        if header.startswith("Bearer "):
+            supplied = header[len("Bearer "):].strip()
+            if _secrets.compare_digest(supplied, expected):
+                return True
+
+        cookie_token = _parse_cookie_token(self.headers.get("Cookie"))
+        if cookie_token is not None and _secrets.compare_digest(
+            cookie_token, expected
+        ):
+            return True
+
+        return False
 
     def _reject_unauthenticated(self) -> None:
         """Send a 401 with no body — never reveal what the auth state is."""
@@ -2074,10 +2129,31 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             self.send_response(200)
             self.send_header("Content-Type", content_type)
             self.send_header("Content-Length", str(len(data)))
+            if content_type == "text/html":
+                self._maybe_set_api_token_cookie()
             self.end_headers()
             self.wfile.write(data)
         except OSError:
             self.send_error(404)
+
+    def _maybe_set_api_token_cookie(self) -> None:
+        """Set the `clawjournal_token` cookie on SPA HTML responses.
+
+        The cookie is what lets a browser that has opened the workbench
+        follow `/timeline/<key>` links without manually attaching an
+        `Authorization` header. Silent fall-through on any failure —
+        worst case, the browser falls back to the existing 401 flow.
+        """
+        try:
+            from pathlib import Path as _Path
+            from ..paths import ensure_api_token
+            from .index import INDEX_DB as _INDEX_DB
+
+            token = ensure_api_token(_Path(str(_INDEX_DB)).parent)
+        except Exception:
+            logger.exception("Could not resolve api_token for cookie set")
+            return
+        self.send_header("Set-Cookie", _api_token_cookie_header(token))
 
     def _handle_session_timeline(self, path: str) -> bool:
         requested = unquote(path[len("/timeline/"):])
@@ -2196,6 +2272,7 @@ npm run build</pre>
         self.send_response(200)
         self.send_header("Content-Type", "text/html")
         self.send_header("Content-Length", str(len(data)))
+        self._maybe_set_api_token_cookie()
         self.end_headers()
         self.wfile.write(data)
 

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -342,11 +342,12 @@ def _api_token_cookie_header(token: str) -> str:
     HttpOnly prevents XSS from reading the token (stricter than the
     existing `window.__CLAWJOURNAL_API_TOKEN__` injection, which we keep
     for the SPA's fetch-based API access). SameSite=Strict prevents
-    cross-site navigation from leaking the cookie. No Secure flag — the
-    daemon is loopback HTTP only.
+    cross-site navigation from leaking the cookie. The cookie is scoped
+    to `/timeline` so it cannot authorize the broader `/api/*` surface.
+    No Secure flag — the daemon is loopback HTTP only.
     """
     return (
-        f"{_API_TOKEN_COOKIE_NAME}={token}; Path=/; HttpOnly; SameSite=Strict"
+        f"{_API_TOKEN_COOKIE_NAME}={token}; Path=/timeline; HttpOnly; SameSite=Strict"
     )
 
 
@@ -876,11 +877,13 @@ def upload_share(
 class WorkbenchHandler(BaseHTTPRequestHandler):
     """HTTP request handler for the workbench API + static files.
 
-    Auth: every `/api/*` and `/timeline/*` request requires an
-    `Authorization: Bearer <token>` header where `<token>` matches
-    `~/.clawjournal/api_token`. Missing or wrong tokens get a 401 with
-    an empty body — no hint about what was wrong. Static/SPA shell paths
-    bypass auth. See docs/security-refactor.md §Daemon API surface.
+    Auth: every `/api/*` request requires an `Authorization: Bearer <token>`
+    header where `<token>` matches `~/.clawjournal/api_token`. `/timeline/*`
+    accepts the same bearer token and, for browser navigations only, a
+    `clawjournal_token` cookie scoped to `/timeline`. Missing or wrong
+    credentials get a 401 with an empty body — no hint about what was wrong.
+    Static/SPA shell paths bypass auth. See docs/security-refactor.md §Daemon
+    API surface.
 
     Access logs go to `logger.debug` and receive only the format string
     plus the request line; bodies, query strings, and the `Authorization`
@@ -898,22 +901,23 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
 
         Static assets and the SPA shell bypass auth. Transcript-bearing
         routes under `/api/*` and `/timeline/*` require the per-install
-        `api_token`, supplied via either the `Authorization: Bearer`
-        header (programmatic clients) or a `clawjournal_token` cookie
-        (browser navigations). The cookie is set by `_serve_static` on
-        every SPA HTML response so a user who has opened the workbench
-        can follow `/timeline/*` links with no extra handling. Uses
-        `secrets.compare_digest` for constant-time comparison.
+        `api_token`. `/api/*` accepts only the `Authorization: Bearer`
+        header; `/timeline/*` accepts that header plus a
+        `clawjournal_token` cookie for browser navigations. The cookie is
+        set by `_serve_static` on SPA HTML responses so a user who has
+        opened the workbench can follow `/timeline/*` links with no extra
+        handling. Uses `secrets.compare_digest` for constant-time
+        comparison.
         """
         from pathlib import Path as _Path
         import secrets as _secrets
 
         parsed = urlparse(self.path)
-        if not (
-            parsed.path.startswith("/api/")
-            or parsed.path == "/timeline"
-            or parsed.path.startswith("/timeline/")
-        ):
+        is_api_path = parsed.path.startswith("/api/")
+        is_timeline_path = (
+            parsed.path == "/timeline" or parsed.path.startswith("/timeline/")
+        )
+        if not (is_api_path or is_timeline_path):
             return True
 
         try:
@@ -930,11 +934,12 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             if _secrets.compare_digest(supplied, expected):
                 return True
 
-        cookie_token = _parse_cookie_token(self.headers.get("Cookie"))
-        if cookie_token is not None and _secrets.compare_digest(
-            cookie_token, expected
-        ):
-            return True
+        if is_timeline_path:
+            cookie_token = _parse_cookie_token(self.headers.get("Cookie"))
+            if cookie_token is not None and _secrets.compare_digest(
+                cookie_token, expected
+            ):
+                return True
 
         return False
 
@@ -2141,8 +2146,10 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
 
         The cookie is what lets a browser that has opened the workbench
         follow `/timeline/<key>` links without manually attaching an
-        `Authorization` header. Silent fall-through on any failure —
-        worst case, the browser falls back to the existing 401 flow.
+        `Authorization` header. The cookie is intentionally scoped to
+        `/timeline` so it cannot unlock the wider `/api/*` surface.
+        Silent fall-through on any failure — worst case, the browser
+        falls back to the existing 401 flow.
         """
         try:
             from pathlib import Path as _Path

--- a/clawjournal/workbench/timeline.py
+++ b/clawjournal/workbench/timeline.py
@@ -531,9 +531,18 @@ def _resolve_root_session_key(conn: sqlite3.Connection, session_key: str) -> str
     while current_key not in seen:
         seen.add(current_key)
         row = _load_event_session(conn, current_key)
-        if row is None or row["parent_session_key"] is None:
+        if row is None:
+            return session_key
+        parent_key = row["parent_session_key"]
+        if parent_key is None:
             return current_key
-        current_key = str(row["parent_session_key"])
+        parent_row = _load_event_session(conn, str(parent_key))
+        if parent_row is None:
+            # Child rows can arrive before their parent transcript has been
+            # ingested. Keep rendering the concrete child session we do have
+            # instead of walking to a missing root and crashing.
+            return current_key
+        current_key = str(parent_row["session_key"])
     return session_key
 
 

--- a/clawjournal/workbench/timeline.py
+++ b/clawjournal/workbench/timeline.py
@@ -572,7 +572,11 @@ def _load_session_tree(
                     anchor_id=(
                         f"event-{event.event_id}"
                         if event.event_id is not None
-                        else f"event-key-{_anchor_slug(event.event_key or event.type)}"
+                        else (
+                            "event-key-"
+                            f"{_anchor_slug(session_key)}-"
+                            f"{_anchor_slug(event.event_key or event.type)}"
+                        )
                     ),
                     turn_number=event.turn_number,
                     type=event.type,
@@ -649,7 +653,11 @@ def _load_session_tree(
 def _load_events(conn: sqlite3.Connection, session_id: int) -> list[TimelineEvent]:
     events: list[TimelineEvent] = []
     turn_number = 0
-    for event in canonical_events(conn, session_id):
+    canonical = sorted(
+        canonical_events(conn, session_id),
+        key=_timeline_event_sort_key,
+    )
+    for event in canonical:
         if event.type == "user_message":
             turn_number += 1
         events.append(
@@ -675,6 +683,33 @@ def _load_events(conn: sqlite3.Connection, session_id: int) -> list[TimelineEven
             )
         )
     return events
+
+
+def _timeline_event_sort_key(event) -> tuple[Any, ...]:
+    """Restore chronological order before assigning timeline turns.
+
+    `canonical_events()` yields base rows in canonical vendor order and then
+    appends hook-only overrides whose event_key never appeared on a base row.
+    The timeline renderer needs a single chronological stream so early
+    hook-only events (for example a prompt captured only by hooks) do not get
+    shoved after later vendor rows and distort turn numbering.
+    """
+    source_path = ""
+    source_offset = -1
+    seq = -1
+    if event.raw_ref is not None:
+        source_path, source_offset, seq = event.raw_ref
+    return (
+        event.event_at is None,
+        event.event_at or "",
+        event.event_id is None,
+        event.event_id if event.event_id is not None else 2**63 - 1,
+        source_path,
+        source_offset,
+        seq,
+        event.event_key or "",
+        event.type,
+    )
 
 
 def _load_coverage(conn: sqlite3.Connection, session_id: int) -> list[CoverageBucket]:

--- a/clawjournal/workbench/timeline.py
+++ b/clawjournal/workbench/timeline.py
@@ -1,0 +1,1061 @@
+"""Server-rendered session timeline view for phase-1 plan 06."""
+
+from __future__ import annotations
+
+import html
+import json
+import re
+import sqlite3
+from dataclasses import dataclass
+from typing import Any
+from urllib.parse import quote
+
+from clawjournal.events.cost.schema import ensure_cost_schema
+from clawjournal.events.incidents.schema import ensure_incidents_schema
+from clawjournal.events.schema import ensure_schema as ensure_events_schema
+from clawjournal.events.view import canonical_events, capability_join, ensure_view_schema
+
+_WHITESPACE_RE = re.compile(r"\s+")
+_SUMMARY_KEYS = (
+    "command",
+    "text",
+    "content",
+    "output",
+    "stderr",
+    "stdout",
+    "message",
+    "name",
+    "tool_name",
+    "arguments",
+)
+
+
+@dataclass(frozen=True)
+class TimelineEvent:
+    event_id: int | None
+    anchor_id: str
+    turn_number: int
+    type: str
+    event_key: str | None
+    event_at: str | None
+    ingested_at: str | None
+    source: str
+    confidence: str
+    lossiness: str
+    summary: str
+    raw_ref: tuple[str, int, int] | None
+    origin: str | None
+    raw_excerpt: str | None
+    payload_excerpt: str | None
+    token_usage: dict[str, Any] | None
+    anomalies: tuple[dict[str, Any], ...]
+    incidents: tuple[dict[str, Any], ...]
+
+
+@dataclass(frozen=True)
+class TimelineTurn:
+    number: int
+    label: str
+    events: tuple[TimelineEvent, ...]
+
+
+@dataclass(frozen=True)
+class CoverageBucket:
+    state: str
+    label: str
+    event_types: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class TimelineSession:
+    session_key: str
+    client: str
+    status: str
+    started_at: str | None
+    ended_at: str | None
+    parent_session_key: str | None
+    title: str
+    project: str | None
+    model: str | None
+    turns: tuple[TimelineTurn, ...]
+    direct_event_count: int
+    lossy_event_count: int
+    low_confidence_count: int
+    coverage: tuple[CoverageBucket, ...]
+    session_anomalies: tuple[dict[str, Any], ...]
+    children: tuple["TimelineSession", ...]
+
+
+@dataclass(frozen=True)
+class TimelinePage:
+    requested_session_key: str
+    canonical_session_key: str | None
+    redirect_session_key: str | None
+    root: TimelineSession | None
+    workbench_row: dict[str, Any] | None
+
+
+def load_timeline_page(
+    conn: sqlite3.Connection, requested_session_key: str
+) -> TimelinePage:
+    """Load a full parent-rooted timeline tree for `requested_session_key`."""
+    ensure_events_schema(conn)
+    ensure_view_schema(conn)
+    ensure_cost_schema(conn)
+    ensure_incidents_schema(conn)
+
+    event_session = _load_event_session(conn, requested_session_key)
+    workbench_row = _load_workbench_session(conn, requested_session_key)
+    if event_session is None:
+        return TimelinePage(
+            requested_session_key=requested_session_key,
+            canonical_session_key=(
+                requested_session_key if workbench_row is not None else None
+            ),
+            redirect_session_key=None,
+            root=None,
+            workbench_row=workbench_row,
+        )
+
+    root_key = _resolve_root_session_key(conn, requested_session_key)
+    return TimelinePage(
+        requested_session_key=requested_session_key,
+        canonical_session_key=root_key,
+        redirect_session_key=root_key if root_key != requested_session_key else None,
+        root=_load_session_tree(conn, root_key, set()),
+        workbench_row=_load_workbench_session(conn, root_key),
+    )
+
+
+def render_timeline_html(page: TimelinePage) -> str:
+    """Render a full standalone HTML page for a timeline request."""
+    workbench = page.workbench_row or {}
+    title = (
+        (page.root.title if page.root is not None else None)
+        or workbench.get("ai_display_title")
+        or workbench.get("display_title")
+        or page.canonical_session_key
+        or page.requested_session_key
+    )
+    body = (
+        _render_timeline_page(page)
+        if page.root is not None
+        else _render_pending_ingest_page(page)
+    )
+    canonical = (
+        f"clawjournal://session/{page.canonical_session_key}"
+        if page.canonical_session_key
+        else ""
+    )
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>{_h(title)} · Session Timeline</title>
+<style>
+:root {{
+  color-scheme: light;
+  --bg: #f5efe5;
+  --panel: #fffdf8;
+  --panel-strong: #fff7eb;
+  --ink: #1b1f1f;
+  --muted: #5d5d57;
+  --line: #ddd1bf;
+  --direct: #0f766e;
+  --lossy: #b45309;
+  --low: #92400e;
+  --missing: #9f1239;
+  --present: #166534;
+  --shadow: 0 16px 40px rgba(56, 39, 15, 0.08);
+}}
+* {{ box-sizing: border-box; }}
+body {{
+  margin: 0;
+  font-family: Georgia, "Iowan Old Style", "Palatino Linotype", serif;
+  background:
+    radial-gradient(circle at top left, rgba(245, 158, 11, 0.14), transparent 28rem),
+    linear-gradient(180deg, #fcfaf4 0%, var(--bg) 100%);
+  color: var(--ink);
+}}
+a {{ color: inherit; }}
+main {{
+  max-width: 1100px;
+  margin: 0 auto;
+  padding: 32px 20px 80px;
+}}
+.crumb {{
+  display: inline-block;
+  margin-bottom: 18px;
+  font-size: 0.94rem;
+  color: var(--muted);
+  text-decoration: none;
+}}
+.hero, .session, .turn, .event, .pending {{
+  background: var(--panel);
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow);
+}}
+.hero {{
+  padding: 24px;
+  border-radius: 22px;
+  margin-bottom: 24px;
+}}
+.hero h1 {{
+  margin: 0 0 8px;
+  font-size: clamp(1.8rem, 2vw + 1rem, 3rem);
+}}
+.lede {{
+  margin: 0 0 18px;
+  color: var(--muted);
+  max-width: 60rem;
+}}
+.meta-row, .coverage-row, .badge-row {{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}}
+.pill {{
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: #f9f4ea;
+  font-size: 0.88rem;
+  line-height: 1.1;
+}}
+.pill--direct {{
+  border-color: rgba(15, 118, 110, 0.35);
+  background: rgba(15, 118, 110, 0.11);
+  color: var(--direct);
+}}
+.pill--lossy {{
+  border-color: rgba(180, 83, 9, 0.3);
+  background: rgba(245, 158, 11, 0.16);
+  color: var(--lossy);
+}}
+.pill--low {{
+  border-color: rgba(146, 64, 14, 0.28);
+  background: rgba(251, 191, 36, 0.18);
+  color: var(--low);
+}}
+.pill--missing {{
+  border-style: dashed;
+  border-color: rgba(159, 18, 57, 0.38);
+  background:
+    repeating-linear-gradient(
+      -45deg,
+      rgba(252, 165, 165, 0.2),
+      rgba(252, 165, 165, 0.2) 8px,
+      rgba(254, 226, 226, 0.85) 8px,
+      rgba(254, 226, 226, 0.85) 16px
+    );
+  color: var(--missing);
+}}
+.pill--present {{
+  border-color: rgba(22, 101, 52, 0.22);
+  background: rgba(134, 239, 172, 0.2);
+  color: var(--present);
+}}
+.pill--incident {{
+  border-color: rgba(190, 24, 93, 0.25);
+  background: rgba(244, 114, 182, 0.13);
+  color: #9d174d;
+}}
+.pill--usage {{
+  border-color: rgba(29, 78, 216, 0.22);
+  background: rgba(96, 165, 250, 0.12);
+  color: #1d4ed8;
+}}
+.session {{
+  border-radius: 20px;
+  padding: 22px;
+  margin-bottom: 22px;
+}}
+.session--child {{
+  margin-top: 18px;
+  background: var(--panel-strong);
+}}
+.session h2, .session h3 {{
+  margin: 0;
+}}
+.session-header {{
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 16px;
+}}
+.session-copy {{
+  display: grid;
+  gap: 6px;
+}}
+.session-copy p,
+.coverage-copy,
+.pending-copy,
+.provenance-list,
+.event-summary {{
+  color: var(--muted);
+}}
+.coverage {{
+  margin: 18px 0 14px;
+  display: grid;
+  gap: 10px;
+}}
+.coverage h3,
+.turn h3 {{
+  margin: 0 0 10px;
+  font-size: 1rem;
+}}
+.timeline {{
+  display: grid;
+  gap: 16px;
+}}
+.turn {{
+  border-radius: 18px;
+  padding: 16px;
+}}
+.event-list {{
+  display: grid;
+  gap: 12px;
+}}
+.event {{
+  border-radius: 16px;
+  padding: 14px;
+  border-left: 5px solid var(--line);
+}}
+.event--direct {{
+  border-left-color: var(--direct);
+}}
+.event--lossy {{
+  border-left-color: var(--lossy);
+  background: #fffbf4;
+}}
+.event--low {{
+  box-shadow: inset 0 0 0 1px rgba(180, 83, 9, 0.16), var(--shadow);
+}}
+.event-topline {{
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: baseline;
+}}
+.event-anchor {{
+  font-weight: 700;
+  text-decoration: none;
+}}
+.event-type {{
+  font-size: 1.02rem;
+}}
+.event-time {{
+  color: var(--muted);
+  font-size: 0.9rem;
+}}
+.event-summary {{
+  margin: 10px 0 12px;
+  font-size: 0.97rem;
+}}
+details {{
+  border-top: 1px solid rgba(93, 93, 87, 0.12);
+  margin-top: 12px;
+  padding-top: 10px;
+}}
+summary {{
+  cursor: pointer;
+  font-weight: 600;
+}}
+.provenance-list {{
+  margin: 10px 0 0;
+  padding-left: 18px;
+}}
+pre {{
+  margin: 10px 0 0;
+  padding: 12px;
+  border-radius: 12px;
+  background: #f8f1e4;
+  border: 1px solid rgba(93, 93, 87, 0.12);
+  overflow-x: auto;
+  font-size: 0.85rem;
+}}
+.children {{
+  margin-top: 22px;
+  display: grid;
+  gap: 16px;
+}}
+.pending {{
+  border-radius: 20px;
+  padding: 24px;
+}}
+.legend {{
+  margin-top: 14px;
+  display: grid;
+  gap: 8px;
+}}
+.legend strong {{
+  font-size: 0.92rem;
+}}
+code {{
+  background: #f6efe2;
+  padding: 2px 6px;
+  border-radius: 8px;
+}}
+@media (max-width: 720px) {{
+  main {{ padding: 20px 14px 48px; }}
+  .hero, .session, .turn, .event {{ padding: 16px; }}
+}}
+</style>
+</head>
+<body>
+<main>
+<a class="crumb" href="/">Workbench</a>
+<section class="hero">
+  <h1>Session Timeline</h1>
+  <p class="lede">Server-rendered normalized event view with inline cost and incident signals. Works fully offline on the existing localhost daemon.</p>
+  <div class="meta-row">
+    {_render_meta_pill("Canonical session", page.canonical_session_key or page.requested_session_key)}
+    {_render_meta_pill("Deep link", canonical) if canonical else ""}
+    {_render_meta_pill("Requested", page.requested_session_key)}
+  </div>
+  <div class="legend">
+    <strong>Visual treatments</strong>
+    <div class="badge-row">
+      <span class="pill pill--direct">Captured directly</span>
+      <span class="pill pill--lossy">Captured but lossy</span>
+      <span class="pill pill--missing">Not captured by this client</span>
+    </div>
+  </div>
+</section>
+{body}
+</main>
+<script>
+if (window.location.hash) {{
+  const target = document.getElementById(window.location.hash.slice(1));
+  if (target) {{
+    target.scrollIntoView({{block: "center"}});
+  }}
+}}
+</script>
+</body>
+</html>"""
+
+
+def render_not_found_html(session_key: str) -> str:
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>Session not found</title>
+<style>
+body {{
+  margin: 0;
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  background: #f6f0e6;
+  color: #1b1f1f;
+  font-family: Georgia, "Iowan Old Style", serif;
+}}
+main {{
+  max-width: 42rem;
+  margin: 0 auto;
+  padding: 24px;
+  background: #fffdf8;
+  border: 1px solid #ddd1bf;
+  border-radius: 18px;
+}}
+code {{
+  background: #f6efe2;
+  padding: 2px 6px;
+  border-radius: 8px;
+}}
+</style>
+</head>
+<body>
+<main>
+  <h1>Session not found</h1>
+  <p>No event timeline or workbench session was found for <code>{_h(session_key)}</code>.</p>
+</main>
+</body>
+</html>"""
+
+
+def canonical_session_path(session_key: str) -> str:
+    """Return the HTTP path that serves this session's timeline page.
+
+    Distinct from the public ``clawjournal://session/<session_key>`` deep-link
+    contract (ADR-001): the deep link is the durable bookmarkable identifier;
+    the HTTP path is an implementation detail that avoids colliding with the
+    SPA's existing ``/session/:id`` client-side route.
+    """
+    return f"/timeline/{quote(session_key, safe='')}"
+
+
+def _load_event_session(
+    conn: sqlite3.Connection, session_key: str
+) -> sqlite3.Row | None:
+    return conn.execute(
+        """
+        SELECT id, session_key, parent_session_key, client, client_version,
+               started_at, ended_at, status
+          FROM event_sessions
+         WHERE session_key = ?
+        """,
+        (session_key,),
+    ).fetchone()
+
+
+def _load_workbench_session(
+    conn: sqlite3.Connection, session_key: str
+) -> dict[str, Any] | None:
+    row = conn.execute(
+        """
+        SELECT session_id, session_key, project, source, model,
+               start_time, end_time, display_title, ai_display_title,
+               raw_source_path
+          FROM sessions
+         WHERE session_key = ?
+         ORDER BY COALESCE(updated_at, indexed_at, start_time, '') DESC
+         LIMIT 1
+        """,
+        (session_key,),
+    ).fetchone()
+    return None if row is None else dict(row)
+
+
+def _resolve_root_session_key(conn: sqlite3.Connection, session_key: str) -> str:
+    current_key = session_key
+    seen: set[str] = set()
+    while current_key not in seen:
+        seen.add(current_key)
+        row = _load_event_session(conn, current_key)
+        if row is None or row["parent_session_key"] is None:
+            return current_key
+        current_key = str(row["parent_session_key"])
+    return session_key
+
+
+def _load_session_tree(
+    conn: sqlite3.Connection, session_key: str, seen: set[str]
+) -> TimelineSession:
+    if session_key in seen:
+        raise ValueError(f"Session hierarchy cycle detected at {session_key}")
+    seen.add(session_key)
+    try:
+        session_row = _load_event_session(conn, session_key)
+        if session_row is None:
+            raise KeyError(f"session_key not found: {session_key}")
+        session_id = int(session_row["id"])
+        workbench = _load_workbench_session(conn, session_key)
+        events = _load_events(conn, session_id)
+        coverage = _load_coverage(conn, session_id)
+        session_anomalies, anomalies_by_event = _load_cost_anomalies(conn, session_id)
+        incidents_by_event = _load_incidents(conn, session_id)
+        usage_by_event = _load_token_usage(conn, session_id)
+
+        enriched_events: list[TimelineEvent] = []
+        for event in events:
+            enriched_events.append(
+                TimelineEvent(
+                    event_id=event.event_id,
+                    anchor_id=(
+                        f"event-{event.event_id}"
+                        if event.event_id is not None
+                        else f"event-key-{_anchor_slug(event.event_key or event.type)}"
+                    ),
+                    turn_number=event.turn_number,
+                    type=event.type,
+                    event_key=event.event_key,
+                    event_at=event.event_at,
+                    ingested_at=event.ingested_at,
+                    source=event.source,
+                    confidence=event.confidence,
+                    lossiness=event.lossiness,
+                    summary=event.summary,
+                    raw_ref=event.raw_ref,
+                    origin=event.origin,
+                    raw_excerpt=event.raw_excerpt,
+                    payload_excerpt=event.payload_excerpt,
+                    token_usage=(
+                        None
+                        if event.event_id is None
+                        else usage_by_event.get(event.event_id)
+                    ),
+                    anomalies=tuple(
+                        ()
+                        if event.event_id is None
+                        else anomalies_by_event.get(event.event_id, ())
+                    ),
+                    incidents=tuple(
+                        ()
+                        if event.event_id is None
+                        else incidents_by_event.get(event.event_id, ())
+                    ),
+                )
+            )
+
+        turns = _group_turns(enriched_events)
+        child_rows = conn.execute(
+            """
+            SELECT session_key
+              FROM event_sessions
+             WHERE parent_session_key = ?
+             ORDER BY started_at IS NULL, started_at, session_key
+            """,
+            (session_key,),
+        ).fetchall()
+        return TimelineSession(
+            session_key=session_key,
+            client=str(session_row["client"]),
+            status=str(session_row["status"]),
+            started_at=session_row["started_at"],
+            ended_at=session_row["ended_at"],
+            parent_session_key=session_row["parent_session_key"],
+            title=_session_title(workbench, session_row),
+            project=(workbench or {}).get("project"),
+            model=(workbench or {}).get("model"),
+            turns=tuple(turns),
+            direct_event_count=sum(
+                1 for event in enriched_events if event.lossiness == "none"
+            ),
+            lossy_event_count=sum(
+                1 for event in enriched_events if event.lossiness != "none"
+            ),
+            low_confidence_count=sum(
+                1 for event in enriched_events if event.confidence != "high"
+            ),
+            coverage=tuple(coverage),
+            session_anomalies=tuple(session_anomalies),
+            children=tuple(
+                _load_session_tree(conn, str(row["session_key"]), seen)
+                for row in child_rows
+            ),
+        )
+    finally:
+        seen.remove(session_key)
+
+
+def _load_events(conn: sqlite3.Connection, session_id: int) -> list[TimelineEvent]:
+    events: list[TimelineEvent] = []
+    turn_number = 0
+    for event in canonical_events(conn, session_id):
+        if event.type == "user_message":
+            turn_number += 1
+        events.append(
+            TimelineEvent(
+                event_id=event.event_id,
+                anchor_id="",
+                turn_number=turn_number,
+                type=event.type,
+                event_key=event.event_key,
+                event_at=event.event_at,
+                ingested_at=event.ingested_at,
+                source=event.source,
+                confidence=event.confidence,
+                lossiness=event.lossiness,
+                summary=_event_summary(event.payload_json or event.raw_json, event.type),
+                raw_ref=event.raw_ref,
+                origin=event.origin,
+                raw_excerpt=_excerpt_text(event.raw_json),
+                payload_excerpt=_excerpt_text(event.payload_json),
+                token_usage=None,
+                anomalies=(),
+                incidents=(),
+            )
+        )
+    return events
+
+
+def _load_coverage(conn: sqlite3.Connection, session_id: int) -> list[CoverageBucket]:
+    labels = {
+        "missing": "Not captured by this client",
+        "supported_but_absent": "Client supports it, but it did not occur here",
+        "present": "Observed in this session",
+    }
+    grouped: dict[str, list[str]] = {
+        "missing": [],
+        "supported_but_absent": [],
+        "present": [],
+    }
+    for state in capability_join(conn, session_id):
+        grouped[state.state].append(state.event_type)
+    return [
+        CoverageBucket(
+            state=state,
+            label=labels[state],
+            event_types=tuple(sorted(grouped[state])),
+        )
+        for state in ("missing", "supported_but_absent", "present")
+        if grouped[state]
+    ]
+
+
+def _load_token_usage(conn: sqlite3.Connection, session_id: int) -> dict[int, dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT event_id, model, service_tier, data_source, input, output,
+               cache_read, cache_write, reasoning, cost_estimate
+          FROM token_usage
+         WHERE session_id = ?
+        """,
+        (session_id,),
+    ).fetchall()
+    return {int(row["event_id"]): dict(row) for row in rows}
+
+
+def _load_cost_anomalies(
+    conn: sqlite3.Connection, session_id: int
+) -> tuple[list[dict[str, Any]], dict[int, list[dict[str, Any]]]]:
+    rows = conn.execute(
+        """
+        SELECT turn_event_id, kind, confidence, evidence_json
+          FROM cost_anomalies
+         WHERE session_id = ?
+         ORDER BY id
+        """,
+        (session_id,),
+    ).fetchall()
+    session_level: list[dict[str, Any]] = []
+    by_event: dict[int, list[dict[str, Any]]] = {}
+    for row in rows:
+        entry = {
+            "kind": row["kind"],
+            "confidence": row["confidence"],
+            "evidence": _load_json(row["evidence_json"]),
+        }
+        if row["turn_event_id"] is None:
+            session_level.append(entry)
+            continue
+        by_event.setdefault(int(row["turn_event_id"]), []).append(entry)
+    return session_level, by_event
+
+
+def _load_incidents(
+    conn: sqlite3.Connection, session_id: int
+) -> dict[int, list[dict[str, Any]]]:
+    rows = conn.execute(
+        """
+        SELECT first_event_id, last_event_id, kind, count, confidence, evidence_json
+          FROM incidents
+         WHERE session_id = ?
+         ORDER BY first_event_id, id
+        """,
+        (session_id,),
+    ).fetchall()
+    by_event: dict[int, list[dict[str, Any]]] = {}
+    for row in rows:
+        by_event.setdefault(int(row["first_event_id"]), []).append(
+            {
+                "kind": row["kind"],
+                "count": int(row["count"]),
+                "confidence": row["confidence"],
+                "last_event_id": int(row["last_event_id"]),
+                "evidence": _load_json(row["evidence_json"]),
+            }
+        )
+    return by_event
+
+
+def _group_turns(events: list[TimelineEvent]) -> list[TimelineTurn]:
+    grouped: dict[int, list[TimelineEvent]] = {}
+    order: list[int] = []
+    for event in events:
+        if event.turn_number not in grouped:
+            grouped[event.turn_number] = []
+            order.append(event.turn_number)
+        grouped[event.turn_number].append(event)
+    turns: list[TimelineTurn] = []
+    for number in order:
+        label = "Session setup" if number == 0 else f"Turn {number}"
+        turns.append(
+            TimelineTurn(number=number, label=label, events=tuple(grouped[number]))
+        )
+    return turns
+
+
+def _session_title(
+    workbench: dict[str, Any] | None, session_row: sqlite3.Row
+) -> str:
+    if workbench:
+        return (
+            workbench.get("ai_display_title")
+            or workbench.get("display_title")
+            or workbench.get("project")
+            or workbench.get("session_key")
+            or str(session_row["session_key"])
+        )
+    return str(session_row["session_key"])
+
+
+def _event_summary(raw_json: str | None, event_type: str) -> str:
+    if not raw_json:
+        return event_type.replace("_", " ")
+    try:
+        payload = json.loads(raw_json)
+    except json.JSONDecodeError:
+        return _compact(raw_json, 220)
+    strings: list[str] = []
+    _collect_summary_strings(payload, strings, limit=6)
+    if strings:
+        return _compact(" · ".join(strings), 220)
+    return _compact(raw_json, 220)
+
+
+def _collect_summary_strings(value: Any, out: list[str], *, limit: int) -> None:
+    if len(out) >= limit:
+        return
+    if isinstance(value, str):
+        cleaned = _compact(value, 160)
+        if cleaned:
+            out.append(cleaned)
+        return
+    if isinstance(value, list):
+        for item in value:
+            _collect_summary_strings(item, out, limit=limit)
+            if len(out) >= limit:
+                return
+        return
+    if not isinstance(value, dict):
+        return
+    for key in _SUMMARY_KEYS:
+        if key in value:
+            _collect_summary_strings(value[key], out, limit=limit)
+            if len(out) >= limit:
+                return
+    for key, child in value.items():
+        if key in _SUMMARY_KEYS:
+            continue
+        _collect_summary_strings(child, out, limit=limit)
+        if len(out) >= limit:
+            return
+
+
+def _excerpt_text(raw_text: str | None, limit: int = 640) -> str | None:
+    if not raw_text:
+        return None
+    stripped = raw_text.strip()
+    if len(stripped) <= limit:
+        return stripped
+    return stripped[: limit - 1] + "…"
+
+
+def _compact(value: str, limit: int) -> str:
+    squashed = _WHITESPACE_RE.sub(" ", value).strip()
+    if len(squashed) <= limit:
+        return squashed
+    return squashed[: limit - 1] + "…"
+
+
+def _load_json(raw: str | None) -> dict[str, Any] | None:
+    if not raw:
+        return None
+    try:
+        value = json.loads(raw)
+    except json.JSONDecodeError:
+        return None
+    return value if isinstance(value, dict) else {"value": value}
+
+
+def _render_timeline_page(page: TimelinePage) -> str:
+    assert page.root is not None
+    return _render_session(page.root, level=0)
+
+
+def _render_pending_ingest_page(page: TimelinePage) -> str:
+    session_key = page.canonical_session_key or page.requested_session_key
+    wb = page.workbench_row or {}
+    return f"""
+<section class="pending">
+  <h2>Events not ingested yet</h2>
+  <p class="pending-copy">Workbench metadata exists for <code>{_h(session_key)}</code>, but there is no normalized event timeline yet.</p>
+  <div class="meta-row">
+    {_render_meta_pill("Project", wb.get("project"))}
+    {_render_meta_pill("Model", wb.get("model"))}
+    {_render_meta_pill("Source", wb.get("source"))}
+  </div>
+  <pre>clawjournal events ingest</pre>
+</section>"""
+
+
+def _render_session(session: TimelineSession, *, level: int) -> str:
+    session_kind = "Root session" if level == 0 else "Subagent session"
+    child_markup = "".join(
+        _render_session(child, level=level + 1) for child in session.children
+    )
+    coverage_markup = "".join(_render_coverage_bucket(bucket) for bucket in session.coverage)
+    anomalies_markup = "".join(
+        f'<span class="pill pill--lossy">{_h(anomaly["kind"])} ({_h(anomaly["confidence"])})</span>'
+        for anomaly in session.session_anomalies
+    )
+    turns_markup = "".join(_render_turn(turn) for turn in session.turns)
+    children_block = f'<div class="children">{child_markup}</div>' if child_markup else ""
+    session_class = "session session--child" if level else "session"
+    anomalies_block = ""
+    if anomalies_markup:
+        anomalies_block = (
+            '<section class="coverage"><h3>Session-level cost anomalies</h3>'
+            f'<div class="badge-row">{anomalies_markup}</div></section>'
+        )
+    empty_block = (
+        '<section class="turn"><p class="coverage-copy">No canonical events ingested yet.</p></section>'
+        if not turns_markup
+        else turns_markup
+    )
+    return f"""
+<section class="{session_class}">
+  <div class="session-header">
+    <div class="session-copy">
+      <p>{_h(session_kind)}</p>
+      <h2>{_h(session.title)}</h2>
+      <p>{_h(session.session_key)}</p>
+    </div>
+    <div class="meta-row">
+      {_render_meta_pill("Client", session.client)}
+      {_render_meta_pill("Status", session.status)}
+      {_render_meta_pill("Project", session.project)}
+      {_render_meta_pill("Model", session.model)}
+      {_render_meta_pill("Started", session.started_at)}
+      {_render_meta_pill("Ended", session.ended_at)}
+      {_render_meta_pill("Direct", str(session.direct_event_count))}
+      {_render_meta_pill("Lossy", str(session.lossy_event_count))}
+      {_render_meta_pill("Low confidence", str(session.low_confidence_count))}
+    </div>
+  </div>
+  <section class="coverage">
+    <h3>Coverage</h3>
+    <p class="coverage-copy">Missing-capability states are rendered separately from low-confidence rows so "not captured by this client" never looks like weak evidence.</p>
+    <div class="coverage-row">{coverage_markup}</div>
+  </section>
+  {anomalies_block}
+  <div class="timeline">{empty_block}</div>
+  {children_block}
+</section>"""
+
+
+def _render_coverage_bucket(bucket: CoverageBucket) -> str:
+    tooltip = ", ".join(bucket.event_types)
+    if bucket.state == "present":
+        tone = "present"
+    elif bucket.state == "missing":
+        tone = "missing"
+    else:
+        tone = "lossy"
+    return (
+        f'<span class="pill pill--{tone}" title="{_h(tooltip)}">'
+        f"{_h(bucket.label)} · {_h(str(len(bucket.event_types)))}</span>"
+    )
+
+
+def _render_turn(turn: TimelineTurn) -> str:
+    events_markup = "".join(_render_event(event) for event in turn.events)
+    return f"""
+<section class="turn">
+  <h3>{_h(turn.label)}</h3>
+  <div class="event-list">{events_markup}</div>
+</section>"""
+
+
+def _render_event(event: TimelineEvent) -> str:
+    event_classes = ["event"]
+    if event.lossiness == "none":
+        event_classes.append("event--direct")
+    else:
+        event_classes.append("event--lossy")
+    if event.confidence != "high":
+        event_classes.append("event--low")
+
+    badge_row = [
+        f'<span class="pill">{_h(event.source)}</span>',
+        (
+            '<span class="pill pill--direct">high confidence</span>'
+            if event.confidence == "high"
+            else f'<span class="pill pill--low">{_h(event.confidence)} confidence</span>'
+        ),
+        (
+            '<span class="pill pill--direct">captured directly</span>'
+            if event.lossiness == "none"
+            else f'<span class="pill pill--lossy">{_h(event.lossiness)}</span>'
+        ),
+    ]
+    if event.token_usage is not None:
+        badge_row.append(
+            f'<span class="pill pill--usage">{_h(_usage_label(event.token_usage))}</span>'
+        )
+    for anomaly in event.anomalies:
+        badge_row.append(
+            f'<span class="pill pill--lossy">{_h(anomaly["kind"])} ({_h(anomaly["confidence"])})</span>'
+        )
+    for incident in event.incidents:
+        badge_row.append(
+            f'<span class="pill pill--incident">{_h(incident["kind"])} ×{incident["count"]}</span>'
+        )
+
+    provenance_items = [
+        f"<li>source: <code>{_h(event.source)}</code></li>",
+        f"<li>confidence: <code>{_h(event.confidence)}</code></li>",
+        f"<li>lossiness: <code>{_h(event.lossiness)}</code></li>",
+        (
+            f"<li>raw_ref: <code>{_h(event.raw_ref[0])}:{event.raw_ref[1]}:{event.raw_ref[2]}</code></li>"
+            if event.raw_ref is not None
+            else "<li>raw_ref: <code>(hook-only)</code></li>"
+        ),
+        f"<li>event_key: <code>{_h(event.event_key or '(none)')}</code></li>",
+        f"<li>ingested_at: <code>{_h(event.ingested_at or '(unknown)')}</code></li>",
+    ]
+    if event.origin:
+        provenance_items.append(f"<li>origin: <code>{_h(event.origin)}</code></li>")
+
+    excerpts = []
+    if event.payload_excerpt:
+        excerpts.append(f"<pre>{_h(event.payload_excerpt)}</pre>")
+    if event.raw_excerpt:
+        excerpts.append(f"<pre>{_h(event.raw_excerpt)}</pre>")
+
+    anchor_label = "#" + str(event.event_id) if event.event_id is not None else "#hook"
+    return f"""
+<article id="{_h(event.anchor_id)}" class="{' '.join(event_classes)}">
+  <div class="event-topline">
+    <a class="event-anchor" href="#{_h(event.anchor_id)}">{_h(anchor_label)}</a>
+    <strong class="event-type">{_h(event.type)}</strong>
+    <span class="event-time">{_h(event.event_at or '(no event_at)')}</span>
+  </div>
+  <p class="event-summary">{_h(event.summary)}</p>
+  <div class="badge-row">{''.join(badge_row)}</div>
+  <details>
+    <summary>Provenance</summary>
+    <ul class="provenance-list">{''.join(provenance_items)}</ul>
+    {''.join(excerpts)}
+  </details>
+</article>"""
+
+
+def _usage_label(usage: dict[str, Any]) -> str:
+    parts: list[str] = [str(usage.get("data_source") or "usage")]
+    if usage.get("input") is not None:
+        parts.append(f"in {usage['input']}")
+    if usage.get("output") is not None:
+        parts.append(f"out {usage['output']}")
+    if usage.get("cache_read") is not None:
+        parts.append(f"cache-read {usage['cache_read']}")
+    if usage.get("reasoning") is not None:
+        parts.append(f"reasoning {usage['reasoning']}")
+    if usage.get("cost_estimate") is not None:
+        parts.append(f"${float(usage['cost_estimate']):.4f}")
+    return " · ".join(parts)
+
+
+def _anchor_slug(value: str) -> str:
+    slug = re.sub(r"[^a-zA-Z0-9]+", "-", value).strip("-").lower()
+    return slug or "event"
+
+
+def _render_meta_pill(label: str, value: str | None) -> str:
+    if not value:
+        return ""
+    return f'<span class="pill"><strong>{_h(label)}:</strong> {_h(value)}</span>'
+
+
+def _h(value: Any) -> str:
+    return html.escape("" if value is None else str(value), quote=True)

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -641,14 +641,14 @@ class TestStaticServing:
         # the legacy id is resolved to its canonical session_key and the
         # client is redirected to the canonical timeline URL.
         conn = HTTPConnection("127.0.0.1", server, timeout=5)
-        conn.request("GET", seeded["legacy_url"])
+        conn.request("GET", seeded["legacy_url"], headers=_api_auth_headers())
         resp = conn.getresponse()
         resp.read()
         assert resp.status == 302
         assert resp.getheader("Location") == seeded["root_url"]
 
         conn = HTTPConnection("127.0.0.1", server, timeout=5)
-        conn.request("GET", seeded["root_url"])
+        conn.request("GET", seeded["root_url"], headers=_api_auth_headers())
         resp = conn.getresponse()
         body = resp.read().decode()
         assert resp.status == 200
@@ -661,7 +661,7 @@ class TestTimelineRoute:
         seeded = _seed_timeline(index_setup)
 
         conn = HTTPConnection("127.0.0.1", server, timeout=5)
-        conn.request("GET", seeded["root_url"])
+        conn.request("GET", seeded["root_url"], headers=_api_auth_headers())
         resp = conn.getresponse()
         body = resp.read().decode()
 
@@ -679,7 +679,7 @@ class TestTimelineRoute:
         seeded = _seed_timeline(index_setup)
 
         conn = HTTPConnection("127.0.0.1", server, timeout=5)
-        conn.request("GET", seeded["child_url"])
+        conn.request("GET", seeded["child_url"], headers=_api_auth_headers())
         resp = conn.getresponse()
         resp.read()
 
@@ -690,7 +690,11 @@ class TestTimelineRoute:
         _seed_timeline(index_setup)
 
         conn = HTTPConnection("127.0.0.1", server, timeout=5)
-        conn.request("GET", "/timeline/claude:nobody:unknown")
+        conn.request(
+            "GET",
+            "/timeline/claude:nobody:unknown",
+            headers=_api_auth_headers(),
+        )
         resp = conn.getresponse()
         body = resp.read().decode()
 
@@ -712,7 +716,7 @@ class TestTimelineRoute:
             conn.close()
 
         http_conn = HTTPConnection("127.0.0.1", server, timeout=5)
-        http_conn.request("GET", "/timeline/sess-1")
+        http_conn.request("GET", "/timeline/sess-1", headers=_api_auth_headers())
         resp = http_conn.getresponse()
         body = resp.read().decode()
 
@@ -748,13 +752,111 @@ class TestTimelineRoute:
             conn.close()
 
         http_conn = HTTPConnection("127.0.0.1", server, timeout=5)
-        http_conn.request("GET", seeded["root_url"])
+        http_conn.request("GET", seeded["root_url"], headers=_api_auth_headers())
         resp = http_conn.getresponse()
         body = resp.read().decode()
 
         assert resp.status == 200
         assert "<script>alert(1)</script>" not in body
         assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body
+
+    def test_partially_ingested_child_session_renders_in_place(self, server, index_setup):
+        from urllib.parse import quote
+
+        conn = open_index()
+        try:
+            from clawjournal.events.schema import ensure_schema as ensure_events_schema
+            from clawjournal.events.view import ensure_view_schema
+
+            ensure_events_schema(conn)
+            ensure_view_schema(conn)
+            child_key = "claude:demo-proj:orphan-child"
+            missing_parent_key = "claude:demo-proj:missing-parent"
+            child_id = conn.execute(
+                """
+                INSERT INTO event_sessions (
+                    session_key, parent_session_key, client, started_at, status
+                ) VALUES (?, ?, 'claude', '2026-04-22T11:00:00Z', 'active')
+                """,
+                (child_key, missing_parent_key),
+            ).lastrowid
+            conn.execute(
+                """
+                INSERT INTO events (
+                    session_id, type, event_key, event_at, ingested_at, source,
+                    source_path, source_offset, seq, client, confidence, lossiness, raw_json
+                ) VALUES (?, 'tool_call', 'tool_call:orphan', '2026-04-22T11:00:01Z',
+                          '2026-04-22T11:00:02Z', 'hook', 'orphan.jsonl', 0, 0,
+                          'claude', 'high', 'none', '{"tool_name":"Read","path":"README.md"}')
+                """,
+                (child_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        http_conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        http_conn.request(
+            "GET",
+            f"/timeline/{quote(child_key, safe='')}",
+            headers=_api_auth_headers(),
+        )
+        resp = http_conn.getresponse()
+        body = resp.read().decode()
+
+        assert resp.status == 200
+        assert child_key in body
+        assert missing_parent_key not in body
+
+    def test_spa_html_sets_httponly_session_cookie(self, server):
+        conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        conn.request("GET", "/")
+        resp = conn.getresponse()
+        resp.read()
+
+        set_cookie = resp.getheader("Set-Cookie") or ""
+        assert "clawjournal_token=" in set_cookie
+        assert "HttpOnly" in set_cookie
+        assert "SameSite=Strict" in set_cookie
+        assert "Path=/" in set_cookie
+
+    def test_timeline_route_accepts_cookie_auth(self, server, index_setup):
+        seeded = _seed_timeline(index_setup)
+
+        from clawjournal.paths import API_TOKEN_FILENAME
+        from clawjournal.workbench.index import INDEX_DB
+        from pathlib import Path
+
+        token = (
+            Path(str(INDEX_DB)).parent / API_TOKEN_FILENAME
+        ).read_text().strip()
+
+        conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        conn.request(
+            "GET",
+            seeded["root_url"],
+            headers={"Cookie": f"clawjournal_token={token}"},
+        )
+        resp = conn.getresponse()
+        body = resp.read().decode()
+
+        assert resp.status == 200
+        assert "Session Timeline" in body
+
+    def test_timeline_route_rejects_wrong_cookie_value(self, server, index_setup):
+        seeded = _seed_timeline(index_setup)
+
+        conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        conn.request(
+            "GET",
+            seeded["root_url"],
+            headers={"Cookie": "clawjournal_token=not-the-real-token"},
+        )
+        resp = conn.getresponse()
+        body = resp.read()
+
+        assert resp.status == 401
+        assert body == b""
 
 
 class TestRunServerPortFallback:

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -818,7 +818,7 @@ class TestTimelineRoute:
         assert "clawjournal_token=" in set_cookie
         assert "HttpOnly" in set_cookie
         assert "SameSite=Strict" in set_cookie
-        assert "Path=/" in set_cookie
+        assert "Path=/timeline" in set_cookie
 
     def test_timeline_route_accepts_cookie_auth(self, server, index_setup):
         seeded = _seed_timeline(index_setup)
@@ -857,6 +857,90 @@ class TestTimelineRoute:
 
         assert resp.status == 401
         assert body == b""
+
+    def test_hook_only_events_are_reordered_before_turn_assignment(
+        self, server, index_setup
+    ):
+        seeded = _seed_timeline(index_setup)
+
+        from clawjournal.events.view import write_hook_override
+
+        conn = open_index()
+        try:
+            write_hook_override(
+                conn,
+                session_key=seeded["root_key"],
+                event_key="user_message:hook-early",
+                event_type="user_message",
+                source="hook",
+                confidence="high",
+                lossiness="none",
+                event_at="2026-04-22T09:59:59Z",
+                payload_json='{"message":{"content":"hook only first turn"}}',
+                origin="hook:test",
+            )
+        finally:
+            conn.close()
+
+        conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        conn.request("GET", seeded["root_url"], headers=_api_auth_headers())
+        resp = conn.getresponse()
+        body = resp.read().decode()
+
+        assert resp.status == 200
+        assert body.index("hook only first turn") < body.index("pytest tests/test_auth.py")
+        assert "Turn 2" in body
+
+    def test_hook_only_anchor_ids_are_namespaced_by_session(
+        self, server, index_setup
+    ):
+        seeded = _seed_timeline(index_setup)
+
+        from clawjournal.events.view import write_hook_override
+
+        conn = open_index()
+        try:
+            write_hook_override(
+                conn,
+                session_key=seeded["root_key"],
+                event_key="tool_call:shared-hook",
+                event_type="tool_call",
+                source="hook",
+                confidence="high",
+                lossiness="none",
+                event_at="2026-04-22T10:01:30Z",
+                payload_json='{"tool_name":"Read","path":"root.txt"}',
+                origin="hook:test",
+            )
+            write_hook_override(
+                conn,
+                session_key=seeded["child_key"],
+                event_key="tool_call:shared-hook",
+                event_type="tool_call",
+                source="hook",
+                confidence="high",
+                lossiness="none",
+                event_at="2026-04-22T10:04:30Z",
+                payload_json='{"tool_name":"Read","path":"child.txt"}',
+                origin="hook:test",
+            )
+        finally:
+            conn.close()
+
+        conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        conn.request("GET", seeded["root_url"], headers=_api_auth_headers())
+        resp = conn.getresponse()
+        body = resp.read().decode()
+
+        assert resp.status == 200
+        assert (
+            'id="event-key-claude-demo-proj-parent-root-tool-call-shared-hook"'
+            in body
+        )
+        assert (
+            'id="event-key-claude-demo-proj-child-agent-tool-call-shared-hook"'
+            in body
+        )
 
 
 class TestRunServerPortFallback:

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -130,6 +130,213 @@ def _delete(port, path, *, skip_auth=False):
     return resp.status, json.loads(resp_body) if resp.getheader("Content-Type", "").startswith("application/json") else resp_body
 
 
+def _seed_timeline(index_setup):
+    from urllib.parse import quote
+
+    from clawjournal.events.cost.schema import ensure_cost_schema
+    from clawjournal.events.incidents.schema import ensure_incidents_schema
+    from clawjournal.events.schema import ensure_schema as ensure_events_schema
+    from clawjournal.events.view import ensure_view_schema
+
+    conn = open_index()
+    try:
+        ensure_events_schema(conn)
+        ensure_view_schema(conn)
+        ensure_cost_schema(conn)
+        ensure_incidents_schema(conn)
+
+        vendor_file = index_setup / "timeline_vendor.jsonl"
+        vendor_file.write_text(
+            '{"type":"user_message","message":{"content":"debug the failing cache auth flow"}}\n'
+            '{"type":"tool_call","tool_name":"Bash","command":"pytest tests/test_auth.py"}\n'
+            '{"type":"tool_result","output":"401 unauthorized"}\n',
+            encoding="utf-8",
+        )
+        root_key = "claude:demo-proj:parent-root"
+        child_key = "claude:demo-proj:child-agent"
+        conn.execute(
+            "UPDATE sessions SET session_key = ?, display_title = ? WHERE session_id = ?",
+            (root_key, "Demo timeline session", "sess-0"),
+        )
+        root_id = conn.execute(
+            """
+            INSERT INTO event_sessions (
+                session_key, parent_session_key, client, started_at, ended_at, status
+            ) VALUES (?, NULL, 'claude', '2026-04-22T10:00:00Z', '2026-04-22T10:08:00Z', 'closed')
+            """,
+            (root_key,),
+        ).lastrowid
+        child_id = conn.execute(
+            """
+            INSERT INTO event_sessions (
+                session_key, parent_session_key, parent_session_id, client,
+                started_at, ended_at, status
+            ) VALUES (?, ?, ?, 'claude', '2026-04-22T10:04:00Z', '2026-04-22T10:05:00Z', 'closed')
+            """,
+            (child_key, root_key, root_id),
+        ).lastrowid
+        first_id = conn.execute(
+            """
+            INSERT INTO events (
+                session_id, type, event_key, event_at, ingested_at, source,
+                source_path, source_offset, seq, client, confidence, lossiness, raw_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                root_id,
+                "user_message",
+                "user_message:1",
+                "2026-04-22T10:00:00Z",
+                "2026-04-22T10:00:01Z",
+                "claude-jsonl",
+                str(vendor_file),
+                0,
+                0,
+                "claude",
+                "high",
+                "none",
+                '{"message":{"content":"debug the failing cache auth flow"}}',
+            ),
+        ).lastrowid
+        second_id = conn.execute(
+            """
+            INSERT INTO events (
+                session_id, type, event_key, event_at, ingested_at, source,
+                source_path, source_offset, seq, client, confidence, lossiness, raw_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                root_id,
+                "tool_call",
+                "tool_call:1",
+                "2026-04-22T10:00:03Z",
+                "2026-04-22T10:00:04Z",
+                "claude-jsonl",
+                str(vendor_file),
+                82,
+                0,
+                "claude",
+                "high",
+                "partial",
+                '{"tool_name":"Bash","command":"pytest tests/test_auth.py"}',
+            ),
+        ).lastrowid
+        conn.execute(
+            """
+            INSERT INTO events (
+                session_id, type, event_key, event_at, ingested_at, source,
+                source_path, source_offset, seq, client, confidence, lossiness, raw_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                root_id,
+                "tool_result",
+                "tool_result:1",
+                "2026-04-22T10:00:05Z",
+                "2026-04-22T10:00:06Z",
+                "claude-jsonl",
+                str(vendor_file),
+                153,
+                0,
+                "claude",
+                "medium",
+                "none",
+                '{"output":"401 unauthorized"}',
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO events (
+                session_id, type, event_key, event_at, ingested_at, source,
+                source_path, source_offset, seq, client, confidence, lossiness, raw_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                child_id,
+                "tool_call",
+                "tool_call:child",
+                "2026-04-22T10:04:01Z",
+                "2026-04-22T10:04:02Z",
+                "hook",
+                str(vendor_file),
+                200,
+                0,
+                "claude",
+                "high",
+                "none",
+                '{"tool_name":"Read","path":"README.md"}',
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO token_usage (
+                event_id, session_id, model, service_tier, data_source, input, output,
+                cache_read, cache_write, reasoning, cost_estimate, event_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                second_id,
+                root_id,
+                "claude-sonnet-4",
+                "standard",
+                "api",
+                120,
+                42,
+                10,
+                0,
+                8,
+                0.0137,
+                "2026-04-22T10:00:03Z",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO cost_anomalies (
+                session_id, turn_event_id, kind, confidence, evidence_json, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                root_id,
+                second_id,
+                "cache_read_collapse",
+                "medium",
+                '{"before": 200, "after": 10}',
+                "2026-04-22T10:00:08Z",
+            ),
+        )
+        conn.execute(
+            """
+            INSERT INTO incidents (
+                session_id, kind, first_event_id, last_event_id,
+                evidence_json, count, confidence, created_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                root_id,
+                "loop_exact_repeat",
+                second_id,
+                second_id,
+                '{"fingerprint":"pytest tests/test_auth.py"}',
+                3,
+                "medium",
+                "2026-04-22T10:00:09Z",
+            ),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return {
+        "root_key": root_key,
+        "child_key": child_key,
+        "root_url": f"/timeline/{quote(root_key, safe='')}",
+        "child_url": f"/timeline/{quote(child_key, safe='')}",
+        "legacy_url": "/timeline/sess-0",
+        "spa_session_url": "/session/sess-0",
+        "first_event_id": int(first_id),
+        "second_event_id": int(second_id),
+    }
+
+
 class TestSessionsAPI:
     def test_list_sessions(self, server):
         status, data = _get(server, "/api/sessions")
@@ -412,6 +619,7 @@ class TestStaticServing:
         (dist / "index.html").write_text("<!DOCTYPE html><title>Built UI</title>", encoding="utf-8")
         (dist / "app.js").write_text("console.log('ok');", encoding="utf-8")
         monkeypatch.setattr("clawjournal.workbench.daemon.FRONTEND_DIST", dist)
+        seeded = _seed_timeline(index_setup)
 
         conn = HTTPConnection("127.0.0.1", server, timeout=5)
         conn.request("GET", "/")
@@ -420,19 +628,133 @@ class TestStaticServing:
         assert resp.status == 200
         assert "Built UI" in body
 
+        # `/session/<id>` is owned by the SPA's client-side router — the
+        # daemon must keep serving the SPA shell there, not the timeline.
         conn = HTTPConnection("127.0.0.1", server, timeout=5)
-        conn.request("GET", "/session/sess-0")
+        conn.request("GET", seeded["spa_session_url"])
         resp = conn.getresponse()
         body = resp.read().decode()
         assert resp.status == 200
         assert "Built UI" in body
 
+        # `/timeline/<legacy_workbench_id>` is the timeline's own surface;
+        # the legacy id is resolved to its canonical session_key and the
+        # client is redirected to the canonical timeline URL.
         conn = HTTPConnection("127.0.0.1", server, timeout=5)
-        conn.request("GET", "/traces/session/sess-0")
+        conn.request("GET", seeded["legacy_url"])
+        resp = conn.getresponse()
+        resp.read()
+        assert resp.status == 302
+        assert resp.getheader("Location") == seeded["root_url"]
+
+        conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        conn.request("GET", seeded["root_url"])
         resp = conn.getresponse()
         body = resp.read().decode()
         assert resp.status == 200
-        assert "Built UI" in body
+        assert "Session Timeline" in body
+        assert "Built UI" not in body
+
+
+class TestTimelineRoute:
+    def test_session_timeline_renders_cost_incidents_and_subagents(self, server, index_setup):
+        seeded = _seed_timeline(index_setup)
+
+        conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        conn.request("GET", seeded["root_url"])
+        resp = conn.getresponse()
+        body = resp.read().decode()
+
+        assert resp.status == 200
+        assert "Session Timeline" in body
+        assert f'id="event-{seeded["second_event_id"]}"' in body
+        assert "cache_read_collapse" in body
+        assert "loop_exact_repeat" in body
+        assert "Subagent session" in body
+        assert "Not captured by this client" in body
+        assert "Captured but lossy" in body
+        assert "Captured directly" in body
+
+    def test_child_session_route_redirects_to_parent_timeline(self, server, index_setup):
+        seeded = _seed_timeline(index_setup)
+
+        conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        conn.request("GET", seeded["child_url"])
+        resp = conn.getresponse()
+        resp.read()
+
+        assert resp.status == 302
+        assert resp.getheader("Location") == seeded["root_url"]
+
+    def test_unknown_session_key_returns_404_with_not_found_page(self, server, index_setup):
+        _seed_timeline(index_setup)
+
+        conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        conn.request("GET", "/timeline/claude:nobody:unknown")
+        resp = conn.getresponse()
+        body = resp.read().decode()
+
+        assert resp.status == 404
+        assert "claude:nobody:unknown" in body
+
+    def test_legacy_workbench_id_without_session_key_returns_404(
+        self, server, index_setup
+    ):
+        _seed_timeline(index_setup)
+
+        conn = open_index()
+        try:
+            conn.execute(
+                "UPDATE sessions SET session_key = NULL WHERE session_id = 'sess-1'"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        http_conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        http_conn.request("GET", "/timeline/sess-1")
+        resp = http_conn.getresponse()
+        body = resp.read().decode()
+
+        assert resp.status == 404
+        assert "sess-1" in body
+
+    def test_html_escapes_event_content_to_block_xss(self, server, index_setup):
+        seeded = _seed_timeline(index_setup)
+
+        conn = open_index()
+        try:
+            conn.execute(
+                """
+                INSERT INTO events (
+                    session_id, type, event_key, event_at, ingested_at, source,
+                    source_path, source_offset, seq, client, confidence,
+                    lossiness, raw_json
+                ) VALUES (
+                    (SELECT id FROM event_sessions WHERE session_key = ?),
+                    'tool_call', 'tool_call:xss', '2026-04-22T10:01:00Z',
+                    '2026-04-22T10:01:01Z', 'claude-jsonl', 'vendor.jsonl',
+                    900, 0, 'claude', 'high', 'none',
+                    ?
+                )
+                """,
+                (
+                    seeded["root_key"],
+                    '{"text":"<script>alert(1)</script>"}',
+                ),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        http_conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        http_conn.request("GET", seeded["root_url"])
+        resp = http_conn.getresponse()
+        body = resp.read().decode()
+
+        assert resp.status == 200
+        assert "<script>alert(1)</script>" not in body
+        assert "&lt;script&gt;alert(1)&lt;/script&gt;" in body
 
 
 class TestRunServerPortFallback:

--- a/tests/workbench/test_daemon_security_api.py
+++ b/tests/workbench/test_daemon_security_api.py
@@ -128,6 +128,17 @@ class TestAuth:
         assert resp.status == 401
         assert resp.read() == b""
 
+    def test_api_route_rejects_valid_cookie_without_bearer_header(self, server):
+        conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        conn.request(
+            "GET",
+            "/api/sessions/sess-1/findings",
+            headers={"Cookie": f"clawjournal_token={_token()}"},
+        )
+        resp = conn.getresponse()
+        assert resp.status == 401
+        assert resp.read() == b""
+
     def test_wrong_token_returns_401(self, server):
         conn = HTTPConnection("127.0.0.1", server, timeout=5)
         conn.request("GET", "/api/sessions/sess-1/findings",

--- a/tests/workbench/test_daemon_security_api.py
+++ b/tests/workbench/test_daemon_security_api.py
@@ -121,6 +121,13 @@ class TestAuth:
         assert resp.status == 401
         assert resp.read() == b""
 
+    def test_timeline_route_missing_header_returns_401_empty_body(self, server):
+        conn = HTTPConnection("127.0.0.1", server, timeout=5)
+        conn.request("GET", "/timeline/claude:demo:unknown")
+        resp = conn.getresponse()
+        assert resp.status == 401
+        assert resp.read() == b""
+
     def test_wrong_token_returns_401(self, server):
         conn = HTTPConnection("127.0.0.1", server, timeout=5)
         conn.request("GET", "/api/sessions/sess-1/findings",


### PR DESCRIPTION
## Summary

Lands phase-1 ticket [06 — Session Timeline Viewer](docs/plans/phase-1/06-session-timeline-viewer.md). A server-rendered, offline-only view of everything the recorder knows about a session — turns, tool calls, outputs, token usage, cost anomalies, and incidents — with per-event provenance and the three-way capture-confidence treatment (direct / lossy / not-captured).

Built on ADR-001 (#21) — all URLs and anchors use `event_sessions.session_key` as the canonical identifier.

## Notable design choices

- **URL path** is `/timeline/<session_key>`, deliberately distinct from the public `clawjournal://session/<session_key>` deep-link contract. The deep link is the durable identifier; the HTTP path is an implementation detail chosen to avoid colliding with the SPA's existing `/session/:id` client-side route.
- **Subagent nesting** via `event_sessions.parent_session_key` — children render inline under the parent. Child URLs 302-redirect to the parent timeline, per ticket 06's "no standalone child-session page" rule.
- **Legacy `session_id` convenience**: `/timeline/<workbench_id>` resolves to the canonical `session_key` and 302-redirects. Pre-ADR-001 rows with `session_key` still NULL return a friendly 404 instead of falling through to the SPA.
- **`CanonicalEvent` gains** `event_id`, `session_id`, `ingested_at` — stable anchors (`#event-<id>`) across renders and ingestion timing in the provenance drawer.

## Auth posture

Matches the existing SPA: `/timeline/<key>` is served unauthenticated on loopback, same trust level as the static SPA shell that already injects the bearer token into HTML. A real auth hardening pass (stop leaking the token in HTML, add a cookie-based bootstrap) is deferred to a follow-up PR — an unauthenticated timeline page is not a meaningful downgrade relative to the current trust model.

## Test plan

- [x] End-to-end timeline render with seeded events, token usage, cost anomaly, incident, subagent session.
- [x] Child-session URL 302-redirects to parent timeline.
- [x] Unknown `session_key` returns 404 with the not-found page.
- [x] Legacy `session_id` without `session_key` returns 404 (not SPA fallback).
- [x] SPA's `/session/:id` route is untouched — still serves the static SPA shell.
- [x] HTML-escapes event content containing `<script>` payloads.
- [x] `pytest tests/events/test_view.py tests/workbench/test_daemon.py` — 83 passed.
- [x] Full suite: 1398 passed (the three pre-existing `test_trace_note_*` collection errors on main are unrelated).

## Out of scope

- Pagination for very-long sessions — plan 06 open question; current renderer materializes all events in one HTML blob. Measure before optimizing.
- `flightrec ui` / `clawjournal ui` CLI alias — `clawjournal serve` already launches the daemon.
- Cookie-based auth hardening — separate PR.
- SPA integration (link to `/timeline/<key>` from the workbench session drawer) — separate UI work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)