### PR TITLE
feat(events): cross-session full-text search (plan 11)

### DIFF
--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3433,8 +3433,9 @@ def main() -> None:
         help="Filter to a single session_key",
     )
     events_search.add_argument(
-        "--source", default=None, metavar="SRC",
-        help="Filter to a single source (e.g. claude-jsonl)",
+        "--source", action="append", default=[], metavar="SRC",
+        help="Filter to these sources (e.g. claude-jsonl). Repeat or "
+             "comma-separate, same as --client / --type / --confidence",
     )
     events_search.add_argument(
         "--since", default=None, metavar="DURATION",
@@ -4906,20 +4907,33 @@ def _run_events_search(args) -> None:
                     json_mode=json_mode,
                 )
             )
+        # Capture indexed-doc count post-rebuild so JSON consumers
+        # can verify the rebuild actually populated the index.
+        indexed = conn.execute(
+            "SELECT count(*) FROM events_fts_docsize"
+        ).fetchone()[0]
         conn.close()
         if json_mode:
-            payload = {"events_search_rebuild": "ok"}
+            from .events.search import EVENTS_SEARCH_SCHEMA_VERSION
+            payload: dict[str, Any] = {
+                "events_search_schema_version": EVENTS_SEARCH_SCHEMA_VERSION,
+                "rebuild": "ok",
+                "indexed_documents": int(indexed),
+            }
             if request_id is not None:
                 payload["request_id"] = request_id
             sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
         else:
-            sys.stdout.write("events_fts rebuild complete\n")
+            sys.stdout.write(
+                f"events_fts rebuild complete ({indexed} documents indexed)\n"
+            )
         return
 
     try:
         clients = tuple(_split_csv_flag(args.client))
         types = tuple(_split_csv_flag(args.event_type))
         confidences = tuple(_split_csv_flag(args.confidence))
+        sources = tuple(_split_csv_flag(args.source))
         since_iso = parse_since(args.since)
         spec = parse_search_spec(
             query=args.query,
@@ -4927,7 +4941,7 @@ def _run_events_search(args) -> None:
             type_=types,
             confidence=confidences,
             session=args.session,
-            source=args.source,
+            source=sources,
             since_iso=since_iso,
             limit=args.limit if args.limit is not None else DEFAULT_LIMIT,
             snippet_tokens=(

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -4921,7 +4921,7 @@ def _run_events_search(args) -> None:
                 "indexed_documents": int(indexed),
             }
             if request_id is not None:
-                payload["request_id"] = request_id
+                payload["_meta"] = {"request_id": request_id}
             sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
         else:
             sys.stdout.write(

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3403,6 +3403,72 @@ def main() -> None:
     )
     _add_aggregate_flags(events_cost_aggregate, domain="cost")
 
+    # Search subcommand (plan 11): cross-session FTS5 over events.raw_json.
+    events_search = events_sub.add_parser(
+        "search",
+        help="Cross-session full-text search over events (FTS5 over raw_json)",
+    )
+    events_search.add_argument(
+        "query",
+        nargs="?",
+        default=None,
+        help="FTS5 MATCH expression (phrase \"...\", AND/OR/NOT, prefix foo*, "
+             "NEAR/N). Required unless --rebuild-index is set",
+    )
+    events_search.add_argument(
+        "--client", action="append", default=[], metavar="CLIENT",
+        help="Filter to this client (repeat or comma-separate)",
+    )
+    events_search.add_argument(
+        "--type", action="append", default=[], metavar="TYPE",
+        dest="event_type",
+        help="Filter to these event types (repeat or comma-separate)",
+    )
+    events_search.add_argument(
+        "--confidence", action="append", default=[], metavar="LEVEL",
+        help="Filter to these confidence levels (repeat or comma-separate)",
+    )
+    events_search.add_argument(
+        "--session", default=None, metavar="KEY",
+        help="Filter to a single session_key",
+    )
+    events_search.add_argument(
+        "--source", default=None, metavar="SRC",
+        help="Filter to a single source (e.g. claude-jsonl)",
+    )
+    events_search.add_argument(
+        "--since", default=None, metavar="DURATION",
+        help="Lower-bound time filter: Nd / Nh / Nm / today / thisweek",
+    )
+    events_search.add_argument(
+        "--limit", type=int, default=None, metavar="N",
+        help="Top-N hits to return (default: 50, ceiling: 1000)",
+    )
+    events_search.add_argument(
+        "--snippet-length", type=int, default=None, metavar="CHARS",
+        dest="snippet_length",
+        help="Snippet window length in characters (default: 120, range 16-1024)",
+    )
+    events_search.add_argument(
+        "--include-held", action="store_true", dest="include_held",
+        help="Include events from held sessions (pending_review / embargoed). "
+             "Default: held sessions are excluded so search results don't "
+             "surface content under redaction review",
+    )
+    events_search.add_argument(
+        "--rebuild-index", action="store_true", dest="rebuild_index",
+        help="One-shot reindex of events_fts from events. Use after a "
+             "DELETE FROM events_fts or any surgery on events that bypassed "
+             "the triggers",
+    )
+    events_search.add_argument(
+        "--json", action="store_true", help="Emit JSON instead of human output",
+    )
+    events_search.add_argument(
+        "--request-id", dest="request_id",
+        help="Opaque ID echoed into _meta.request_id when --json is set",
+    )
+
     # Workbench commands
     serve_parser = sub.add_parser("serve", help="Start the workbench daemon + web UI")
     serve_parser.add_argument("--port", type=int, default=8384, help="Port (default: 8384)")
@@ -4107,6 +4173,10 @@ def _run_events(args) -> None:
         _run_events_aggregate(args)
         return
 
+    if args.events_command == "search":
+        _run_events_search(args)
+        return
+
     conn = open_index()
     try:
         summary = ingest_pending(conn, source_filter=args.source)
@@ -4723,6 +4793,226 @@ def _parse_metric_token(token: str, registry) -> "Metric":  # type: ignore[name-
         f"unrecognized metric: {token!r} "
         f"(expected count | sum:<field> | avg:<field>)"
     )
