### PR TITLE
release: bump version to 0.1.13

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "clawjournal",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "ClawJournal — review, curate, and share your coding agent conversation traces. 100% local. Scans sessions from Claude Code, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline. Auto-redacts secrets and PII. Browser workbench for triage and export.",
   "owner": {
     "name": "kai-rayward",
@@ -11,7 +11,7 @@
     {
       "name": "clawjournal",
       "description": "ClawJournal agent skills: /clawjournal-setup (install + scan + launch workbench), /clawjournal (review, triage, and share traces), and /clawjournal-score (AI-assisted quality scoring).",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "author": {
         "name": "kai-rayward",
         "url": "https://github.com/kai-rayward"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you have an AI coding assistant — **Claude Code**, **Codex**, **Cursor**, *
 - **Permission prompts — lots of them.** Your AI will ask permission to run several commands. Expect 10–25 prompts before install finishes — more if your computer is fresh, fewer if it already has dev tools. **Click "Allow" each time.** This is normal. The tools the AI installs (git for fetching code, Python for running ClawJournal, Node.js for the browser workbench) are widely-used software your computer probably has parts of already.
 - **A separate password prompt on Mac.** macOS may ask for *your computer password* (the one you use to log in) when installing certain tools. This is your operating system asking, not the AI. Type your password and hit Enter — installing software almost always requires this.
 - **Silent waiting periods.** Some downloads and compiles take 30–90 seconds with no visible progress. **The AI isn't frozen — it's working.** Wait for it to come back. Total install time is usually 2–10 minutes depending on your network and what's already installed.
-- **A success message at the end:** `[ok] ClawJournal 0.1.12 installed.` (the version number may differ).
+- **A success message at the end:** `[ok] ClawJournal 0.1.13 installed.` (the version number may differ).
 
 ### Open the workbench
 

--- a/clawjournal/__init__.py
+++ b/clawjournal/__init__.py
@@ -1,3 +1,3 @@
 """ClawJournal — Export and manage coding agent conversation data."""
 
-__version__ = "0.1.12"
+__version__ = "0.1.13"

--- a/plugins/clawjournal/.claude-plugin/plugin.json
+++ b/plugins/clawjournal/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clawjournal",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Review, curate, and share coding agent conversation traces. Bundles skills for setup, triage, and AI-assisted scoring.",
   "author": {
     "name": "kaiaiagent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawjournal"
-version = "0.0.2"
+version = "0.1.13"
 description = "Review, score, and curate your coding agent conversation traces locally"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Sync versions across all release surfaces to **0.1.13** and pick up the new `rayward-external` Homepage URL on PyPI in the same release.

| Surface | Before | After |
|---|---|---|
| `pyproject.toml` | 0.0.2 | **0.1.13** |
| `clawjournal/__init__.py` | 0.1.12 | **0.1.13** |
| `.claude-plugin/marketplace.json` (root + plugin) | 0.1.12 | **0.1.13** |
| `plugins/clawjournal/.claude-plugin/plugin.json` | 0.1.12 | **0.1.13** |
| `README.md` install-success example | 0.1.12 | **0.1.13** |

## Why

The PyPI release (0.0.2) has lagged the source (`__init__.py` 0.1.12) for many releases — README even hedges *"the PyPI wheel currently lags the source by many releases"*. Now that the repo has moved to `rayward-external/clawjournal`, PyPI's Homepage link still points at the old `kai-rayward` slug. A fresh release fixes both: aligns the version surfaces and refreshes PyPI metadata.

Bumping one minor-patch ahead of `__init__.py` (0.1.12 → 0.1.13) avoids reissuing an existing version while keeping the bump minimal.

## Out of scope

- Test fixtures in `tests/events/doctor/` that hardcode `clawjournal_version="0.0.2"` are intentionally untouched — they're input strings exercising the renderer, not references to the real project version.

## Test plan

- [x] `pytest tests/` — 1750 passed locally.
- [x] `tests/test_repo_layout.py` (asserts marketplace.json version matches `clawjournal.__version__`) passes.
- [ ] After merge: `python -m build && twine upload dist/clawjournal-0.1.13*` to publish to PyPI (manual — no release workflow exists).
- [ ] After publish: verify PyPI Homepage URL on https://pypi.org/project/clawjournal/ shows `rayward-external/clawjournal`.
- [ ] Tag `v0.1.13` on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)