### PR TITLE
feat(workbench): C1 — widened message model (invocations / snippets / extra / author)

### DIFF
--- a/clawjournal/parsing/widened.py
+++ b/clawjournal/parsing/widened.py
@@ -1,0 +1,178 @@
+"""Widened normalized-message shape (NormalizedMessage / NormalizedInvocation / NormalizedSnippet).
+
+Backward-compatible extension to the message dict produced by every
+``parse_*_session`` function. Existing parsers continue to emit
+``role`` / ``content`` / ``thinking`` / ``tool_uses``; this module adds
+four optional fields that future connectors (phase-2 D1-D8) can populate:
+
+- ``invocations``: list of structured tool/skill invocations with both
+  the agent-emitted ``raw_name`` and the canonical ``name``. Distinct
+  from the legacy ``tool_uses`` list, which the existing connectors
+  keep emitting.
+- ``snippets``: list of structured code-region references.
+- ``extra``: dict preserving raw agent-specific JSON the normalizer
+  cannot map onto the canonical shape.
+- ``author``: string distinct from ``role`` (sub-agent / skill wrapper
+  identity).
+
+All four fields are subject to the same redaction passes as ``content``
+— see the corresponding plumbing in ``clawjournal/redaction/secrets.py``
+and ``clawjournal/redaction/pii.py``. The "looks like metadata" trap
+(invariant 8 in phase-2/01) is the reason ``extra`` ships through
+``_apply_to_value`` recursively rather than via a metadata fast path.
+
+Reference: ``franken_agent_detection/src/types.rs`` ``NormalizedMessage``.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Iterator
+
+INVOCATION_ARGUMENTS_CAP_BYTES = 64 * 1024
+
+
+def truncate_invocation_arguments(arguments: Any) -> tuple[Any, bool]:
+    """Cap an invocation's ``arguments`` payload at 64 KiB serialized.
+
+    Returns ``(value, was_truncated)``. When the JSON-serialized form
+    exceeds the cap, the value is replaced with the UTF-8-truncated
+    serialization (a string) and ``was_truncated=True`` is returned so
+    the caller can attach the ``arguments_truncated: true`` marker to
+    the invocation dict.
+
+    String inputs are measured against the cap directly; large strings
+    are truncated by character without re-encoding through ``json``.
+    Other types are JSON-serialized to measure size; oversized values
+    are returned as a string holding the truncated JSON prefix (so the
+    reader sees the leading bytes of the original structure).
+
+    The ``ensure_ascii=False`` flag matches how the rest of the
+    workbench writes blobs.
+    """
+    if arguments is None:
+        return None, False
+
+    if isinstance(arguments, str):
+        encoded = arguments.encode("utf-8")
+        if len(encoded) <= INVOCATION_ARGUMENTS_CAP_BYTES:
+            return arguments, False
+        truncated = encoded[:INVOCATION_ARGUMENTS_CAP_BYTES].decode("utf-8", errors="ignore")
+        return truncated, True
+
+    serialized = json.dumps(arguments, default=str, ensure_ascii=False)
+    encoded = serialized.encode("utf-8")
+    if len(encoded) <= INVOCATION_ARGUMENTS_CAP_BYTES:
+        return arguments, False
+    truncated = encoded[:INVOCATION_ARGUMENTS_CAP_BYTES].decode("utf-8", errors="ignore")
+    return truncated, True
+
+
+def build_invocation(
+    *,
+    name: str,
+    raw_name: str | None = None,
+    arguments: Any = None,
+    **extras: Any,
+) -> dict[str, Any]:
+    """Construct a NormalizedInvocation dict with the 64 KiB arguments cap applied.
+
+    ``raw_name`` is only stored when it differs from ``name`` (Amp's
+    ``skill('foo')`` wrapper is the prototype; for connectors where the
+    agent-emitted name already matches the canonical one, omitting
+    ``raw_name`` keeps blobs compact).
+
+    ``extras`` lets callers attach connector-specific fields (e.g.
+    Pi-Agent's ``thinking_level``) without broadening this signature.
+    """
+    capped, truncated = truncate_invocation_arguments(arguments)
+    inv: dict[str, Any] = {"name": name}
+    if raw_name is not None and raw_name != name:
+        inv["raw_name"] = raw_name
+    inv["arguments"] = capped
+    if truncated:
+        inv["arguments_truncated"] = True
+    for k, v in extras.items():
+        inv[k] = v
+    return inv
+
+
+def build_snippet(
+    *,
+    path: str | None = None,
+    content: str = "",
+    lang: str | None = None,
+    **extras: Any,
+) -> dict[str, Any]:
+    """Construct a NormalizedSnippet dict.
+
+    ``path`` is the filesystem path the snippet was extracted from
+    (display-only — never feed back to the filesystem). ``content`` is
+    the snippet text; ``lang`` is an optional language hint. Connector-
+    specific extras (line ranges, blob hashes) ride along untouched.
+    """
+    snip: dict[str, Any] = {"content": content}
+    if path is not None:
+        snip["path"] = path
+    if lang is not None:
+        snip["lang"] = lang
+    for k, v in extras.items():
+        snip[k] = v
+    return snip
+
+
+def iter_widened_text_locations(msg: dict[str, Any]) -> Iterator[tuple[str, str]]:
+    """Yield ``(text, field_label)`` pairs for every string in a message's widened fields.
+
+    Walks ``invocations``, ``snippets``, ``extra``, and ``author`` —
+    callers handle the legacy ``content`` / ``thinking`` / ``tool_uses``
+    fields themselves. Field labels are stable strings that locate the
+    leaf inside the message for findings storage:
+
+    - ``author``
+    - ``invocations[<idx>].<key>`` and recursively ``...<key>.<subkey>``
+    - ``snippets[<idx>].<key>``
+    - ``extra.<key>`` and recursively ``extra.<key>.<subkey>``
+
+    The traversal is fully recursive — nested secrets in
+    ``extra.foo.bar.token`` are yielded with field
+    ``extra.foo.bar.token``. This matches the recursive writeback in
+    ``_apply_to_value`` so scan and apply stay in sync.
+    """
+    author = msg.get("author")
+    if isinstance(author, str) and author:
+        yield author, "author"
+
+    invocations = msg.get("invocations")
+    if isinstance(invocations, list):
+        for idx, inv in enumerate(invocations):
+            if isinstance(inv, dict):
+                yield from _walk_strings(inv, f"invocations[{idx}]")
+
+    snippets = msg.get("snippets")
+    if isinstance(snippets, list):
+        for idx, snip in enumerate(snippets):
+            if isinstance(snip, dict):
+                yield from _walk_strings(snip, f"snippets[{idx}]")
+
+    extra = msg.get("extra")
+    if isinstance(extra, dict):
+        yield from _walk_strings(extra, "extra")
+
+
+def _walk_strings(value: Any, prefix: str) -> Iterator[tuple[str, str]]:
+    """Recursively yield ``(string, field_label)`` from a JSON-shaped value.
+
+    Non-string scalars (ints, bools, None) are skipped. Lists yield
+    their items with ``prefix[i]``; dicts yield their values with
+    ``prefix.<key>``. Empty strings are skipped.
+    """
+    if isinstance(value, str):
+        if value:
+            yield value, prefix
+    elif isinstance(value, dict):
+        for k, v in value.items():
+            yield from _walk_strings(v, f"{prefix}.{k}")
+    elif isinstance(value, list):
+        for i, item in enumerate(value):
+            yield from _walk_strings(item, f"{prefix}[{i}]")

--- a/clawjournal/redaction/pii.py
+++ b/clawjournal/redaction/pii.py
@@ -340,6 +340,8 @@ def _review_text_with_agent(session_id: str, message_index: int, field: str, tex
 
 def _collect_text_work_items(session: dict[str, Any]) -> list[tuple[str, int, str, str]]:
     """Extract all (session_id, message_index, field, text) tuples from a session."""
+    from ..parsing.widened import iter_widened_text_locations
+
     session_id = str(session.get("session_id") or "")
     messages = session.get("messages", [])
     if not isinstance(messages, list):
@@ -363,6 +365,11 @@ def _collect_text_work_items(session: dict[str, Any]) -> list[tuple[str, int, st
                             work_items.append((session_id, i, f"tool_uses[{tool_index}].{branch}.{key}", nested))
                 elif isinstance(value, str) and value.strip():
                     work_items.append((session_id, i, f"tool_uses[{tool_index}].{branch}", value))
+        # Widened message model (phase-2 C1): same redaction passes
+        # apply to invocations / snippets / extra / author.
+        for text, field_label in iter_widened_text_locations(msg):
+            if text.strip():
+                work_items.append((session_id, i, field_label, text))
     return work_items
 
 
@@ -533,6 +540,8 @@ def _scan_text_for_pii(session_id: str, message_index: int, field: str, text: st
 
 
 def review_session_pii(session: dict[str, Any]) -> list[PIIFinding]:
+    from ..parsing.widened import iter_widened_text_locations
+
     findings: list[PIIFinding] = []
     session_id = str(session.get("session_id") or "")
 
@@ -565,6 +574,9 @@ def review_session_pii(session: dict[str, Any]) -> list[PIIFinding]:
                 elif isinstance(value, str):
                     field = f"tool_uses[{tool_index}].{branch}"
                     findings.extend(_scan_text_for_pii(session_id, i, field, value))
+        # Widened message model (phase-2 C1).
+        for text, field_label in iter_widened_text_locations(msg):
+            findings.extend(_scan_text_for_pii(session_id, i, field_label, text))
     return merge_findings(findings)
 
 

--- a/clawjournal/redaction/secrets.py
+++ b/clawjournal/redaction/secrets.py
@@ -22,6 +22,7 @@ from collections.abc import Iterable
 from typing import Any
 
 from ..findings import RawFinding, hash_entity
+from ..parsing.widened import iter_widened_text_locations
 
 REDACTED = "[REDACTED]"
 
@@ -632,6 +633,12 @@ def _collect_all_text(session: dict) -> list[tuple[str, str, int | None, str | N
                     flat = _flatten_to_strings(val)
                     for s in flat:
                         texts.append((s, f"tool_{tf}", msg_idx, tf))
+        # Widened message model (phase-2 C1): invocations / snippets /
+        # extra / author flow through the same scan as content.
+        # `extra` especially — invariant 8 in phase-2/01: do not
+        # short-circuit because the field looks like metadata.
+        for text, field_label in iter_widened_text_locations(msg):
+            texts.append((text, field_label, msg_idx, None))
 
     return texts
 
@@ -761,6 +768,45 @@ def _apply_to_value(value: Any, secret_map: dict[str, str]) -> tuple[Any, int]:
     return value, 0
 
 
+def _apply_widened_message_fields(msg: dict, secret_map: dict[str, str]) -> int:
+    """Redact secrets across the widened-message fields in place.
+
+    Mutates ``msg`` directly, replacing strings inside ``invocations``,
+    ``snippets``, ``extra`` (recursively) and the scalar ``author``.
+    Returns the number of replacements applied. Used by both
+    ``redact_session`` (legacy path) and ``apply_findings_to_blob``
+    (DB-backed path) so the two stay in sync.
+
+    Skipped silently when none of the widened fields are populated —
+    the cost on legacy-shape messages is one ``msg.get`` per field.
+    """
+    total = 0
+    if not isinstance(msg, dict) or not secret_map:
+        return total
+
+    author = msg.get("author")
+    if isinstance(author, str) and author:
+        msg["author"], n = _apply_redaction_set(author, secret_map)
+        total += n
+
+    invocations = msg.get("invocations")
+    if isinstance(invocations, list):
+        msg["invocations"], n = _apply_to_value(invocations, secret_map)
+        total += n
+
+    snippets = msg.get("snippets")
+    if isinstance(snippets, list):
+        msg["snippets"], n = _apply_to_value(snippets, secret_map)
+        total += n
+
+    extra = msg.get("extra")
+    if isinstance(extra, dict):
+        msg["extra"], n = _apply_to_value(extra, secret_map)
+        total += n
+
+    return total
+
+
 def redact_session(
     session: dict, custom_strings: list[str] | None = None,
     user_allowlist: list[dict] | None = None,
@@ -816,6 +862,10 @@ def redact_session(
                     if tool_use.get(tf):
                         tool_use[tf], n = _apply_to_value(tool_use[tf], secret_map)
                         pass_count += n
+            # Widened message model: redact across invocations /
+            # snippets / extra / author with the same secret_map.
+            n = _apply_widened_message_fields(msg, secret_map)
+            pass_count += n
 
         total += pass_count
 
@@ -889,6 +939,12 @@ def _iter_text_locations(
                                 "tool_dict",
                                 f"{tool_idx}:{branch}:{key}",
                             )
+        # Widened message model (phase-2 C1): yield strings from
+        # invocations / snippets / extra / author so the findings
+        # scan covers them. write_kind="widened" signals
+        # ``apply_findings_to_blob`` to use the recursive writeback.
+        for text, field_label in iter_widened_text_locations(msg):
+            yield text, field_label, msg_idx, None, "widened", field_label
 
 
 def _dedupe_overlapping_matches(matches: list[dict]) -> list[dict]:
@@ -1069,6 +1125,7 @@ def apply_findings_to_blob(
                         continue
                     tool_use[branch], n = _apply_to_value(val, secret_map)
                     pass_count += n
+            pass_count += _apply_widened_message_fields(msg, secret_map)
 
         total += pass_count
         if pass_count == 0 and pass_num > 0:

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -22,11 +22,15 @@ INDEX_DB = CONFIG_DIR / "index.db"
 BLOBS_DIR = CONFIG_DIR / "blobs"
 
 # Schema version sentinels. Version 1 is the bundles→shares migration,
-# version 2 is the security refactor, and version 3 adds the
-# `sessions.session_key` bridge to `event_sessions.session_key`.
+# version 2 is the security refactor, version 3 adds the
+# `sessions.session_key` bridge to `event_sessions.session_key`, and
+# version 4 marks the workbench as widened-message-aware (parser path
+# now produces messages with optional `invocations` / `snippets` /
+# `extra` / `author` fields, all routed through redaction).
 SECURITY_SCHEMA_VERSION = 2
 SESSION_IDENTITY_SCHEMA_VERSION = 3
-WORKBENCH_SCHEMA_VERSION = SESSION_IDENTITY_SCHEMA_VERSION
+WIDENED_MESSAGE_SCHEMA_VERSION = 4
+WORKBENCH_SCHEMA_VERSION = WIDENED_MESSAGE_SCHEMA_VERSION
 BACKFILL_WINDOW = 100
 
 # Display-only normalization from the mixed AI/heuristic outcome vocabulary
@@ -302,6 +306,7 @@ def open_index() -> sqlite3.Connection:
 
     _migrate_security_refactor(conn)
     _migrate_session_identity_bridge(conn)
+    _migrate_widened_message_model(conn)
 
     # Clean up ai_outcome_badge values that the judge wrote before the
     # resolution validator rejected invalid labels. Idempotent: after
@@ -414,6 +419,49 @@ def _migrate_session_identity_bridge(conn: sqlite3.Connection) -> None:
             "ON sessions(session_key) WHERE session_key IS NOT NULL"
         )
         conn.execute(f"PRAGMA user_version = {SESSION_IDENTITY_SCHEMA_VERSION}")
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def _migrate_widened_message_model(conn: sqlite3.Connection) -> None:
+    """Mark this DB as widened-message-aware. Advances PRAGMA user_version 3 → 4.
+
+    Phase-2 C1. The widened message model lives in the per-session JSON
+    blob — message dicts gain optional ``invocations`` / ``snippets`` /
+    ``extra`` / ``author`` fields. Existing blobs remain valid because
+    every reader treats the new fields as optional (``msg.get("invocations", [])``).
+
+    The migration adds ``sessions.message_schema_version`` so future
+    backfills can identify legacy-shape rows without re-parsing each
+    blob. Existing rows are stamped with version 1 (legacy); rows
+    written by widened-aware code use version 2. The column is not
+    consulted by any current reader — it is a forward-compat marker.
+
+    Idempotent. Re-running on a v4 DB is a no-op.
+    """
+    version_row = conn.execute("PRAGMA user_version").fetchone()
+    version = version_row[0] if version_row else 0
+    if version >= WIDENED_MESSAGE_SCHEMA_VERSION:
+        return
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        try:
+            conn.execute(
+                "ALTER TABLE sessions ADD COLUMN message_schema_version INTEGER DEFAULT 2"
+            )
+        except sqlite3.OperationalError as e:
+            if "duplicate column" not in str(e):
+                raise
+        # Backfill existing rows with version 1 (legacy shape). New
+        # inserts get the column default (2).
+        conn.execute(
+            "UPDATE sessions SET message_schema_version = 1 "
+            "WHERE message_schema_version IS NULL OR message_schema_version = 2"
+        )
+        conn.execute(f"PRAGMA user_version = {WIDENED_MESSAGE_SCHEMA_VERSION}")
         conn.commit()
     except Exception:
         conn.rollback()

--- a/tests/redaction/test_widened_message_model.py
+++ b/tests/redaction/test_widened_message_model.py
@@ -1,0 +1,264 @@
+"""Redaction-pipeline tests for the widened message model (phase-2 C1).
+
+Invariant under test: secrets in the new fields (``invocations``,
+``snippets``, ``extra``, ``author``) get the same redaction treatment
+as ``content`` and ``thinking``. The ``extra`` field especially —
+phase-2/01 invariant 8 says metadata is not exempt from redaction,
+because credentials have been observed nested in agent-emitted JSON.
+
+Tests cover:
+- ``redact_session`` (legacy mutate-in-place path).
+- ``apply_findings_to_blob`` (DB-backed share-time apply).
+- ``review_session_pii`` (rule-based PII scan).
+- The 64 KiB ``invocations.arguments`` cap helper.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from clawjournal.findings import write_findings_to_db
+from clawjournal.parsing.widened import (
+    INVOCATION_ARGUMENTS_CAP_BYTES,
+    build_invocation,
+    build_snippet,
+    iter_widened_text_locations,
+    truncate_invocation_arguments,
+)
+from clawjournal.redaction.pii import review_session_pii
+from clawjournal.redaction.secrets import (
+    apply_findings_to_blob,
+    redact_session,
+    scan_session_for_findings,
+)
+
+
+# A real-shape secret that the existing pattern set redacts with high
+# confidence. Using sk-ant- because it has a stable, well-understood
+# placeholder and high entropy.
+ANTHROPIC_KEY = "sk-ant-api03-" + "A" * 90
+EXPECTED_PLACEHOLDER = "[REDACTED_ANTHROPIC_KEY]"
+
+STRIPE_KEY = "sk_live_" + "B" * 30
+EXPECTED_STRIPE_PLACEHOLDER = "[REDACTED_STRIPE_KEY]"
+
+
+def _session_with(msg_extras: dict) -> dict:
+    """Build a minimal session containing one assistant message with the given fields."""
+    msg = {"role": "assistant", "content": "ok"}
+    msg.update(msg_extras)
+    return {
+        "session_id": "test-1",
+        "project": "p",
+        "source": "claude",
+        "messages": [msg],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Truncation helper
+# ---------------------------------------------------------------------------
+
+class TestTruncateInvocationArguments:
+    def test_under_cap_returns_unchanged(self):
+        small = {"file": "/tmp/a.txt", "lines": list(range(100))}
+        capped, truncated = truncate_invocation_arguments(small)
+        assert capped == small
+        assert truncated is False
+
+    def test_over_cap_marks_truncated(self):
+        # 70 KiB string of distinct content forces the cap to fire.
+        big_text = "x" * (70 * 1024)
+        capped, truncated = truncate_invocation_arguments({"payload": big_text})
+        assert truncated is True
+        assert isinstance(capped, str)
+        # Truncated form is the leading bytes of the JSON serialization.
+        assert len(capped.encode("utf-8")) <= INVOCATION_ARGUMENTS_CAP_BYTES
+
+    def test_string_input_truncated_directly(self):
+        big_text = "y" * (80 * 1024)
+        capped, truncated = truncate_invocation_arguments(big_text)
+        assert truncated is True
+        assert capped == big_text[:INVOCATION_ARGUMENTS_CAP_BYTES]
+
+    def test_none_passes_through(self):
+        capped, truncated = truncate_invocation_arguments(None)
+        assert capped is None
+        assert truncated is False
+
+    def test_build_invocation_attaches_marker(self):
+        big = {"blob": "z" * (100 * 1024)}
+        inv = build_invocation(name="read_file", arguments=big)
+        assert inv["arguments_truncated"] is True
+        assert isinstance(inv["arguments"], str)
+
+    def test_build_invocation_omits_raw_name_when_redundant(self):
+        inv = build_invocation(name="read_file", raw_name="read_file", arguments={"a": 1})
+        assert "raw_name" not in inv
+
+    def test_build_invocation_keeps_distinct_raw_name(self):
+        inv = build_invocation(name="read_file", raw_name="skill('read_file')", arguments={"a": 1})
+        assert inv["raw_name"] == "skill('read_file')"
+
+
+# ---------------------------------------------------------------------------
+# iter_widened_text_locations: traversal and field-label correctness
+# ---------------------------------------------------------------------------
+
+class TestIterWidenedTextLocations:
+    def test_legacy_message_yields_nothing(self):
+        msg = {"role": "user", "content": "hi", "tool_uses": []}
+        assert list(iter_widened_text_locations(msg)) == []
+
+    def test_extra_yields_recursively(self):
+        msg = {
+            "role": "assistant",
+            "extra": {"meta": {"trace_id": "abc-123", "nested": {"k": "v"}}},
+        }
+        out = list(iter_widened_text_locations(msg))
+        labels = {label for _, label in out}
+        # Recursion produces the deep field labels.
+        assert "extra.meta.trace_id" in labels
+        assert "extra.meta.nested.k" in labels
+
+    def test_invocations_arguments_yielded(self):
+        msg = {
+            "role": "assistant",
+            "invocations": [build_invocation(name="run", arguments={"cmd": "ls"})],
+        }
+        out = list(iter_widened_text_locations(msg))
+        labels = {label for _, label in out}
+        assert "invocations[0].name" in labels
+        assert "invocations[0].arguments.cmd" in labels
+
+    def test_author_emitted(self):
+        msg = {"role": "assistant", "author": "subagent-1"}
+        out = list(iter_widened_text_locations(msg))
+        assert ("subagent-1", "author") in out
+
+
+# ---------------------------------------------------------------------------
+# redact_session: secrets in widened fields get redacted
+# ---------------------------------------------------------------------------
+
+class TestRedactSessionWidened:
+    def test_secret_in_extra_redacted(self):
+        # Bare key, no Bearer prefix — the Bearer pattern would absorb
+        # the key into a [REDACTED_BEARER] match otherwise. We want to
+        # see the typed Anthropic placeholder to prove specificity.
+        session = _session_with({
+            "extra": {"trace": {"value": ANTHROPIC_KEY}}
+        })
+        out, count, _log = redact_session(session)
+        assert count >= 1
+        assert ANTHROPIC_KEY not in json.dumps(out)
+        assert EXPECTED_PLACEHOLDER == out["messages"][0]["extra"]["trace"]["value"]
+
+    def test_secret_in_invocations_arguments_redacted(self):
+        session = _session_with({
+            "invocations": [
+                build_invocation(name="curl", arguments={"url": f"https://api/{STRIPE_KEY}"})
+            ]
+        })
+        out, count, _log = redact_session(session)
+        assert count >= 1
+        assert STRIPE_KEY not in json.dumps(out)
+        assert EXPECTED_STRIPE_PLACEHOLDER in out["messages"][0]["invocations"][0]["arguments"]["url"]
+
+    def test_secret_in_snippet_content_redacted(self):
+        session = _session_with({
+            "snippets": [build_snippet(path="/etc/keys.txt", content=f"key={ANTHROPIC_KEY}")]
+        })
+        out, _count, _log = redact_session(session)
+        assert ANTHROPIC_KEY not in json.dumps(out)
+        assert EXPECTED_PLACEHOLDER in out["messages"][0]["snippets"][0]["content"]
+
+    def test_secret_in_author_field_redacted(self):
+        # Pathological: an agent puts a secret in the author label.
+        session = _session_with({"author": f"sub-{ANTHROPIC_KEY}"})
+        out, _count, _log = redact_session(session)
+        assert ANTHROPIC_KEY not in out["messages"][0]["author"]
+        assert EXPECTED_PLACEHOLDER in out["messages"][0]["author"]
+
+    def test_legacy_message_unchanged(self):
+        """Backward compat: messages with no widened fields work as before."""
+        session = {
+            "session_id": "t",
+            "project": "p",
+            "source": "claude",
+            "messages": [{"role": "user", "content": f"key={ANTHROPIC_KEY}", "tool_uses": []}],
+        }
+        out, count, _log = redact_session(session)
+        assert count >= 1
+        assert ANTHROPIC_KEY not in out["messages"][0]["content"]
+
+
+# ---------------------------------------------------------------------------
+# apply_findings_to_blob: DB-backed share-time apply
+# ---------------------------------------------------------------------------
+
+class TestApplyFindingsToBlobWidened:
+    @pytest.fixture
+    def in_memory_db(self):
+        from clawjournal.workbench.index import SCHEMA_SQL
+
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript(SCHEMA_SQL)
+        return conn
+
+    def test_apply_redacts_secret_in_extra(self, in_memory_db):
+        session = _session_with({
+            "extra": {"meta": {"value": ANTHROPIC_KEY}}
+        })
+        raw = scan_session_for_findings(session)
+        write_findings_to_db(in_memory_db, "test-1", raw, revision="rev1")
+        in_memory_db.commit()
+
+        blob = json.loads(json.dumps(session))
+        out, count = apply_findings_to_blob(blob, in_memory_db, "test-1")
+        assert count >= 1
+        assert ANTHROPIC_KEY not in json.dumps(out)
+        assert EXPECTED_PLACEHOLDER == out["messages"][0]["extra"]["meta"]["value"]
+
+    def test_apply_redacts_secret_in_invocations(self, in_memory_db):
+        session = _session_with({
+            "invocations": [
+                build_invocation(name="api", arguments={"token": ANTHROPIC_KEY})
+            ]
+        })
+        raw = scan_session_for_findings(session)
+        # Confirm scan found at least one widened-field finding (proves
+        # _iter_text_locations reaches invocations).
+        widened_fields = [f for f in raw if f.field.startswith("invocations[")]
+        assert widened_fields, "scan must locate secrets nested in invocations"
+
+        write_findings_to_db(in_memory_db, "test-1", raw, revision="rev1")
+        in_memory_db.commit()
+
+        blob = json.loads(json.dumps(session))
+        out, count = apply_findings_to_blob(blob, in_memory_db, "test-1")
+        assert count >= 1
+        assert ANTHROPIC_KEY not in json.dumps(out)
+
+
+# ---------------------------------------------------------------------------
+# review_session_pii: rule-based PII scan covers widened fields
+# ---------------------------------------------------------------------------
+
+class TestReviewSessionPiiWidened:
+    def test_email_in_extra_detected(self):
+        # Use a clearly-email-shaped string that the rule-based PII
+        # matcher classifies. The exact field label is not asserted —
+        # only that *some* finding lands inside the widened path.
+        session = _session_with({
+            "extra": {"sender": "alice@example.com"}
+        })
+        findings = review_session_pii(session)
+        # PIIFinding is a TypedDict; index by key. Without widened-field
+        # plumbing this scan would skip extra entirely.
+        widened_findings = [f for f in findings if f.get("field", "").startswith("extra")]
+        assert widened_findings, "PII scan must reach extra.* fields"

--- a/tests/workbench/test_widened_message_migration.py
+++ b/tests/workbench/test_widened_message_migration.py
@@ -1,0 +1,140 @@
+"""Tests for the widened-message-model schema migration (phase-2 C1).
+
+Bumps PRAGMA user_version 3 → 4 and adds the
+``sessions.message_schema_version`` column. Existing rows are stamped
+with version 1 (legacy shape); fresh inserts default to version 2
+(widened shape). The column is a forward-compat marker — current
+readers do not consult it.
+"""
+
+import sqlite3
+
+import pytest
+
+from clawjournal.workbench.index import (
+    SESSION_IDENTITY_SCHEMA_VERSION,
+    WIDENED_MESSAGE_SCHEMA_VERSION,
+    WORKBENCH_SCHEMA_VERSION,
+    open_index,
+)
+
+
+@pytest.fixture
+def fresh_db(tmp_path, monkeypatch):
+    db_path = tmp_path / "index.db"
+    blobs_path = tmp_path / "blobs"
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", db_path)
+    monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", blobs_path)
+    return db_path
+
+
+def _columns(conn, table):
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+class TestFreshInstall:
+    def test_workbench_version_advances_to_widened(self, fresh_db):
+        assert WORKBENCH_SCHEMA_VERSION == WIDENED_MESSAGE_SCHEMA_VERSION
+        assert WIDENED_MESSAGE_SCHEMA_VERSION > SESSION_IDENTITY_SCHEMA_VERSION
+        conn = open_index()
+        try:
+            version = conn.execute("PRAGMA user_version").fetchone()[0]
+            assert version == WIDENED_MESSAGE_SCHEMA_VERSION
+        finally:
+            conn.close()
+
+    def test_message_schema_version_column_exists(self, fresh_db):
+        conn = open_index()
+        try:
+            cols = _columns(conn, "sessions")
+            assert "message_schema_version" in cols
+        finally:
+            conn.close()
+
+
+class TestUpgradeFromV3:
+    def _downgrade_to_v3(self, db_path):
+        """Roll a v4 DB back to v3 state: drop the new column + reset version.
+
+        Rather than constructing a v3 schema from scratch (which would
+        require reproducing every ALTER TABLE addition the v0→v3 path
+        applies), open a fresh DB at v4, then surgically remove the v4
+        artifacts. SQLite 3.35+ supports ``DROP COLUMN`` directly.
+        """
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA foreign_keys=OFF")
+        conn.execute("ALTER TABLE sessions DROP COLUMN message_schema_version")
+        conn.execute(f"PRAGMA user_version = {SESSION_IDENTITY_SCHEMA_VERSION}")
+        conn.commit()
+        conn.close()
+
+    def test_upgrade_adds_column_and_backfills_legacy(self, fresh_db):
+        # Step 1: fresh install lands at v4 with the column.
+        conn = open_index()
+        conn.execute(
+            "INSERT INTO sessions (session_id, project, source, indexed_at) "
+            "VALUES ('legacy-1', 'p', 'claude', '2026-01-01T00:00:00+00:00')"
+        )
+        conn.commit()
+        conn.close()
+
+        # Step 2: roll back to v3 to simulate an existing user upgrading.
+        self._downgrade_to_v3(fresh_db)
+
+        # Step 3: re-open. The migration should run, add the column,
+        # and stamp the pre-existing row as legacy (1).
+        conn = open_index()
+        try:
+            cols = _columns(conn, "sessions")
+            assert "message_schema_version" in cols
+            row = conn.execute(
+                "SELECT message_schema_version FROM sessions WHERE session_id='legacy-1'"
+            ).fetchone()
+            assert row[0] == 1
+            version = conn.execute("PRAGMA user_version").fetchone()[0]
+            assert version == WIDENED_MESSAGE_SCHEMA_VERSION
+        finally:
+            conn.close()
+
+    def test_upgrade_is_idempotent(self, fresh_db):
+        # Open twice from a fresh DB — second open is a no-op for the
+        # widened-message migration since user_version already == 4.
+        conn = open_index()
+        conn.execute(
+            "INSERT INTO sessions (session_id, project, source, indexed_at) "
+            "VALUES ('s1', 'p', 'claude', '2026-01-01T00:00:00+00:00')"
+        )
+        conn.commit()
+        version_before = conn.execute("PRAGMA user_version").fetchone()[0]
+        msv_before = conn.execute(
+            "SELECT message_schema_version FROM sessions WHERE session_id='s1'"
+        ).fetchone()[0]
+        conn.close()
+
+        conn = open_index()
+        try:
+            version_after = conn.execute("PRAGMA user_version").fetchone()[0]
+            msv_after = conn.execute(
+                "SELECT message_schema_version FROM sessions WHERE session_id='s1'"
+            ).fetchone()[0]
+            assert version_after == version_before == WIDENED_MESSAGE_SCHEMA_VERSION
+            # A second open must not flip a widened row back to legacy.
+            assert msv_after == msv_before == 2
+        finally:
+            conn.close()
+
+    def test_fresh_install_inserts_default_to_widened(self, fresh_db):
+        """New rows on a fresh DB get version 2 (widened) via column default."""
+        conn = open_index()
+        try:
+            conn.execute(
+                "INSERT INTO sessions (session_id, project, source, indexed_at) "
+                "VALUES ('new-1', 'p', 'claude', '2026-01-01T00:00:00+00:00')"
+            )
+            conn.commit()
+            row = conn.execute(
+                "SELECT message_schema_version FROM sessions WHERE session_id='new-1'"
+            ).fetchone()
+            assert row[0] == 2
+        finally:
+            conn.close()


### PR DESCRIPTION
## Summary

Phase-2 C1 (per [`docs/plans/sequencing.md`](https://github.com/kai-rayward/clawjournal/blob/main/docs/plans/sequencing.md) §Phase C). Adds the optional widened-message fields to every parsed session dict so future phase-2 connectors (D1-D8) can populate them. Existing connectors keep emitting `content` / `thinking` / `tool_uses` unchanged.

- New optional message fields per `franken_agent_detection`'s `NormalizedMessage`: `invocations` (with `raw_name` vs canonical `name`), `snippets`, `extra`, `author`.
- `clawjournal/parsing/widened.py` carries `build_invocation` / `build_snippet` / `iter_widened_text_locations` and the 64 KiB `truncate_invocation_arguments` helper that emits the `arguments_truncated: true` marker on hit.
- New gated workbench migration bumps `PRAGMA user_version` 3 → 4 and adds `sessions.message_schema_version` (legacy=1, widened=2). Forward-compat marker — current readers don't consult it.

## Redaction invariant

Every new field flows through the same scan + apply passes as `content`. Six walker sites updated:

- `secrets._collect_all_text` + `redact_session` writeback
- `secrets._iter_text_locations` + `apply_findings_to_blob` writeback
- `pii._collect_text_work_items` + `review_session_pii`

`extra` ships through the recursive `_apply_to_value` path — invariant 8 from `phase-2/01`: metadata is not exempt from redaction because credentials have been observed nested in agent-emitted JSON.

## What shipped vs spec

- ✅ Widened fields, all four (invocations, snippets, extra, author).
- ✅ Gated workbench migration; new `WIDENED_MESSAGE_SCHEMA_VERSION = 4` sentinel rather than overloading `SECURITY_SCHEMA_VERSION` (which the spec mentioned but is semantically the security-refactor migration's terminal version).
- ✅ 64 KiB `invocations.arguments` cap with `*_truncated: true` marker.
- ✅ Backward compat: `Anthropic / Codex / OpenClaw / Cursor / Copilot / Aider / Gemini / OpenCode / Kimi` connectors continue emitting empty/absent `invocations` / `snippets`.
- ✅ Routed every new field through both regex secrets and the rule-based PII pipeline.

## LOC

- Production: 298 LOC (spec target: ~300).
- Tests: 404 LOC (24 new tests).

## Test plan

- [x] `pytest tests/redaction/test_widened_message_model.py` — 19 redaction-pipeline tests covering each new field across `redact_session`, `apply_findings_to_blob`, and `review_session_pii`.
- [x] `pytest tests/workbench/test_widened_message_migration.py` — 5 migration regression tests (fresh install, v3 → v4 upgrade, idempotency, fresh-insert default).
- [x] Full suite: `pytest` → 1749 passed in 50s. No regressions in existing redaction, parser, findings-pipeline, or migration paths.
- [x] Smoke import: `python -c "import clawjournal.cli"` — no circular import via `parsing.widened`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)