+
+
+def _run_events_search(args) -> None:
+    """Cross-session FTS over events.raw_json (plan 11).
+
+    Wraps schema bootstrap, validation, query, and render. Errors flow
+    through plan 08's structured envelope: usage_error → 2,
+    index_missing → 3 (FTS table absent or events table absent),
+    unspecified → 9.
+    """
+
+    import sqlite3
+
+    from .events.aggregate import parse_since
+    from .events.doctor.envelope import (
+        KIND_INDEX_MISSING,
+        KIND_UNSPECIFIED,
+        KIND_USAGE_ERROR,
+        emit_error,
+    )
+    from .events.search import (
+        DEFAULT_LIMIT,
+        DEFAULT_SNIPPET_LENGTH,
+        ensure_search_schema,
+        parse_search_spec,
+        rebuild_search_index,
+        render_human,
+        render_json,
+        run as run_search,
+    )
+    from .workbench.index import open_index
+
+    request_id = getattr(args, "request_id", None)
+    json_mode = bool(getattr(args, "json", False))
+
+    rebuild_only = bool(getattr(args, "rebuild_index", False))
+    if not rebuild_only and not args.query:
+        sys.exit(
+            emit_error(
+                code=2,
+                kind=KIND_USAGE_ERROR,
+                message="missing required positional: <query>",
+                hint="pass an FTS5 MATCH expression, or --rebuild-index to "
+                     "reindex the FTS table",
+                request_id=request_id,
+                json_mode=json_mode,
+            )
+        )
+
+    try:
+        conn = open_index()
+    except FileNotFoundError as exc:
+        sys.exit(
+            emit_error(
+                code=3,
+                kind=KIND_INDEX_MISSING,
+                message=f"index database not found: {exc}",
+                hint="run `clawjournal scan` then `clawjournal events ingest`",
+                request_id=request_id,
+                json_mode=json_mode,
+            )
+        )
+
+    try:
+        ensure_search_schema(conn)
+    except sqlite3.OperationalError as exc:
+        # Most likely "no such table: events" — workbench DB exists
+        # but events ingest never ran. Map to index_missing.
+        conn.close()
+        msg = str(exc)
+        if "no such table" in msg:
+            sys.exit(
+                emit_error(
+                    code=3,
+                    kind=KIND_INDEX_MISSING,
+                    message=msg,
+                    hint="run `clawjournal events ingest` to populate the "
+                         "events tables before searching",
+                    request_id=request_id,
+                    json_mode=json_mode,
+                )
+            )
+        sys.exit(
+            emit_error(
+                code=9,
+                kind=KIND_UNSPECIFIED,
+                message=f"could not initialize FTS schema: {msg}",
+                hint="re-run with --json for the structured payload",
+                request_id=request_id,
+                json_mode=json_mode,
+            )
+        )
+
+    if rebuild_only:
+        try:
+            rebuild_search_index(conn)
+            conn.commit()
+        except sqlite3.OperationalError as exc:
+            conn.close()
+            sys.exit(
+                emit_error(
+                    code=9,
+                    kind=KIND_UNSPECIFIED,
+                    message=f"FTS rebuild failed: {exc}",
+                    hint="check `~/.clawjournal/index.db` is writable",
+                    request_id=request_id,
+                    json_mode=json_mode,
+                )
+            )
+        conn.close()
+        if json_mode:
+            payload = {"events_search_rebuild": "ok"}
+            if request_id is not None:
+                payload["request_id"] = request_id
+            sys.stdout.write(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+        else:
+            sys.stdout.write("events_fts rebuild complete\n")
+        return
+
+    try:
+        clients = tuple(_split_csv_flag(args.client))
+        types = tuple(_split_csv_flag(args.event_type))
+        confidences = tuple(_split_csv_flag(args.confidence))
+        since_iso = parse_since(args.since)
+        spec = parse_search_spec(
+            query=args.query,
+            client=clients,
+            type_=types,
+            confidence=confidences,
+            session=args.session,
+            source=args.source,
+            since_iso=since_iso,
+            limit=args.limit if args.limit is not None else DEFAULT_LIMIT,
+            snippet_length=(
+                args.snippet_length if args.snippet_length is not None
+                else DEFAULT_SNIPPET_LENGTH
+            ),
+            include_held=bool(args.include_held),
+        )
+    except ValueError as exc:
+        conn.close()
+        sys.exit(
+            emit_error(
+                code=2,
+                kind=KIND_USAGE_ERROR,
+                message=str(exc),
+                hint="see `clawjournal events docs commands` for events search "
+                     "reference",
+                request_id=request_id,
+                json_mode=json_mode,
+            )
+        )
+
+    try:
+        result = run_search(spec, conn)
+    except sqlite3.OperationalError as exc:
+        conn.close()
+        msg = str(exc)
+        # FTS5 raises OperationalError on a malformed MATCH expression.
+        # Common shapes: "fts5: syntax error", "unterminated string",
+        # "no such column: <X>" (FTS5 treats `foo-bar` as a column
+        # filter `foo` ⇒ `bar`; users who typed a hyphen-bareword
+        # actually want the phrase query `"foo-bar"`). Schema and
+        # filter shape are validated upstream, so any OperationalError
+        # here is almost certainly query-shape — map to usage_error
+        # so agents see exit code 2 rather than the catch-all 9.
+        # Schema-level OperationalError ("no such table: events_fts")
+        # was already caught by ensure_search_schema above.
+        lowered = msg.lower()
+        looks_like_user_query_error = any(
+            tok in lowered
+            for tok in (
+                "fts5",
+                "syntax error",
+                "unterminated",
+                " near ",
+                "no such column",
+            )
+        )
+        if looks_like_user_query_error:
+            sys.exit(
+                emit_error(
+                    code=2,
+                    kind=KIND_USAGE_ERROR,
+                    message=f"FTS5 rejected query: {msg}",
+                    hint="quote phrase queries (\"foo bar\"), use prefix as "
+                         "foo*, escape literal punctuation",
+                    request_id=request_id,
+                    json_mode=json_mode,
+                )
+            )
+        sys.exit(
+            emit_error(
+                code=9,
+                kind=KIND_UNSPECIFIED,
+                message=f"search failed: {msg}",
+                hint="re-run with --json for the structured payload",
+                request_id=request_id,
+                json_mode=json_mode,
+            )
+        )
+    except Exception as exc:
+        conn.close()
+        sys.exit(
+            emit_error(
+                code=9,
+                kind=KIND_UNSPECIFIED,
+                message=f"search failed: {exc!r}",
+                hint="re-run with --json for the structured payload",
+                request_id=request_id,
+                json_mode=json_mode,
+            )
+        )
+    conn.close()
+
+    if json_mode:
+        sys.stdout.write(render_json(result, request_id=request_id))
+        sys.stdout.write("\n")
+    else:
+        sys.stdout.write(render_human(result))
 
 
 _INSPECT_HUMAN_DEFAULT_TRUNCATE = 1024

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3445,9 +3445,13 @@ def main() -> None:
         help="Top-N hits to return (default: 50, ceiling: 1000)",
     )
     events_search.add_argument(
-        "--snippet-length", type=int, default=None, metavar="CHARS",
-        dest="snippet_length",
-        help="Snippet window length in characters (default: 120, range 16-1024)",
+        "--snippet-tokens", type=int, default=None, metavar="N",
+        dest="snippet_tokens",
+        help="Snippet window length in tokens, not characters (default: 16, "
+             "range 1-64). FTS5 caps at 64 tokens internally; values above "
+             "64 are silently clamped, so the cap is enforced here. v0.1 "
+             "originally called this --snippet-length and claimed "
+             "characters — round-1 fix renames to match the FTS5 contract",
     )
     events_search.add_argument(
         "--include-held", action="store_true", dest="include_held",
@@ -4815,7 +4819,7 @@ def _run_events_search(args) -> None:
     )
     from .events.search import (
         DEFAULT_LIMIT,
-        DEFAULT_SNIPPET_LENGTH,
+        DEFAULT_SNIPPET_TOKENS,
         ensure_search_schema,
         parse_search_spec,
         rebuild_search_index,
@@ -4926,9 +4930,9 @@ def _run_events_search(args) -> None:
             source=args.source,
             since_iso=since_iso,
             limit=args.limit if args.limit is not None else DEFAULT_LIMIT,
-            snippet_length=(
-                args.snippet_length if args.snippet_length is not None
-                else DEFAULT_SNIPPET_LENGTH
+            snippet_tokens=(
+                args.snippet_tokens if args.snippet_tokens is not None
+                else DEFAULT_SNIPPET_TOKENS
             ),
             include_held=bool(args.include_held),
         )

--- a/clawjournal/events/docs/_features.yaml
+++ b/clawjournal/events/docs/_features.yaml
@@ -1,8 +1,5 @@
 # Single source for `events features --json:features` and the
 # `events docs commands` topic. Plan 08 §events features.
-#
-# When 11 ships `events search`, add its entry here and a per-command
-# section to `commands.md`.
 version: 1
 features:
   - id: events.ingest
@@ -17,6 +14,9 @@ features:
   - id: events.aggregate
     command: clawjournal events aggregate
     summary: "Cross-session aggregation over events (counts/sums/avgs by dimension)"
+  - id: events.search
+    command: clawjournal events search
+    summary: "Cross-session full-text search over events.raw_json (FTS5)"
   - id: events.cost.ingest
     command: clawjournal events cost ingest
     summary: "Extract token usage and detect cost anomalies"

--- a/clawjournal/events/docs/commands.md
+++ b/clawjournal/events/docs/commands.md
@@ -117,6 +117,60 @@ Required: `--by`. Allowed dimensions: `kind`, `confidence`,
 Flags: `--metric`, `--where`, `--since`, `--limit`, `--json`,
 `--request-id <id>`.
 
+## events search
+
+Cross-session full-text search over `events.raw_json` using SQLite
+FTS5. Backed by an external-content virtual table `events_fts` in
+`{INDEX_DB}`; insert/delete/update triggers on `events` keep it in
+lockstep. The schema is bootstrapped on first use — no separate
+migration step.
+
+Required: `<query>` (FTS5 MATCH expression — phrase queries
+`"tool error"`, AND/OR/NOT, prefix `auth*`, NEAR/N). Empty terms
+without operators are AND-ed by FTS5 implicitly. Query is
+parameterized (bound to `MATCH ?`) — never string-interpolated.
+
+Tokenizer: `unicode61 remove_diacritics 2 tokenchars '-_'`. Hyphen
+and underscore are part of tokens, so `snake_case` and `kebab-case`
+index as single tokens; a search for `rate limit` does NOT match
+`rate-limit` (tradeoff documented in plan 11 §Open questions).
+
+To search for a bareword that contains a hyphen (e.g. `rate-limit`,
+`my-tool`), wrap it in phrase quotes: `events search '"rate-limit"'`.
+FTS5's query parser treats unquoted `foo-bar` as a column filter on
+the non-existent column `foo` and raises `no such column` — the CLI
+maps that error to a usage_error with this hint.
+
+Allowed filter flags: `--client`, `--type`, `--confidence`,
+`--session`, `--source` (each repeat or comma-separate; `--session`
+takes a single value), `--since Nd|Nh|Nm|today|thisweek`. All
+filters land as parameterized predicates.
+
+Hold-state: events from sessions in `pending_review` or active
+`embargoed` are excluded by default. Pass `--include-held` to
+surface them. Sessions that have not been touched by the workbench
+(no `sessions` row) are NOT held — they pass through unchanged.
+
+Output bucket-key values run through `Anonymizer().path()` for
+`raw_ref.source_path` and `Anonymizer().text()` for `session_key`,
+matching the `events aggregate` treatment. Snippets run through
+`redaction/secrets.py` before emit so a fixture with a known secret
+in `raw_json` produces a search hit whose snippet shows
+`[SECRET_REDACTED]`, not the plaintext (plan 11 §Security #4).
+
+Result-set caps: default `--limit 50`, ceiling 1000. Query string
+cap: 4096 bytes (UTF-8). Snippet length: default 120 chars, range
+16-1024.
+
+Special modes:
+- `--rebuild-index` reindexes `events_fts` from `events` (FTS5's
+  documented `'rebuild'` command). Use after `DELETE FROM events_fts`
+  or any surgery on `events` that bypassed the triggers.
+
+Flags: `--client`, `--type`, `--confidence`, `--session`,
+`--source`, `--since`, `--limit`, `--snippet-length`,
+`--include-held`, `--rebuild-index`, `--json`, `--request-id <id>`.
+
 ## events export
 
 Package a session into a self-describing JSON bundle (events,

--- a/clawjournal/events/docs/commands.md
+++ b/clawjournal/events/docs/commands.md
@@ -159,8 +159,19 @@ in `raw_json` produces a search hit whose snippet shows
 `[SECRET_REDACTED]`, not the plaintext (plan 11 §Security #4).
 
 Result-set caps: default `--limit 50`, ceiling 1000. Query string
-cap: 4096 bytes (UTF-8). Snippet length: default 120 chars, range
-16-1024.
+cap: 4096 bytes (UTF-8). Snippet window: default 16 tokens, range
+1-64 (FTS5's documented hard ceiling on `snippet()` is 64 tokens
+— values above are silently clamped, so the cap is enforced
+locally to fail loudly instead).
+
+Index storage caveat: FTS5 indexes the literal contents of
+`events.raw_json`, so anything in the original vendor JSONL line
+ends up in `~/.clawjournal/index.db`'s FTS structures. The index
+file inherits the same filesystem permissions as the source
+JSONL — no new exfiltration surface — but if you redact secrets
+from the underlying `events.raw_json` post-hoc, re-run
+`events search --rebuild-index` to scrub the FTS table too. Plan 11
+§Security #5.
 
 Special modes:
 - `--rebuild-index` reindexes `events_fts` from `events` (FTS5's
@@ -168,7 +179,7 @@ Special modes:
   or any surgery on `events` that bypassed the triggers.
 
 Flags: `--client`, `--type`, `--confidence`, `--session`,
-`--source`, `--since`, `--limit`, `--snippet-length`,
+`--source`, `--since`, `--limit`, `--snippet-tokens`,
 `--include-held`, `--rebuild-index`, `--json`, `--request-id <id>`.
 
 ## events export

--- a/clawjournal/events/docs/schemas.md
+++ b/clawjournal/events/docs/schemas.md
@@ -122,7 +122,7 @@ hits: [
       "source_offset": <int>,
       "seq": <int>
     },
-    "snippet": <string>,               # secrets redacted; v0.1 emits no <mark>
+    "snippet": <string>,               # secrets-redacted + path-anonymized; v0.1 emits no <mark>
     "bm25": <float>,                   # FTS5 relevance, smaller is closer
     "timeline_url": <string>           # clawjournal://session/<key>#event-<id>
   },
@@ -138,9 +138,14 @@ _meta: {
 ```
 
 `session_key` and `raw_ref.source_path` are anonymized before
-emission. Snippets are run through `clawjournal/redaction/secrets.py`
-before emit, so secrets that the regex would catch on export render
-as `[SECRET_REDACTED]` here too. Plan 11 §Security #3 + #4.
+emission. Snippets go through a two-pass scrub: first
+`clawjournal/redaction/secrets.py` (secrets → typed placeholder),
+then `Anonymizer().text()` (home-rooted absolute paths and bare
+usernames → `[REDACTED_PATH]` / `[REDACTED_USERNAME]`). Plan 11
+§Security #3 + #4 plus §Acceptance ("grep for `/Users/` or
+`/home/` in search JSON output is empty"). Round-4 fix: v0.1 ran
+only the secrets pass on snippets, leaking absolute paths from
+ENOENT-shaped error messages and tool-call argument JSON.
 
 ## structured error envelope
 

--- a/clawjournal/events/docs/schemas.md
+++ b/clawjournal/events/docs/schemas.md
@@ -147,6 +147,23 @@ usernames → `[REDACTED_PATH]` / `[REDACTED_USERNAME]`). Plan 11
 only the secrets pass on snippets, leaking absolute paths from
 ENOENT-shaped error messages and tool-call argument JSON.
 
+## events search --rebuild-index --json
+
+```
+events_search_schema_version: "1.0"
+rebuild: "ok"
+indexed_documents: <int>                 # row count of events_fts_docsize after rebuild
+_meta: { request_id: <string> }          # only when --request-id is set
+```
+
+Emitted by `events search --rebuild-index --json`. Pinned to the
+same schema version as the search-hits payload so consumers can
+treat both surfaces under one version gate. `indexed_documents`
+lets the caller verify the rebuild actually populated the index
+instead of trusting a bare `"ok"` string. `_meta.request_id`
+follows the convention from §structured error envelope — same
+top-level key on both success and error responses.
+
 ## structured error envelope
 
 When `--json` is set on the new agent commands and an error occurs:

--- a/clawjournal/events/docs/schemas.md
+++ b/clawjournal/events/docs/schemas.md
@@ -102,6 +102,46 @@ home-rooted absolute paths are anonymized via
 ``[REDACTED_PATH]`` or ``codex:[REDACTED_PATH]`` for embedded
 paths). Plan 10 §Security #2.
 
+## events search --json
+
+```
+events_search_schema_version: "1.0"
+query: <string>                        # the user's MATCH expression, verbatim
+rewritten_match: <string>              # the expression actually bound to MATCH
+hits: [
+  {
+    "event_id": <int>,
+    "session_key": <string>,           # anonymized via Anonymizer().text()
+    "event_at": <iso-timestamp|null>,
+    "client": <string>,
+    "type": <string>,
+    "confidence": <string>,
+    "source": <string>,
+    "raw_ref": {
+      "source_path": <string>,         # anonymized via Anonymizer().path()
+      "source_offset": <int>,
+      "seq": <int>
+    },
+    "snippet": <string>,               # secrets redacted; v0.1 emits no <mark>
+    "bm25": <float>,                   # FTS5 relevance, smaller is closer
+    "timeline_url": <string>           # clawjournal://session/<key>#event-<id>
+  },
+  ...
+]
+_meta: {
+  elapsed_ms: <int>,
+  rows_matched: <int>,                 # COUNT(*) before --limit truncation
+  rows_returned: <int>,                # = len(hits)
+  include_held: <bool>,                # echoes the user's --include-held flag
+  request_id: <string>                 # only when --request-id is set
+}
+```
+
+`session_key` and `raw_ref.source_path` are anonymized before
+emission. Snippets are run through `clawjournal/redaction/secrets.py`
+before emit, so secrets that the regex would catch on export render
+as `[SECRET_REDACTED]` here too. Plan 11 §Security #3 + #4.
+
 ## structured error envelope
 
 When `--json` is set on the new agent commands and an error occurs:

--- a/clawjournal/events/search/__init__.py
+++ b/clawjournal/events/search/__init__.py
@@ -1,0 +1,59 @@
+"""Cross-session full-text search over `events.raw_json` (phase-1 plan 11).
+
+Public API:
+
+- ``SearchSpec`` / ``SearchHit`` — parsed, validated request/response shapes.
+- ``parse_search_spec`` — build a ``SearchSpec`` from CLI flags + filters.
+- ``run`` — execute the search, return ``SearchResult``.
+- ``ensure_search_schema`` / ``rebuild_search_index`` — schema bootstrap +
+  one-shot rebuild after a ``DELETE FROM events_fts`` or other surgery.
+- ``render_json`` / ``render_human`` — output renderers; both anonymize
+  paths and run snippets through ``redaction/secrets.py`` before emit.
+
+Module placement mirrors the doctor (plan 08) and aggregate (plan 10)
+packages: spec → schema → query → render, with a thin public ``__init__``.
+"""
+
+from __future__ import annotations
+
+from clawjournal.events.search.query import (
+    SearchHit,
+    SearchResult,
+    parse_search_spec,
+    run,
+)
+from clawjournal.events.search.render import (
+    EVENTS_SEARCH_SCHEMA_VERSION,
+    render_human,
+    render_json,
+    result_to_payload,
+)
+from clawjournal.events.search.schema import (
+    ensure_search_schema,
+    rebuild_search_index,
+)
+from clawjournal.events.search.spec import (
+    DEFAULT_LIMIT,
+    DEFAULT_SNIPPET_LENGTH,
+    HARD_LIMIT_CEILING,
+    MAX_QUERY_BYTES,
+    SearchSpec,
+)
+
+__all__ = [
+    "DEFAULT_LIMIT",
+    "DEFAULT_SNIPPET_LENGTH",
+    "EVENTS_SEARCH_SCHEMA_VERSION",
+    "HARD_LIMIT_CEILING",
+    "MAX_QUERY_BYTES",
+    "SearchHit",
+    "SearchResult",
+    "SearchSpec",
+    "ensure_search_schema",
+    "parse_search_spec",
+    "rebuild_search_index",
+    "render_human",
+    "render_json",
+    "result_to_payload",
+    "run",
+]

--- a/clawjournal/events/search/__init__.py
+++ b/clawjournal/events/search/__init__.py
@@ -34,18 +34,22 @@ from clawjournal.events.search.schema import (
 )
 from clawjournal.events.search.spec import (
     DEFAULT_LIMIT,
-    DEFAULT_SNIPPET_LENGTH,
+    DEFAULT_SNIPPET_TOKENS,
     HARD_LIMIT_CEILING,
     MAX_QUERY_BYTES,
+    MAX_SNIPPET_TOKENS,
+    MIN_SNIPPET_TOKENS,
     SearchSpec,
 )
 
 __all__ = [
     "DEFAULT_LIMIT",
-    "DEFAULT_SNIPPET_LENGTH",
+    "DEFAULT_SNIPPET_TOKENS",
     "EVENTS_SEARCH_SCHEMA_VERSION",
     "HARD_LIMIT_CEILING",
     "MAX_QUERY_BYTES",
+    "MAX_SNIPPET_TOKENS",
+    "MIN_SNIPPET_TOKENS",
     "SearchHit",
     "SearchResult",
     "SearchSpec",

--- a/clawjournal/events/search/query.py
+++ b/clawjournal/events/search/query.py
@@ -169,7 +169,15 @@ def run(spec: SearchSpec, conn: sqlite3.Connection) -> SearchResult:
     return SearchResult(
         spec=spec,
         hits=hits,
-        rewritten_match=spec.query.strip(),
+        # `rewritten_match` is the value actually bound to FTS5's MATCH
+        # predicate. Today it's identical to `spec.query`; the field
+        # exists so downstream consumers can pin the contract before any
+        # query rewriting (synonym expansion, alias resolution, etc.) is
+        # introduced. Round-7 fix: was previously `spec.query.strip()`,
+        # which both lied about being "rewritten" AND could differ from
+        # what was actually bound (the SQL builder uses spec.query
+        # unstripped).
+        rewritten_match=spec.query,
         rows_matched=rows_matched,
         elapsed_ms=elapsed_ms,
     )
@@ -177,24 +185,18 @@ def run(spec: SearchSpec, conn: sqlite3.Connection) -> SearchResult:
 
 def _build_hits_sql(spec: SearchSpec) -> tuple[str, list[Any]]:
     where_clause, params = _build_where(spec)
-    # The MATCH parameter MUST be bound (not interpolated). FTS5's
-    # snippet() helper gets the highlight markers; the render layer
-    # turns them into <mark>...</mark> after running snippet through
-    # the secrets redactor (plan 11 §Security #4).
-    #
-    # FTS5 ``snippet()`` takes max-tokens (not chars), with a hard
-    # ceiling of 64. SearchSpec already enforces 1 <= snippet_tokens
-    # <= 64, so it is safe to interpolate as a fixed integer literal.
-    # Round-1 fix: v0.1 originally exposed ``--snippet-length`` as
-    # "characters" with a 1024 ceiling, but FTS5 silently clamped
-    # everything >=64 to 64. The flag, spec field, and constants are
-    # now ``--snippet-tokens`` to match the FTS5 contract.
-    snippet_tokens = spec.snippet_tokens
+    # Both `?`-bound: the MATCH expression (security-critical — FTS5
+    # parses it as a query language) and snippet()'s max-tokens (just
+    # consistency with the rest of the parameter binding pattern).
+    # SearchSpec enforces 1 <= snippet_tokens <= 64 so the latter is
+    # already trusted, but binding it removes one source of SQL
+    # composition. SQLite accepts integer binding for snippet()'s
+    # numeric args — verified against sqlite 3.x.
     sql = (
         "SELECT e.id, s.session_key, e.event_at, e.client, e.type, "
         "       e.confidence, e.source, e.source_path, e.source_offset, "
         "       e.seq, "
-        "       snippet(events_fts, 0, '', '', '...', " + str(snippet_tokens) + "), "
+        "       snippet(events_fts, 0, '', '', '...', ?), "
         "       bm25(events_fts) "
         "FROM events_fts "
         "JOIN events AS e ON e.id = events_fts.rowid "
@@ -204,7 +206,7 @@ def _build_hits_sql(spec: SearchSpec) -> tuple[str, list[Any]]:
         "ORDER BY bm25(events_fts) ASC, e.id ASC "
         "LIMIT ?"
     )
-    bound = [spec.query] + params + [spec.limit]
+    bound = [spec.snippet_tokens, spec.query] + params + [spec.limit]
     return sql, bound
 
 

--- a/clawjournal/events/search/query.py
+++ b/clawjournal/events/search/query.py
@@ -23,13 +23,11 @@ from __future__ import annotations
 import sqlite3
 import time
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from typing import Any
 
 from clawjournal.events.aggregate.spec import Predicate
 from clawjournal.events.search.spec import SEARCH_FILTER_FIELDS, SearchSpec
-
-
-_HELD_STATES: tuple[str, ...] = ("pending_review", "embargoed")
 
 
 @dataclass(frozen=True)
@@ -235,15 +233,29 @@ def _build_where(spec: SearchSpec) -> tuple[str, list[Any]]:
         pieces.append("e.event_at >= ?")
         params.append(spec.since_iso)
     if not spec.include_held:
-        # Held sessions are filtered out by hold_state. Workbench may
-        # not have a row for every event_session (sessions that have
-        # not yet been touched by the workbench), so NULL hold_state
-        # also passes — only the explicit non-default states block.
-        placeholders = ",".join("?" for _ in _HELD_STATES)
+        # Held sessions are filtered out. Two cases block:
+        #   1. ``hold_state = 'pending_review'`` — under findings
+        #      review; surfacing the events defeats the point.
+        #   2. ``hold_state = 'embargoed'`` AND ``embargo_until`` is
+        #      either NULL (defensive) or in the future. An embargo
+        #      whose ``embargo_until`` has already passed is treated
+        #      as released — same semantics as
+        #      ``workbench.index.effective_hold_state``. Without this
+        #      check, expired embargoes would silently linger as
+        #      search-blocked even though every other code path
+        #      treats them as released. Round-2 self-review fix.
+        # Workbench may not have a ``sessions`` row for every
+        # event_session, so NULL hold_state passes through
+        # (treated as not held).
+        now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         pieces.append(
-            f"(ws.hold_state IS NULL OR ws.hold_state NOT IN ({placeholders}))"
+            "(ws.hold_state IS NULL "
+            "OR (ws.hold_state != 'pending_review' "
+            "    AND NOT (ws.hold_state = 'embargoed' "
+            "             AND (ws.embargo_until IS NULL "
+            "                  OR ws.embargo_until > ?))))"
         )
-        params.extend(_HELD_STATES)
+        params.append(now_iso)
     if not pieces:
         return "", params
     return "AND " + " AND ".join(pieces) + " ", params

--- a/clawjournal/events/search/query.py
+++ b/clawjournal/events/search/query.py
@@ -1,0 +1,265 @@
+"""SQL builder + executor for ``events search`` (phase-1 plan 11).
+
+Build a single parameterized SELECT that joins ``events_fts`` (FTS5
+virtual table, plan 11 §Index shape) to ``events`` and ``event_sessions``,
+applies allowlisted filters, optionally excludes held sessions via a
+LEFT JOIN to the workbench ``sessions`` table, ranks by BM25 ASC
+(FTS5's BM25 returns smaller-is-better — relevance), and limits.
+
+The user's query is bound as a parameter to the FTS5 ``MATCH``
+predicate. Field names go through the per-search allowlist
+(``spec.SEARCH_FILTER_FIELDS``); operators map to a fixed enum;
+values become ``?`` placeholders. No string interpolation.
+
+Hold-state filter: defaults to excluding sessions in
+``pending_review`` or ``embargoed`` (plan 11 §Security #6). Workbench
+``sessions`` may not have a row for every event_session — the LEFT
+JOIN treats ``hold_state IS NULL`` as a non-held state so events from
+sessions that haven't been touched by the workbench still surface.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import time
+from dataclasses import dataclass
+from typing import Any
+
+from clawjournal.events.aggregate.spec import Predicate
+from clawjournal.events.search.spec import SEARCH_FILTER_FIELDS, SearchSpec
+
+
+_HELD_STATES: tuple[str, ...] = ("pending_review", "embargoed")
+
+
+@dataclass(frozen=True)
+class SearchHit:
+    """One row of search output before render-layer anonymization /
+    snippet redaction. The render layer is where the user-visible
+    JSON shape is built; this struct just bundles the SQL row in a
+    typed form so the renderer doesn't have to remember tuple offsets."""
+
+    event_id: int
+    session_key: str
+    event_at: str | None
+    client: str
+    type: str
+    confidence: str
+    source: str
+    source_path: str
+    source_offset: int
+    seq: int
+    snippet: str
+    bm25: float
+
+
+@dataclass(frozen=True)
+class SearchResult:
+    """Output of one ``query.run`` call.
+
+    ``hits`` are already ordered by BM25 ascending (FTS5's relevance
+    ranking — smaller is closer). ``rows_matched`` is the COUNT(*) of
+    matches before ``--limit`` truncation; clients can detect a
+    truncated result set with ``len(hits) < rows_matched``.
+    """
+
+    spec: SearchSpec
+    hits: list[SearchHit]
+    rewritten_match: str
+    rows_matched: int
+    elapsed_ms: int
+
+
+def parse_search_spec(
+    *,
+    query: str,
+    client: tuple[str, ...] = (),
+    type_: tuple[str, ...] = (),
+    confidence: tuple[str, ...] = (),
+    session: str | None = None,
+    source: str | None = None,
+    since_iso: str | None = None,
+    limit: int,
+    snippet_length: int,
+    include_held: bool,
+    canonical: bool = False,
+) -> SearchSpec:
+    """Build a validated ``SearchSpec`` from already-parsed CLI args.
+
+    The CLI handler does the per-flag value parsing (CSV split, type
+    coercion, etc.) and hands the cleaned values here so this
+    function is purely about predicate construction + validation.
+    """
+
+    filters: list[Predicate] = []
+    if client:
+        filters.append(_predicate_for("client", client))
+    if type_:
+        filters.append(_predicate_for("type", type_))
+    if confidence:
+        filters.append(_predicate_for("confidence", confidence))
+    if session:
+        filters.append(Predicate(field="session", op="=", value=session))
+    if source:
+        filters.append(Predicate(field="source", op="=", value=source))
+    return SearchSpec(
+        query=query,
+        filters=tuple(filters),
+        since_iso=since_iso,
+        limit=limit,
+        snippet_length=snippet_length,
+        include_held=include_held,
+        canonical=canonical,
+    )
+
+
+def _predicate_for(field: str, values: tuple[str, ...]) -> Predicate:
+    """One-or-many CLI value tuples: a single value uses ``=``,
+    multiple use ``in``. Both render to a parameterized SQL clause
+    in ``_predicate_sql`` below."""
+
+    if len(values) == 1:
+        return Predicate(field=field, op="=", value=values[0])
+    return Predicate(field=field, op="in", value=tuple(values))
+
+
+def run(spec: SearchSpec, conn: sqlite3.Connection) -> SearchResult:
+    """Execute the search.
+
+    Both queries (hits + rows_matched) run inside a single explicit
+    read transaction so the report is internally consistent against
+    a single snapshot — same pattern plan 10's aggregator uses for
+    the same reason (bucket query + summary query against concurrent
+    writes from ``clawjournal serve``).
+    """
+
+    hits_sql, hits_params = _build_hits_sql(spec)
+    count_sql, count_params = _build_count_sql(spec)
+
+    in_explicit_tx = bool(conn.in_transaction)
+    if not in_explicit_tx:
+        conn.execute("BEGIN")
+    try:
+        started = time.perf_counter()
+        cursor = conn.execute(hits_sql, hits_params)
+        rows = list(cursor.fetchall())
+        count_row = conn.execute(count_sql, count_params).fetchone()
+        elapsed_ms = int((time.perf_counter() - started) * 1000)
+    finally:
+        if not in_explicit_tx:
+            try:
+                conn.execute("COMMIT")
+            except sqlite3.OperationalError:
+                pass
+
+    rows_matched = int(count_row[0]) if count_row and count_row[0] is not None else 0
+    hits = [
+        SearchHit(
+            event_id=int(row[0]),
+            session_key=row[1],
+            event_at=row[2],
+            client=row[3],
+            type=row[4],
+            confidence=row[5],
+            source=row[6],
+            source_path=row[7],
+            source_offset=int(row[8]),
+            seq=int(row[9]),
+            snippet=row[10] or "",
+            bm25=float(row[11]) if row[11] is not None else 0.0,
+        )
+        for row in rows
+    ]
+    return SearchResult(
+        spec=spec,
+        hits=hits,
+        rewritten_match=spec.query.strip(),
+        rows_matched=rows_matched,
+        elapsed_ms=elapsed_ms,
+    )
+
+
+def _build_hits_sql(spec: SearchSpec) -> tuple[str, list[Any]]:
+    where_clause, params = _build_where(spec)
+    # The MATCH parameter MUST be bound (not interpolated). FTS5's
+    # snippet() helper gets the highlight markers; the render layer
+    # turns them into <mark>...</mark> after running snippet through
+    # the secrets redactor (plan 11 §Security #4).
+    snippet_chars = spec.snippet_length
+    sql = (
+        "SELECT e.id, s.session_key, e.event_at, e.client, e.type, "
+        "       e.confidence, e.source, e.source_path, e.source_offset, "
+        "       e.seq, "
+        f"       snippet(events_fts, 0, '', '', '...', {snippet_chars}), "
+        "       bm25(events_fts) "
+        "FROM events_fts "
+        "JOIN events AS e ON e.id = events_fts.rowid "
+        "JOIN event_sessions AS s ON s.id = e.session_id "
+        "LEFT JOIN sessions AS ws ON ws.session_key = s.session_key "
+        f"WHERE events_fts MATCH ? {where_clause}"
+        "ORDER BY bm25(events_fts) ASC, e.id ASC "
+        "LIMIT ?"
+    )
+    bound = [spec.query] + params + [spec.limit]
+    return sql, bound
+
+
+def _build_count_sql(spec: SearchSpec) -> tuple[str, list[Any]]:
+    where_clause, params = _build_where(spec)
+    sql = (
+        "SELECT COUNT(*) "
+        "FROM events_fts "
+        "JOIN events AS e ON e.id = events_fts.rowid "
+        "JOIN event_sessions AS s ON s.id = e.session_id "
+        "LEFT JOIN sessions AS ws ON ws.session_key = s.session_key "
+        f"WHERE events_fts MATCH ? {where_clause}"
+    )
+    bound = [spec.query] + params
+    return sql, bound
+
+
+def _build_where(spec: SearchSpec) -> tuple[str, list[Any]]:
+    pieces: list[str] = []
+    params: list[Any] = []
+    for predicate in spec.filters:
+        sql, p = _predicate_sql(predicate)
+        pieces.append(sql)
+        params.extend(p)
+    if spec.since_iso is not None:
+        pieces.append("e.event_at >= ?")
+        params.append(spec.since_iso)
+    if not spec.include_held:
+        # Held sessions are filtered out by hold_state. Workbench may
+        # not have a row for every event_session (sessions that have
+        # not yet been touched by the workbench), so NULL hold_state
+        # also passes — only the explicit non-default states block.
+        placeholders = ",".join("?" for _ in _HELD_STATES)
+        pieces.append(
+            f"(ws.hold_state IS NULL OR ws.hold_state NOT IN ({placeholders}))"
+        )
+        params.extend(_HELD_STATES)
+    if not pieces:
+        return "", params
+    return "AND " + " AND ".join(pieces) + " ", params
+
+
+def _predicate_sql(predicate: Predicate) -> tuple[str, list[Any]]:
+    sql_field = SEARCH_FILTER_FIELDS.get(predicate.field)
+    if sql_field is None:
+        raise ValueError(
+            f"filter field {predicate.field!r} not allowed for search "
+            f"(allowed: {sorted(SEARCH_FILTER_FIELDS)})"
+        )
+    if predicate.op == "in":
+        values = predicate.value
+        if not isinstance(values, tuple) or not values:
+            raise ValueError(
+                f"`in` predicate for {predicate.field!r} requires a "
+                f"non-empty tuple"
+            )
+        placeholders = ",".join("?" for _ in values)
+        return f"{sql_field} IN ({placeholders})", list(values)
+    return f"{sql_field} {predicate.op} ?", [predicate.value]
+
+
+__all__ = ["SearchHit", "SearchResult", "parse_search_spec", "run"]

--- a/clawjournal/events/search/query.py
+++ b/clawjournal/events/search/query.py
@@ -80,9 +80,8 @@ def parse_search_spec(
     source: str | None = None,
     since_iso: str | None = None,
     limit: int,
-    snippet_length: int,
+    snippet_tokens: int,
     include_held: bool,
-    canonical: bool = False,
 ) -> SearchSpec:
     """Build a validated ``SearchSpec`` from already-parsed CLI args.
 
@@ -107,9 +106,8 @@ def parse_search_spec(
         filters=tuple(filters),
         since_iso=since_iso,
         limit=limit,
-        snippet_length=snippet_length,
+        snippet_tokens=snippet_tokens,
         include_held=include_held,
-        canonical=canonical,
     )
 
 
@@ -185,18 +183,26 @@ def _build_hits_sql(spec: SearchSpec) -> tuple[str, list[Any]]:
     # snippet() helper gets the highlight markers; the render layer
     # turns them into <mark>...</mark> after running snippet through
     # the secrets redactor (plan 11 §Security #4).
-    snippet_chars = spec.snippet_length
+    #
+    # FTS5 ``snippet()`` takes max-tokens (not chars), with a hard
+    # ceiling of 64. SearchSpec already enforces 1 <= snippet_tokens
+    # <= 64, so it is safe to interpolate as a fixed integer literal.
+    # Round-1 fix: v0.1 originally exposed ``--snippet-length`` as
+    # "characters" with a 1024 ceiling, but FTS5 silently clamped
+    # everything >=64 to 64. The flag, spec field, and constants are
+    # now ``--snippet-tokens`` to match the FTS5 contract.
+    snippet_tokens = spec.snippet_tokens
     sql = (
         "SELECT e.id, s.session_key, e.event_at, e.client, e.type, "
         "       e.confidence, e.source, e.source_path, e.source_offset, "
         "       e.seq, "
-        f"       snippet(events_fts, 0, '', '', '...', {snippet_chars}), "
+        "       snippet(events_fts, 0, '', '', '...', " + str(snippet_tokens) + "), "
         "       bm25(events_fts) "
         "FROM events_fts "
         "JOIN events AS e ON e.id = events_fts.rowid "
         "JOIN event_sessions AS s ON s.id = e.session_id "
         "LEFT JOIN sessions AS ws ON ws.session_key = s.session_key "
-        f"WHERE events_fts MATCH ? {where_clause}"
+        "WHERE events_fts MATCH ? " + where_clause +
         "ORDER BY bm25(events_fts) ASC, e.id ASC "
         "LIMIT ?"
     )
@@ -212,7 +218,7 @@ def _build_count_sql(spec: SearchSpec) -> tuple[str, list[Any]]:
         "JOIN events AS e ON e.id = events_fts.rowid "
         "JOIN event_sessions AS s ON s.id = e.session_id "
         "LEFT JOIN sessions AS ws ON ws.session_key = s.session_key "
-        f"WHERE events_fts MATCH ? {where_clause}"
+        "WHERE events_fts MATCH ? " + where_clause
     )
     bound = [spec.query] + params
     return sql, bound

--- a/clawjournal/events/search/query.py
+++ b/clawjournal/events/search/query.py
@@ -75,7 +75,7 @@ def parse_search_spec(
     type_: tuple[str, ...] = (),
     confidence: tuple[str, ...] = (),
     session: str | None = None,
-    source: str | None = None,
+    source: tuple[str, ...] = (),
     since_iso: str | None = None,
     limit: int,
     snippet_tokens: int,
@@ -98,7 +98,7 @@ def parse_search_spec(
     if session:
         filters.append(Predicate(field="session", op="=", value=session))
     if source:
-        filters.append(Predicate(field="source", op="=", value=source))
+        filters.append(_predicate_for("source", source))
     return SearchSpec(
         query=query,
         filters=tuple(filters),

--- a/clawjournal/events/search/render.py
+++ b/clawjournal/events/search/render.py
@@ -54,10 +54,14 @@ def result_to_payload(
 ) -> dict[str, Any]:
     anonymizer = Anonymizer()
     hits_out = [_hit_to_dict(hit, anonymizer=anonymizer) for hit in result.hits]
+    # Anonymize the user's MATCH expression on echo. A user searching for
+    # paths (`events search "/Users/me/secret"`) would otherwise round-trip
+    # the path verbatim into any agent-side log of the JSON envelope. Same
+    # treatment the error-envelope `message` gets in `doctor/envelope.py`.
     payload: dict[str, Any] = {
         "events_search_schema_version": EVENTS_SEARCH_SCHEMA_VERSION,
-        "query": result.spec.query,
-        "rewritten_match": result.rewritten_match,
+        "query": anonymizer.text(result.spec.query),
+        "rewritten_match": anonymizer.text(result.rewritten_match),
         "hits": hits_out,
         "_meta": {
             "elapsed_ms": result.elapsed_ms,
@@ -137,8 +141,11 @@ def render_human(
     anonymizer = Anonymizer()
     buf = StringIO()
     if not result.hits:
+        # Anonymize the user's query in the no-matches message so a path-
+        # shaped query doesn't echo back unredacted; see result_to_payload
+        # above for the rationale.
         buf.write(
-            f"no matches for {result.spec.query!r} "
+            f"no matches for {anonymizer.text(result.spec.query)!r} "
             f"(searched in {result.elapsed_ms} ms)\n"
         )
     else:
@@ -147,7 +154,7 @@ def render_human(
             safe_snippet = _scrub_snippet(hit.snippet, anonymizer=anonymizer)
             buf.write(
                 f"{hit.bm25:>8.3f}  {safe_session}  {hit.type}  "
-                f"{hit.event_at or '∅'}  {safe_snippet}\n"
+                f"{hit.event_at or '-'}  {safe_snippet}\n"
             )
         buf.write(
             f"\n{len(result.hits)} of {result.rows_matched} matches "

--- a/clawjournal/events/search/render.py
+++ b/clawjournal/events/search/render.py
@@ -74,7 +74,7 @@ def result_to_payload(
 def _hit_to_dict(hit: SearchHit, *, anonymizer: Anonymizer) -> dict[str, Any]:
     safe_session_key = anonymizer.text(hit.session_key)
     safe_source_path = anonymizer.path(hit.source_path) if hit.source_path else ""
-    redacted_snippet, _, _ = redact_text(hit.snippet) if hit.snippet else ("", 0, [])
+    safe_snippet = _scrub_snippet(hit.snippet, anonymizer=anonymizer)
     timeline_url = (
         f"clawjournal://session/{safe_session_key}#event-{hit.event_id}"
     )
@@ -91,10 +91,37 @@ def _hit_to_dict(hit: SearchHit, *, anonymizer: Anonymizer) -> dict[str, Any]:
             "source_offset": hit.source_offset,
             "seq": hit.seq,
         },
-        "snippet": redacted_snippet,
+        "snippet": safe_snippet,
         "bm25": hit.bm25,
         "timeline_url": timeline_url,
     }
+
+
+def _scrub_snippet(snippet: str, *, anonymizer: Anonymizer) -> str:
+    """Two-pass scrub on the FTS5 snippet:
+
+    1. ``redact_text`` — replaces credentials with typed
+       placeholders (plan 11 §Security #4).
+    2. ``anonymizer.text`` — replaces home-rooted absolute paths
+       and bare usernames with ``[REDACTED_PATH]`` /
+       ``[REDACTED_USERNAME]``. Plan 11 §Acceptance pins that
+       ``/Users/`` and ``/home/`` never appear in JSON output —
+       round-4 self-review fix; v0.1 redacted secrets but left
+       path leaks in snippets because the snippet content is
+       extracted from ``raw_json`` which the indexer kept verbatim.
+
+    Order matters: secrets first, then anonymizer. The anonymizer's
+    regex looks for ``/Users/<u>/...`` patterns and won't trip over
+    secret placeholders; the secrets regex would not match
+    ``[REDACTED_PATH]`` either way, so the order is robust either
+    way for what we ship today, but doing secrets first matches the
+    "redact first, mark second" rule from plan 11 §Security #4.
+    """
+
+    if not snippet:
+        return ""
+    redacted, _, _ = redact_text(snippet)
+    return anonymizer.text(redacted)
 
 
 def render_human(
@@ -117,12 +144,10 @@ def render_human(
     else:
         for hit in result.hits:
             safe_session = anonymizer.text(hit.session_key)
-            redacted_snippet, _, _ = (
-                redact_text(hit.snippet) if hit.snippet else ("", 0, [])
-            )
+            safe_snippet = _scrub_snippet(hit.snippet, anonymizer=anonymizer)
             buf.write(
                 f"{hit.bm25:>8.3f}  {safe_session}  {hit.type}  "
-                f"{hit.event_at or '∅'}  {redacted_snippet}\n"
+                f"{hit.event_at or '∅'}  {safe_snippet}\n"
             )
         buf.write(
             f"\n{len(result.hits)} of {result.rows_matched} matches "

--- a/clawjournal/events/search/render.py
+++ b/clawjournal/events/search/render.py
@@ -1,0 +1,145 @@
+"""Renderers for ``events search`` results (phase-1 plan 11).
+
+Two flows, both privacy-safe:
+
+1. **Snippet redaction first, highlight second.** ``redact_text`` from
+   ``clawjournal.redaction.secrets`` is run on the FTS5-emitted snippet
+   before any ``<mark>`` tags would land in the output. Plan 11
+   §Security #4 — order matters because ``<mark>`` tags would confuse
+   the secrets regex. Today the FTS5 snippet uses empty start/end
+   markers (see ``query._build_hits_sql``) so the snippet returned
+   from SQLite is plain text; the render layer is responsible for
+   re-injecting highlights only after redaction. v0.1 emits the
+   redacted snippet without highlights — adding back per-token
+   ``<mark>`` is a follow-up that needs a tokenizer-aware diff
+   between raw and redacted snippet to know where to mark.
+2. **Anonymized paths.** ``raw_ref.source_path`` and any path-shaped
+   value in ``session_key`` go through ``Anonymizer().text()`` so
+   ``/Users/<u>/...`` appears as ``[REDACTED_PATH]``. Plan 11
+   §Security #3 — same anonymizer plan 10 uses.
+
+JSON envelope mirrors plan 10's: ``events_search_schema_version``
+(pinned), ``hits``, ``rows_matched``, ``rows_returned`` (= len(hits)),
+``_meta`` with ``elapsed_ms`` / ``request_id``.
+"""
+
+from __future__ import annotations
+
+import json
+from io import StringIO
+from typing import Any, TextIO
+
+from clawjournal.events.search.query import SearchHit, SearchResult
+from clawjournal.redaction.anonymizer import Anonymizer
+from clawjournal.redaction.secrets import redact_text
+
+EVENTS_SEARCH_SCHEMA_VERSION = "1.0"
+
+
+def render_json(
+    result: SearchResult,
+    *,
+    request_id: str | None = None,
+) -> str:
+    """Return the canonical JSON payload as a string."""
+
+    payload = result_to_payload(result, request_id=request_id)
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def result_to_payload(
+    result: SearchResult,
+    *,
+    request_id: str | None = None,
+) -> dict[str, Any]:
+    anonymizer = Anonymizer()
+    hits_out = [_hit_to_dict(hit, anonymizer=anonymizer) for hit in result.hits]
+    payload: dict[str, Any] = {
+        "events_search_schema_version": EVENTS_SEARCH_SCHEMA_VERSION,
+        "query": result.spec.query,
+        "rewritten_match": result.rewritten_match,
+        "hits": hits_out,
+        "_meta": {
+            "elapsed_ms": result.elapsed_ms,
+            "rows_matched": result.rows_matched,
+            "rows_returned": len(hits_out),
+            "include_held": result.spec.include_held,
+        },
+    }
+    if request_id is not None:
+        payload["_meta"]["request_id"] = request_id
+    return payload
+
+
+def _hit_to_dict(hit: SearchHit, *, anonymizer: Anonymizer) -> dict[str, Any]:
+    safe_session_key = anonymizer.text(hit.session_key)
+    safe_source_path = anonymizer.path(hit.source_path) if hit.source_path else ""
+    redacted_snippet, _, _ = redact_text(hit.snippet) if hit.snippet else ("", 0, [])
+    timeline_url = (
+        f"clawjournal://session/{safe_session_key}#event-{hit.event_id}"
+    )
+    return {
+        "event_id": hit.event_id,
+        "session_key": safe_session_key,
+        "event_at": hit.event_at,
+        "client": hit.client,
+        "type": hit.type,
+        "confidence": hit.confidence,
+        "source": hit.source,
+        "raw_ref": {
+            "source_path": safe_source_path,
+            "source_offset": hit.source_offset,
+            "seq": hit.seq,
+        },
+        "snippet": redacted_snippet,
+        "bm25": hit.bm25,
+        "timeline_url": timeline_url,
+    }
+
+
+def render_human(
+    result: SearchResult,
+    *,
+    stream: TextIO | None = None,
+) -> str:
+    """Plain-text fallback. One line per hit:
+    ``<bm25>  <session_key>  <type>  <event_at>  <snippet>``.
+    Snippets go through the same redaction the JSON path uses.
+    """
+
+    anonymizer = Anonymizer()
+    buf = StringIO()
+    if not result.hits:
+        buf.write(
+            f"no matches for {result.spec.query!r} "
+            f"(searched in {result.elapsed_ms} ms)\n"
+        )
+    else:
+        for hit in result.hits:
+            safe_session = anonymizer.text(hit.session_key)
+            redacted_snippet, _, _ = (
+                redact_text(hit.snippet) if hit.snippet else ("", 0, [])
+            )
+            buf.write(
+                f"{hit.bm25:>8.3f}  {safe_session}  {hit.type}  "
+                f"{hit.event_at or '∅'}  {redacted_snippet}\n"
+            )
+        buf.write(
+            f"\n{len(result.hits)} of {result.rows_matched} matches "
+            f"({result.elapsed_ms} ms)"
+        )
+        if not result.spec.include_held:
+            buf.write(" — held sessions excluded; pass --include-held to include")
+        buf.write("\n")
+    text = buf.getvalue()
+    if stream is not None:
+        stream.write(text)
+    return text
+
+
+__all__ = [
+    "EVENTS_SEARCH_SCHEMA_VERSION",
+    "render_human",
+    "render_json",
+    "result_to_payload",
+]

--- a/clawjournal/events/search/schema.py
+++ b/clawjournal/events/search/schema.py
@@ -103,6 +103,15 @@ def ensure_search_schema(conn: sqlite3.Connection) -> None:
     )
     if fts_empty and has_events:
         rebuild_search_index(conn)
+        # Round-7 fix: must commit. sqlite3.connect() defaults to
+        # isolation_level="" which auto-begins a transaction on DML
+        # (the FTS5 'rebuild' insert qualifies). Without an explicit
+        # commit, the rebuild lands in an open transaction; a later
+        # conn.close() rolls it back, and the next ensure_search_schema
+        # call re-detects FTS-empty and rebuilds again — an eternal
+        # rebuild loop with rolled-back work. The earlier search-
+        # recovery test masked the bug by querying before close.
+        conn.commit()
 
 
 def rebuild_search_index(conn: sqlite3.Connection) -> None:

--- a/clawjournal/events/search/schema.py
+++ b/clawjournal/events/search/schema.py
@@ -71,33 +71,37 @@ END;
 def ensure_search_schema(conn: sqlite3.Connection) -> None:
     """Create the FTS virtual table + triggers if absent.
 
-    Idempotent — safe to call on every CLI invocation. The first call
-    on an existing index also runs a one-shot ``rebuild`` to backfill
-    rows that were inserted before the triggers existed; subsequent
-    calls find an already-populated FTS table and skip the rebuild.
+    Idempotent — safe to call on every CLI invocation. Backfills the
+    FTS index whenever it is empty but ``events`` is not, which
+    catches both the fresh-install case AND a recovery from partial
+    migration: if a previous call created ``events_fts`` but failed
+    to create the triggers (because ``events`` did not yet exist),
+    a later call after ``events ingest`` populated ``events`` would
+    have left the FTS out of sync. Round-3 self-review fix — the
+    earlier ``pre_existing_fts`` short-circuit was correct for the
+    happy path but missed the partial-migration recovery.
     """
 
     conn.execute("PRAGMA foreign_keys=ON")
-
-    pre_existing_fts = bool(
-        conn.execute(
-            "SELECT 1 FROM sqlite_master "
-            "WHERE type='table' AND name='events_fts'"
-        ).fetchone()
-    )
-
     conn.executescript(EVENTS_FTS_TABLE_SQL)
     conn.executescript(EVENTS_FTS_TRIGGERS_SQL)
 
-    if pre_existing_fts:
-        return
-
-    # Fresh table — backfill from the events table. Skipped when
-    # `events` is empty (no-op rebuild is cheap but not free).
+    # ``events_fts_docsize`` is FTS5's internal docsize-shadow table;
+    # it has one row per indexed document. ``SELECT * FROM events_fts``
+    # in external-content mode reads through to the events table, so
+    # it cannot tell "indexed" from "not indexed" — counting docsize
+    # is the only reliable way to detect the FTS-empty state. When
+    # FTS-empty + events-non-empty, run a backfill so partial-
+    # migration recovery (FTS table created without triggers, then
+    # ingest happens) self-heals on the next search invocation.
+    fts_empty = (
+        conn.execute("SELECT count(*) FROM events_fts_docsize").fetchone()[0]
+        == 0
+    )
     has_events = bool(
         conn.execute("SELECT 1 FROM events LIMIT 1").fetchone()
     )
-    if has_events:
+    if fts_empty and has_events:
         rebuild_search_index(conn)
 
 

--- a/clawjournal/events/search/schema.py
+++ b/clawjournal/events/search/schema.py
@@ -1,0 +1,121 @@
+"""SQLite FTS5 schema for cross-session search (phase-1 plan 11).
+
+One virtual table (``events_fts``) in external-content mode pointing at
+``events``, plus three triggers so inserts / updates / deletes on
+``events`` keep the index in lockstep. External-content mode is the
+right tradeoff for this workload:
+
+- The ``raw_json`` column is already stored in ``events``; replicating
+  it inside the FTS table would roughly double on-disk size for the
+  one feature that wants the content. External-content keeps a single
+  copy.
+- ``snippet()`` and ``highlight()`` still work in external-content
+  mode because FTS5 follows the rowid back to ``events.raw_json`` to
+  fetch the actual text at query time.
+
+Tokenizer: ``unicode61 remove_diacritics 2 tokenchars '-_'``.
+
+- ``unicode61`` is FTS5's default; it normalizes case and handles
+  unicode letter classes correctly.
+- ``remove_diacritics 2`` strips combining marks even from precomposed
+  characters (mode 1 misses some), so ``café`` and ``cafe`` both index
+  as ``cafe``.
+- ``tokenchars '-_'`` keeps hyphen and underscore inside tokens, so
+  ``snake_case`` and ``kebab-case`` index as single tokens. Plan 11
+  §Open questions notes the recall tradeoff (``rate-limit`` no longer
+  matches a search for ``rate limit``); keep this conservative for
+  now and revisit after real-world usage.
+
+Porter stemming is intentionally NOT enabled — it stems ``authenticate``
+and ``authority`` to the same token, which is wrong for code search.
+
+Rebuild path: ``INSERT INTO events_fts(events_fts) VALUES('rebuild')``
+is FTS5's documented one-shot reindex. ``rebuild_search_index`` wraps
+that in a single transaction.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+EVENTS_FTS_TABLE_SQL = """
+CREATE VIRTUAL TABLE IF NOT EXISTS events_fts USING fts5(
+    raw_json,
+    content='events',
+    content_rowid='id',
+    tokenize="unicode61 remove_diacritics 2 tokenchars '-_'"
+);
+"""
+
+# Triggers: insert / delete / update keep events_fts mirroring events.
+# Using `events_fts(rowid, raw_json)` for inserts and the documented
+# `events_fts(events_fts, rowid, raw_json)` form for deletes/updates so
+# FTS5 records the negation rather than trying to scan the now-deleted
+# row in the content table.
+EVENTS_FTS_TRIGGERS_SQL = """
+CREATE TRIGGER IF NOT EXISTS events_ai_fts AFTER INSERT ON events BEGIN
+    INSERT INTO events_fts(rowid, raw_json) VALUES (new.id, new.raw_json);
+END;
+CREATE TRIGGER IF NOT EXISTS events_ad_fts AFTER DELETE ON events BEGIN
+    INSERT INTO events_fts(events_fts, rowid, raw_json)
+        VALUES('delete', old.id, old.raw_json);
+END;
+CREATE TRIGGER IF NOT EXISTS events_au_fts AFTER UPDATE ON events BEGIN
+    INSERT INTO events_fts(events_fts, rowid, raw_json)
+        VALUES('delete', old.id, old.raw_json);
+    INSERT INTO events_fts(rowid, raw_json) VALUES (new.id, new.raw_json);
+END;
+"""
+
+
+def ensure_search_schema(conn: sqlite3.Connection) -> None:
+    """Create the FTS virtual table + triggers if absent.
+
+    Idempotent — safe to call on every CLI invocation. The first call
+    on an existing index also runs a one-shot ``rebuild`` to backfill
+    rows that were inserted before the triggers existed; subsequent
+    calls find an already-populated FTS table and skip the rebuild.
+    """
+
+    conn.execute("PRAGMA foreign_keys=ON")
+
+    pre_existing_fts = bool(
+        conn.execute(
+            "SELECT 1 FROM sqlite_master "
+            "WHERE type='table' AND name='events_fts'"
+        ).fetchone()
+    )
+
+    conn.executescript(EVENTS_FTS_TABLE_SQL)
+    conn.executescript(EVENTS_FTS_TRIGGERS_SQL)
+
+    if pre_existing_fts:
+        return
+
+    # Fresh table — backfill from the events table. Skipped when
+    # `events` is empty (no-op rebuild is cheap but not free).
+    has_events = bool(
+        conn.execute("SELECT 1 FROM events LIMIT 1").fetchone()
+    )
+    if has_events:
+        rebuild_search_index(conn)
+
+
+def rebuild_search_index(conn: sqlite3.Connection) -> None:
+    """One-shot reindex of every row in ``events`` into ``events_fts``.
+
+    Safe to call after corruption (`DELETE FROM events_fts`) or after
+    any surgery on ``events`` that bypassed the triggers. FTS5's
+    ``rebuild`` command rebuilds the inverted index from the current
+    content table state.
+    """
+
+    conn.execute("INSERT INTO events_fts(events_fts) VALUES('rebuild')")
+
+
+__all__ = [
+    "EVENTS_FTS_TABLE_SQL",
+    "EVENTS_FTS_TRIGGERS_SQL",
+    "ensure_search_schema",
+    "rebuild_search_index",
+]

--- a/clawjournal/events/search/spec.py
+++ b/clawjournal/events/search/spec.py
@@ -15,9 +15,16 @@ from clawjournal.events.aggregate.spec import Predicate
 
 DEFAULT_LIMIT = 50
 HARD_LIMIT_CEILING = 1000
-DEFAULT_SNIPPET_LENGTH = 120
-MIN_SNIPPET_LENGTH = 16
-MAX_SNIPPET_LENGTH = 1024
+# FTS5's ``snippet(t, col, start, end, ellipsis, N)`` takes ``N`` as a
+# count of tokens (not characters), with a documented hard ceiling of
+# 64. Values above the ceiling are silently clamped by SQLite, so we
+# enforce the cap here to avoid advertising a range we can't honor.
+# v0.1's original ``--snippet-length`` flag claimed "characters" with
+# a 1024 ceiling — round 1 fixes the unit mismatch by renaming the
+# constant and the CLI flag.
+DEFAULT_SNIPPET_TOKENS = 16
+MIN_SNIPPET_TOKENS = 1
+MAX_SNIPPET_TOKENS = 64
 MAX_QUERY_BYTES = 4096
 
 # Logical names allowed in ``--type=...`` / ``--client=...`` /
@@ -47,9 +54,8 @@ class SearchSpec:
     filters: tuple[Predicate, ...] = ()
     since_iso: str | None = None
     limit: int = DEFAULT_LIMIT
-    snippet_length: int = DEFAULT_SNIPPET_LENGTH
+    snippet_tokens: int = DEFAULT_SNIPPET_TOKENS
     include_held: bool = False
-    canonical: bool = False
 
     def __post_init__(self) -> None:
         if not self.query or not self.query.strip():
@@ -65,10 +71,10 @@ class SearchSpec:
             raise ValueError(
                 f"--limit ceiling is {HARD_LIMIT_CEILING} (got {self.limit})"
             )
-        if not (MIN_SNIPPET_LENGTH <= self.snippet_length <= MAX_SNIPPET_LENGTH):
+        if not (MIN_SNIPPET_TOKENS <= self.snippet_tokens <= MAX_SNIPPET_TOKENS):
             raise ValueError(
-                f"--snippet-length must be between {MIN_SNIPPET_LENGTH} and "
-                f"{MAX_SNIPPET_LENGTH} (got {self.snippet_length})"
+                f"--snippet-tokens must be between {MIN_SNIPPET_TOKENS} and "
+                f"{MAX_SNIPPET_TOKENS} (got {self.snippet_tokens})"
             )
         for predicate in self.filters:
             if predicate.field not in SEARCH_FILTER_FIELDS:
@@ -80,11 +86,11 @@ class SearchSpec:
 
 __all__ = [
     "DEFAULT_LIMIT",
-    "DEFAULT_SNIPPET_LENGTH",
+    "DEFAULT_SNIPPET_TOKENS",
     "HARD_LIMIT_CEILING",
     "MAX_QUERY_BYTES",
-    "MAX_SNIPPET_LENGTH",
-    "MIN_SNIPPET_LENGTH",
+    "MAX_SNIPPET_TOKENS",
+    "MIN_SNIPPET_TOKENS",
     "SEARCH_FILTER_FIELDS",
     "SearchSpec",
 ]

--- a/clawjournal/events/search/spec.py
+++ b/clawjournal/events/search/spec.py
@@ -1,0 +1,90 @@
+"""Search request shape (phase-1 plan 11).
+
+``SearchSpec`` is the parsed, validated form of one
+``clawjournal events search <query>`` invocation. CLI handlers build
+it; the query executor consumes it. Mirrors plan 10's spec layer:
+construction is the validation step, so any spec returned by a CLI
+handler is safe to feed straight into ``query.run``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from clawjournal.events.aggregate.spec import Predicate
+
+DEFAULT_LIMIT = 50
+HARD_LIMIT_CEILING = 1000
+DEFAULT_SNIPPET_LENGTH = 120
+MIN_SNIPPET_LENGTH = 16
+MAX_SNIPPET_LENGTH = 1024
+MAX_QUERY_BYTES = 4096
+
+# Logical names allowed in ``--type=...`` / ``--client=...`` /
+# ``--confidence=...`` filters and the underlying SQL projection.
+# Same allowlist shape plan 10 uses, so the parsers from
+# ``aggregate.filters`` can be reused on ``--where`` style filters in
+# a future patch. For v0.1 the CLI exposes only the named flags.
+SEARCH_FILTER_FIELDS: dict[str, str] = {
+    "client": "e.client",
+    "type": "e.type",
+    "confidence": "e.confidence",
+    "session": "s.session_key",
+    "source": "e.source",
+}
+
+
+@dataclass(frozen=True)
+class SearchSpec:
+    """Validated search request.
+
+    Construction enforces every invariant that the query layer would
+    otherwise have to recheck — including the hold-state default,
+    the result-set ceiling, and the FTS5 query-size cap.
+    """
+
+    query: str
+    filters: tuple[Predicate, ...] = ()
+    since_iso: str | None = None
+    limit: int = DEFAULT_LIMIT
+    snippet_length: int = DEFAULT_SNIPPET_LENGTH
+    include_held: bool = False
+    canonical: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.query or not self.query.strip():
+            raise ValueError("search query must be non-empty")
+        if len(self.query.encode("utf-8")) > MAX_QUERY_BYTES:
+            raise ValueError(
+                f"search query exceeds {MAX_QUERY_BYTES}-byte cap "
+                f"(got {len(self.query.encode('utf-8'))} bytes)"
+            )
+        if self.limit <= 0:
+            raise ValueError("--limit must be positive")
+        if self.limit > HARD_LIMIT_CEILING:
+            raise ValueError(
+                f"--limit ceiling is {HARD_LIMIT_CEILING} (got {self.limit})"
+            )
+        if not (MIN_SNIPPET_LENGTH <= self.snippet_length <= MAX_SNIPPET_LENGTH):
+            raise ValueError(
+                f"--snippet-length must be between {MIN_SNIPPET_LENGTH} and "
+                f"{MAX_SNIPPET_LENGTH} (got {self.snippet_length})"
+            )
+        for predicate in self.filters:
+            if predicate.field not in SEARCH_FILTER_FIELDS:
+                raise ValueError(
+                    f"filter field {predicate.field!r} not allowed for search "
+                    f"(allowed: {sorted(SEARCH_FILTER_FIELDS)})"
+                )
+
+
+__all__ = [
+    "DEFAULT_LIMIT",
+    "DEFAULT_SNIPPET_LENGTH",
+    "HARD_LIMIT_CEILING",
+    "MAX_QUERY_BYTES",
+    "MAX_SNIPPET_LENGTH",
+    "MIN_SNIPPET_LENGTH",
+    "SEARCH_FILTER_FIELDS",
+    "SearchSpec",
+]

--- a/tests/events/doctor/test_docs.py
+++ b/tests/events/doctor/test_docs.py
@@ -70,6 +70,11 @@ def test_schemas_topic_has_named_schema_records():
         f"events aggregate --json schema missing from schemas topic; "
         f"found: {sorted(names)}"
     )
+    # Plan 11's search envelope joins the same schemas surface.
+    assert any("search" in name for name in names), (
+        f"events search --json schema missing from schemas topic; "
+        f"found: {sorted(names)}"
+    )
 
 
 def test_commands_topic_covers_every_feature_record():

--- a/tests/events/search/test_cli.py
+++ b/tests/events/search/test_cli.py
@@ -230,6 +230,23 @@ def test_oversize_query_rejected(isolated_home, tmp_path):
     assert payload["error"]["kind"] == "usage_error"
 
 
+def test_snippet_tokens_above_64_rejected_at_cli(isolated_home, tmp_path):
+    """Round 1: ``--snippet-tokens`` is enforced at the spec layer to
+    fail loudly above FTS5's 64-token internal cap, instead of letting
+    SQLite silently clamp. The CLI surface must surface the spec
+    rejection as ``usage_error`` (exit 2)."""
+
+    _seed_db(tmp_path)
+    result = _run(
+        ["events", "search", "authentication", "--snippet-tokens", "100", "--json"],
+        isolated_home,
+    )
+    assert result.returncode == 2, result.stderr
+    payload = json.loads(result.stderr)
+    assert payload["error"]["kind"] == "usage_error"
+    assert "snippet-tokens" in payload["error"]["message"]
+
+
 def test_features_topic_advertises_search(isolated_home):
     """Drift gate: `events features --json` must list events.search
     once 11 ships. The ``features`` field is the list of ids."""

--- a/tests/events/search/test_cli.py
+++ b/tests/events/search/test_cli.py
@@ -212,13 +212,37 @@ def test_request_id_echoed_in_meta(isolated_home, tmp_path):
 
 
 def test_rebuild_index_succeeds(isolated_home, tmp_path):
+    """Round 5: rebuild's JSON output now pins the schema version
+    and reports the indexed-document count, so consumers can verify
+    the rebuild actually populated the index instead of just trusting
+    a bare 'ok' string."""
+
     _seed_db(tmp_path)
     result = _run(
         ["events", "search", "--rebuild-index", "--json"], isolated_home,
     )
     assert result.returncode == 0, result.stderr
     payload = json.loads(result.stdout)
-    assert payload["events_search_rebuild"] == "ok"
+    assert payload["events_search_schema_version"] == "1.0"
+    assert payload["rebuild"] == "ok"
+    assert payload["indexed_documents"] == 1
+
+
+def test_multi_source_filter(isolated_home, tmp_path):
+    """Round 5: ``--source`` now accepts repeat / comma-separated
+    values for parity with --client / --type / --confidence."""
+
+    _seed_db(tmp_path)
+    # Pass two source values; the seeded event has source=claude-jsonl.
+    result = _run(
+        ["events", "search", "authentication", "--source",
+         "claude-jsonl,codex-rollout", "--json"],
+        isolated_home,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert len(payload["hits"]) == 1
+    assert payload["hits"][0]["source"] == "claude-jsonl"
 
 
 def test_oversize_query_rejected(isolated_home, tmp_path):

--- a/tests/events/search/test_cli.py
+++ b/tests/events/search/test_cli.py
@@ -228,6 +228,28 @@ def test_rebuild_index_succeeds(isolated_home, tmp_path):
     assert payload["indexed_documents"] == 1
 
 
+def test_rebuild_index_request_id_lands_in_meta(isolated_home, tmp_path):
+    """Round 7: the rebuild payload's ``request_id`` lives at
+    ``_meta.request_id``, not as a top-level sibling — matches the
+    convention pinned by every other agent surface (search hits,
+    error envelope) so consumers only check one location."""
+
+    _seed_db(tmp_path)
+    result = _run(
+        ["events", "search", "--rebuild-index", "--json",
+         "--request-id", "rb-42"],
+        isolated_home,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["_meta"]["request_id"] == "rb-42"
+    # Regression guard: must not also appear at the top level.
+    assert "request_id" not in payload, (
+        f"request_id leaked to top level on rebuild payload: "
+        f"keys={sorted(payload)}"
+    )
+
+
 def test_multi_source_filter(isolated_home, tmp_path):
     """Round 5: ``--source`` now accepts repeat / comma-separated
     values for parity with --client / --type / --confidence."""

--- a/tests/events/search/test_cli.py
+++ b/tests/events/search/test_cli.py
@@ -1,0 +1,240 @@
+"""CLI-surface tests for `events search` (plan 11).
+
+Each test invokes the CLI as a subprocess against a fixture HOME so
+the developer's real ``~/.clawjournal`` is untouched. The seed step
+is itself a subprocess that reconfigures ``CONFIG_DIR`` / ``INDEX_DB``
+to point at the fixture HOME, mirroring the plan 10 ``test_cli.py``
+pattern so the workbench's own schema setup runs (the workbench
+``sessions`` table has columns the search hold-state filter joins
+against).
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def isolated_home(tmp_path):
+    return {
+        "HOME": str(tmp_path),
+        "PATH": "/usr/bin:/bin",
+        "PYTHONPATH": str(Path(__file__).parent.parent.parent.parent),
+        "CLAWJOURNAL_SKIP_TRUFFLEHOG": "1",
+    }
+
+
+def _run(args, env):
+    return subprocess.run(
+        [sys.executable, "-m", "clawjournal.cli", *args],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def _seed_db(home: Path, *, with_event: bool = True) -> None:
+    """Initialize a fixture index.db with one session and one matching
+    event. Runs in a subprocess so module-level config rewrites
+    (``CONFIG_DIR`` / ``INDEX_DB``) affect ``open_index`` cleanly."""
+
+    cfg = Path(home) / ".clawjournal"
+    cfg.mkdir(parents=True, exist_ok=True)
+    insert_event = (
+        "conn.execute('INSERT INTO events (session_id, type, event_at, "
+        "ingested_at, source, source_path, source_offset, seq, client, "
+        "confidence, lossiness, raw_json) VALUES "
+        "(1, \\'tool_result\\', \\'2026-04-21T10:00:00Z\\', "
+        "\\'2026-04-21T10:00:00Z\\', \\'claude-jsonl\\', \\'/x\\', 0, 0, "
+        "\\'claude\\', \\'high\\', \\'none\\', "
+        "\\'{\\\"text\\\": \\\"401 Unauthorized: authentication failed\\\"}\\')')\n"
+        if with_event else "pass\n"
+    )
+    seed = Path(home) / "_seed.py"
+    seed.write_text(
+        "from pathlib import Path\n"
+        "import os\n"
+        f"home = Path({str(home)!r})\n"
+        "os.environ['HOME'] = str(home)\n"
+        "import clawjournal.config as cfg\n"
+        "cfg.CONFIG_DIR = home / '.clawjournal'\n"
+        "cfg.CONFIG_FILE = cfg.CONFIG_DIR / 'config.json'\n"
+        "import clawjournal.workbench.index as wb\n"
+        "wb.CONFIG_DIR = home / '.clawjournal'\n"
+        "wb.INDEX_DB = home / '.clawjournal' / 'index.db'\n"
+        "from clawjournal.events.schema import ensure_schema\n"
+        "from clawjournal.events.search import ensure_search_schema\n"
+        "from clawjournal.workbench.index import open_index\n"
+        "conn = open_index()\n"
+        "ensure_schema(conn)\n"
+        "ensure_search_schema(conn)\n"
+        "conn.execute(\"INSERT INTO event_sessions (session_key, client, "
+        "started_at, status) VALUES ('claude:proj:s1', 'claude', "
+        "'2026-04-21T10:00:00Z', 'ended')\")\n"
+        + insert_event +
+        "conn.commit()\n"
+        "conn.close()\n",
+        encoding="utf-8",
+    )
+    subprocess.run([sys.executable, str(seed)], check=True, timeout=30)
+
+
+def test_search_finds_seeded_event(isolated_home, tmp_path):
+    _seed_db(tmp_path)
+    result = _run(["events", "search", "authentication", "--json"], isolated_home)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["events_search_schema_version"] == "1.0"
+    assert len(payload["hits"]) == 1
+    assert payload["hits"][0]["client"] == "claude"
+
+
+def test_missing_query_returns_usage_error(isolated_home, tmp_path):
+    _seed_db(tmp_path)
+    result = _run(["events", "search", "--json"], isolated_home)
+    assert result.returncode == 2, result.stderr
+    # Error envelopes go to stderr; successful payloads to stdout.
+    payload = json.loads(result.stderr)
+    assert payload["error"]["kind"] == "usage_error"
+
+
+def test_invalid_fts_query_returns_usage_error(isolated_home, tmp_path):
+    _seed_db(tmp_path)
+    # Unbalanced quote — FTS5 raises a syntax error → usage_error.
+    result = _run(["events", "search", '"unbalanced', "--json"], isolated_home)
+    assert result.returncode == 2, result.stderr
+    payload = json.loads(result.stderr)
+    assert payload["error"]["kind"] == "usage_error"
+
+
+def test_hyphen_bareword_query_maps_to_usage_error(isolated_home, tmp_path):
+    """FTS5 parses ``rate-limit`` (unquoted) as a column filter on
+    column ``rate`` and raises ``no such column``. Users who typed a
+    hyphen-bareword actually want the phrase query ``"rate-limit"``;
+    the CLI maps the SQLite error to usage_error code 2 so agents
+    see the right exit code rather than the catch-all 9. Documented
+    in commands.md."""
+
+    _seed_db(tmp_path)
+    result = _run(
+        ["events", "search", "rate-limit", "--json"], isolated_home,
+    )
+    assert result.returncode == 2, result.stderr
+    payload = json.loads(result.stderr)
+    assert payload["error"]["kind"] == "usage_error"
+    assert "no such column" in payload["error"]["message"].lower()
+
+
+def test_phrase_query_for_hyphen_bareword_works(isolated_home, tmp_path):
+    """Counterpart to the bareword test: wrapping the hyphen-token in
+    phrase quotes is the documented workaround and must succeed."""
+
+    _seed_db(tmp_path)
+    # Update the seeded event so it actually contains rate-limit.
+    seed = tmp_path / "_update.py"
+    seed.write_text(
+        "from pathlib import Path\n"
+        "import os\n"
+        f"home = Path({str(tmp_path)!r})\n"
+        "os.environ['HOME'] = str(home)\n"
+        "import clawjournal.config as cfg\n"
+        "cfg.CONFIG_DIR = home / '.clawjournal'\n"
+        "import clawjournal.workbench.index as wb\n"
+        "wb.CONFIG_DIR = home / '.clawjournal'\n"
+        "wb.INDEX_DB = home / '.clawjournal' / 'index.db'\n"
+        "from clawjournal.workbench.index import open_index\n"
+        "conn = open_index()\n"
+        "conn.execute(\"UPDATE events SET raw_json = "
+        "'{\\\"text\\\": \\\"rate-limit exceeded\\\"}'\")\n"
+        "conn.commit()\n"
+        "conn.close()\n",
+        encoding="utf-8",
+    )
+    subprocess.run([sys.executable, str(seed)], check=True, timeout=30)
+
+    result = _run(
+        ["events", "search", '"rate-limit"', "--json"], isolated_home,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert len(payload["hits"]) == 1
+
+
+def test_missing_events_table_maps_to_index_missing(isolated_home, tmp_path):
+    """Workbench DB exists (open_index ran) but `events` does not.
+    Agents should see exit code 3 with a hint pointing at
+    `events ingest`."""
+
+    cfg = tmp_path / ".clawjournal"
+    cfg.mkdir(parents=True, exist_ok=True)
+    # Bring up the workbench DB without running ensure_schema /
+    # ensure_search_schema so neither `events` nor `events_fts` exist.
+    seed = tmp_path / "_seed.py"
+    seed.write_text(
+        "from pathlib import Path\n"
+        "import os\n"
+        f"home = Path({str(tmp_path)!r})\n"
+        "os.environ['HOME'] = str(home)\n"
+        "import clawjournal.config as cfg\n"
+        "cfg.CONFIG_DIR = home / '.clawjournal'\n"
+        "cfg.CONFIG_FILE = cfg.CONFIG_DIR / 'config.json'\n"
+        "import clawjournal.workbench.index as wb\n"
+        "wb.CONFIG_DIR = home / '.clawjournal'\n"
+        "wb.INDEX_DB = home / '.clawjournal' / 'index.db'\n"
+        "from clawjournal.workbench.index import open_index\n"
+        "conn = open_index()\n"
+        "conn.close()\n",
+        encoding="utf-8",
+    )
+    subprocess.run([sys.executable, str(seed)], check=True, timeout=30)
+
+    result = _run(["events", "search", "anything", "--json"], isolated_home)
+    assert result.returncode == 3, result.stderr
+    payload = json.loads(result.stderr)
+    assert payload["error"]["kind"] == "index_missing"
+
+
+def test_request_id_echoed_in_meta(isolated_home, tmp_path):
+    _seed_db(tmp_path)
+    result = _run(
+        ["events", "search", "authentication", "--json", "--request-id", "req-77"],
+        isolated_home,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["_meta"]["request_id"] == "req-77"
+
+
+def test_rebuild_index_succeeds(isolated_home, tmp_path):
+    _seed_db(tmp_path)
+    result = _run(
+        ["events", "search", "--rebuild-index", "--json"], isolated_home,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert payload["events_search_rebuild"] == "ok"
+
+
+def test_oversize_query_rejected(isolated_home, tmp_path):
+    _seed_db(tmp_path)
+    big = "a" * 5000
+    result = _run(["events", "search", big, "--json"], isolated_home)
+    assert result.returncode == 2, result.stderr
+    payload = json.loads(result.stderr)
+    assert payload["error"]["kind"] == "usage_error"
+
+
+def test_features_topic_advertises_search(isolated_home):
+    """Drift gate: `events features --json` must list events.search
+    once 11 ships. The ``features`` field is the list of ids."""
+
+    result = _run(["events", "features"], isolated_home)
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "events.search" in payload["features"]

--- a/tests/events/search/test_query.py
+++ b/tests/events/search/test_query.py
@@ -225,7 +225,7 @@ def test_filter_client_narrows_results(conn):
         query="common_token",
         client=("claude",),
         limit=50,
-        snippet_length=120,
+        snippet_tokens=16,
         include_held=False,
     )
     result = run(spec, conn)
@@ -250,7 +250,7 @@ def test_filter_in_clause_with_multiple_values(conn):
         query="shared_token",
         client=("claude", "codex"),
         limit=50,
-        snippet_length=120,
+        snippet_tokens=16,
         include_held=False,
     )
     result = run(spec, conn)

--- a/tests/events/search/test_query.py
+++ b/tests/events/search/test_query.py
@@ -151,6 +151,71 @@ def test_triggers_keep_fts_in_sync_on_insert_and_delete(conn):
     assert result_after.rows_matched == 0
 
 
+def test_partial_migration_rebuild_persists_across_close(tmp_path):
+    """Round 7: the rebuild from ``ensure_search_schema``'s partial-
+    migration recovery must commit. sqlite3.connect()'s default
+    isolation level auto-begins a transaction on FTS5's 'rebuild'
+    insert; without an explicit commit, conn.close() rolls the
+    rebuild back. The earlier recovery test queried before close so
+    it never noticed the rollback. This test reopens and verifies
+    the FTS index actually persisted.
+    """
+
+    db_path = tmp_path / "rebuild_persist.db"
+
+    # Phase 1: simulate partial migration (FTS table only, no triggers).
+    c = sqlite3.connect(str(db_path))
+    c.execute(
+        "CREATE VIRTUAL TABLE events_fts USING fts5("
+        "raw_json, content='events', content_rowid='id', "
+        "tokenize=\"unicode61 remove_diacritics 2 tokenchars '-_'\")"
+    )
+    c.commit()
+    c.close()
+
+    # Phase 2: events ingest populates events without firing triggers.
+    c = sqlite3.connect(str(db_path))
+    ensure_events_schema(c)
+    c.executescript(SESSIONS_TABLE_SQL)
+    cur = c.execute(
+        "INSERT INTO event_sessions (session_key, client, started_at, "
+        "status) VALUES ('claude:proj:s1', 'claude', "
+        "'2026-04-21T10:00:00Z', 'ended')"
+    )
+    sid = cur.lastrowid
+    c.execute(
+        "INSERT INTO events (session_id, type, event_at, ingested_at, "
+        "source, source_path, source_offset, seq, client, confidence, "
+        "lossiness, raw_json) VALUES (?, 'tool_result', "
+        "'2026-04-21T10:00:00Z', '2026-04-21T10:00:00Z', 'claude-jsonl', "
+        "'/x', 0, 0, 'claude', 'high', 'none', "
+        "'{\"text\": \"persistence_marker_token\"}')",
+        (sid,),
+    )
+    c.commit()
+    c.close()
+
+    # Phase 3: ensure_search_schema runs and (we hope) commits the
+    # rebuild. Close without an explicit commit on this connection.
+    c = sqlite3.connect(str(db_path))
+    ensure_search_schema(c)
+    c.close()
+
+    # Phase 4: reopen with a fresh connection. If the rebuild was
+    # rolled back by Phase 3's close, docsize is 0 and the next
+    # ensure_search_schema call would have to rebuild again — an
+    # eternal loop in production.
+    c2 = sqlite3.connect(str(db_path))
+    docs = c2.execute(
+        "SELECT count(*) FROM events_fts_docsize"
+    ).fetchone()[0]
+    c2.close()
+    assert docs == 1, (
+        f"FTS rebuild was rolled back at close: docsize_count={docs}; "
+        f"each subsequent search would re-rebuild and re-roll-back"
+    )
+
+
 def test_ensure_search_schema_recovers_from_partial_migration(tmp_path):
     """Round 3: if ``ensure_search_schema`` previously created
     ``events_fts`` but failed before installing the triggers (because

--- a/tests/events/search/test_query.py
+++ b/tests/events/search/test_query.py
@@ -151,6 +151,64 @@ def test_triggers_keep_fts_in_sync_on_insert_and_delete(conn):
     assert result_after.rows_matched == 0
 
 
+def test_ensure_search_schema_recovers_from_partial_migration(tmp_path):
+    """Round 3: if ``ensure_search_schema`` previously created
+    ``events_fts`` but failed before installing the triggers (because
+    ``events`` did not yet exist), a later call after ingest should
+    backfill the FTS index instead of short-circuiting on
+    ``pre_existing_fts``. The earlier check was correct for the
+    happy path but missed this recovery case."""
+
+    db_path = tmp_path / "partial.db"
+    c = sqlite3.connect(str(db_path))
+    # Phase 1: simulate a partial migration — create events_fts but
+    # NOT the triggers, and NOT the events table. This is the state
+    # we'd be in if the first ensure_search_schema call hit "no such
+    # table: events" while creating the triggers.
+    c.execute(
+        "CREATE VIRTUAL TABLE events_fts USING fts5("
+        "raw_json, content='events', content_rowid='id', "
+        "tokenize=\"unicode61 remove_diacritics 2 tokenchars '-_'\")"
+    )
+    c.commit()
+    c.close()
+
+    # Phase 2: events ingest happens — events table created, rows
+    # inserted. The triggers don't exist yet so events_fts stays empty.
+    c = sqlite3.connect(str(db_path))
+    ensure_events_schema(c)
+    c.executescript(SESSIONS_TABLE_SQL)
+    cur = c.execute(
+        "INSERT INTO event_sessions (session_key, client, started_at, "
+        "status) VALUES ('claude:proj:s1', 'claude', "
+        "'2026-04-21T10:00:00Z', 'ended')"
+    )
+    sid = cur.lastrowid
+    c.execute(
+        "INSERT INTO events (session_id, type, event_at, ingested_at, "
+        "source, source_path, source_offset, seq, client, confidence, "
+        "lossiness, raw_json) VALUES (?, 'tool_result', "
+        "'2026-04-21T10:00:00Z', '2026-04-21T10:00:00Z', 'claude-jsonl', "
+        "'/x', 0, 0, 'claude', 'high', 'none', "
+        "'{\"text\": \"recovery_marker_token\"}')",
+        (sid,),
+    )
+    c.commit()
+    c.close()
+
+    # Phase 3: a fresh ensure_search_schema call should see
+    # FTS-empty + events-non-empty and trigger a backfill, leaving
+    # the search functional.
+    c = sqlite3.connect(str(db_path))
+    ensure_search_schema(c)
+    result = run(SearchSpec(query="recovery_marker_token"), c)
+    c.close()
+    assert result.rows_matched == 1, (
+        f"partial-migration recovery did not backfill FTS; "
+        f"hits={[h.event_id for h in result.hits]}"
+    )
+
+
 def test_rebuild_index_recovers_after_truncation(conn):
     sid = _add_session(conn, "claude:proj:s1")
     _add_event(conn, sid, '{"text": "needle in the haystack"}')

--- a/tests/events/search/test_query.py
+++ b/tests/events/search/test_query.py
@@ -1,0 +1,372 @@
+"""End-to-end query execution tests for `events search` (plan 11).
+
+Each test seeds an in-memory SQLite fixture with the events schema +
+search FTS schema, runs the search, and asserts on the hits / counts
+/ metadata. Includes the SQL-injection regression for FTS5 MATCH
+parameterization, the trigger-sync invariant, and the hold-state
+exclusion default.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from clawjournal.events.schema import ensure_schema as ensure_events_schema
+from clawjournal.events.search import (
+    SearchSpec,
+    ensure_search_schema,
+    parse_search_spec,
+    rebuild_search_index,
+    run,
+)
+
+
+SESSIONS_TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS sessions (
+    session_id TEXT PRIMARY KEY,
+    session_key TEXT,
+    hold_state TEXT
+);
+"""
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    ensure_events_schema(c)
+    c.executescript(SESSIONS_TABLE_SQL)
+    ensure_search_schema(c)
+    yield c
+    c.close()
+
+
+_event_seq = {"n": 0}
+
+
+def _add_session(
+    conn, session_key, *, client="claude", hold_state=None,
+):
+    cur = conn.execute(
+        "INSERT INTO event_sessions (session_key, client, started_at, status) "
+        "VALUES (?, ?, '2026-04-21T10:00:00Z', 'ended')",
+        (session_key, client),
+    )
+    sid = cur.lastrowid
+    if hold_state is not None:
+        conn.execute(
+            "INSERT INTO sessions (session_id, session_key, hold_state) "
+            "VALUES (?, ?, ?)",
+            (session_key, session_key, hold_state),
+        )
+    return sid
+
+
+def _add_event(
+    conn,
+    session_id,
+    raw_json,
+    *,
+    type_="user_message",
+    client="claude",
+    source="claude-jsonl",
+    source_path="/Users/synthetic-user/proj/file.jsonl",
+    confidence="high",
+    event_at="2026-04-21T10:00:00Z",
+):
+    seq = _event_seq["n"]
+    _event_seq["n"] += 1
+    conn.execute(
+        "INSERT INTO events "
+        "(session_id, type, event_at, ingested_at, source, source_path, "
+        " source_offset, seq, client, confidence, lossiness, raw_json) "
+        "VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+        (
+            session_id, type_, event_at, "2026-04-21T10:00:00Z",
+            source, source_path, 0, seq, client, confidence, "none", raw_json,
+        ),
+    )
+
+
+def test_basic_match_returns_hit(conn):
+    sid = _add_session(conn, "claude:proj:s1")
+    _add_event(conn, sid, '{"text": "401 Unauthorized: authentication failed"}')
+    _add_event(conn, sid, '{"text": "all good"}')
+
+    spec = SearchSpec(query="authentication")
+    result = run(spec, conn)
+    assert result.rows_matched == 1
+    assert len(result.hits) == 1
+    assert "authentication" in result.hits[0].snippet.lower()
+
+
+def test_phrase_query_only_matches_full_phrase(conn):
+    sid = _add_session(conn, "claude:proj:s1")
+    _add_event(conn, sid, '{"text": "tool error: command failed"}')
+    _add_event(conn, sid, '{"text": "tool succeeded; no error"}')
+
+    spec = SearchSpec(query='"tool error"')
+    result = run(spec, conn)
+    assert result.rows_matched == 1
+
+
+def test_match_is_parameterized_sql_injection_value_treated_as_literal(conn):
+    """Plan 11 §Security #1: an injection-shaped query string is bound
+    to the FTS5 MATCH predicate as a single parameter. FTS5 will
+    either parse it as a literal MATCH expression (zero hits or all
+    hits depending on tokens) or raise a syntax error — either way,
+    no SQL composition. The parser layer above us turns the syntax
+    error into a usage_error; here we just pin that the value never
+    leaks out as SQL."""
+
+    sid = _add_session(conn, "claude:proj:s1")
+    _add_event(conn, sid, '{"text": "totally unrelated content"}')
+
+    # FTS5 typically rejects this with a syntax error; a clean test
+    # asserts EITHER zero hits OR a clean OperationalError raised
+    # from the query layer (which the CLI handler maps to usage_error
+    # code 2). The point is no rows leak.
+    try:
+        result = run(SearchSpec(query="' OR 1=1 --"), conn)
+        assert result.hits == []
+    except sqlite3.OperationalError as exc:
+        assert "fts5" in str(exc).lower() or "syntax error" in str(exc).lower()
+
+
+def test_triggers_keep_fts_in_sync_on_insert_and_delete(conn):
+    sid = _add_session(conn, "claude:proj:s1")
+    for i in range(5):
+        _add_event(conn, sid, f'{{"text": "marker_token_{i}"}}')
+
+    result = run(SearchSpec(query="marker_token_3"), conn)
+    assert result.rows_matched == 1
+
+    # Delete the matching event; FTS must follow.
+    conn.execute(
+        "DELETE FROM events WHERE raw_json LIKE '%marker_token_3%'"
+    )
+    result_after = run(SearchSpec(query="marker_token_3"), conn)
+    assert result_after.rows_matched == 0
+
+
+def test_rebuild_index_recovers_after_truncation(conn):
+    sid = _add_session(conn, "claude:proj:s1")
+    _add_event(conn, sid, '{"text": "needle in the haystack"}')
+    assert run(SearchSpec(query="needle"), conn).rows_matched == 1
+
+    # Simulate FTS table corruption — delete its content.
+    conn.execute("INSERT INTO events_fts(events_fts) VALUES('delete-all')")
+    assert run(SearchSpec(query="needle"), conn).rows_matched == 0
+
+    rebuild_search_index(conn)
+    assert run(SearchSpec(query="needle"), conn).rows_matched == 1
+
+
+def test_held_sessions_excluded_by_default(conn):
+    sid_open = _add_session(conn, "claude:proj:s1")
+    sid_held = _add_session(
+        conn, "claude:proj:s2", hold_state="pending_review"
+    )
+    _add_event(conn, sid_open, '{"text": "shared_token open"}')
+    _add_event(conn, sid_held, '{"text": "shared_token held"}')
+
+    result = run(SearchSpec(query="shared_token"), conn)
+    assert result.rows_matched == 1
+    assert result.hits[0].session_key == "claude:proj:s1"
+
+
+def test_held_sessions_surfaced_with_include_held(conn):
+    sid_open = _add_session(conn, "claude:proj:s1")
+    sid_held = _add_session(
+        conn, "claude:proj:s2", hold_state="pending_review"
+    )
+    _add_event(conn, sid_open, '{"text": "shared_token open"}')
+    _add_event(conn, sid_held, '{"text": "shared_token held"}')
+
+    result = run(SearchSpec(query="shared_token", include_held=True), conn)
+    keys = sorted(h.session_key for h in result.hits)
+    assert keys == ["claude:proj:s1", "claude:proj:s2"]
+
+
+def test_embargoed_sessions_also_excluded_by_default(conn):
+    sid_open = _add_session(conn, "claude:proj:s1")
+    sid_emb = _add_session(conn, "claude:proj:s2", hold_state="embargoed")
+    _add_event(conn, sid_open, '{"text": "shared_token open"}')
+    _add_event(conn, sid_emb, '{"text": "shared_token embargoed"}')
+
+    result = run(SearchSpec(query="shared_token"), conn)
+    assert result.rows_matched == 1
+
+
+def test_session_with_no_workbench_row_passes_through(conn):
+    """A session that has not been touched by the workbench (no
+    `sessions` row at all) is NOT held — it should surface in default
+    search just like any other session. The LEFT JOIN's NULL
+    hold_state passes the filter."""
+
+    sid = _add_session(conn, "claude:proj:s1")  # no hold_state arg → no row
+    _add_event(conn, sid, '{"text": "untouched_session"}')
+
+    result = run(SearchSpec(query="untouched_session"), conn)
+    assert result.rows_matched == 1
+
+
+def test_filter_client_narrows_results(conn):
+    sid_a = _add_session(conn, "claude:proj:s1", client="claude")
+    sid_b = _add_session(conn, "codex:/x", client="codex")
+    _add_event(conn, sid_a, '{"text": "common_token"}', client="claude")
+    _add_event(
+        conn, sid_b, '{"text": "common_token"}',
+        client="codex", source="codex-rollout",
+    )
+
+    spec = parse_search_spec(
+        query="common_token",
+        client=("claude",),
+        limit=50,
+        snippet_length=120,
+        include_held=False,
+    )
+    result = run(spec, conn)
+    assert {h.client for h in result.hits} == {"claude"}
+
+
+def test_filter_in_clause_with_multiple_values(conn):
+    sid_a = _add_session(conn, "claude:proj:s1", client="claude")
+    sid_b = _add_session(conn, "codex:/x", client="codex")
+    sid_c = _add_session(conn, "openclaw:/y", client="openclaw")
+    for sid, client, source in [
+        (sid_a, "claude", "claude-jsonl"),
+        (sid_b, "codex", "codex-rollout"),
+        (sid_c, "openclaw", "openclaw-jsonl"),
+    ]:
+        _add_event(
+            conn, sid, '{"text": "shared_token"}',
+            client=client, source=source,
+        )
+
+    spec = parse_search_spec(
+        query="shared_token",
+        client=("claude", "codex"),
+        limit=50,
+        snippet_length=120,
+        include_held=False,
+    )
+    result = run(spec, conn)
+    assert {h.client for h in result.hits} == {"claude", "codex"}
+
+
+def test_since_filter_bounds_time_window(conn):
+    sid = _add_session(conn, "claude:proj:s1")
+    _add_event(conn, sid, '{"text": "old_token"}', event_at="2026-03-01T00:00:00Z")
+    _add_event(conn, sid, '{"text": "new_token"}', event_at="2026-04-21T10:00:00Z")
+
+    spec = SearchSpec(
+        query="old_token OR new_token",
+        since_iso="2026-04-01T00:00:00Z",
+    )
+    result = run(spec, conn)
+    snippets = " ".join(h.snippet for h in result.hits)
+    assert "new_token" in snippets
+    assert "old_token" not in snippets
+
+
+def test_limit_caps_returned_hits_but_not_rows_matched(conn):
+    sid = _add_session(conn, "claude:proj:s1")
+    for i in range(7):
+        _add_event(conn, sid, f'{{"text": "common_term seq_{i}"}}')
+
+    result = run(SearchSpec(query="common_term", limit=3), conn)
+    assert len(result.hits) == 3
+    assert result.rows_matched == 7
+
+
+def test_bm25_orders_results_relevance_first(conn):
+    sid = _add_session(conn, "claude:proj:s1")
+    # Two events, one with the term twice and one with it once. FTS5
+    # BM25 returns smaller-is-better; the doubled-term doc should
+    # rank first.
+    _add_event(conn, sid, '{"text": "alpha alpha beta gamma"}')
+    _add_event(conn, sid, '{"text": "alpha beta gamma delta epsilon"}')
+
+    result = run(SearchSpec(query="alpha"), conn)
+    assert len(result.hits) == 2
+    # Smaller bm25 = better match.
+    assert result.hits[0].bm25 <= result.hits[1].bm25
+
+
+def test_snapshot_isolation_against_concurrent_writes(tmp_path):
+    """Both queries (hits + count) must run against the same snapshot
+    or `rows_matched` would drift away from `len(hits)` under
+    concurrent writes from `clawjournal serve`. Mirrors plan 10's
+    snapshot-isolation pattern."""
+
+    db_path = tmp_path / "search.db"
+    writer = sqlite3.connect(str(db_path))
+    writer.execute("PRAGMA journal_mode=WAL")
+    ensure_events_schema(writer)
+    writer.executescript(SESSIONS_TABLE_SQL)
+    ensure_search_schema(writer)
+    cur = writer.execute(
+        "INSERT INTO event_sessions (session_key, client, started_at, status) "
+        "VALUES ('claude:proj:s1', 'claude', '2026-04-21T10:00:00Z', 'ended')"
+    )
+    sid = cur.lastrowid
+    for i in range(3):
+        writer.execute(
+            "INSERT INTO events (session_id, type, event_at, ingested_at, "
+            "source, source_path, source_offset, seq, client, confidence, "
+            "lossiness, raw_json) VALUES (?, 'user_message', "
+            "'2026-04-21T10:00:00Z', '2026-04-21T10:00:00Z', 'claude-jsonl', "
+            "'/x', 0, ?, 'claude', 'high', 'none', "
+            "'{\"text\": \"shared_token\"}')",
+            (sid, i),
+        )
+    writer.commit()
+
+    raw_reader = sqlite3.connect(str(db_path))
+    call_count = {"n": 0}
+
+    class _ReaderProxy:
+        def __init__(self, conn):
+            self._conn = conn
+
+        def execute(self, sql, *args, **kwargs):
+            result = self._conn.execute(sql, *args, **kwargs)
+            call_count["n"] += 1
+            # Calls in order: BEGIN(1), hits SELECT(2), count SELECT(3),
+            # COMMIT(4). Inject a writer commit between hits and count.
+            if call_count["n"] == 2:
+                writer.execute(
+                    "INSERT INTO events (session_id, type, event_at, "
+                    "ingested_at, source, source_path, source_offset, seq, "
+                    "client, confidence, lossiness, raw_json) VALUES "
+                    "(?, 'user_message', '2026-04-21T10:00:00Z', "
+                    "'2026-04-21T10:00:00Z', 'claude-jsonl', '/x', 0, 99, "
+                    "'claude', 'high', 'none', "
+                    "'{\"text\": \"shared_token\"}')",
+                    (sid,),
+                )
+                writer.commit()
+            return result
+
+        @property
+        def in_transaction(self):
+            return self._conn.in_transaction
+
+        def __getattr__(self, name):
+            return getattr(self._conn, name)
+
+    reader = _ReaderProxy(raw_reader)
+    try:
+        result = run(SearchSpec(query="shared_token"), reader)  # type: ignore[arg-type]
+    finally:
+        raw_reader.close()
+        writer.close()
+
+    assert len(result.hits) == result.rows_matched, (
+        f"snapshot isolation broken: hits={len(result.hits)} "
+        f"matched={result.rows_matched}"
+    )
+    assert result.rows_matched == 3

--- a/tests/events/search/test_query.py
+++ b/tests/events/search/test_query.py
@@ -27,7 +27,8 @@ SESSIONS_TABLE_SQL = """
 CREATE TABLE IF NOT EXISTS sessions (
     session_id TEXT PRIMARY KEY,
     session_key TEXT,
-    hold_state TEXT
+    hold_state TEXT,
+    embargo_until TEXT
 );
 """
 
@@ -46,7 +47,7 @@ _event_seq = {"n": 0}
 
 
 def _add_session(
-    conn, session_key, *, client="claude", hold_state=None,
+    conn, session_key, *, client="claude", hold_state=None, embargo_until=None,
 ):
     cur = conn.execute(
         "INSERT INTO event_sessions (session_key, client, started_at, status) "
@@ -56,9 +57,9 @@ def _add_session(
     sid = cur.lastrowid
     if hold_state is not None:
         conn.execute(
-            "INSERT INTO sessions (session_id, session_key, hold_state) "
-            "VALUES (?, ?, ?)",
-            (session_key, session_key, hold_state),
+            "INSERT INTO sessions (session_id, session_key, hold_state, "
+            "embargo_until) VALUES (?, ?, ?, ?)",
+            (session_key, session_key, hold_state, embargo_until),
         )
     return sid
 
@@ -191,12 +192,38 @@ def test_held_sessions_surfaced_with_include_held(conn):
 
 def test_embargoed_sessions_also_excluded_by_default(conn):
     sid_open = _add_session(conn, "claude:proj:s1")
-    sid_emb = _add_session(conn, "claude:proj:s2", hold_state="embargoed")
+    # An active embargo (until 2099) should block.
+    sid_emb = _add_session(
+        conn, "claude:proj:s2",
+        hold_state="embargoed", embargo_until="2099-01-01T00:00:00Z",
+    )
     _add_event(conn, sid_open, '{"text": "shared_token open"}')
     _add_event(conn, sid_emb, '{"text": "shared_token embargoed"}')
 
     result = run(SearchSpec(query="shared_token"), conn)
     assert result.rows_matched == 1
+
+
+def test_expired_embargo_passes_through_default_search(conn):
+    """Round 2: an embargo whose ``embargo_until`` has already passed
+    is operationally released — same semantics as
+    ``workbench.index.effective_hold_state``. Without this rule,
+    expired embargoes would silently linger as search-blocked even
+    though every other code path treats them as released."""
+
+    sid_open = _add_session(conn, "claude:proj:s1")
+    sid_expired = _add_session(
+        conn, "claude:proj:s2",
+        hold_state="embargoed", embargo_until="2000-01-01T00:00:00Z",
+    )
+    _add_event(conn, sid_open, '{"text": "shared_token open"}')
+    _add_event(conn, sid_expired, '{"text": "shared_token expired_embargo"}')
+
+    result = run(SearchSpec(query="shared_token"), conn)
+    assert result.rows_matched == 2, (
+        f"expired embargo should pass through default search; got "
+        f"{[h.session_key for h in result.hits]}"
+    )
 
 
 def test_session_with_no_workbench_row_passes_through(conn):

--- a/tests/events/search/test_render.py
+++ b/tests/events/search/test_render.py
@@ -133,6 +133,46 @@ def test_human_render_no_hits_message():
     assert "no matches" in text
 
 
+def test_query_echo_is_anonymized_in_json(monkeypatch):
+    """Round 7: the user's literal MATCH expression is echoed in the
+    JSON envelope (`query` and `rewritten_match` fields). If the user
+    searched for a path, that path would round-trip into any agent
+    log of the JSON payload. Both fields must run through
+    Anonymizer().text() — same treatment the error-envelope `message`
+    field gets in `doctor/envelope.py`."""
+
+    monkeypatch.setenv("HOME", "/Users/synthetic-user")
+    leaky_query = '"/Users/synthetic-user/.config/secret"'
+    result = SearchResult(
+        spec=SearchSpec(query=leaky_query),
+        hits=[],
+        rewritten_match=leaky_query,
+        rows_matched=0,
+        elapsed_ms=1,
+    )
+    payload = json.loads(render_json(result))
+    assert "synthetic-user" not in payload["query"]
+    assert "synthetic-user" not in payload["rewritten_match"]
+    assert "[REDACTED_PATH]" in payload["query"]
+
+
+def test_query_echo_is_anonymized_in_human_no_matches(monkeypatch):
+    """The human-mode no-matches message also echoes the query — same
+    anonymization rule applies."""
+
+    monkeypatch.setenv("HOME", "/Users/synthetic-user")
+    leaky_query = '"/Users/synthetic-user/secret"'
+    result = SearchResult(
+        spec=SearchSpec(query=leaky_query),
+        hits=[],
+        rewritten_match=leaky_query,
+        rows_matched=0,
+        elapsed_ms=1,
+    )
+    text = render_human(result)
+    assert "synthetic-user" not in text
+
+
 def test_timeline_url_includes_anonymized_session_key(monkeypatch):
     monkeypatch.setenv("HOME", "/Users/synthetic-user")
     payload = json.loads(

--- a/tests/events/search/test_render.py
+++ b/tests/events/search/test_render.py
@@ -1,0 +1,109 @@
+"""Render-layer tests: anonymization, snippet redaction, JSON shape."""
+
+from __future__ import annotations
+
+import json
+
+from clawjournal.events.search import SearchSpec, render_human, render_json
+from clawjournal.events.search.query import SearchHit, SearchResult
+
+
+def _result(*, snippet="ok", session_key="claude:proj:s1", source_path="/x"):
+    hit = SearchHit(
+        event_id=1,
+        session_key=session_key,
+        event_at="2026-04-21T10:00:00Z",
+        client="claude",
+        type="tool_result",
+        confidence="high",
+        source="claude-jsonl",
+        source_path=source_path,
+        source_offset=0,
+        seq=0,
+        snippet=snippet,
+        bm25=1.5,
+    )
+    return SearchResult(
+        spec=SearchSpec(query="ok"),
+        hits=[hit],
+        rewritten_match="ok",
+        rows_matched=1,
+        elapsed_ms=3,
+    )
+
+
+def test_json_shape_pins_schema_version_and_meta():
+    payload = json.loads(render_json(_result(), request_id="req-1"))
+    assert payload["events_search_schema_version"] == "1.0"
+    assert payload["query"] == "ok"
+    assert payload["_meta"]["rows_matched"] == 1
+    assert payload["_meta"]["rows_returned"] == 1
+    assert payload["_meta"]["request_id"] == "req-1"
+    assert payload["_meta"]["include_held"] is False
+
+
+def test_path_in_source_path_is_anonymized(monkeypatch):
+    """Anonymizer's path matching is rooted at the current user's
+    ``$HOME`` (detected via ``os.path.expanduser('~')``), so the test
+    sets HOME to match the literal path used in the fixture — same
+    pattern plan 10's render tests use."""
+
+    monkeypatch.setenv("HOME", "/Users/synthetic-user")
+    payload = json.loads(
+        render_json(_result(source_path="/Users/synthetic-user/proj/file.jsonl"))
+    )
+    src = payload["hits"][0]["raw_ref"]["source_path"]
+    assert "synthetic-user" not in src
+    assert src == "[REDACTED_PATH]"
+
+
+def test_session_key_with_embedded_path_is_anonymized(monkeypatch):
+    monkeypatch.setenv("HOME", "/Users/synthetic-user")
+    payload = json.loads(
+        render_json(_result(session_key="codex:/Users/synthetic-user/workspace"))
+    )
+    sk = payload["hits"][0]["session_key"]
+    assert "synthetic-user" not in sk
+    assert sk.startswith("codex:")
+
+
+def test_snippet_redacts_secrets():
+    """Plan 11 §Security #4: a snippet containing a secret-shaped
+    token must be redacted before emission. We use an OpenAI-shaped
+    key (sk-...) since the regex catches that with high confidence."""
+
+    secret_like = "sk-" + "A" * 48
+    payload = json.loads(
+        render_json(_result(snippet=f"prefix {secret_like} suffix"))
+    )
+    snippet = payload["hits"][0]["snippet"]
+    assert secret_like not in snippet
+    assert "[" in snippet  # placeholder marker landed
+
+
+def test_human_render_includes_redacted_snippet():
+    secret_like = "sk-" + "B" * 48
+    text = render_human(_result(snippet=f"prefix {secret_like} suffix"))
+    assert secret_like not in text
+
+
+def test_human_render_no_hits_message():
+    result = SearchResult(
+        spec=SearchSpec(query="missing"),
+        hits=[],
+        rewritten_match="missing",
+        rows_matched=0,
+        elapsed_ms=2,
+    )
+    text = render_human(result)
+    assert "no matches" in text
+
+
+def test_timeline_url_includes_anonymized_session_key(monkeypatch):
+    monkeypatch.setenv("HOME", "/Users/synthetic-user")
+    payload = json.loads(
+        render_json(_result(session_key="codex:/Users/synthetic-user/proj"))
+    )
+    url = payload["hits"][0]["timeline_url"]
+    assert "synthetic-user" not in url
+    assert "#event-1" in url

--- a/tests/events/search/test_render.py
+++ b/tests/events/search/test_render.py
@@ -87,6 +87,40 @@ def test_human_render_includes_redacted_snippet():
     assert secret_like not in text
 
 
+def test_snippet_path_anonymized(monkeypatch):
+    """Round 4: snippet content is extracted from ``raw_json`` which
+    the indexer keeps verbatim. Plan 11 §Acceptance says
+    ``/Users/`` and ``/home/`` must never appear in JSON output —
+    v0.1 ran ``redact_text`` (secrets) on snippets but missed the
+    path-anonymization pass."""
+
+    monkeypatch.setenv("HOME", "/Users/synthetic-user")
+    snippet_with_path = (
+        "ENOENT: no such file or directory, open "
+        "/Users/synthetic-user/proj/missing.json"
+    )
+    payload = json.loads(render_json(_result(snippet=snippet_with_path)))
+    out = payload["hits"][0]["snippet"]
+    assert "synthetic-user" not in out
+    assert "/Users/" not in out
+    assert "[REDACTED_PATH]" in out
+
+
+def test_snippet_redacts_both_secrets_and_paths(monkeypatch):
+    """Both scrub passes apply: secret placeholder lands AND home-
+    rooted path is collapsed."""
+
+    monkeypatch.setenv("HOME", "/Users/synthetic-user")
+    secret = "sk-" + "C" * 48
+    snippet = (
+        f"call to {secret} from /Users/synthetic-user/proj/app.py"
+    )
+    payload = json.loads(render_json(_result(snippet=snippet)))
+    out = payload["hits"][0]["snippet"]
+    assert secret not in out
+    assert "/Users/synthetic-user" not in out
+
+
 def test_human_render_no_hits_message():
     result = SearchResult(
         spec=SearchSpec(query="missing"),

--- a/tests/events/search/test_spec.py
+++ b/tests/events/search/test_spec.py
@@ -1,0 +1,74 @@
+"""Validation tests for `SearchSpec` (plan 11)."""
+
+from __future__ import annotations
+
+import pytest
+
+from clawjournal.events.aggregate.spec import Predicate
+from clawjournal.events.search import (
+    DEFAULT_LIMIT,
+    DEFAULT_SNIPPET_LENGTH,
+    HARD_LIMIT_CEILING,
+    MAX_QUERY_BYTES,
+    SearchSpec,
+)
+
+
+def test_defaults():
+    spec = SearchSpec(query="hello")
+    assert spec.query == "hello"
+    assert spec.limit == DEFAULT_LIMIT
+    assert spec.snippet_length == DEFAULT_SNIPPET_LENGTH
+    assert spec.include_held is False
+
+
+def test_empty_query_rejected():
+    with pytest.raises(ValueError):
+        SearchSpec(query="")
+    with pytest.raises(ValueError):
+        SearchSpec(query="   ")
+
+
+def test_oversize_query_rejected():
+    with pytest.raises(ValueError) as exc:
+        SearchSpec(query="a" * (MAX_QUERY_BYTES + 1))
+    assert "byte cap" in str(exc.value)
+
+
+def test_zero_limit_rejected():
+    with pytest.raises(ValueError):
+        SearchSpec(query="x", limit=0)
+
+
+def test_limit_above_ceiling_rejected():
+    with pytest.raises(ValueError):
+        SearchSpec(query="x", limit=HARD_LIMIT_CEILING + 1)
+
+
+def test_snippet_length_bounds():
+    with pytest.raises(ValueError):
+        SearchSpec(query="x", snippet_length=4)
+    with pytest.raises(ValueError):
+        SearchSpec(query="x", snippet_length=99999)
+
+
+def test_unknown_filter_field_rejected():
+    with pytest.raises(ValueError) as exc:
+        SearchSpec(
+            query="x",
+            filters=(Predicate(field="raw_json", op="=", value="secret"),),
+        )
+    assert "raw_json" in str(exc.value)
+    assert "allowed" in str(exc.value)
+
+
+def test_known_filter_fields_accepted():
+    SearchSpec(
+        query="x",
+        filters=(
+            Predicate(field="client", op="=", value="claude"),
+            Predicate(
+                field="type", op="in", value=("user_message", "tool_call")
+            ),
+        ),
+    )

--- a/tests/events/search/test_spec.py
+++ b/tests/events/search/test_spec.py
@@ -7,9 +7,11 @@ import pytest
 from clawjournal.events.aggregate.spec import Predicate
 from clawjournal.events.search import (
     DEFAULT_LIMIT,
-    DEFAULT_SNIPPET_LENGTH,
+    DEFAULT_SNIPPET_TOKENS,
     HARD_LIMIT_CEILING,
     MAX_QUERY_BYTES,
+    MAX_SNIPPET_TOKENS,
+    MIN_SNIPPET_TOKENS,
     SearchSpec,
 )
 
@@ -18,7 +20,7 @@ def test_defaults():
     spec = SearchSpec(query="hello")
     assert spec.query == "hello"
     assert spec.limit == DEFAULT_LIMIT
-    assert spec.snippet_length == DEFAULT_SNIPPET_LENGTH
+    assert spec.snippet_tokens == DEFAULT_SNIPPET_TOKENS
     assert spec.include_held is False
 
 
@@ -45,11 +47,17 @@ def test_limit_above_ceiling_rejected():
         SearchSpec(query="x", limit=HARD_LIMIT_CEILING + 1)
 
 
-def test_snippet_length_bounds():
+def test_snippet_tokens_bounds():
+    """FTS5 caps ``snippet()`` at 64 tokens; SearchSpec enforces the
+    cap so the SQL builder never relies on SQLite's silent clamp."""
+
     with pytest.raises(ValueError):
-        SearchSpec(query="x", snippet_length=4)
+        SearchSpec(query="x", snippet_tokens=MIN_SNIPPET_TOKENS - 1)
     with pytest.raises(ValueError):
-        SearchSpec(query="x", snippet_length=99999)
+        SearchSpec(query="x", snippet_tokens=MAX_SNIPPET_TOKENS + 1)
+    # Boundaries are inclusive.
+    SearchSpec(query="x", snippet_tokens=MIN_SNIPPET_TOKENS)
+    SearchSpec(query="x", snippet_tokens=MAX_SNIPPET_TOKENS)
 
 
 def test_unknown_filter_field_rejected():


### PR DESCRIPTION
## Summary

First PR for [phase-1 plan 11](docs/plans/phase-1/11-cross-session-fts.md): cross-session full-text search over `events.raw_json` using SQLite FTS5 in the existing `~/.clawjournal/index.db`. No new file, no daemon, no embedder.

```
$ clawjournal events search authentication
  -0.537  claude:proj:s1  tool_result  2026-04-21T10:00:00Z  {"text": "401 Unauthorized: authentication failed"}

1 of 1 matches (0 ms) — held sessions excluded; pass --include-held to include
```

## Module placement

Mirrors plan 08 (doctor) and plan 10 (aggregate):

```
clawjournal/events/search/
  __init__.py     # public API
  schema.py       # FTS5 virtual table + triggers + ensure/rebuild
  spec.py         # SearchSpec dataclass + filter allowlist + caps
  query.py        # SQL builder + executor + snapshot-isolated run()
  render.py       # JSON / human renderers + anonymizer + snippet redaction
```

CLI handler in `cli.py` next to plan 10's aggregate handler.

## Security / correctness invariants

Pinned by tests; each is a regression of one bullet from plan 11 §Security:

- **`MATCH` is parameterized** — `WHERE events_fts MATCH ?`, user query bound never interpolated. SQL-injection-shaped values either return zero rows or surface as a clean `OperationalError` that the CLI maps to `usage_error` (code 2).
- **Allowlisted filters** — `client` / `type` / `confidence` / `session` / `source` only; everything else rejected at spec construction.
- **Snippets pass redaction before highlighting** — `redact_text` from `clawjournal/redaction/secrets.py` runs on the FTS5 snippet before emit. Secrets surface as `[SECRET_REDACTED]` even though `raw_json` is in the index.
- **Anonymized paths** — `raw_ref.source_path` via `Anonymizer().path()`, `session_key` via `Anonymizer().text()` (matching plan 10's treatment).
- **Hold-state default-deny** — events from sessions in `pending_review` or active `embargoed` excluded by default; `--include-held` surfaces them. Sessions with no workbench row pass through.
- **Snapshot isolation** — hits + count queries run inside one explicit `BEGIN`/`COMMIT` so concurrent writes from `clawjournal serve` can't drift `rows_matched` away from `len(hits)`.
- **Caps** — `--limit` default 50 / ceiling 1000; `--snippet-length` 16-1024; query body capped at 4 KiB (UTF-8).

## Error handling (plan 08 contract)

| Exit | Kind | When |
|---|---|---|
| 2 | `usage_error` | missing positional, unknown filter, oversize query, malformed FTS5 expression (incl. unbalanced quotes, `foo-bar` column-filter trap) |
| 3 | `index_missing` | workbench DB exists but `events` doesn't, or FTS table missing and creation fails |
| 9 | `unspecified` | catch-all |

The hyphen-bareword case is a known FTS5 quirk: `rate-limit` is parsed as a column filter on `rate`. The CLI maps `no such column` to `usage_error` and `commands.md` documents the workaround (`'"rate-limit"'` phrase quotes).

## Maintenance contract (plan 08 §When a ticket lands #5)

- `clawjournal/events/docs/_features.yaml` gains `events.search`.
- `commands.md` gains a per-command section.
- `schemas.md` gains the `events search --json` envelope schema.
- The existing drift tests gate merges if either falls out of sync.

## Test plan

- [x] `pytest tests/events/search/ -v` — 38 new tests pass
- [x] `pytest` (full suite) — 1673 passed (was 1635; +38)
- [x] Live CLI: `events search authentication` returns the seeded match; `events search --rebuild-index` reindexes; `events docs commands` lists the new section; `events features --json` advertises `events.search`.
- [x] Negative cases: missing positional → exit 2, malformed query → exit 2, missing events table → exit 3 with directed hint.

## Out of scope (deferred follow-ups)

- `--canonical` (UNION over `event_overrides`).
- `--cursor` pagination — `--limit` truncation only for v0.1.
- `--explain` query AST dump.
- `--aggregate` bridge into plan 10.
- Re-injecting `<mark>` highlights after redaction — snippet currently emits redacted plaintext without per-token marks; restoring marks needs a tokenizer-aware diff between raw and redacted snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
