### PR TITLE
feat(install): cross-platform install scripts + dual-audience README (agents + non-coders)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,20 @@
+* text=auto eol=lf
+
+# Force LF for shell scripts so they remain executable when cloned on Windows
+# with core.autocrlf=true (CRLF in a shebang breaks bash with "bad interpreter").
+*.sh    text eol=lf
+
+# PowerShell scripts work fine with either, but pin to CRLF for native tooling.
+*.ps1   text eol=crlf
+
+# Binary files: skip line-ending normalization.
+*.png   binary
+*.jpg   binary
+*.jpeg  binary
+*.gif   binary
+*.ico   binary
+*.woff  binary
+*.woff2 binary
+*.ttf   binary
+*.zip   binary
+*.gz    binary

--- a/README.md
+++ b/README.md
@@ -2,6 +2,14 @@
 
 Review and curate your coding agent conversation traces — 100% locally. ClawJournal scans session logs from Claude Code, Claude Desktop, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline, automatically anonymizes secrets and personal information, and gives you a browser workbench to review everything before it ever leaves your machine.
 
+## Install in one step
+
+**Copy this README into Claude Code, Codex, OpenClaw, Hermes, OpenCode, Cursor, or any other coding agent, and ask it to install ClawJournal.** The agent reads the rest of this file, detects your OS, installs any missing prerequisites, runs the install script, and verifies the result. That's the whole install.
+
+Prefer to run the commands yourself? The [Quickstart](#quickstart) section below has the explicit per-OS shell commands the agent would execute. Same end result either way.
+
+> *Coding agents reading this README directly: you already have everything you need. Detect the user's OS, follow the matching block in [Quickstart](#quickstart), then verify with `clawjournal status`. The install script handles Python detection, venv creation, and dependency install — your only job is picking the right OS block and installing missing prereqs (git, Python 3.10+, optionally Node.js for the workbench).*
+
 ## Your data stays local
 
 Everything in the default workflow runs on your own computer:

--- a/README.md
+++ b/README.md
@@ -27,18 +27,19 @@ See [PRIVACY.md](PRIVACY.md) for the full redaction list and the two sharing pat
 **Prerequisites** — `git` + Python 3.10+ are required; Node.js 18+ is required only for the browser workbench (`--with-frontend`). Skip any line whose tool is already installed:
 
 ```bash
-# macOS (install Homebrew first if you don't have it):
+# macOS (install Homebrew first if you don't have it; second line puts brew on PATH for the current shell):
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || /usr/local/bin/brew shellenv)"
 brew install git python              # workbench (optional): brew install node
 
 # Debian / Ubuntu (drop `sudo` if you're root in a container):
 sudo apt update && sudo apt install -y git curl python3-full python3-venv
 sudo apt install -y nodejs npm       # workbench (optional). 24.04+ ships Node 18; on older LTS use NodeSource: curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo bash - && sudo apt install -y nodejs
 
-# Windows (PowerShell, native package manager):
-winget install --id Git.Git -e
-winget install --id Python.Python.3.12 -e
-winget install --id OpenJS.NodeJS.LTS -e   # workbench (optional)
+# Windows (PowerShell, native package manager). The flags suppress interactive prompts that block autonomous installs:
+winget install --id Git.Git -e --accept-source-agreements --accept-package-agreements --scope user
+winget install --id Python.Python.3.12 -e --accept-source-agreements --accept-package-agreements --scope user
+winget install --id OpenJS.NodeJS.LTS -e --accept-source-agreements --accept-package-agreements --scope user   # workbench (optional)
 
 # Refresh PATH in the current PowerShell session (winget doesn't do this for you):
 $env:Path = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [Environment]::GetEnvironmentVariable('Path','User')

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ After install, your AI will give you a web address that looks like `http://local
 
 Ask your AI: *"Open ClawJournal and help me set it up to review my coding-agent conversations."* It'll walk you through configure, scan, and review in your browser.
 
+Your first scan may take a minute or two if you have lots of past sessions, and the workbench may show an empty list briefly while it indexes — that's normal. The page refreshes automatically as conversations are added.
+
 ---
 
 <details>

--- a/README.md
+++ b/README.md
@@ -24,17 +24,21 @@ See [PRIVACY.md](PRIVACY.md) for the full redaction list and the two sharing pat
 
 ## Quickstart
 
-**Prerequisites** — `git` + Python 3.10+ are required; Node.js 18+ is required only for the browser workbench (`--with-frontend`). Install per OS:
+**Prerequisites** — `git` + Python 3.10+ are required; Node.js 18+ is required only for the browser workbench (`--with-frontend`). Skip any line whose tool is already installed:
 
 ```bash
 # macOS:
-brew install git python              # Node (optional, for workbench): brew install node
+brew install git python              # workbench (optional): brew install node
 
-# Debian / Ubuntu (run on bare containers; safe to skip if already installed):
-sudo apt update && sudo apt install -y git python3-full python3-venv
-sudo apt install -y nodejs npm        # optional, for workbench (24.04+ is fine; older LTS may need NodeSource)
+# Debian / Ubuntu (drop `sudo` if you're root in a container):
+sudo apt update && sudo apt install -y git curl python3-full python3-venv
+sudo apt install -y nodejs npm       # workbench (optional). 24.04+ ships Node 18; on older LTS use NodeSource: curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo bash - && sudo apt install -y nodejs
 
-# Windows: install Git for Windows, Python 3.10+ from python.org, and (optionally) Node.js LTS from nodejs.org.
+# Windows (PowerShell, native package manager):
+winget install --id Git.Git -e
+winget install --id Python.Python.3.12 -e
+winget install --id OpenJS.NodeJS.LTS -e   # workbench (optional)
+# winget doesn't refresh the current shell's PATH; close this PowerShell window and open a new one before continuing.
 ```
 
 Then pick the block for your OS and run it. The install script handles Python detection, venv creation, and editable install. Run `./scripts/install.sh --help` for all options.

--- a/README.md
+++ b/README.md
@@ -24,28 +24,60 @@ See [PRIVACY.md](PRIVACY.md) for the full redaction list and the two sharing pat
 
 ## Quickstart
 
-Inside any compatible coding agent (Claude Code, Codex, Cursor, Gemini CLI, OpenCode, [many more](https://github.com/nicepkg/skills)):
+Pick the block for your OS and run all the commands in it. The install script handles Python detection, venv creation, and editable install on macOS, Linux, WSL, and Windows.
+
+**macOS / Linux / WSL / Git Bash on Windows:**
 
 ```bash
-npx skills add kai-rayward/clawjournal
+git clone https://github.com/kai-rayward/clawjournal.git ~/clawjournal
+cd ~/clawjournal
+./scripts/install.sh
 ```
 
-Then tell the agent: *"setup clawjournal"*. It clones the repo into `~/clawjournal`, installs ClawJournal in an isolated venv, scans your local sessions with default settings, and opens the workbench at `http://localhost:8384`. Nothing is uploaded.
+**Native Windows PowerShell:**
 
-Prefer the terminal? See Stage 1 in the flow below — every stage shows both skills and shell commands.
+```powershell
+git clone https://github.com/kai-rayward/clawjournal.git "$HOME\clawjournal"
+Set-Location "$HOME\clawjournal"
+powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1
+```
+
+The script prints `[ok] ClawJournal <version> installed.` on success. Pass `--with-frontend` (POSIX) or `-WithFrontend` (PowerShell) to also build the browser workbench (requires Node.js).
+
+**Verify** — you should see a JSON response with `"stage"` and `"stage_number"`:
+
+```bash
+~/.clawjournal-venv/bin/clawjournal status                              # POSIX
+```
+
+```powershell
+& "$HOME\.clawjournal-venv\Scripts\clawjournal.exe" status              # PowerShell
+```
+
+```json
+{ "stage": "configure", "stage_number": 2, "total_stages": 4, ... }
+```
+
+The CLI lives at `~/.clawjournal-venv/bin/clawjournal` (POSIX) or `$HOME\.clawjournal-venv\Scripts\clawjournal.exe` (Windows). Add the venv bin directory to your `PATH` to call it as plain `clawjournal`. The install is idempotent — re-run the script any time to upgrade against the latest `git pull`.
+
+> **Already inside a coding agent and want it to drive ClawJournal for you?** `npx skills add kai-rayward/clawjournal` adds three skills (Claude Code, Codex, Cursor, …); then say *"setup clawjournal"* — the wizard runs the same script above. Optional convenience, not a separate install path. See [Stage 1: Install](#1-install).
+>
+> **Can't clone? Behind a firewall?** `pipx install clawjournal` works as a fallback, but the PyPI wheel currently lags the source by many releases. See [Stage 1: Install](#1-install).
 
 ---
 
 ## End-to-end flow
 
-Six stages from a blank machine to a shared bundle. Each stage shows the skills-first way (inside your coding agent) and the shell-direct way.
+After install, six stages take you from indexing local sessions to optionally sharing a redacted bundle. Each stage shows the shell command (the canonical path) and the equivalent skill prompt (if you've done `npx skills add`).
+
+> **Heads up on `PATH`:** the shell snippets below use bare `clawjournal`. If you haven't added the venv bin to `PATH`, prefix every command with `~/.clawjournal-venv/bin/` (POSIX) or `$HOME\.clawjournal-venv\Scripts\` (Windows).
 
 ```
  Install ──► Configure ──► Scan ──► Triage ──► Score ──► Package & Share
     1            2           3          4          5              6
 ```
 
-**Three skills are installed by `npx skills add`:**
+**Optional skills layer** — `npx skills add kai-rayward/clawjournal` installs three skills into Claude Code / Codex / Cursor / Gemini CLI / OpenCode and similar agents:
 
 | Skill | Covers stages |
 |-------|---------------|
@@ -53,57 +85,29 @@ Six stages from a blank machine to a shared bundle. Each stage shows the skills-
 | **clawjournal** | 4 Triage · 6 Package & Share |
 | **clawjournal-score** | 5 Score |
 
-Day-to-day, prompts like *"triage my new sessions"*, *"score everything unscored"*, or *"package my approved sessions for export"* route to the right skill automatically.
+With skills installed, prompts like *"triage my new sessions"*, *"score everything unscored"*, or *"package my approved sessions for export"* route to the right skill. Skills are a convenience for agent-driven workflows — the shell commands below work the same without them.
 
 ### 1. Install
 
-**Skills — in your coding agent (Claude Code, Codex, Cursor, …):**
+If you followed [Quickstart](#quickstart) above, you're done — skip to Stage 2. Two alternative paths:
+
+**Skills install (guided wizard inside your coding agent):**
 
 ```bash
 npx skills add kai-rayward/clawjournal
 ```
 
-Adds the three ClawJournal skills to your agent. ClawJournal itself is installed when you run `setup clawjournal` (the wizard executes the same source-install path documented below).
+Then say *"setup clawjournal"* inside the agent. The `clawjournal-setup` wizard runs `scripts/install.sh` (or `install.ps1`) under the hood and walks through scan + workbench launch. The end state is identical to the Quickstart shell install.
 
-**Shell — install from source (recommended):**
-
-The GitHub source is the canonical version. The PyPI wheel currently lags behind, so features documented in this README may not be present in `pip install clawjournal`. The bundled installer script picks a Python 3.10+ interpreter, creates an isolated venv at `~/.clawjournal-venv`, and installs ClawJournal in editable mode. It's idempotent — re-run any time to upgrade against the latest checkout.
-
-macOS / Linux / WSL / Git Bash on Windows — clone, then run *one* of the install commands (`--with-frontend` requires Node.js):
-
-```bash
-git clone https://github.com/kai-rayward/clawjournal.git ~/clawjournal
-cd ~/clawjournal
-
-./scripts/install.sh                  # CLI only
-# or
-./scripts/install.sh --with-frontend  # also build the browser workbench
-```
-
-Native Windows PowerShell — clone, then run *one* of the install commands:
-
-```powershell
-git clone https://github.com/kai-rayward/clawjournal.git "$HOME\clawjournal"
-Set-Location "$HOME\clawjournal"
-
-powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1                 # CLI only
-# or
-powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1 -WithFrontend   # also build the browser workbench
-```
-
-After the script completes, either add the venv bin directory to your `PATH` or invoke the binary directly: `~/.clawjournal-venv/bin/clawjournal` on POSIX, or `$HOME\.clawjournal-venv\Scripts\clawjournal.exe` on Windows.
-
-The browser workbench (`clawjournal serve`) needs a one-time frontend build — pass the `--with-frontend` / `-WithFrontend` flag during install, or see [Build the browser workbench](#build-the-browser-workbench) below. Skip it if you'll only use the CLI.
-
-**Shell — install from PyPI (fallback, may be out of date):**
+**PyPI install (fallback, lags GitHub source):**
 
 ```bash
 pipx install clawjournal        # or: pip install clawjournal
 ```
 
-Faster, and the wheel ships the pre-built workbench (no Node.js needed). Use this only if installing from source isn't an option — `pip show clawjournal` will tell you the wheel's version, which currently lags the GitHub source by many releases.
+The PyPI wheel ships the pre-built workbench (no Node.js needed) but is currently many versions behind the source — features documented in this README may be missing. Use this only when installing from source isn't an option. `pip show clawjournal` reports the wheel's version.
 
-**TruffleHog (required for sharing):**
+**TruffleHog (required for sharing exports, regardless of install path):**
 
 ```bash
 brew install trufflehog      # macOS; Linux/Windows: see upstream installer
@@ -115,19 +119,7 @@ Every `bundle-export` and `share` runs an independent secrets scan on the redact
 
 Tell ClawJournal which agents' sessions to scan and what to exclude or redact.
 
-**Skills — in your coding agent (Claude Code, Codex, Cursor, …):**
-
-For a first-time run with defaults (all sources, no exclusions), say:
-
-> *"setup clawjournal"*
-
-The skill installs ClawJournal from GitHub, runs a first scan, and opens the workbench. Later, to narrow scope or add redactions:
-
-> *"Configure clawjournal to scan only claude and codex, exclude the `scratch` project, and always redact the string `acme-internal`."*
-
-Subsequent scans pick up the new settings automatically.
-
-**Shell — in any bash/zsh terminal:**
+**Shell:**
 
 ```bash
 clawjournal config --source all                   # claude | codex | gemini | opencode | openclaw | kimi | custom | all
@@ -140,15 +132,17 @@ clawjournal config --confirm-projects             # lock in project selection
 
 `--exclude`, `--redact`, and `--redact-usernames` all append; they never overwrite. Safe to call repeatedly.
 
+**Skill prompt** (if you've done `npx skills add`):
+
+> *"setup clawjournal"* — first-time run with defaults (all sources, no exclusions). The skill runs install + scan; if ClawJournal is already installed it skips to scan.
+>
+> *"Configure clawjournal to scan only claude and codex, exclude the `scratch` project, and always redact the string `acme-internal`."* — narrow scope after the fact. Subsequent scans pick up new settings automatically.
+
 ### 3. Scan
 
 Reads your local session files into a SQLite DB and runs a per-session findings pipeline (secrets engine + PII engine). Findings are stored as hashed references — plaintext is never persisted.
 
-**Skills — in your coding agent (Claude Code, Codex, Cursor, …):**
-
-Your agent runs scan as part of `setup clawjournal`. Re-scan any time with: *"scan my sessions again."*
-
-**Shell — in any bash/zsh terminal:**
+**Shell:**
 
 ```bash
 clawjournal scan
@@ -156,15 +150,13 @@ clawjournal scan
 
 The workbench daemon (`clawjournal serve`) also scans continuously in the background.
 
+**Skill prompt:** *"scan my sessions again"* (a first scan also runs as part of `setup clawjournal`).
+
 ### 4. Triage
 
 Approve sessions worth keeping, block the rest. Happens in the workbench (Sessions page) or the CLI.
 
-**Skills — in your coding agent (Claude Code, Codex, Cursor, …):**
-
-> *"Open clawjournal and help me triage the unreviewed sessions."*
-
-**Shell — in any bash/zsh terminal:**
+**Shell:**
 
 ```bash
 clawjournal serve                                    # workbench UI — the primary review surface
@@ -175,6 +167,8 @@ clawjournal approve <session_id> --reason "clean"    # approve
 clawjournal block <session_id> --reason "private"    # block
 clawjournal shortlist <session_id>                   # mark for deeper review
 ```
+
+**Skill prompt:** *"Open clawjournal and help me triage the unreviewed sessions."*
 
 Optional hold-state controls — useful when you want to quarantine a session without blocking it (CLI only):
 
@@ -189,19 +183,15 @@ clawjournal hold-history <id>
 
 AI-assisted quality scoring on a 1–5 scale (1 = noise, 5 = excellent). Home-dir paths and usernames are anonymized before anything is sent to the judge.
 
-**Skills — in your coding agent (Claude Code, Codex, Cursor, …):**
-
-> *"Score my unscored sessions."*
-
-This runs through the `clawjournal-score` skill and uses your current agent's automation CLI.
-
-**Shell — in any bash/zsh terminal:**
+**Shell:**
 
 ```bash
 clawjournal score --batch --auto-triage              # batch-score; auto-blocks noise (score 1) sessions
 clawjournal score-view <id>                          # show score details
 clawjournal set-score <id> --quality 4               # manual override
 ```
+
+**Skill prompt:** *"Score my unscored sessions."* (runs through the `clawjournal-score` skill, uses your current agent's automation CLI.)
 
 `--auto-triage` moves sessions with quality score 1 to `blocked`. Sessions scored 2–5 stay visible for you to decide.
 
@@ -211,17 +201,7 @@ By default scoring uses the current agent's automation CLI (e.g. `codex exec` in
 
 Bundle approved sessions into a redacted export on disk. Uploading that bundle is a separate, opt-in step.
 
-**Skills — in your coding agent (Claude Code, Codex, Cursor, …):**
-
-> *"Package my approved sessions and export them locally."*
->
-> *(optional)* *"Then share the bundle through the ingest service."*
-
-**Workbench — in your browser:**
-
-Open the workbench (`clawjournal serve`) and walk the Share page: **Queue → Redact → Review → Package → Done**. The Redact step layers AI-assisted PII detection on top of the scan-time findings.
-
-**Shell — in any bash/zsh terminal:**
+**Shell:**
 
 ```bash
 clawjournal bundle-create --status approved          # bundle all approved sessions
@@ -229,6 +209,13 @@ clawjournal bundle-list
 clawjournal bundle-view <bundle_id>                  # inspect before exporting
 clawjournal bundle-export <bundle_id>                # write sessions.jsonl + manifest.json to disk
 ```
+
+**Workbench:** open `clawjournal serve` and walk the Share page: **Queue → Redact → Review → Package → Done**. The Redact step layers AI-assisted PII detection on top of the scan-time findings.
+
+**Skill prompts:**
+> *"Package my approved sessions and export them locally."*
+>
+> *(optional)* *"Then share the bundle through the ingest service."*
 
 Optional upload:
 

--- a/README.md
+++ b/README.md
@@ -202,13 +202,18 @@ pipx install clawjournal        # or: pip install clawjournal
 
 The PyPI wheel ships the pre-built workbench (no Node.js needed) but is currently many versions behind the source — features documented in this README may be missing. Use this only when installing from source isn't an option. `pip show clawjournal` reports the wheel's version.
 
-**TruffleHog** is **not** required to install or use ClawJournal locally. It is required only for [Stage 6 Package & Share](#6-package--share) — every `bundle-export` and `share` runs an independent secrets scan on the redacted output, and exports are blocked if TruffleHog is missing or finds anything. Install it before your first share; you can defer it.
+**TruffleHog** is **not** required to install or use ClawJournal locally. It is only needed for [Stage 6 Package & Share](#6-package--share) — every `bundle-export` and `share` runs an independent secrets scan on the redacted output, and exports are blocked if TruffleHog is missing or finds anything. Your AI can install it for you when you reach Stage 6, or you can defer it entirely if you only plan to use ClawJournal locally.
+
+<details>
+<summary><b>Show TruffleHog install commands (your AI handles this for you)</b></summary>
 
 ```bash
 brew install trufflehog                                    # macOS
 curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin   # Linux
 # Windows: download a release binary from https://github.com/trufflesecurity/trufflehog/releases
 ```
+
+</details>
 
 See [PRIVACY.md](PRIVACY.md) for the full gate semantics.
 
@@ -278,7 +283,10 @@ clawjournal shortlist <session_id>                   # mark for deeper review
 
 </details>
 
-Optional hold-state controls — useful when you want to quarantine a session without blocking it (CLI only):
+Sometimes you want to set a conversation aside without blocking it permanently — for example, "this might be useful but I need to clear it with legal first." That's called a "hold." Just say to your AI: *"Put this session on hold pending legal review."* The agent will mark it. You can release it later, or set an embargo (auto-release at a specific date).
+
+<details>
+<summary><b>Show hold-state shell commands (CLI only — non-coders can ignore)</b></summary>
 
 ```bash
 clawjournal hold <id> --reason "pending legal review"
@@ -286,6 +294,8 @@ clawjournal release <id>
 clawjournal embargo <id> --until 2026-06-01
 clawjournal hold-history <id>
 ```
+
+</details>
 
 ### 5. Score
 
@@ -345,6 +355,13 @@ Upload is gated on hold-state: only sessions in `auto_redacted` or `released` ca
 
 ## Build the browser workbench
 
+If you followed the **Install in one step** section at the top of this README, the workbench is already built — you don't need this section.
+
+This section is only for developers who installed without the workbench (no `--with-frontend` flag) and want to add it later, or who want to do the frontend build by hand.
+
+<details>
+<summary><b>Show frontend-build shell commands</b></summary>
+
 `clawjournal serve` opens a local Vite app from `clawjournal/web/frontend/dist/`. The PyPI wheel ships this `dist/` pre-built; a source install needs a one-time build.
 
 The simplest way is to re-run the installer with the frontend flag:
@@ -363,6 +380,8 @@ npm run build
 ```
 
 Either path requires Node.js. Skip the build entirely if you're only using the CLI (`scan`, `inbox`, `search`, `bundle-export`, …).
+
+</details>
 
 <details>
 <summary><b>Python not installed?</b></summary>

--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ $env:Path = "$HOME\.clawjournal-venv\Scripts;" + $env:Path   # PowerShell
 
 ## End-to-end flow
 
-After install, six stages take you from indexing local sessions to optionally sharing a redacted bundle. Each stage shows the shell command (the canonical path) and the equivalent skill prompt (if you've done `npx skills add`).
+After install, six stages take you from indexing local sessions to (optionally) sharing a redacted bundle. **Non-coders: each stage starts with the natural-language prompt to give your AI assistant.** The shell commands the agent runs are tucked into expandable "Show shell commands" sections — you can ignore them.
 
-> **Heads up on `PATH`:** the shell snippets below use bare `clawjournal`. If you haven't added the venv bin to `PATH`, prefix every command with `~/.clawjournal-venv/bin/` (POSIX) or `$HOME\.clawjournal-venv\Scripts\` (Windows).
+> *Heads up for developers running commands by hand: the shell snippets use bare `clawjournal`. If you haven't added the venv bin to `PATH`, prefix every command with `~/.clawjournal-venv/bin/` (POSIX) or `$HOME\.clawjournal-venv\Scripts\` (Windows).*
 
 ```
  Install ──► Configure ──► Scan ──► Triage ──► Score ──► Package & Share
@@ -214,7 +214,16 @@ See [PRIVACY.md](PRIVACY.md) for the full gate semantics.
 
 Tell ClawJournal which agents' sessions to scan and what to exclude or redact.
 
-**Shell:**
+**Just say to your AI:**
+
+> *"Configure clawjournal — scan all sources with defaults, no exclusions."*
+>
+> Or, to narrow scope: *"Configure clawjournal to scan only claude and codex, exclude the `scratch` project, and always redact the string `acme-internal`."*
+
+The agent translates this into the right CLI calls. Subsequent scans pick up new settings automatically.
+
+<details>
+<summary><b>Show shell commands (what the agent runs)</b></summary>
 
 ```bash
 clawjournal config --source all                   # claude | codex | gemini | opencode | openclaw | kimi | custom | all
@@ -227,17 +236,16 @@ clawjournal config --confirm-projects             # lock in project selection
 
 `--exclude`, `--redact`, and `--redact-usernames` all append; they never overwrite. Safe to call repeatedly.
 
-**Skill prompt** (if you've done `npx skills add`):
-
-> *"setup clawjournal"* — first-time run with defaults (all sources, no exclusions). The skill runs install + scan; if ClawJournal is already installed it skips to scan.
->
-> *"Configure clawjournal to scan only claude and codex, exclude the `scratch` project, and always redact the string `acme-internal`."* — narrow scope after the fact. Subsequent scans pick up new settings automatically.
+</details>
 
 ### 3. Scan
 
-Reads your local session files into a SQLite DB and runs a per-session findings pipeline (secrets engine + PII engine). Findings are stored as hashed references — plaintext is never persisted.
+Reads your local session files into a private database on your computer. As it reads, ClawJournal automatically detects secrets and personal information so you can review them before sharing anything. Plaintext is never saved — only safe references.
 
-**Shell:**
+**Just say to your AI:** *"scan my coding-agent sessions"* (a first scan also runs automatically as part of *"setup clawjournal"*).
+
+<details>
+<summary><b>Show shell command</b></summary>
 
 ```bash
 clawjournal scan
@@ -245,13 +253,16 @@ clawjournal scan
 
 The workbench daemon (`clawjournal serve`) also scans continuously in the background.
 
-**Skill prompt:** *"scan my sessions again"* (a first scan also runs as part of `setup clawjournal`).
+</details>
 
 ### 4. Triage
 
-Approve sessions worth keeping, block the rest. Happens in the workbench (Sessions page) or the CLI.
+Mark which conversations you want to keep ("approve") and which to discard ("block"). The browser workbench at `localhost:8384` is the easiest place to do this — you'll see each conversation with a summary, and click Approve or Block.
 
-**Shell:**
+**Just say to your AI:** *"Open clawjournal and help me triage my unreviewed sessions."*
+
+<details>
+<summary><b>Show shell commands</b></summary>
 
 ```bash
 clawjournal serve                                    # workbench UI — the primary review surface
@@ -263,7 +274,7 @@ clawjournal block <session_id> --reason "private"    # block
 clawjournal shortlist <session_id>                   # mark for deeper review
 ```
 
-**Skill prompt:** *"Open clawjournal and help me triage the unreviewed sessions."*
+</details>
 
 Optional hold-state controls — useful when you want to quarantine a session without blocking it (CLI only):
 
@@ -276,9 +287,14 @@ clawjournal hold-history <id>
 
 ### 5. Score
 
-AI-assisted quality scoring on a 1–5 scale (1 = noise, 5 = excellent). Home-dir paths and usernames are anonymized before anything is sent to the judge.
+AI-assisted quality rating on a 1–5 scale (1 = noise, 5 = excellent). Personal info in your conversations is removed before anything is sent to the AI judge — your home folder paths and usernames are anonymized first.
 
-**Shell:**
+**Just say to your AI:** *"Score my unscored ClawJournal sessions and auto-block the noise."*
+
+The agent batches the scoring; sessions rated 1 get auto-blocked, sessions rated 2–5 stay visible for you to decide.
+
+<details>
+<summary><b>Show shell commands</b></summary>
 
 ```bash
 clawjournal score --batch --auto-triage              # batch-score; auto-blocks noise (score 1) sessions
@@ -286,41 +302,42 @@ clawjournal score-view <id>                          # show score details
 clawjournal set-score <id> --quality 4               # manual override
 ```
 
-**Skill prompt:** *"Score my unscored sessions."* (runs through the `clawjournal-score` skill, uses your current agent's automation CLI.)
-
-`--auto-triage` moves sessions with quality score 1 to `blocked`. Sessions scored 2–5 stay visible for you to decide.
-
 By default scoring uses the current agent's automation CLI (e.g. `codex exec` inside Codex, the Claude CLI inside Claude Code). Use `--backend` to override. For Codex specifically, `codex exec` reuses saved CLI authentication by default; for automation the recommended explicit credential is `CODEX_API_KEY`.
+
+</details>
 
 ### 6. Package & Share
 
-Bundle approved sessions into a redacted export on disk. Uploading that bundle is a separate, opt-in step.
+Package the conversations you approved into a redacted file on your computer. Uploading anywhere is a separate, opt-in step — by default the file just sits on your disk.
 
-**Shell:**
+**Just say to your AI:** *"Package my approved ClawJournal sessions and export them to a file on my computer."*
+
+The agent walks you through the Share page in the browser workbench: **Queue → Redact → Review → Package → Done**. The Redact step uses AI to catch any personal info the automatic scan missed.
+
+To actually upload after packaging (optional, requires a one-time email verification):
+
+> *(optional)* *"Now share the bundle through the ClawJournal ingest service. My email is you@university.edu."*
+
+Uploads are gated: only conversations you approved and confirmed for sharing leave your machine.
+
+<details>
+<summary><b>Show shell commands</b></summary>
 
 ```bash
 clawjournal bundle-create --status approved          # bundle all approved sessions
 clawjournal bundle-list
 clawjournal bundle-view <bundle_id>                  # inspect before exporting
 clawjournal bundle-export <bundle_id>                # write sessions.jsonl + manifest.json to disk
-```
 
-**Workbench:** open `clawjournal serve` and walk the Share page: **Queue → Redact → Review → Package → Done**. The Redact step layers AI-assisted PII detection on top of the scan-time findings.
-
-**Skill prompts:**
-> *"Package my approved sessions and export them locally."*
->
-> *(optional)* *"Then share the bundle through the ingest service."*
-
-Optional upload:
-
-```bash
+# Optional upload:
 clawjournal verify-email you@university.edu          # one-time email verification
 clawjournal share --preview --status approved        # dry-run
 clawjournal bundle-share <bundle_id>                 # upload through the configured ingest service
 ```
 
 Upload is gated on hold-state: only sessions in `auto_redacted` or `released` can leave the machine.
+
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Inside any compatible coding agent (Claude Code, Codex, Cursor, Gemini CLI, Open
 npx skills add kai-rayward/clawjournal
 ```
 
-Then tell the agent: *"setup clawjournal"*. It installs the PyPI package, scans your local sessions with default settings, and opens the workbench at `http://localhost:8384`. Nothing is uploaded.
+Then tell the agent: *"setup clawjournal"*. It clones the repo into `~/clawjournal`, installs ClawJournal in an isolated venv, scans your local sessions with default settings, and opens the workbench at `http://localhost:8384`. Nothing is uploaded.
 
 Prefer the terminal? See Stage 1 in the flow below — every stage shows both skills and shell commands.
 
@@ -63,15 +63,45 @@ Day-to-day, prompts like *"triage my new sessions"*, *"score everything unscored
 npx skills add kai-rayward/clawjournal
 ```
 
-Adds the three ClawJournal skills to your agent. The PyPI package itself is installed in Stage 2 as part of `setup clawjournal`.
+Adds the three ClawJournal skills to your agent. ClawJournal itself is installed when you run `setup clawjournal` (the wizard executes the same source-install path documented below).
 
-**Shell — in any bash/zsh terminal:**
+**Shell — install from source (recommended):**
+
+The GitHub source is the canonical version. The PyPI wheel currently lags behind, so features documented in this README may not be present in `pip install clawjournal`. The bundled installer script picks a Python 3.10+ interpreter, creates an isolated venv at `~/.clawjournal-venv`, and installs ClawJournal in editable mode. It's idempotent — re-run any time to upgrade against the latest checkout.
+
+macOS / Linux / WSL / Git Bash on Windows — clone, then run *one* of the install commands (`--with-frontend` requires Node.js):
+
+```bash
+git clone https://github.com/kai-rayward/clawjournal.git ~/clawjournal
+cd ~/clawjournal
+
+./scripts/install.sh                  # CLI only
+# or
+./scripts/install.sh --with-frontend  # also build the browser workbench
+```
+
+Native Windows PowerShell — clone, then run *one* of the install commands:
+
+```powershell
+git clone https://github.com/kai-rayward/clawjournal.git "$HOME\clawjournal"
+Set-Location "$HOME\clawjournal"
+
+powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1                 # CLI only
+# or
+powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1 -WithFrontend   # also build the browser workbench
+```
+
+After the script completes, either add the venv bin directory to your `PATH` or invoke the binary directly: `~/.clawjournal-venv/bin/clawjournal` on POSIX, or `$HOME\.clawjournal-venv\Scripts\clawjournal.exe` on Windows.
+
+The browser workbench (`clawjournal serve`) needs a one-time frontend build — pass the `--with-frontend` / `-WithFrontend` flag during install, or see [Build the browser workbench](#build-the-browser-workbench) below. Skip it if you'll only use the CLI.
+
+**Shell — install from PyPI (fallback, may be out of date):**
 
 ```bash
 pipx install clawjournal        # or: pip install clawjournal
 ```
 
-Requires Python 3.10+. `pipx` is preferred because it isolates the CLI in its own environment and puts `clawjournal` on your `PATH`. The PyPI wheel already includes the pre-built browser workbench — no frontend build required.
+Faster, and the wheel ships the pre-built workbench (no Node.js needed). Use this only if installing from source isn't an option — `pip show clawjournal` will tell you the wheel's version, which currently lags the GitHub source by many releases.
 
 **TruffleHog (required for sharing):**
 
@@ -91,7 +121,7 @@ For a first-time run with defaults (all sources, no exclusions), say:
 
 > *"setup clawjournal"*
 
-The skill installs the PyPI package, runs a first scan, and opens the workbench. Later, to narrow scope or add redactions:
+The skill installs ClawJournal from GitHub, runs a first scan, and opens the workbench. Later, to narrow scope or add redactions:
 
 > *"Configure clawjournal to scan only claude and codex, exclude the `scratch` project, and always redact the string `acme-internal`."*
 
@@ -212,28 +242,26 @@ Upload is gated on hold-state: only sessions in `auto_redacted` or `released` ca
 
 ---
 
-## Build from source (contributors)
+## Build the browser workbench
 
-You only need this path if you're developing ClawJournal itself — the PyPI wheel is the right choice for everyone else.
+`clawjournal serve` opens a local Vite app from `clawjournal/web/frontend/dist/`. The PyPI wheel ships this `dist/` pre-built; a source install needs a one-time build.
 
-> Commands below assume a POSIX shell (bash/zsh). On Windows, run them inside WSL or Git Bash. Native PowerShell users: replace `source .venv/bin/activate` with `.venv\Scripts\Activate.ps1`.
+The simplest way is to re-run the installer with the frontend flag:
 
 ```bash
-git clone https://github.com/kai-rayward/clawjournal.git
-cd clawjournal
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install -e .
+~/clawjournal/scripts/install.sh --with-frontend                    # POSIX
+powershell -ExecutionPolicy Bypass -File "$HOME\clawjournal\scripts\install.ps1" -WithFrontend   # Windows
+```
 
-# One-time frontend build for the browser workbench
-cd clawjournal/web/frontend
+Or do it manually:
+
+```bash
+cd ~/clawjournal/clawjournal/web/frontend
 npm install
 npm run build
-cd ../../..
-
-clawjournal scan
-clawjournal serve
 ```
+
+Either path requires Node.js. Skip the build entirely if you're only using the CLI (`scan`, `inbox`, `search`, `bundle-export`, …).
 
 <details>
 <summary><b>Python not installed?</b></summary>
@@ -249,26 +277,7 @@ ClawJournal requires Python 3.10+.
 </details>
 
 <details>
-<summary><b>Using a virtual environment (recommended)</b></summary>
-
-Modern Linux distributions (Debian 12+, Ubuntu 23.04+) and some macOS setups block system-wide pip installs ([PEP 668](https://peps.python.org/pep-0668/)).
-
-From the repo root:
-
-```bash
-python3 -m venv .venv
-source .venv/bin/activate
-python -m pip install -e .
-```
-
-> If you see `externally-managed-environment`, make sure the venv is activated before running `python -m pip`.
-
-</details>
-
-<details>
-<summary><b>Node.js required only when building from source</b></summary>
-
-The PyPI wheel ships the pre-built workbench. You only need Node if you're building from source.
+<summary><b>Node.js (only for the frontend build)</b></summary>
 
 | Platform | Install command |
 |----------|----------------|
@@ -276,11 +285,23 @@ The PyPI wheel ships the pre-built workbench. You only need Node if you're build
 | **Windows** | Download from [nodejs.org](https://nodejs.org) |
 | **Linux** | `sudo apt install nodejs npm` |
 
+</details>
+
+<details>
+<summary><b>Developing ClawJournal itself</b></summary>
+
 ```bash
-cd clawjournal/web/frontend
-npm install
-npm run build
+git clone https://github.com/kai-rayward/clawjournal.git
+cd clawjournal
+python3 -m venv .venv
+source .venv/bin/activate
+python -m pip install -e ".[dev]"
+pytest
 ```
+
+On native Windows (no WSL / Git Bash), replace `source .venv/bin/activate` with `.venv\Scripts\Activate.ps1`.
+
+If you see `externally-managed-environment` on Linux/macOS, make sure the venv is activated before running `python -m pip` ([PEP 668](https://peps.python.org/pep-0668/)).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,27 @@
 
 Review and curate your coding agent conversation traces — 100% locally. ClawJournal scans session logs from Claude Code, Claude Desktop, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline, automatically anonymizes secrets and personal information, and gives you a browser workbench to review everything before it ever leaves your machine.
 
-## Install in one step
+## Install in one step (no coding required)
 
-> **You — coding agent reading this README:** detect the user's OS, follow the matching block in [Quickstart](#quickstart) below, install all missing prereqs (git, Python 3.10+, and Node.js — the install includes the browser workbench by default), then verify with `clawjournal status`. The install script handles Python detection, venv creation, and dependency install. You have everything you need; proceed.
+If you have an AI coding assistant — **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Hermes**, **Gemini CLI**, or similar — you can install ClawJournal without writing any code or running any commands yourself.
 
-**You — human:** copy this README into Claude Code, Codex, OpenClaw, Hermes, OpenCode, Cursor, or any other coding agent and ask it to install ClawJournal. The agent will follow the instruction above and take care of the rest. Prefer to run the commands yourself? The [Quickstart](#quickstart) below is exactly what the agent would execute.
+**1.** Open your AI assistant.
+
+**2.** Paste this message:
+
+> *Install ClawJournal from https://github.com/kai-rayward/clawjournal. Read its README and follow the install instructions for my operating system. Install any missing prerequisites. Verify it works at the end.*
+
+**3.** The AI does the rest. It'll figure out your OS (Mac, Windows, Linux), install any tools it needs (git, Python, Node.js), run the install script, and tell you when it's done.
+
+**Done?** You'll see something like `[ok] ClawJournal 0.1.12 installed.` and a web address (`http://localhost:8384`) — that's the ClawJournal workbench in your browser.
+
+**Something went wrong?** Tell your AI *"it didn't work, please fix it."* Most install hiccups (a missing tool, a permission prompt, a stale package) are routine — the agent has the context to recover.
+
+**What to do next?** Ask your AI: *"Open ClawJournal and help me set it up to review my coding-agent conversations."* It'll walk you through scan, score, and review in your browser.
+
+> *AI agent reading this README:* detect the user's OS, follow the matching block in [Quickstart](#quickstart) below, install all missing prereqs (git, Python 3.10+, and Node.js — the install includes the browser workbench by default), then verify with `clawjournal status`. The install script handles Python detection, venv creation, and dependency install. You have everything you need; proceed.
+
+Already a developer and prefer to run the commands yourself? The [Quickstart](#quickstart) section below is the same path the agent would execute, in plain shell commands.
 
 ## Your data stays local
 

--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ See [PRIVACY.md](PRIVACY.md) for the full redaction list and the two sharing pat
 **Prerequisites** — `git` + Python 3.10+ are required; Node.js 18+ is required only for the browser workbench (`--with-frontend`). Skip any line whose tool is already installed:
 
 ```bash
-# macOS (install Homebrew first if you don't have it; second line puts brew on PATH for the current shell):
-/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+# macOS (install Homebrew first if you don't have it; NONINTERACTIVE=1 skips the RETURN prompt
+# that would otherwise hang an autonomous install. Second line puts brew on PATH for the current shell):
+NONINTERACTIVE=1 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 eval "$(/opt/homebrew/bin/brew shellenv 2>/dev/null || /usr/local/bin/brew shellenv)"
 brew install git python              # workbench (optional): brew install node
 
@@ -39,7 +40,7 @@ sudo apt install -y nodejs npm       # workbench (optional). 24.04+ ships Node 1
 # Windows (PowerShell, native package manager). The flags suppress interactive prompts that block autonomous installs:
 winget install --id Git.Git -e --accept-source-agreements --accept-package-agreements --scope user
 winget install --id Python.Python.3.12 -e --accept-source-agreements --accept-package-agreements --scope user
-winget install --id OpenJS.NodeJS.LTS -e --accept-source-agreements --accept-package-agreements --scope user   # workbench (optional)
+winget install --id OpenJS.NodeJS.LTS -e --accept-source-agreements --accept-package-agreements              # workbench (optional). The Node MSI doesn't support --scope user; this needs admin or will prompt for elevation.
 
 # Refresh PATH in the current PowerShell session (winget doesn't do this for you):
 $env:Path = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [Environment]::GetEnvironmentVariable('Path','User')

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ If you have an AI coding assistant — **Claude Code**, **Codex**, **Cursor**, *
 
 ### What to expect
 
-- **Permission prompts.** Your AI will ask permission to run several commands and install tools — typically 5 to 10 prompts. **Click "Allow" each time.** This is normal. The tools (git for fetching code, Python for running ClawJournal, Node.js for the browser workbench) are widely-used software your computer probably has parts of already.
-- **A few minutes of waiting.** Downloads and installs take 1–5 minutes total on a modern laptop. The agent will tell you what it's doing.
+- **Permission prompts — lots of them.** Your AI will ask permission to run several commands. Expect 10–25 prompts before install finishes — more if your computer is fresh, fewer if it already has dev tools. **Click "Allow" each time.** This is normal. The tools the AI installs (git for fetching code, Python for running ClawJournal, Node.js for the browser workbench) are widely-used software your computer probably has parts of already.
+- **A separate password prompt on Mac.** macOS may ask for *your computer password* (the one you use to log in) when installing certain tools. This is your operating system asking, not the AI. Type your password and hit Enter — installing software almost always requires this.
+- **Silent waiting periods.** Some downloads and compiles take 30–90 seconds with no visible progress. **The AI isn't frozen — it's working.** Wait for it to come back. Total install time is usually 2–10 minutes depending on your network and what's already installed.
 - **A success message at the end:** `[ok] ClawJournal 0.1.12 installed.` (the version number may differ).
 
 ### Open the workbench
@@ -71,6 +72,11 @@ See [PRIVACY.md](PRIVACY.md) for the full redaction list and the two sharing pat
 ---
 
 ## Quickstart
+
+> Non-coders following the **Install in one step** section above don't need to read this. The shell commands here are for AI agents and developers who run installs by hand. Click the section below to expand it.
+
+<details>
+<summary><b>Show shell commands (for AI agents and developers)</b></summary>
 
 **Prerequisites** — `git` + Python 3.10+ are required; Node.js 18+ is required only for the browser workbench (`--with-frontend`). Skip any line whose tool is already installed:
 
@@ -148,6 +154,8 @@ $env:Path = "$HOME\.clawjournal-venv\Scripts;" + $env:Path   # PowerShell
 > **Already inside a coding agent and want it to drive ClawJournal for you?** `npx skills add kai-rayward/clawjournal` adds three skills (Claude Code, Codex, Cursor, …); then say *"setup clawjournal"* — the wizard runs the same script above. Optional convenience, not a separate install path. See [Stage 1: Install](#1-install).
 >
 > **Can't clone? Behind a firewall?** `pipx install clawjournal` works as a fallback, but the PyPI wheel currently lags the source by many releases. See [Stage 1: Install](#1-install).
+
+</details>
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ brew install git python              # workbench (optional): brew install node
 
 # Debian / Ubuntu (drop `sudo` if you're root in a container):
 sudo apt update && sudo apt install -y git curl python3-full python3-venv
-sudo apt install -y nodejs npm       # workbench (optional). 24.04+ ships Node 18; on older LTS use NodeSource: curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo bash - && sudo apt install -y nodejs
+
+# Workbench (optional). Ubuntu 24.04+ apt is fine; on 22.04 or older, distro Node
+# is too old for the Vite build — install the LTS via NodeSource first:
+curl -fsSL https://deb.nodesource.com/setup_lts.x | sudo bash -
+sudo apt install -y nodejs
 
 # Windows (PowerShell, native package manager). The flags suppress interactive prompts that block autonomous installs:
 winget install --id Git.Git -e --accept-source-agreements --accept-package-agreements --scope user

--- a/README.md
+++ b/README.md
@@ -24,25 +24,27 @@ See [PRIVACY.md](PRIVACY.md) for the full redaction list and the two sharing pat
 
 ## Quickstart
 
-Pick the block for your OS and run all the commands in it. The install script handles Python detection, venv creation, and editable install on macOS, Linux, WSL, and Windows.
+**Prerequisites:** `git` and a Python 3.10+ interpreter (the install script auto-detects Python). Optional: Node.js / npm for the browser workbench. On bare Ubuntu/Debian containers you may also need `sudo apt install -y git python3-venv python3-full`.
+
+Pick the block for your OS and run the commands in order. The script handles Python detection, venv creation, and editable install.
 
 **macOS / Linux / WSL / Git Bash on Windows:**
 
 ```bash
 git clone https://github.com/kai-rayward/clawjournal.git ~/clawjournal
 cd ~/clawjournal
-./scripts/install.sh --with-frontend       # (or `sh scripts/install.sh --with-frontend` if a tarball clone dropped the +x bit)
+./scripts/install.sh --with-frontend       # or: sh scripts/install.sh --with-frontend  (if the +x bit is missing)
 ```
 
-**Native Windows PowerShell** (`pwsh` 7+ is fine; legacy `powershell` 5.1 also works):
+**Native Windows PowerShell** (`pwsh` 7+ on modern Windows; substitute `powershell` for the legacy 5.1 launcher):
 
 ```powershell
 git clone https://github.com/kai-rayward/clawjournal.git "$HOME\clawjournal"
 Set-Location "$HOME\clawjournal"
-powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1 -WithFrontend
+pwsh -ExecutionPolicy Bypass -File .\scripts\install.ps1 -WithFrontend
 ```
 
-The script prints `[ok] ClawJournal <version> installed.` on success. The default above includes `--with-frontend` / `-WithFrontend` which builds the browser workbench at `localhost:8384` (requires Node.js — the script warns and continues if `npm` is missing). Drop the flag for a CLI-only install if you don't need `clawjournal serve`; `scan`, `inbox`, `search`, and `bundle-export` work without the workbench.
+The script prints `[ok] ClawJournal <version> installed.` on success. The default above includes `--with-frontend` / `-WithFrontend` which builds the browser workbench at `localhost:8384`. **If Node.js is not installed, the script warns and continues with a CLI-only install** — `clawjournal serve` will then 404; install Node and re-run the script with the flag to fix. Drop the flag entirely if you only need `scan`, `inbox`, `search`, and `bundle-export` (these don't need the workbench).
 
 **Verify** — you should see a JSON response with `"stage"` and `"stage_number"`:
 
@@ -58,7 +60,17 @@ The script prints `[ok] ClawJournal <version> installed.` on success. The defaul
 { "stage": "configure", "stage_number": 2, "total_stages": 4, ... }
 ```
 
-The CLI lives at `~/.clawjournal-venv/bin/clawjournal` (POSIX) or `$HOME\.clawjournal-venv\Scripts\clawjournal.exe` (Windows). Add the venv bin directory to your `PATH` to call it as plain `clawjournal`. The install is idempotent — re-run the script any time to upgrade against the latest `git pull`.
+The CLI lives at `~/.clawjournal-venv/bin/clawjournal` (POSIX) or `$HOME\.clawjournal-venv\Scripts\clawjournal.exe` (Windows). The install is idempotent — re-run the script any time to upgrade against the latest `git pull`.
+
+**To call it as plain `clawjournal` instead of the full path** (current shell session; add to your shell profile to persist):
+
+```bash
+export PATH="$HOME/.clawjournal-venv/bin:$PATH"          # POSIX (bash/zsh)
+```
+
+```powershell
+$env:Path = "$HOME\.clawjournal-venv\Scripts;" + $env:Path   # PowerShell
+```
 
 > **Already inside a coding agent and want it to drive ClawJournal for you?** `npx skills add kai-rayward/clawjournal` adds three skills (Claude Code, Codex, Cursor, …); then say *"setup clawjournal"* — the wizard runs the same script above. Optional convenience, not a separate install path. See [Stage 1: Install](#1-install).
 >

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ See [PRIVACY.md](PRIVACY.md) for the full redaction list and the two sharing pat
 **Prerequisites** — `git` + Python 3.10+ are required; Node.js 18+ is required only for the browser workbench (`--with-frontend`). Skip any line whose tool is already installed:
 
 ```bash
-# macOS:
+# macOS (install Homebrew first if you don't have it):
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 brew install git python              # workbench (optional): brew install node
 
 # Debian / Ubuntu (drop `sudo` if you're root in a container):
@@ -38,7 +39,9 @@ sudo apt install -y nodejs npm       # workbench (optional). 24.04+ ships Node 1
 winget install --id Git.Git -e
 winget install --id Python.Python.3.12 -e
 winget install --id OpenJS.NodeJS.LTS -e   # workbench (optional)
-# winget doesn't refresh the current shell's PATH; close this PowerShell window and open a new one before continuing.
+
+# Refresh PATH in the current PowerShell session (winget doesn't do this for you):
+$env:Path = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [Environment]::GetEnvironmentVariable('Path','User')
 ```
 
 Then pick the block for your OS and run it. The install script handles Python detection, venv creation, and editable install. Run `./scripts/install.sh --help` for all options.

--- a/README.md
+++ b/README.md
@@ -31,18 +31,18 @@ Pick the block for your OS and run all the commands in it. The install script ha
 ```bash
 git clone https://github.com/kai-rayward/clawjournal.git ~/clawjournal
 cd ~/clawjournal
-./scripts/install.sh
+./scripts/install.sh --with-frontend       # (or `sh scripts/install.sh --with-frontend` if a tarball clone dropped the +x bit)
 ```
 
-**Native Windows PowerShell:**
+**Native Windows PowerShell** (`pwsh` 7+ is fine; legacy `powershell` 5.1 also works):
 
 ```powershell
 git clone https://github.com/kai-rayward/clawjournal.git "$HOME\clawjournal"
 Set-Location "$HOME\clawjournal"
-powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1
+powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1 -WithFrontend
 ```
 
-The script prints `[ok] ClawJournal <version> installed.` on success. Pass `--with-frontend` (POSIX) or `-WithFrontend` (PowerShell) to also build the browser workbench (requires Node.js).
+The script prints `[ok] ClawJournal <version> installed.` on success. The default above includes `--with-frontend` / `-WithFrontend` which builds the browser workbench at `localhost:8384` (requires Node.js — the script warns and continues if `npm` is missing). Drop the flag for a CLI-only install if you don't need `clawjournal serve`; `scan`, `inbox`, `search`, and `bundle-export` work without the workbench.
 
 **Verify** — you should see a JSON response with `"stage"` and `"stage_number"`:
 
@@ -89,7 +89,7 @@ With skills installed, prompts like *"triage my new sessions"*, *"score everythi
 
 ### 1. Install
 
-If you followed [Quickstart](#quickstart) above, you're done — skip to Stage 2. Two alternative paths:
+The canonical install is the shell script in [Quickstart](#quickstart) above — that's what you want unless your environment blocks it. If you used Quickstart, skip to Stage 2. Two fallbacks:
 
 **Skills install (guided wizard inside your coding agent):**
 
@@ -107,13 +107,15 @@ pipx install clawjournal        # or: pip install clawjournal
 
 The PyPI wheel ships the pre-built workbench (no Node.js needed) but is currently many versions behind the source — features documented in this README may be missing. Use this only when installing from source isn't an option. `pip show clawjournal` reports the wheel's version.
 
-**TruffleHog (required for sharing exports, regardless of install path):**
+**TruffleHog** is **not** required to install or use ClawJournal locally. It is required only for [Stage 6 Package & Share](#6-package--share) — every `bundle-export` and `share` runs an independent secrets scan on the redacted output, and exports are blocked if TruffleHog is missing or finds anything. Install it before your first share; you can defer it.
 
 ```bash
-brew install trufflehog      # macOS; Linux/Windows: see upstream installer
+brew install trufflehog                                    # macOS
+curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin   # Linux
+# Windows: download a release binary from https://github.com/trufflesecurity/trufflehog/releases
 ```
 
-Every `bundle-export` and `share` runs an independent secrets scan on the redacted output before the export is considered complete. Exports are blocked if TruffleHog is missing or finds anything. See [PRIVACY.md](PRIVACY.md) for the full gate semantics.
+See [PRIVACY.md](PRIVACY.md) for the full gate semantics.
 
 ### 2. Configure
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Review and curate your coding agent conversation traces — 100% locally. ClawJo
 
 ## Install in one step
 
-> **You — coding agent reading this README:** detect the user's OS, follow the matching block in [Quickstart](#quickstart) below, install any missing prereqs (git, Python 3.10+, and Node.js if the user wants the workbench), then verify with `clawjournal status`. The install script handles Python detection, venv creation, and dependency install. You have everything you need; proceed.
+> **You — coding agent reading this README:** detect the user's OS, follow the matching block in [Quickstart](#quickstart) below, install all missing prereqs (git, Python 3.10+, and Node.js — the install includes the browser workbench by default), then verify with `clawjournal status`. The install script handles Python detection, venv creation, and dependency install. You have everything you need; proceed.
 
 **You — human:** copy this README into Claude Code, Codex, OpenClaw, Hermes, OpenCode, Cursor, or any other coding agent and ask it to install ClawJournal. The agent will follow the instruction above and take care of the rest. Prefer to run the commands yourself? The [Quickstart](#quickstart) below is exactly what the agent would execute.
 

--- a/README.md
+++ b/README.md
@@ -12,17 +12,43 @@ If you have an AI coding assistant — **Claude Code**, **Codex**, **Cursor**, *
 
 > *Install ClawJournal from https://github.com/kai-rayward/clawjournal. Read its README and follow the install instructions for my operating system. Install any missing prerequisites. Verify it works at the end.*
 
-**3.** The AI does the rest. It'll figure out your OS (Mac, Windows, Linux), install any tools it needs (git, Python, Node.js), run the install script, and tell you when it's done.
+**3.** The AI does the rest. It'll figure out your operating system (Mac, Windows, Linux), install any background tools it needs (git, Python, Node.js), run the install script, and tell you when it's done.
 
-**Done?** You'll see something like `[ok] ClawJournal 0.1.12 installed.` and a web address (`http://localhost:8384`) — that's the ClawJournal workbench in your browser.
+### What to expect
 
-**Something went wrong?** Tell your AI *"it didn't work, please fix it."* Most install hiccups (a missing tool, a permission prompt, a stale package) are routine — the agent has the context to recover.
+- **Permission prompts.** Your AI will ask permission to run several commands and install tools — typically 5 to 10 prompts. **Click "Allow" each time.** This is normal. The tools (git for fetching code, Python for running ClawJournal, Node.js for the browser workbench) are widely-used software your computer probably has parts of already.
+- **A few minutes of waiting.** Downloads and installs take 1–5 minutes total on a modern laptop. The agent will tell you what it's doing.
+- **A success message at the end:** `[ok] ClawJournal 0.1.12 installed.` (the version number may differ).
 
-**What to do next?** Ask your AI: *"Open ClawJournal and help me set it up to review my coding-agent conversations."* It'll walk you through scan, score, and review in your browser.
+### Open the workbench
 
-> *AI agent reading this README:* detect the user's OS, follow the matching block in [Quickstart](#quickstart) below, install all missing prereqs (git, Python 3.10+, and Node.js — the install includes the browser workbench by default), then verify with `clawjournal status`. The install script handles Python detection, venv creation, and dependency install. You have everything you need; proceed.
+After install, your AI will give you a web address that looks like `http://localhost:8384`. **That's a URL — copy it into the address bar of your web browser** (Chrome, Safari, Firefox, Edge — any of them) and press Enter. The ClawJournal workbench opens locally on your own computer; nothing is uploaded.
 
-Already a developer and prefer to run the commands yourself? The [Quickstart](#quickstart) section below is the same path the agent would execute, in plain shell commands.
+### If something doesn't work
+
+- **General fix:** tell your AI *"it didn't work, please fix it."* Most install hiccups (a missing tool, a stale package) are routine.
+- **If the AI says it can't do something:** reply *"try a different approach"* or *"are you sure? please try another way."* Installation problems usually have multiple solutions; the agent can find one.
+- **If a permission prompt scares you:** ask your AI *"what does this command do, and is it safe?"* before clicking Allow.
+
+### What to do next
+
+Ask your AI: *"Open ClawJournal and help me set it up to review my coding-agent conversations."* It'll walk you through configure, scan, and review in your browser.
+
+---
+
+<details>
+<summary><b>For AI agents reading this README directly</b> (humans following the 3 steps above can skip this)</summary>
+
+Detect the user's OS, follow the matching block in [Quickstart](#quickstart) below, install all missing prereqs (git, Python 3.10+, and Node.js — the install includes the browser workbench by default), then verify with `clawjournal status`. The install script handles Python detection, venv creation, and dependency install. You have everything you need; proceed.
+
+</details>
+
+<details>
+<summary><b>For developers who want to run the commands by hand</b></summary>
+
+The [Quickstart](#quickstart) section below has the explicit per-OS shell commands the agent would execute. Same end result as the AI-driven path.
+
+</details>
 
 ## Your data stays local
 

--- a/README.md
+++ b/README.md
@@ -24,9 +24,20 @@ See [PRIVACY.md](PRIVACY.md) for the full redaction list and the two sharing pat
 
 ## Quickstart
 
-**Prerequisites:** `git` and a Python 3.10+ interpreter (the install script auto-detects Python). Optional: Node.js / npm for the browser workbench. On bare Ubuntu/Debian containers you may also need `sudo apt install -y git python3-venv python3-full`.
+**Prerequisites** — `git` + Python 3.10+ are required; Node.js 18+ is required only for the browser workbench (`--with-frontend`). Install per OS:
 
-Pick the block for your OS and run the commands in order. The script handles Python detection, venv creation, and editable install.
+```bash
+# macOS:
+brew install git python              # Node (optional, for workbench): brew install node
+
+# Debian / Ubuntu (run on bare containers; safe to skip if already installed):
+sudo apt update && sudo apt install -y git python3-full python3-venv
+sudo apt install -y nodejs npm        # optional, for workbench (24.04+ is fine; older LTS may need NodeSource)
+
+# Windows: install Git for Windows, Python 3.10+ from python.org, and (optionally) Node.js LTS from nodejs.org.
+```
+
+Then pick the block for your OS and run it. The install script handles Python detection, venv creation, and editable install. Run `./scripts/install.sh --help` for all options.
 
 **macOS / Linux / WSL / Git Bash on Windows:**
 
@@ -36,12 +47,13 @@ cd ~/clawjournal
 ./scripts/install.sh --with-frontend       # or: sh scripts/install.sh --with-frontend  (if the +x bit is missing)
 ```
 
-**Native Windows PowerShell** (`pwsh` 7+ on modern Windows; substitute `powershell` for the legacy 5.1 launcher):
+**Native Windows PowerShell** — use `pwsh` (PowerShell 7+) if available, otherwise `powershell` (legacy 5.1) works the same:
 
 ```powershell
 git clone https://github.com/kai-rayward/clawjournal.git "$HOME\clawjournal"
 Set-Location "$HOME\clawjournal"
 pwsh -ExecutionPolicy Bypass -File .\scripts\install.ps1 -WithFrontend
+# If `pwsh` is not installed: powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1 -WithFrontend
 ```
 
 The script prints `[ok] ClawJournal <version> installed.` on success. The default above includes `--with-frontend` / `-WithFrontend` which builds the browser workbench at `localhost:8384`. **If Node.js is not installed, the script warns and continues with a CLI-only install** — `clawjournal serve` will then 404; install Node and re-run the script with the flag to fix. Drop the flag entirely if you only need `scan`, `inbox`, `search`, and `bundle-export` (these don't need the workbench).
@@ -250,8 +262,8 @@ Upload is gated on hold-state: only sessions in `auto_redacted` or `released` ca
 The simplest way is to re-run the installer with the frontend flag:
 
 ```bash
-~/clawjournal/scripts/install.sh --with-frontend                    # POSIX
-powershell -ExecutionPolicy Bypass -File "$HOME\clawjournal\scripts\install.ps1" -WithFrontend   # Windows
+~/clawjournal/scripts/install.sh --with-frontend                                            # POSIX
+pwsh -ExecutionPolicy Bypass -File "$HOME\clawjournal\scripts\install.ps1" -WithFrontend    # Windows (substitute `powershell` if pwsh isn't installed)
 ```
 
 Or do it manually:

--- a/README.md
+++ b/README.md
@@ -4,11 +4,9 @@ Review and curate your coding agent conversation traces — 100% locally. ClawJo
 
 ## Install in one step
 
-**Copy this README into Claude Code, Codex, OpenClaw, Hermes, OpenCode, Cursor, or any other coding agent, and ask it to install ClawJournal.** The agent reads the rest of this file, detects your OS, installs any missing prerequisites, runs the install script, and verifies the result. That's the whole install.
+> **You — coding agent reading this README:** detect the user's OS, follow the matching block in [Quickstart](#quickstart) below, install any missing prereqs (git, Python 3.10+, and Node.js if the user wants the workbench), then verify with `clawjournal status`. The install script handles Python detection, venv creation, and dependency install. You have everything you need; proceed.
 
-Prefer to run the commands yourself? The [Quickstart](#quickstart) section below has the explicit per-OS shell commands the agent would execute. Same end result either way.
-
-> *Coding agents reading this README directly: you already have everything you need. Detect the user's OS, follow the matching block in [Quickstart](#quickstart), then verify with `clawjournal status`. The install script handles Python detection, venv creation, and dependency install — your only job is picking the right OS block and installing missing prereqs (git, Python 3.10+, optionally Node.js for the workbench).*
+**You — human:** copy this README into Claude Code, Codex, OpenClaw, Hermes, OpenCode, Cursor, or any other coding agent and ask it to install ClawJournal. The agent will follow the instruction above and take care of the rest. Prefer to run the commands yourself? The [Quickstart](#quickstart) below is exactly what the agent would execute.
 
 ## Your data stays local
 

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -103,7 +103,8 @@ if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 & $VenvPy -m pip install --quiet -e $RepoDir
 if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 
-# 4) Optional frontend build.
+# 4) Optional frontend build. Failures here are non-fatal — the CLI install
+#    already succeeded; only the opt-in frontend is missing.
 if ($WithFrontend) {
     $npm = Get-Command npm -ErrorAction SilentlyContinue
     if (-not $npm) {
@@ -113,7 +114,14 @@ if ($WithFrontend) {
         Push-Location (Join-Path $RepoDir 'clawjournal\web\frontend')
         try {
             & npm install --silent
-            & npm run build --silent
+            if ($LASTEXITCODE -ne 0) {
+                Write-Warning "npm install failed (exit $LASTEXITCODE); workbench not built. The CLI is installed."
+            } else {
+                & npm run build --silent
+                if ($LASTEXITCODE -ne 0) {
+                    Write-Warning "npm run build failed (exit $LASTEXITCODE); workbench not built. The CLI is installed."
+                }
+            }
         } finally {
             Pop-Location
         }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -1,0 +1,148 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    Install ClawJournal in editable mode into a venv on Windows.
+
+.DESCRIPTION
+    Native Windows PowerShell installer. For macOS / Linux / WSL / Git Bash,
+    use scripts/install.sh instead. Idempotent: re-running upgrades the
+    existing install.
+
+.PARAMETER WithFrontend
+    Also build the browser workbench (requires Node.js / npm).
+
+.PARAMETER VenvPath
+    Where to create the venv. Default: $HOME\.clawjournal-venv (or the
+    CLAWJOURNAL_VENV environment variable, if set).
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1
+
+.EXAMPLE
+    .\scripts\install.ps1 -WithFrontend
+#>
+[CmdletBinding()]
+param(
+    [switch]$WithFrontend,
+    [string]$VenvPath
+)
+
+$ErrorActionPreference = 'Stop'
+
+# Resolve repo root (parent of scripts\). If we were piped via iwr|iex with no
+# script on disk, $PSScriptRoot is empty — clone the repo first.
+$RepoDir = $null
+if ($PSScriptRoot -and (Test-Path (Join-Path $PSScriptRoot '..\pyproject.toml'))) {
+    $RepoDir = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+} else {
+    $target = if ($env:CLAWJOURNAL_REPO) { $env:CLAWJOURNAL_REPO } else { Join-Path $HOME 'clawjournal' }
+    if (Test-Path (Join-Path $target '.git')) {
+        Write-Host "-> Updating existing checkout at $target"
+        & git -C $target pull --ff-only --quiet
+    } else {
+        Write-Host "-> Cloning ClawJournal to $target"
+        & git clone --quiet https://github.com/kai-rayward/clawjournal.git $target
+        if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+    }
+    $RepoDir = $target
+}
+
+if (-not $VenvPath) {
+    $VenvPath = if ($env:CLAWJOURNAL_VENV) { $env:CLAWJOURNAL_VENV } else { Join-Path $HOME '.clawjournal-venv' }
+}
+
+# 1) Find a Python 3.10+ launcher. The 'py' launcher is the canonical choice on
+#    Windows, but fall back to python3 / python in case it's missing.
+function Find-Python {
+    $candidates = @(
+        @{ Exe = 'py';      Prefix = @('-3') },
+        @{ Exe = 'python3'; Prefix = @() },
+        @{ Exe = 'python';  Prefix = @() }
+    )
+    $code = 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)'
+    foreach ($c in $candidates) {
+        $cmd = Get-Command $c.Exe -ErrorAction SilentlyContinue
+        if (-not $cmd) { continue }
+        $checkArgs = @($c.Prefix + @('-c', $code))
+        & $cmd.Source @checkArgs *> $null
+        if ($LASTEXITCODE -eq 0) {
+            return [pscustomobject]@{ Source = $cmd.Source; Prefix = $c.Prefix }
+        }
+    }
+    return $null
+}
+
+$python = Find-Python
+if (-not $python) {
+    Write-Host @"
+[x] Python 3.10+ not found on PATH.
+    Install from https://python.org/downloads (check "Add Python to PATH"),
+    open a new PowerShell window, then re-run this script.
+"@ -ForegroundColor Red
+    exit 1
+}
+
+$versionLine = (& $python.Source @($python.Prefix + @('--version')) 2>&1) -join ' '
+Write-Host "[ok] Python: $versionLine ($($python.Source))"
+
+# 2) Create venv if missing.
+$VenvPy = Join-Path $VenvPath 'Scripts\python.exe'
+if (-not (Test-Path $VenvPy)) {
+    Write-Host "-> Creating venv at $VenvPath"
+    & $python.Source @($python.Prefix + @('-m', 'venv', $VenvPath))
+    if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+}
+
+$VenvBin = Join-Path $VenvPath 'Scripts'
+$ClawJournalExe = Join-Path $VenvBin 'clawjournal.exe'
+
+# 3) Install ClawJournal in editable mode.
+Write-Host "-> Installing ClawJournal (editable) from $RepoDir"
+& $VenvPy -m pip install --quiet --upgrade pip
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+& $VenvPy -m pip install --quiet -e $RepoDir
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
+
+# 4) Optional frontend build.
+if ($WithFrontend) {
+    $npm = Get-Command npm -ErrorAction SilentlyContinue
+    if (-not $npm) {
+        Write-Warning "-WithFrontend requested but npm not found. Install Node.js (https://nodejs.org) and re-run."
+    } else {
+        Write-Host "-> Building browser workbench"
+        Push-Location (Join-Path $RepoDir 'clawjournal\web\frontend')
+        try {
+            & npm install --silent
+            & npm run build --silent
+        } finally {
+            Pop-Location
+        }
+    }
+}
+
+# 5) Report.
+$InstalledVersion = & $VenvPy -c "import clawjournal; print(clawjournal.__version__)" 2>$null
+if (-not $InstalledVersion) { $InstalledVersion = '?' }
+Write-Host ""
+Write-Host "[ok] ClawJournal $InstalledVersion installed."
+
+Write-Host ""
+Write-Host "Run:    $ClawJournalExe scan"
+Write-Host "        $ClawJournalExe serve"
+Write-Host ""
+Write-Host "Or add the venv to PATH for this session:"
+Write-Host "        `$env:Path = `"$VenvBin;`" + `$env:Path"
+
+# 6) Soft hints for optional runtime deps.
+$frontendBuilt = Test-Path (Join-Path $RepoDir 'clawjournal\web\frontend\dist\index.html')
+if (-not $frontendBuilt) {
+    Write-Host ""
+    Write-Host "[i] Browser workbench not built. To enable 'clawjournal serve':"
+    Write-Host "      .\scripts\install.ps1 -WithFrontend     (requires Node.js)"
+}
+
+if (-not (Get-Command trufflehog -ErrorAction SilentlyContinue)) {
+    Write-Host ""
+    Write-Host "[i] TruffleHog is required when sharing exports."
+    Write-Host "    Download a release binary: https://github.com/trufflesecurity/trufflehog/releases"
+}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env sh
+# Install ClawJournal in editable mode into a venv.
+#
+# Works on macOS, Linux, WSL, and Git Bash on Windows. Idempotent: re-running
+# upgrades the existing install. For native Windows PowerShell, use
+# scripts/install.ps1 instead.
+#
+# Usage:
+#   ./scripts/install.sh                # CLI install (recommended for first run)
+#   ./scripts/install.sh --with-frontend  # also build the browser workbench
+#   ./scripts/install.sh --help
+#
+# Environment:
+#   CLAWJOURNAL_VENV  Path to the venv (default: ~/.clawjournal-venv)
+#   CLAWJOURNAL_REPO  Where to clone the repo if running outside one
+#                     (default: ~/clawjournal). Only used when piped via curl.
+
+set -eu
+
+WITH_FRONTEND=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --with-frontend) WITH_FRONTEND=1 ;;
+    -h|--help)
+      sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0 ;;
+    *)
+      echo "Unknown option: $1" >&2
+      exit 2 ;;
+  esac
+  shift
+done
+
+# Resolve the repo root. If the script is run from a checkout, REPO_DIR is the
+# parent of scripts/. If piped via `curl | sh`, $0 is "sh" and we clone fresh.
+SCRIPT_PATH="${0:-}"
+REPO_DIR=""
+if [ -n "$SCRIPT_PATH" ] && [ -f "$SCRIPT_PATH" ]; then
+  REPO_DIR="$(cd "$(dirname "$SCRIPT_PATH")/.." 2>/dev/null && pwd)" || REPO_DIR=""
+fi
+if [ -z "$REPO_DIR" ] || [ ! -f "$REPO_DIR/pyproject.toml" ]; then
+  TARGET="${CLAWJOURNAL_REPO:-$HOME/clawjournal}"
+  if [ -d "$TARGET/.git" ]; then
+    echo "-> Updating existing checkout at $TARGET"
+    git -C "$TARGET" pull --ff-only --quiet || true
+  else
+    echo "-> Cloning ClawJournal to $TARGET"
+    git clone --quiet https://github.com/kai-rayward/clawjournal.git "$TARGET"
+  fi
+  REPO_DIR="$TARGET"
+fi
+
+VENV_DIR="${CLAWJOURNAL_VENV:-$HOME/.clawjournal-venv}"
+
+# 1) Locate a Python 3.10+ interpreter.
+PYTHON=""
+for candidate in python3.13 python3.12 python3.11 python3.10 python3 python; do
+  if command -v "$candidate" >/dev/null 2>&1; then
+    if "$candidate" -c 'import sys; raise SystemExit(0 if sys.version_info >= (3, 10) else 1)' >/dev/null 2>&1; then
+      PYTHON="$candidate"
+      break
+    fi
+  fi
+done
+
+if [ -z "$PYTHON" ]; then
+  cat >&2 <<EOF
+[x] Python 3.10+ not found on PATH.
+
+  macOS:    brew install python
+  Debian/Ubuntu:  sudo apt install -y python3 python3-venv python3-full
+  Fedora/RHEL:    sudo dnf install -y python3 python3-virtualenv
+  Windows:  https://python.org/downloads  (check "Add Python to PATH")
+EOF
+  exit 1
+fi
+
+echo "[ok] Python: $("$PYTHON" --version 2>&1) ($(command -v "$PYTHON"))"
+
+# 2) Create or reuse the venv. On Debian-likes, "python3 -m venv" fails when
+#    python3-venv isn't installed — surface that clearly.
+if [ ! -x "$VENV_DIR/bin/python" ] && [ ! -x "$VENV_DIR/Scripts/python.exe" ]; then
+  echo "-> Creating venv at $VENV_DIR"
+  if ! "$PYTHON" -m venv "$VENV_DIR" 2>/tmp/clawjournal-venv.err; then
+    cat /tmp/clawjournal-venv.err >&2
+    cat >&2 <<EOF
+
+Hint: on Debian/Ubuntu the venv module is in a separate package:
+  sudo apt install -y python3-venv python3-full
+EOF
+    rm -f /tmp/clawjournal-venv.err
+    exit 1
+  fi
+  rm -f /tmp/clawjournal-venv.err
+fi
+
+if [ -x "$VENV_DIR/bin/python" ]; then
+  VENV_PY="$VENV_DIR/bin/python"
+  VENV_BIN="$VENV_DIR/bin"
+else
+  VENV_PY="$VENV_DIR/Scripts/python.exe"
+  VENV_BIN="$VENV_DIR/Scripts"
+fi
+
+# 3) Install ClawJournal in editable mode.
+echo "-> Installing ClawJournal (editable) from $REPO_DIR"
+"$VENV_PY" -m pip install --quiet --upgrade pip
+"$VENV_PY" -m pip install --quiet -e "$REPO_DIR"
+
+# 4) Optional: build the browser workbench.
+if [ "$WITH_FRONTEND" -eq 1 ]; then
+  if ! command -v npm >/dev/null 2>&1; then
+    cat >&2 <<EOF
+[!] --with-frontend requested but npm not found. Skipping the workbench build.
+  Install Node.js (https://nodejs.org), then re-run with --with-frontend.
+EOF
+  else
+    echo "-> Building browser workbench"
+    (cd "$REPO_DIR/clawjournal/web/frontend" && npm install --silent && npm run build --silent)
+  fi
+fi
+
+# 5) Report.
+echo
+INSTALLED_VERSION="$("$VENV_PY" -c 'import clawjournal; print(clawjournal.__version__)' 2>/dev/null || echo "?")"
+echo "[ok] ClawJournal $INSTALLED_VERSION installed."
+
+cat <<EOF
+
+Run:    $VENV_BIN/clawjournal scan
+        $VENV_BIN/clawjournal serve
+
+Or add the venv to your PATH:
+        export PATH="$VENV_BIN:\$PATH"
+EOF
+
+# 6) Soft hints for optional runtime deps.
+if [ ! -f "$REPO_DIR/clawjournal/web/frontend/dist/index.html" ]; then
+  cat <<EOF
+
+[i] Browser workbench not built. To enable 'clawjournal serve':
+    ./scripts/install.sh --with-frontend       (requires Node.js)
+EOF
+fi
+
+if ! command -v trufflehog >/dev/null 2>&1; then
+  cat <<EOF
+
+[i] TruffleHog is required when sharing exports. Install it before 'bundle-export':
+    macOS:    brew install trufflehog
+    Linux:    curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
+    Windows:  https://github.com/trufflesecurity/trufflehog/releases
+EOF
+fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -17,6 +17,11 @@
 
 set -eu
 
+# Capture stderr from venv creation in a per-run temp file. mktemp avoids the
+# /tmp/<predictable-name> race (multi-user systems, symlink attacks).
+ERR_LOG="$(mktemp 2>/dev/null || echo "/tmp/clawjournal-venv.$$.err")"
+trap 'rm -f "$ERR_LOG"' EXIT INT TERM
+
 WITH_FRONTEND=0
 while [ $# -gt 0 ]; do
   case "$1" in
@@ -81,17 +86,15 @@ echo "[ok] Python: $("$PYTHON" --version 2>&1) ($(command -v "$PYTHON"))"
 #    python3-venv isn't installed — surface that clearly.
 if [ ! -x "$VENV_DIR/bin/python" ] && [ ! -x "$VENV_DIR/Scripts/python.exe" ]; then
   echo "-> Creating venv at $VENV_DIR"
-  if ! "$PYTHON" -m venv "$VENV_DIR" 2>/tmp/clawjournal-venv.err; then
-    cat /tmp/clawjournal-venv.err >&2
+  if ! "$PYTHON" -m venv "$VENV_DIR" 2>"$ERR_LOG"; then
+    cat "$ERR_LOG" >&2
     cat >&2 <<EOF
 
 Hint: on Debian/Ubuntu the venv module is in a separate package:
   sudo apt install -y python3-venv python3-full
 EOF
-    rm -f /tmp/clawjournal-venv.err
     exit 1
   fi
-  rm -f /tmp/clawjournal-venv.err
 fi
 
 if [ -x "$VENV_DIR/bin/python" ]; then
@@ -107,7 +110,8 @@ echo "-> Installing ClawJournal (editable) from $REPO_DIR"
 "$VENV_PY" -m pip install --quiet --upgrade pip
 "$VENV_PY" -m pip install --quiet -e "$REPO_DIR"
 
-# 4) Optional: build the browser workbench.
+# 4) Optional: build the browser workbench. Failures here are non-fatal — the
+#    CLI install already succeeded; only the opt-in frontend is missing.
 if [ "$WITH_FRONTEND" -eq 1 ]; then
   if ! command -v npm >/dev/null 2>&1; then
     cat >&2 <<EOF
@@ -116,7 +120,9 @@ if [ "$WITH_FRONTEND" -eq 1 ]; then
 EOF
   else
     echo "-> Building browser workbench"
-    (cd "$REPO_DIR/clawjournal/web/frontend" && npm install --silent && npm run build --silent)
+    if ! ( cd "$REPO_DIR/clawjournal/web/frontend" && npm install --silent && npm run build --silent ); then
+      echo "[!] Frontend build failed. The CLI is installed; re-run with --with-frontend after fixing the build." >&2
+    fi
   fi
 fi
 

--- a/skills/clawjournal-setup/SKILL.md
+++ b/skills/clawjournal-setup/SKILL.md
@@ -12,58 +12,64 @@ Interactive setup wizard. Walk the user through each step. Only pause when user 
 ## 0. Preflight
 
 Check if `clawjournal` is already installed:
-- `which clawjournal && clawjournal --version`
-- `test -x ~/.clawjournal-venv/bin/clawjournal && ~/.clawjournal-venv/bin/clawjournal --version`
+- `command -v clawjournal && clawjournal status`
+- `test -x ~/.clawjournal-venv/bin/clawjournal && ~/.clawjournal-venv/bin/clawjournal status`
 
-**If found:** Skip to Step 2. If only `~/.clawjournal-venv/bin/clawjournal` exists, use that full path for commands below.
+**If found and the user is just resuming:** skip to Step 2. If only `~/.clawjournal-venv/bin/clawjournal` exists, use that full path for commands below.
+**If found but the user wants the latest:** re-run Step 1's installer (idempotent — it'll fast-forward the checkout and reinstall in place), then continue to Step 2.
 **If not found:** Continue to Step 1.
 
 ## 1. Install
 
-Check Python environment:
-- `python3 --version`
+Use the bundled installer scripts. They detect a Python 3.10+ interpreter, create an isolated venv at `~/.clawjournal-venv`, and `pip install -e` the repo. Idempotent — safe to re-run.
 
-If Python not found or < 3.10:
-- Ask: "Python 3.10+ is required. Would you like me to install it?"
-- macOS: `brew install python`
-- Linux: `sudo apt-get install -y python3 python3-full`
-- Windows: direct user to python.org/downloads
+First, ask: "Do you want the browser workbench? (Recommended — it's the primary review surface. Otherwise the CLI works alone.)" Use the answer to pick whether to pass the frontend flag below.
 
-Install clawjournal from GitHub. The snippets below assume a POSIX shell. On native Windows (no WSL / Git Bash), translate each step to the equivalent PowerShell commands before running them.
+**macOS / Linux / WSL / Git Bash on Windows:**
 
-1. Clone or update the repo:
-   ```bash
-   if [ -d ~/clawjournal/.git ]; then
-     git -C ~/clawjournal pull --ff-only
-   else
-     git clone https://github.com/kai-rayward/clawjournal.git ~/clawjournal
-   fi
-   ```
-2. Create a venv and install editable:
-   ```bash
-   python3 -m venv ~/.clawjournal-venv
-   ~/.clawjournal-venv/bin/python -m pip install -e ~/clawjournal
-   ```
-3. If the user wants the browser UI, ensure Node.js/npm is available and build the frontend once:
-   ```bash
-   cd ~/clawjournal/clawjournal/web/frontend
-   npm install
-   npm run build
-   cd ~/clawjournal
-   ```
+```bash
+if [ -d ~/clawjournal/.git ]; then
+  git -C ~/clawjournal pull --ff-only
+else
+  git clone https://github.com/kai-rayward/clawjournal.git ~/clawjournal
+fi
 
-If `node` / `npm` is missing and the user wants the browser UI:
-- Ask: "Node.js is required for the browser workbench. Would you like me to install it?"
-- macOS: `brew install node`
-- Linux: `sudo apt-get install -y nodejs npm`
-- Windows: direct user to nodejs.org
+# Pick ONE based on the user's answer above:
+~/clawjournal/scripts/install.sh                    # CLI only
+~/clawjournal/scripts/install.sh --with-frontend    # also build the browser workbench (needs Node.js)
+```
 
-Verify:
-- `~/.clawjournal-venv/bin/clawjournal --version`
+**Native Windows PowerShell** (no WSL / Git Bash):
 
-If verification fails, read the error and fix. Common issues:
-- `clawjournal` not on PATH — use `~/.clawjournal-venv/bin/clawjournal` directly
-- repo clone missing or stale — verify `~/clawjournal` exists and retry `python -m pip install -e ~/clawjournal`
+```powershell
+if (Test-Path "$HOME\clawjournal\.git") {
+  git -C "$HOME\clawjournal" pull --ff-only
+} else {
+  git clone https://github.com/kai-rayward/clawjournal.git "$HOME\clawjournal"
+}
+
+# Pick ONE based on the user's answer above:
+powershell -ExecutionPolicy Bypass -File "$HOME\clawjournal\scripts\install.ps1"                # CLI only
+powershell -ExecutionPolicy Bypass -File "$HOME\clawjournal\scripts\install.ps1" -WithFrontend  # also build the browser workbench (needs Node.js)
+```
+
+The script's exit code and printed output tell you exactly what to do next. Common failure modes the script surfaces directly:
+
+- **Python 3.10+ not found** — install via the platform hint the script prints, then re-run. macOS users may also need `xcode-select --install` to get a working `python3`.
+- **`python3 -m venv` fails on Debian/Ubuntu** — run `sudo apt install -y python3-venv python3-full`, then re-run the script.
+- **`node` / `npm` missing** when `--with-frontend` was requested — the script skips the frontend with a warning. Install Node.js (macOS: `brew install node`, Linux: `sudo apt-get install -y nodejs npm`, Windows: nodejs.org) and re-run with the flag.
+
+Verify (POSIX):
+
+```bash
+~/.clawjournal-venv/bin/clawjournal status
+```
+
+Verify (PowerShell):
+
+```powershell
+& "$HOME\.clawjournal-venv\Scripts\clawjournal.exe" status
+```
 
 ## 2. Scan Sessions
 
@@ -101,14 +107,25 @@ Ask: "How would you like to review your traces?"
 
 **Option A — Browser UI (recommended for local machines):**
 
-Build the frontend first if `~/clawjournal/clawjournal/web/frontend/dist/index.html` is missing:
+Check whether the frontend is already built:
 
 ```bash
-cd ~/clawjournal/clawjournal/web/frontend
-npm install
-npm run build
-cd ~/clawjournal
+test -f ~/clawjournal/clawjournal/web/frontend/dist/index.html && echo built || echo missing
 ```
+
+If missing, re-run the installer with the frontend flag (POSIX):
+
+```bash
+~/clawjournal/scripts/install.sh --with-frontend
+```
+
+PowerShell equivalent:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File "$HOME\clawjournal\scripts\install.ps1" -WithFrontend
+```
+
+Then start the workbench:
 
 ```bash
 ~/.clawjournal-venv/bin/clawjournal serve
@@ -147,6 +164,6 @@ Tell the user:
 
 **Permission errors on scan:** ClawJournal reads session files from `~/.claude/`, `~/.codex/`, etc. Ensure these directories are readable.
 
-**Browser UI shows a placeholder page:** The frontend has not been built yet. Run `cd ~/clawjournal/clawjournal/web/frontend && npm install && npm run build`.
+**Browser UI shows a placeholder page:** The frontend has not been built yet. Re-run the installer with the frontend flag: `~/clawjournal/scripts/install.sh --with-frontend` (or `.\scripts\install.ps1 -WithFrontend` on PowerShell). Requires Node.js.
 
 **venv issues on Linux:** If you see `externally-managed-environment`, make sure you're installing into the venv: `python3 -m venv ~/.clawjournal-venv && ~/.clawjournal-venv/bin/python -m pip install -e ~/clawjournal`.


### PR DESCRIPTION
## Summary

Make ClawJournal trivial to install for two distinct audiences:

1. **Autonomous AI coding agents** (Claude Code, Codex, Cursor, Hermes, OpenCode, …) handed this repo to install for a user. They now have one canonical install path that works on macOS, Linux, WSL, Git Bash, and native Windows, with platform-specific failure hints surfaced inline.
2. **Non-coders who use AI agents as their interface.** The top of the README is now a 3-step "Install in one step (no coding required)" recipe — paste a single message into your agent, click Allow on the prompts, open a URL in your browser. No shell commands required for the entire install + first-use flow.

## What's new

**Install scripts** (the foundation):
- `scripts/install.sh` (POSIX) and `scripts/install.ps1` (PowerShell). Detect a Python 3.10+ interpreter, create an isolated venv at `~/.clawjournal-venv`, and `pip install -e` the repo in one idempotent command per platform.
- `.gitattributes` pins LF on `.sh` so shebangs survive Windows clones with `core.autocrlf=true`.
- `clawjournal-setup` skill invokes the same scripts so agents get the documented path.

**Failure modes the scripts surface directly:**
- Python 3.10+ not found → platform-specific install hints.
- `python3 -m venv` fails on Debian/Ubuntu → `apt install python3-venv` hint.
- `npm` missing when `--with-frontend` was requested → warn and continue (CLI still works).
- TruffleHog missing → soft hint (only needed at share time).
- `mktemp` + trap-based cleanup for the venv error log (closes a multi-user race).

**README rewrite** — the larger half of the PR:
- Top-of-file "Install in one step (no coding required)" with paste-this-prompt + expectation-setting (10–25 permission prompts, macOS sudo password explanation, silent-wait reassurance, recovery scripts like *"try a different approach"*, browser instructions for `localhost:8384`).
- Single agent-direct blockquote: *"You — coding agent reading this README: detect the user's OS, follow the matching block in Quickstart below … you have everything you need; proceed."*
- Per-OS Quickstart with concrete prereq commands (`brew install` / `apt install` / `winget install` with non-interactive flags), Homebrew bootstrap (`NONINTERACTIVE=1`), `pwsh`-first PowerShell, NodeSource fallback for older Ubuntu LTS.
- Stages 2–6 of the End-to-end flow restructured: each leads with `**Just say to your AI:**` natural-language prompts; shell commands tucked into `<details>` collapsibles. A non-coder scrolling top-to-bottom on github.com sees zero raw shell commands without explicit click.

## How it converged

Validated across 12 fresh-agent walkthroughs (autonomous-agent and non-coder personas, both spawned with no prior context):

| Audience | Trajectory | Final |
|----------|-----------|-------|
| Autonomous AI agent | 7 → 7.5 → 8 → 8 → 8 → 9 → 8.5 → 9 | **9/10** |
| Non-coder with AI access | 5 → 7 → 8 → 9 → 8 → 9 | **9/10** |

Final non-coder verdict: *"Yes — confident hand-off [to a non-technical friend]. The 3-step paste-and-allow flow … reads like a layperson onboarding doc, not a dev README."*
Final agent verdict: *"The dedicated agent block is a UX win — explicitly says 'You have everything you need; proceed', killing ambiguity. … No regression."*

## Side note (not addressed in this PR)

`pyproject.toml` says `version = "0.0.2"` while `clawjournal/__init__.py` reports `0.1.12` — that's why PyPI is so far behind even though the code has moved on. The install script reads `__version__` for accurate post-install reporting; the release-process fix is left for a follow-up.

## Test plan

- [x] Fresh install into isolated venv (POSIX, macOS): `[ok] ClawJournal 0.1.12 installed.` and `clawjournal status` returns valid JSON.
- [x] Idempotent re-run on existing venv — clean second pass.
- [x] `--help` parses correctly (no leak of `set -eu` etc.).
- [x] `--bogus` unknown flag exits 2.
- [x] Python-not-found path prints platform hints and exits 1.
- [x] `--with-frontend` with no `npm` on PATH: warns, install completes, exits 0.
- [x] `--with-frontend` with a fake `npm` that exits 1: warns, install completes, exits 0 (frontend build is non-fatal).
- [x] `mktemp` cleanup leaves no `/tmp/clawjournal-venv*` leftovers post-run.
- [x] `.gitattributes` correctly converts `install.ps1` to CRLF on commit (verified by Git's LF→CRLF warning during `git add`).
- [x] 12 fresh-agent evaluations across iterations (autonomous + non-coder personas).
- [ ] Verify on Linux (Debian/Ubuntu fresh container) — would exercise the `python3-venv` missing path live.
- [ ] Verify on native Windows PowerShell — would exercise `py -3` / `pwsh` launcher path and CRLF handling live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)