### PR TITLE
feat(selfupdate): silent throttled auto-update + canonical URL swap

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,8 +4,8 @@
   "version": "0.1.13",
   "description": "ClawJournal — review, curate, and share your coding agent conversation traces. 100% local. Scans sessions from Claude Code, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline. Auto-redacts secrets and PII. Browser workbench for triage and export.",
   "owner": {
-    "name": "kai-rayward",
-    "url": "https://github.com/kai-rayward"
+    "name": "rayward-external",
+    "url": "https://github.com/rayward-external"
   },
   "plugins": [
     {
@@ -13,8 +13,8 @@
       "description": "ClawJournal agent skills: /clawjournal-setup (install + scan + launch workbench), /clawjournal (review, triage, and share traces), and /clawjournal-score (AI-assisted quality scoring).",
       "version": "0.1.13",
       "author": {
-        "name": "kai-rayward",
-        "url": "https://github.com/kai-rayward"
+        "name": "rayward-external",
+        "url": "https://github.com/rayward-external"
       },
       "source": "../plugins/clawjournal",
       "category": "productivity"

--- a/README.md
+++ b/README.md
@@ -127,6 +127,8 @@ pwsh -ExecutionPolicy Bypass -File .\scripts\install.ps1 -WithFrontend
 
 The script prints `[ok] ClawJournal <version> installed.` on success. The default above includes `--with-frontend` / `-WithFrontend` which builds the browser workbench at `localhost:8384`. **If Node.js is not installed, the script warns and continues with a CLI-only install** — `clawjournal serve` will then 404; install Node and re-run the script with the flag to fix. Drop the flag entirely if you only need `scan`, `inbox`, `search`, and `bundle-export` (these don't need the workbench).
 
+**Stays current automatically.** Each invocation runs a silent, throttled background fast-forward from `rayward-external/clawjournal` (once per hour, capped on time, network-failure-safe). New code is picked up by the editable install on the next run — no manual upgrades. Skipped on dirty trees, local-only commits, diverged histories, or non-`main` branches. Opt out with `CLAWJOURNAL_NO_AUTO_UPDATE=1`, or run a synchronous update anytime with `clawjournal selfupdate` (`--check` to peek, `--force` to discard local changes on `main` only).
+
 **Verify** — you should see a JSON response with `"stage"` and `"stage_number"`:
 
 ```bash
@@ -141,7 +143,7 @@ The script prints `[ok] ClawJournal <version> installed.` on success. The defaul
 { "stage": "configure", "stage_number": 2, "total_stages": 4, ... }
 ```
 
-The CLI lives at `~/.clawjournal-venv/bin/clawjournal` (POSIX) or `$HOME\.clawjournal-venv\Scripts\clawjournal.exe` (Windows). The install is idempotent — re-run the script any time to upgrade against the latest `git pull`.
+The CLI lives at `~/.clawjournal-venv/bin/clawjournal` (POSIX) or `$HOME\.clawjournal-venv\Scripts\clawjournal.exe` (Windows). The install is idempotent — re-run the script any time to fast-forward to the latest source.
 
 **To call it as plain `clawjournal` instead of the full path** (current shell session; add to your shell profile to persist):
 
@@ -527,6 +529,8 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal list` | List all projects with exclusion status |
 | `clawjournal status` | Show current stage and next steps (JSON) |
 | `clawjournal update-skill <agent>` | Install/update the clawjournal skill for an agent |
+| `clawjournal selfupdate` | Fast-forward to latest from `rayward-external/clawjournal` (sync) |
+| `clawjournal selfupdate --check` | Report whether updates are available without applying |
 | `clawjournal serve --remote` | Print SSH tunnel command for remote VM access |
 
 ### Export & sanitize (advanced)

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3324,7 +3324,44 @@ def _run_note(args: argparse.Namespace) -> None:
     sys.exit(2)
 
 
+_AUTO_UPDATE_SKIP_FLAGS = frozenset({"-h", "--help", "--version"})
+
+
+def _should_auto_update(argv: list[str] | None = None) -> bool:
+    """Return False for commands where a pre-parse update changes semantics.
+
+    Suppresses in two cases:
+      - The user explicitly invoked `clawjournal selfupdate` — let
+        that command be the only updater for this invocation.
+      - The user invoked help/version (`-h`, `--help`, `--version`)
+        with no real subcommand — argparse prints and exits, so a
+        background fetch is wasted work that surprises the user.
+
+    Matching `"selfupdate"` anywhere in argv produced false positives
+    like `clawjournal export --output ./selfupdate`.
+    """
+    tokens = (sys.argv if argv is None else argv)[1:]
+    if not tokens:
+        return True
+    for token in tokens:
+        if token.startswith("-"):
+            continue
+        return token != "selfupdate"
+    # All tokens were flags — no subcommand. Skip when any are help/version.
+    return not any(t in _AUTO_UPDATE_SKIP_FLAGS for t in tokens)
+
+
 def main() -> None:
+    # Fire the silent, throttled auto-update before any work. Returns
+    # immediately on opt-out, non-git installs, or throttle hits.
+    if _should_auto_update():
+        try:
+            from .selfupdate import maybe_self_update
+            maybe_self_update()
+        except Exception:
+            # Auto-update must never block the CLI. Swallow anything.
+            pass
+
     parser = argparse.ArgumentParser(description="ClawJournal — coding agent conversation exporter")
     sub = parser.add_subparsers(dest="command")
 
@@ -3353,6 +3390,14 @@ def main() -> None:
     us = sub.add_parser("update-skill", help="Install/update the clawjournal skill for a coding agent")
     us.add_argument("target", choices=["claude", "openclaw", "codex", "cline"],
                     help="Agent to install skill for")
+
+    su = sub.add_parser("selfupdate",
+                        help="Pull the latest clawjournal from the public repo (manual sync update)")
+    su.add_argument("--check", action="store_true",
+                    help="Report whether updates are available without applying them")
+    su.add_argument("--force", action="store_true",
+                    help="Discard local changes on main before applying a fast-forward update")
+    su.add_argument("--json", action="store_true", help="Output result as JSON")
 
     cfg = sub.add_parser("config", help="View or set config")
     cfg.add_argument("--repo", type=str, help=argparse.SUPPRESS)
@@ -4173,6 +4218,45 @@ def main() -> None:
 
     if command == "update-skill":
         update_skill(args.target)
+        return
+
+    if command == "selfupdate":
+        from .selfupdate import selfupdate_sync
+        result = selfupdate_sync(check_only=args.check, force=args.force)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            status = result.get("status")
+            if status == "not-a-checkout":
+                print("clawjournal is not installed from an editable git checkout — nothing to update.")
+            elif status == "up-to-date":
+                print(f"Already up to date ({str(result.get('head', ''))[:7]}).")
+            elif status == "behind":
+                print(
+                    f"Update available: {str(result.get('head', ''))[:7]} -> "
+                    f"{str(result.get('upstream', ''))[:7]}. Run `clawjournal selfupdate` to apply."
+                )
+            elif status == "updated":
+                print(
+                    f"Updated {str(result.get('head', ''))[:7]} -> "
+                    f"{str(result.get('upstream', ''))[:7]}."
+                )
+            elif status == "dirty":
+                print("Skipped: the checkout has local changes. Commit/stash or pass --force.")
+            elif isinstance(status, str) and status.startswith("branch-"):
+                print(f"Skipped: not on the main branch ({status[len('branch-'):]}). Check out main first.")
+            elif status == "ahead":
+                print("Skipped: local main has commits not present on origin/main. Update manually.")
+            elif status == "diverged":
+                print("Skipped: local main has diverged from origin/main. Update manually.")
+            elif status == "ancestry-failed":
+                print("Skipped: could not compare local main with origin/main.")
+            elif status == "fetch-failed":
+                print(f"Fetch failed: {result.get('stderr', '')}".rstrip())
+            elif status == "update-failed":
+                print(f"Update failed: {result.get('stderr', '')}".rstrip())
+            else:
+                print(f"selfupdate status: {status}")
         return
 
     if command == "list":

--- a/clawjournal/selfupdate.py
+++ b/clawjournal/selfupdate.py
@@ -1,0 +1,514 @@
+"""Silent, throttled, background auto-update for the editable git checkout.
+
+Inspired by gstack: every CLI invocation triggers a fast update check
+(throttled to once an hour, network-failure-safe, completely silent).
+The fast-forward runs in a detached subprocess so it can't slow down the
+user; the editable install means the next invocation picks up new code.
+
+The check is a no-op when any of these is true:
+  - opt-out env var ``CLAWJOURNAL_NO_AUTO_UPDATE`` is set to a truthy value
+  - the install isn't an editable git checkout (e.g. PyPI wheel)
+  - ``~/.clawjournal/`` doesn't exist yet (fresh install)
+  - the checkout has uncommitted changes (don't clobber WIP)
+  - the checkout is on a non-main branch (don't surprise contributors)
+  - the checkout has local-only commits or diverged history
+  - the throttle stamp is younger than the throttle window
+  - another concurrent CLI invocation already claimed the throttle slot
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+from .config import CONFIG_DIR
+
+STAMP_FILENAME = "last_update_check"
+THROTTLE_SECONDS = 60 * 60  # once per hour
+FETCH_TIMEOUT_SECONDS = 8
+APPLY_TIMEOUT_SECONDS = 5
+# The lock is held only across the brief spawn window (parent releases
+# immediately after Popen returns). 60s is generous for that; using the
+# full THROTTLE_SECONDS would mean a crashed CLI blocks updates for an
+# hour instead of for the lifetime of one spawn.
+LOCK_STALE_SECONDS = 60
+DEFAULT_BRANCH = "main"
+DEFAULT_REMOTE = "origin"
+
+OPT_OUT_ENV = "CLAWJOURNAL_NO_AUTO_UPDATE"
+DEBUG_ENV = "CLAWJOURNAL_AUTO_UPDATE_DEBUG"
+
+
+def _truthy(value: str | None) -> bool:
+    return bool(value) and value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def _debug(msg: str) -> None:
+    if _truthy(os.environ.get(DEBUG_ENV)):
+        print(f"[selfupdate] {msg}", file=sys.stderr)
+
+
+def _package_repo_root() -> Path | None:
+    """Return the git checkout root that contains this package, or None."""
+    here = Path(__file__).resolve().parent.parent
+    if (here / ".git").exists():
+        return here
+    return None
+
+
+def _stamp_path() -> Path:
+    return CONFIG_DIR / STAMP_FILENAME
+
+
+def _throttle_fresh(now: float, *, window: int = THROTTLE_SECONDS) -> bool:
+    """Return True when the throttle stamp is younger than `window`.
+
+    A negative delta (system clock jumped backward — VM resume, NTP
+    correction) is treated as "not fresh" so the user isn't locked out
+    of updates for hours while the clock catches up.
+    """
+    stamp = _stamp_path()
+    try:
+        mtime = stamp.stat().st_mtime
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return False
+    delta = now - mtime
+    if delta < 0:
+        return False
+    return delta < window
+
+
+def _claim_throttle_slot(now: float) -> bool:
+    """Atomically claim the throttle slot. Returns True if we won the race.
+
+    Two-layer atomicity:
+      1. ``O_CREAT|O_EXCL`` for the common "no lock yet" case.
+      2. For stale-lock reclaim, write our PID to a tmpfile and use
+         ``os.link`` to atomically move it into the lock path. Two
+         concurrent reclaimers will race on the link step — only one
+         gets a successful link, the other raises ``FileExistsError``.
+
+    The lock is only meant to exclude during the brief spawn window;
+    the parent releases it as soon as ``Popen`` returns. The throttle
+    stamp's mtime is what gates the next invocation's hour-long
+    throttle.
+    """
+    stamp = _stamp_path()
+    try:
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        _debug(f"could not create stamp dir: {exc}")
+        return False
+
+    lock_path = stamp.with_suffix(".lock")
+    try:
+        fd = os.open(str(lock_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+        try:
+            os.close(fd)
+        except OSError:
+            pass
+        return True
+    except FileExistsError:
+        pass
+    except OSError as exc:
+        _debug(f"could not open lock: {exc}")
+        return False
+
+    # Lock exists. Is it stale (from a crashed CLI)? If so, try an
+    # atomic reclaim. Otherwise a peer is currently spawning — bail.
+    try:
+        lock_age = now - lock_path.stat().st_mtime
+    except OSError:
+        return False
+    if lock_age < 0 or lock_age < LOCK_STALE_SECONDS:
+        return False
+
+    # Atomic reclaim: write a tmpfile in the same dir, then link it
+    # into place. `os.link` raises FileExistsError if the target now
+    # exists — so if two CLIs race the reclaim, only one wins.
+    tmp_path = lock_path.with_suffix(f".lock.tmp.{os.getpid()}.{int(now * 1e6)}")
+    try:
+        fd = os.open(str(tmp_path), os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o600)
+    except OSError as exc:
+        _debug(f"could not create reclaim tmpfile: {exc}")
+        return False
+    try:
+        os.close(fd)
+    except OSError:
+        pass
+
+    # Remove the dead lock so link can succeed. Another racer may also
+    # be unlinking; we don't care which unlink wins because link is
+    # what actually claims ownership.
+    try:
+        os.unlink(lock_path)
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        _debug(f"could not remove stale lock: {exc}")
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        return False
+
+    try:
+        os.link(str(tmp_path), str(lock_path))
+        return True
+    except FileExistsError:
+        # Another reclaimer won the race.
+        _debug("lost stale-reclaim race")
+        return False
+    except OSError as exc:
+        _debug(f"could not link reclaim tmpfile: {exc}")
+        return False
+    finally:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+
+
+def _write_stamp(now: float) -> None:
+    """Refresh the throttle stamp's mtime. Called after state checks pass."""
+    stamp = _stamp_path()
+    try:
+        stamp.parent.mkdir(parents=True, exist_ok=True)
+        stamp.touch(exist_ok=True)
+        os.utime(stamp, (now, now))
+    except OSError as exc:
+        _debug(f"could not write stamp: {exc}")
+
+
+def _release_lock() -> None:
+    try:
+        os.unlink(str(_stamp_path().with_suffix(".lock")))
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        _debug(f"could not release lock: {exc}")
+
+
+def _git(repo: Path, *args: str, timeout: float | None = None,
+         capture: bool = False) -> subprocess.CompletedProcess[bytes] | None:
+    """Run a git subcommand silently. Returns None on any error."""
+    try:
+        return subprocess.run(
+            ["git", "-C", str(repo), *args],
+            stdout=subprocess.PIPE if capture else subprocess.DEVNULL,
+            stderr=subprocess.PIPE if capture else subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            timeout=timeout,
+            check=False,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        _debug(f"git {' '.join(args)} failed: {exc}")
+        return None
+
+
+def _git_status_ok(repo: Path) -> tuple[bool | None, str]:
+    """Return (is_dirty, error_kind). is_dirty is None when git itself failed.
+
+    Distinguishing "definitely clean" from "couldn't tell" is important:
+    a transient `git status` failure (Windows AV, index lock contention)
+    should NOT count as dirty and burn the throttle slot.
+    """
+    result = _git(repo, "status", "--porcelain", "--untracked-files=no",
+                  timeout=2, capture=True)
+    if result is None:
+        return (None, "git-unavailable")
+    if result.returncode != 0:
+        return (None, "git-status-failed")
+    return (bool(result.stdout.strip()), "")
+
+
+def _current_branch(repo: Path) -> str | None:
+    result = _git(repo, "rev-parse", "--abbrev-ref", "HEAD",
+                  timeout=2, capture=True)
+    if result is None or result.returncode != 0:
+        return None
+    return result.stdout.decode("utf-8", "replace").strip() or None
+
+
+def _rev_parse(repo: Path, rev: str) -> str | None:
+    result = _git(repo, "rev-parse", rev, timeout=2, capture=True)
+    if result is None or result.returncode != 0:
+        return None
+    return result.stdout.decode("ascii", "replace").strip() or None
+
+
+def _is_ancestor(repo: Path, ancestor: str, descendant: str) -> bool | None:
+    result = _git(repo, "merge-base", "--is-ancestor", ancestor, descendant,
+                  timeout=2, capture=True)
+    if result is None:
+        return None
+    if result.returncode == 0:
+        return True
+    if result.returncode == 1:
+        return False
+    return None
+
+
+def _history_relation(repo: Path, head: str, upstream: str) -> str:
+    """Classify local HEAD relative to upstream."""
+    if head == upstream:
+        return "up-to-date"
+
+    head_is_ancestor = _is_ancestor(repo, head, upstream)
+    upstream_is_ancestor = _is_ancestor(repo, upstream, head)
+    if head_is_ancestor is None or upstream_is_ancestor is None:
+        return "ancestry-failed"
+    if head_is_ancestor:
+        return "behind"
+    if upstream_is_ancestor:
+        return "ahead"
+    return "diverged"
+
+
+def _apply_fast_forward(
+    repo: Path, upstream: str, *, force: bool
+) -> subprocess.CompletedProcess[bytes] | None:
+    """Apply a known-safe fast-forward.
+
+    ``force`` only controls whether local uncommitted changes are discarded.
+    Callers must already have proven that HEAD is an ancestor of upstream, so
+    neither path can discard local commits.
+    """
+    if force:
+        return _git(repo, "reset", "--hard", "--quiet", upstream,
+                    timeout=APPLY_TIMEOUT_SECONDS, capture=True)
+    return _git(repo, "merge", "--ff-only", "--quiet", upstream,
+                timeout=APPLY_TIMEOUT_SECONDS, capture=True)
+
+
+def _run_background_update(repo: Path) -> int:
+    """Fetch and apply a silent fast-forward update if it is still safe.
+
+    Wrapped in a top-level ``BaseException`` handler because the child's
+    stdio is DEVNULL: an uncaught exception would crash silently, which
+    is OK for correctness but means we lose the ability to record a
+    silent failure status. Returning 1 keeps behavior consistent across
+    expected and unexpected errors.
+    """
+    try:
+        fetch = _git(repo, "fetch", "--quiet", DEFAULT_REMOTE, DEFAULT_BRANCH,
+                     timeout=FETCH_TIMEOUT_SECONDS)
+        if fetch is None or fetch.returncode != 0:
+            return 1
+
+        # Re-check safety in the child after the fetch. The parent may have
+        # spawned us while the user continued working in the checkout.
+        if _current_branch(repo) != DEFAULT_BRANCH:
+            return 0
+
+        is_dirty, _ = _git_status_ok(repo)
+        if is_dirty is None or is_dirty:
+            return 0
+
+        upstream_ref = f"{DEFAULT_REMOTE}/{DEFAULT_BRANCH}"
+        head_sha = _rev_parse(repo, "HEAD")
+        upstream_sha = _rev_parse(repo, upstream_ref)
+        if not head_sha or not upstream_sha:
+            return 1
+
+        if _history_relation(repo, head_sha, upstream_sha) != "behind":
+            return 0
+
+        update = _apply_fast_forward(repo, upstream_ref, force=False)
+        if update is None:
+            return 1
+        return update.returncode
+    except BaseException as exc:  # noqa: BLE001 - silent child, see docstring
+        _debug(f"background update crashed: {exc}")
+        return 1
+
+
+def _spawn_background_update(repo: Path) -> bool:
+    """Spawn a detached child that runs a safe fast-forward, return immediately.
+
+    Implementation: spawn `python -c "<inline script>"` rather than
+    `sh -c` / `cmd /c`. The inline script uses ``subprocess.run`` with
+    list-form argv, so repo paths with shell metacharacters
+    (spaces, ``&``, ``|``, quotes, etc.) are safe — there's no shell
+    in the loop at all.
+
+    The child inherits no stdio. We use ``setsid`` (POSIX) /
+    ``DETACHED_PROCESS`` (Windows) so it survives the parent CLI
+    exiting. Returns False on spawn failure so the caller can decide
+    whether to release the lock or leave it for the next throttle
+    window.
+    """
+    kwargs: dict[str, object] = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+        "close_fds": True,
+        "cwd": str(repo),
+    }
+    if os.name == "posix":
+        kwargs["start_new_session"] = True
+    else:
+        CREATE_NEW_PROCESS_GROUP = 0x00000200
+        DETACHED_PROCESS = 0x00000008
+        kwargs["creationflags"] = CREATE_NEW_PROCESS_GROUP | DETACHED_PROCESS
+
+    inline = (
+        "import sys;"
+        "from pathlib import Path;"
+        "from clawjournal.selfupdate import _run_background_update;"
+        "sys.exit(_run_background_update(Path(sys.argv[1])))"
+    )
+
+    try:
+        # Bind the Popen object so it isn't garbage-collected before the
+        # detached child is reaped — CPython would otherwise emit a
+        # ResourceWarning under certain pytest configurations. The
+        # detached session/process group means we never need to wait()
+        # on it; the binding just suppresses the warning.
+        _proc = subprocess.Popen(  # noqa: F841 - see comment above
+            [sys.executable, "-c", inline, str(repo)], **kwargs
+        )
+        _debug(f"spawned background update (pid {_proc.pid})")
+        return True
+    except OSError as exc:
+        _debug(f"could not spawn background update: {exc}")
+        return False
+
+
+def maybe_self_update(*, now: float | None = None) -> str:
+    """Possibly fire a silent background update. Returns a short status.
+
+    Status strings exist for tests and the manual `selfupdate --check`
+    path; they are never surfaced to normal users.
+    """
+    if _truthy(os.environ.get(OPT_OUT_ENV)):
+        return "opt-out"
+
+    repo = _package_repo_root()
+    if repo is None:
+        return "not-a-checkout"
+
+    # Pre-scan install: ~/.clawjournal/ doesn't exist yet. Don't
+    # bootstrap it just to drop a throttle stamp — the user hasn't
+    # run anything that needs updating against, and doing so makes
+    # `clawjournal events doctor` think this is no longer a fresh
+    # install. Wait until the user has actually used the tool.
+    if not CONFIG_DIR.exists():
+        return "no-config-dir"
+
+    when = time.time() if now is None else now
+    if _throttle_fresh(when):
+        return "throttled"
+
+    # Check repo state BEFORE writing the stamp, so a transient
+    # `git status` failure doesn't burn a throttle slot.
+    branch = _current_branch(repo)
+    if branch != DEFAULT_BRANCH:
+        return f"branch-{branch or 'unknown'}"
+
+    is_dirty, err = _git_status_ok(repo)
+    if is_dirty is None:
+        # Transient git failure (index lock, AV scan, git missing) —
+        # don't burn the throttle window; try again next invocation.
+        return f"skip-{err}"
+    if is_dirty:
+        return "dirty"
+
+    # Atomically claim the throttle slot. If two CLIs race here, only
+    # one wins and spawns the background update; the other returns
+    # "throttled" and exits cleanly.
+    if not _claim_throttle_slot(when):
+        return "throttled"
+
+    _write_stamp(when)
+    spawned = _spawn_background_update(repo)
+    # Release the lock — the stamp's fresh mtime is what gates the next
+    # invocation; the lock is only for the brief spawn window.
+    _release_lock()
+    return "spawned" if spawned else "spawn-failed"
+
+
+def selfupdate_sync(repo: Path | None = None, *, check_only: bool = False,
+                    force: bool = False) -> dict[str, object]:
+    """Synchronous variant for the `clawjournal selfupdate` subcommand.
+
+    Returns a small dict describing what happened. Surfaces errors as
+    fields (no exceptions) so the CLI can render them deterministically.
+
+    `--force` only overrides the dirty-tree guard (the user explicitly
+    asked to discard local changes). It does NOT override the branch,
+    local-commit, or diverged-history guards.
+    """
+    target = repo or _package_repo_root()
+    if target is None:
+        return {"status": "not-a-checkout", "repo": None}
+
+    info: dict[str, object] = {"repo": str(target)}
+    branch = _current_branch(target)
+    info["branch"] = branch
+
+    # Branch guard is non-negotiable even with --force: we update
+    # `main` only. Checking out another branch and resetting it to
+    # `origin/main` would silently discard the user's commits.
+    if branch != DEFAULT_BRANCH:
+        info["status"] = f"branch-{branch or 'unknown'}"
+        return info
+
+    if not force:
+        is_dirty, err = _git_status_ok(target)
+        if is_dirty is None:
+            info["status"] = f"skip-{err}"
+            return info
+        if is_dirty:
+            info["status"] = "dirty"
+            return info
+
+    fetch = _git(target, "fetch", "--quiet", DEFAULT_REMOTE, DEFAULT_BRANCH,
+                 timeout=FETCH_TIMEOUT_SECONDS, capture=True)
+    if fetch is None or fetch.returncode != 0:
+        info["status"] = "fetch-failed"
+        if fetch is not None:
+            info["stderr"] = fetch.stderr.decode("utf-8", "replace").strip()
+        return info
+
+    upstream_ref = f"{DEFAULT_REMOTE}/{DEFAULT_BRANCH}"
+    head_sha = _rev_parse(target, "HEAD") or ""
+    upstream_sha = _rev_parse(target, upstream_ref) or ""
+    info["head"] = head_sha
+    info["upstream"] = upstream_sha
+
+    if not head_sha or not upstream_sha:
+        info["status"] = "rev-parse-failed"
+        return info
+
+    relation = _history_relation(target, head_sha, upstream_sha)
+    info["relation"] = relation
+
+    if relation == "up-to-date":
+        info["status"] = "up-to-date"
+        _write_stamp(time.time())
+        return info
+
+    if relation in {"ahead", "diverged", "ancestry-failed"}:
+        info["status"] = relation
+        return info
+
+    if check_only:
+        info["status"] = "behind"
+        return info
+
+    update = _apply_fast_forward(target, upstream_ref, force=force)
+    if update is None or update.returncode != 0:
+        info["status"] = "update-failed"
+        if update is not None:
+            info["stderr"] = update.stderr.decode("utf-8", "replace").strip()
+        return info
+
+    info["status"] = "updated"
+    _write_stamp(time.time())
+    return info

--- a/clawjournal/web/frontend/README.md
+++ b/clawjournal/web/frontend/README.md
@@ -1,73 +1,96 @@
-# React + TypeScript + Vite
+# ClawJournal Workbench Frontend
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This is the React + TypeScript + Vite app for the ClawJournal browser
+workbench. The Python daemon serves the built files from `dist/` at
+`http://localhost:8384`.
 
-Currently, two official plugins are available:
+Most users do not need this directory. Use it when you are changing the UI,
+rebuilding the bundled workbench, or debugging frontend/API behavior.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+## Quick Start
 
-## React Compiler
+From the repository root:
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
-
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
-
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
-
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+```bash
+cd clawjournal/web/frontend
+npm install
+npm run build
+cd ../../..
+clawjournal serve
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+Open `http://localhost:8384`. If `clawjournal serve` shows a placeholder page,
+the frontend has not been built yet or `dist/` is stale.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Choose A Workflow
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+### Build the workbench users see
+
+Use this path before testing the real installed experience:
+
+```bash
+cd clawjournal/web/frontend
+npm install
+npm run build
+clawjournal serve
 ```
+
+`npm run build` writes `dist/`. The daemon in
+`clawjournal/workbench/daemon.py` serves that folder and injects the local API
+token into `index.html`, so browser requests to `/api/*` work without manual
+setup.
+
+### Iterate on UI code
+
+Use Vite when you want fast reloads while editing React components:
+
+```bash
+clawjournal serve --no-browser
+cd clawjournal/web/frontend
+npm run dev
+```
+
+Open `http://localhost:5173`. Vite proxies `/api` to
+`http://localhost:8384`.
+
+Auth note: the daemon injects `window.__CLAWJOURNAL_API_TOKEN__` only when it
+serves the built `dist/index.html`. The Vite dev server does not inject that
+token. If dev-server API calls return `401`, verify the behavior through the
+built app at `http://localhost:8384`, or temporarily add a local-only token
+script while developing. Never commit a pasted token.
+
+## Useful Commands
+
+```bash
+npm run dev      # Vite dev server on localhost:5173
+npm run build    # Type-check and build dist/
+npm run lint     # ESLint
+npm run preview  # Preview built static files without the ClawJournal daemon
+```
+
+`npm run preview` is only a static Vite preview. It does not replace
+`clawjournal serve` because it does not run the scanner, SQLite workbench API,
+or token injection.
+
+## Code Map
+
+- `src/App.tsx` defines the top-level routes and sidebar.
+- `src/views/` contains the main screens: Dashboard, Insights, Search,
+  Sessions, Session Detail, Share, and Policies.
+- `src/components/` contains reusable UI pieces.
+- `src/api.ts` wraps the workbench API under `/api`.
+- `src/types.ts` keeps frontend response types in one place.
+- `src/theme.ts` holds shared colors and typography.
+- `vite.config.ts` sets the dev port to `5173` and proxies `/api` to the
+  daemon on `8384`.
+
+## Troubleshooting
+
+- Placeholder page on `localhost:8384`: run `npm install && npm run build`.
+- Stale UI after edits: rebuild, then restart or refresh `clawjournal serve`.
+- `401` from `localhost:5173`: use the built daemon-served app, or inject the
+  local API token only for the current dev session.
+- API looks empty: run `clawjournal scan` or let `clawjournal serve` finish its
+  background scan.
+- Port conflict: run the daemon on another port with `clawjournal serve --port
+  <port>`. If you change the daemon port, update the Vite proxy target too.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 license-files = ["LICENSE"]
 readme = "README.md"
 authors = [
-    {name = "kai-rayward"},
+    {name = "rayward-external"},
 ]
 keywords = ["claude-code", "codex", "gemini-cli", "opencode", "openclaw", "dataset", "conversations"]
 classifiers = [

--- a/tests/test_repo_layout.py
+++ b/tests/test_repo_layout.py
@@ -17,7 +17,7 @@ def test_claude_marketplace_points_to_plugin_wrapper():
     assert plugin["version"] == clawjournal.__version__
     assert plugin["source"] == "../plugins/clawjournal"
     assert plugin["category"] == "productivity"
-    assert plugin["author"]["name"] == "kai-rayward"
+    assert plugin["author"]["name"] == "rayward-external"
     assert plugin.get("description"), "plugin description must be present but can evolve freely"
 
 

--- a/tests/test_selfupdate.py
+++ b/tests/test_selfupdate.py
@@ -1,0 +1,566 @@
+"""Tests for the silent auto-update module."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+from clawjournal import selfupdate
+
+
+# ---------- fixtures ----------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_config_dir(tmp_path, monkeypatch):
+    """Point CONFIG_DIR at a tmp path so the stamp doesn't leak globally."""
+    cfg_dir = tmp_path / "clawjournal_home"
+    cfg_dir.mkdir()
+    monkeypatch.setattr("clawjournal.selfupdate.CONFIG_DIR", cfg_dir)
+    return cfg_dir
+
+
+def _init_repo(repo: Path) -> None:
+    repo.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "--quiet", "-b", "main", str(repo)], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(repo), "config", "user.name", "t"], check=True)
+    (repo / "README").write_text("x\n")
+    subprocess.run(["git", "-C", str(repo), "add", "README"], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "--quiet", "-m", "init"],
+        check=True,
+    )
+
+
+def _commit_file(repo: Path, name: str, content: str, message: str) -> str:
+    path = repo / name
+    path.write_text(content)
+    subprocess.run(["git", "-C", str(repo), "add", name], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "--quiet", "-m", message],
+        check=True,
+    )
+    return _head(repo)
+
+
+def _head(repo: Path) -> str:
+    return subprocess.run(
+        ["git", "-C", str(repo), "rev-parse", "HEAD"],
+        capture_output=True,
+        text=True,
+        check=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def fake_repo(tmp_path, monkeypatch):
+    """Create a tiny git repo and pretend the package lives inside it."""
+    repo = tmp_path / "repo"
+    _init_repo(repo)
+    monkeypatch.setattr("clawjournal.selfupdate._package_repo_root", lambda: repo)
+    return repo
+
+
+def _stub_spawn_ok(monkeypatch, sink: list[Path]) -> None:
+    def fake(repo: Path) -> bool:
+        sink.append(repo)
+        return True
+    monkeypatch.setattr("clawjournal.selfupdate._spawn_background_update", fake)
+
+
+# ---------- basic guards ------------------------------------------------------
+
+
+def test_opt_out_env_short_circuits(monkeypatch, isolated_config_dir):
+    monkeypatch.setenv("CLAWJOURNAL_NO_AUTO_UPDATE", "1")
+    assert selfupdate.maybe_self_update() == "opt-out"
+    assert not (isolated_config_dir / "last_update_check").exists()
+
+
+def test_not_a_checkout_returns_quietly(monkeypatch, isolated_config_dir):
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+    monkeypatch.setattr("clawjournal.selfupdate._package_repo_root", lambda: None)
+    assert selfupdate.maybe_self_update() == "not-a-checkout"
+
+
+def test_skips_when_config_dir_absent(monkeypatch, tmp_path, fake_repo):
+    """Fresh install — no ~/.clawjournal yet — must not be bootstrapped
+    by auto-update. Otherwise `events doctor` would stop seeing this as
+    a fresh install."""
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+    missing = tmp_path / "never_created"
+    monkeypatch.setattr("clawjournal.selfupdate.CONFIG_DIR", missing)
+    spawned: list[Path] = []
+    _stub_spawn_ok(monkeypatch, spawned)
+    assert selfupdate.maybe_self_update() == "no-config-dir"
+    assert not missing.exists()
+    assert spawned == []
+
+
+# ---------- throttle / clock-skew --------------------------------------------
+
+
+def test_throttle_skips_when_stamp_fresh(monkeypatch, isolated_config_dir, fake_repo):
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+    stamp = isolated_config_dir / "last_update_check"
+    stamp.write_bytes(b"")
+    now = time.time()
+    os.utime(stamp, (now, now))
+
+    spawned: list[Path] = []
+    _stub_spawn_ok(monkeypatch, spawned)
+    assert selfupdate.maybe_self_update(now=now) == "throttled"
+    assert spawned == []
+
+
+def test_clock_skew_does_not_lock_out_updates(
+    monkeypatch, isolated_config_dir, fake_repo
+):
+    """If the wall clock jumps backward, a stamp from the 'future' must
+    not be treated as fresh — otherwise the user is locked out of
+    updates until the clock catches up."""
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+    stamp = isolated_config_dir / "last_update_check"
+    stamp.write_bytes(b"")
+    now = time.time()
+    # Stamp is one hour in the FUTURE relative to `now` (clock rewound).
+    future = now + 3600
+    os.utime(stamp, (future, future))
+
+    spawned: list[Path] = []
+    _stub_spawn_ok(monkeypatch, spawned)
+    assert selfupdate.maybe_self_update(now=now) == "spawned"
+    assert spawned == [fake_repo]
+
+
+# ---------- stamp ordering / transient git failure ---------------------------
+
+
+def test_stamp_written_before_spawn_so_failures_dont_loop(
+    monkeypatch, isolated_config_dir, fake_repo
+):
+    """If the network hangs forever, the *next* invocation must see the
+    fresh throttle stamp and bail out — so the stamp has to be on disk
+    by the time _spawn_background_update is called."""
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+
+    stamp_seen_at_spawn = {"existed": False}
+
+    def fake_spawn(repo: Path) -> bool:
+        stamp_seen_at_spawn["existed"] = (
+            isolated_config_dir / "last_update_check"
+        ).exists()
+        return True
+
+    monkeypatch.setattr("clawjournal.selfupdate._spawn_background_update", fake_spawn)
+    assert selfupdate.maybe_self_update() == "spawned"
+    assert stamp_seen_at_spawn["existed"] is True
+
+
+def test_transient_git_failure_does_not_burn_throttle(
+    monkeypatch, isolated_config_dir, fake_repo
+):
+    """A transient `git status` failure (Windows AV, index lock contention)
+    must not write the throttle stamp — otherwise the user is silently
+    locked out of updates for an hour after every hiccup."""
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+
+    # Make _git_status_ok report "git failed" (None) without dirtying tree.
+    monkeypatch.setattr(
+        "clawjournal.selfupdate._git_status_ok",
+        lambda repo: (None, "git-status-failed"),
+    )
+    spawned: list[Path] = []
+    _stub_spawn_ok(monkeypatch, spawned)
+
+    result = selfupdate.maybe_self_update()
+    assert result == "skip-git-status-failed"
+    assert spawned == []
+    assert not (isolated_config_dir / "last_update_check").exists()
+
+
+# ---------- state checks -----------------------------------------------------
+
+
+def test_dirty_tree_skips(monkeypatch, isolated_config_dir, fake_repo):
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+    (fake_repo / "README").write_text("dirty\n")
+
+    spawned: list[Path] = []
+    _stub_spawn_ok(monkeypatch, spawned)
+    assert selfupdate.maybe_self_update() == "dirty"
+    assert spawned == []
+
+
+def test_non_main_branch_skips(monkeypatch, isolated_config_dir, fake_repo):
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+    subprocess.run(
+        ["git", "-C", str(fake_repo), "checkout", "--quiet", "-b", "feature"],
+        check=True,
+    )
+
+    spawned: list[Path] = []
+    _stub_spawn_ok(monkeypatch, spawned)
+    assert selfupdate.maybe_self_update() == "branch-feature"
+    assert spawned == []
+
+
+def test_spawn_path_fires_for_clean_main_checkout(
+    monkeypatch, isolated_config_dir, fake_repo
+):
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+    spawned: list[Path] = []
+    _stub_spawn_ok(monkeypatch, spawned)
+    assert selfupdate.maybe_self_update() == "spawned"
+    assert spawned == [fake_repo]
+
+
+# ---------- concurrent invocations -------------------------------------------
+
+
+def test_concurrent_invocation_is_excluded_by_lock(
+    monkeypatch, isolated_config_dir, fake_repo
+):
+    """If a parallel CLI invocation already holds the lock, this one
+    must bail out as throttled and NOT spawn a second update."""
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+    lock = isolated_config_dir / "last_update_check.lock"
+    # Simulate a peer that just claimed the slot.
+    lock.write_bytes(b"")
+
+    spawned: list[Path] = []
+    _stub_spawn_ok(monkeypatch, spawned)
+    assert selfupdate.maybe_self_update() == "throttled"
+    assert spawned == []
+
+
+def test_stale_lock_is_reclaimed(monkeypatch, isolated_config_dir, fake_repo):
+    """A lock older than LOCK_STALE_SECONDS came from a crashed CLI —
+    the next invocation must adopt it instead of being permanently
+    stuck behind a dead peer."""
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+    lock = isolated_config_dir / "last_update_check.lock"
+    lock.write_bytes(b"")
+    very_old = time.time() - selfupdate.LOCK_STALE_SECONDS * 10
+    os.utime(lock, (very_old, very_old))
+
+    spawned: list[Path] = []
+    _stub_spawn_ok(monkeypatch, spawned)
+    assert selfupdate.maybe_self_update() == "spawned"
+    assert spawned == [fake_repo]
+
+
+def test_lock_younger_than_stale_window_blocks_reclaim(
+    monkeypatch, isolated_config_dir, fake_repo
+):
+    """A lock that's older than nothing (a real peer mid-spawn) must
+    block reclaim even though it's much younger than THROTTLE_SECONDS.
+    Confirms LOCK_STALE_SECONDS is the cutoff, not THROTTLE_SECONDS."""
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+    lock = isolated_config_dir / "last_update_check.lock"
+    lock.write_bytes(b"")
+    # 10 seconds old — peer just started a spawn. Well within
+    # LOCK_STALE_SECONDS (60s) but way under THROTTLE_SECONDS (3600s).
+    recent = time.time() - 10
+    os.utime(lock, (recent, recent))
+
+    spawned: list[Path] = []
+    _stub_spawn_ok(monkeypatch, spawned)
+    assert selfupdate.maybe_self_update() == "throttled"
+    assert spawned == []
+
+
+def test_stale_lock_reclaim_only_one_winner_under_contention(
+    monkeypatch, isolated_config_dir, fake_repo
+):
+    """Two threads simultaneously reclaim a stale lock — exactly one
+    must win. The os.link atomicity is what makes this safe; an
+    unlink-then-O_EXCL implementation would have let both proceed."""
+    import threading
+
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+    lock = isolated_config_dir / "last_update_check.lock"
+    lock.write_bytes(b"")
+    very_old = time.time() - selfupdate.LOCK_STALE_SECONDS * 10
+    os.utime(lock, (very_old, very_old))
+
+    spawned: list[Path] = []
+    spawn_lock = threading.Lock()
+
+    def fake_spawn(repo: Path) -> bool:
+        with spawn_lock:
+            spawned.append(repo)
+        # Hold the slot briefly so racers genuinely overlap.
+        time.sleep(0.05)
+        return True
+    monkeypatch.setattr("clawjournal.selfupdate._spawn_background_update", fake_spawn)
+
+    barrier = threading.Barrier(8)
+    results: list[str] = []
+    results_lock = threading.Lock()
+
+    def worker() -> None:
+        barrier.wait()
+        r = selfupdate.maybe_self_update()
+        with results_lock:
+            results.append(r)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    # Exactly one thread should have spawned; the rest must have
+    # bailed out as throttled.
+    assert results.count("spawned") == 1, results
+    assert len(spawned) == 1
+
+
+# ---------- spawn safety (no shell injection / path quoting) -----------------
+
+
+def test_spawn_handles_repo_path_with_spaces(monkeypatch, tmp_path, isolated_config_dir):
+    """A clone path like '~/code/foo bar/clawjournal' must not break the
+    fetch — historically shell=True with f-string interpolation would
+    have split this into separate args."""
+    repo = tmp_path / "weird path with spaces" / "repo"
+    _init_repo(repo)
+    monkeypatch.setattr("clawjournal.selfupdate._package_repo_root", lambda: repo)
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+
+    # Don't stub — actually invoke the real spawner. There's no remote
+    # configured so `git fetch` will fail in the background, but the
+    # important thing is that Popen accepts the command without raising
+    # and that maybe_self_update returns "spawned" not "spawn-failed".
+    result = selfupdate.maybe_self_update()
+    assert result == "spawned"
+
+
+def test_spawn_handles_repo_path_with_shell_metachars(
+    monkeypatch, tmp_path, isolated_config_dir
+):
+    """Repo paths containing shell metacharacters (`&`, `$`, `'`) would
+    break a shell=True spawn even with quoting. The python -c child
+    layer makes these safe by passing the path as argv."""
+    repo = tmp_path / "weird & path's $name" / "repo"
+    _init_repo(repo)
+    monkeypatch.setattr("clawjournal.selfupdate._package_repo_root", lambda: repo)
+    monkeypatch.delenv("CLAWJOURNAL_NO_AUTO_UPDATE", raising=False)
+
+    result = selfupdate.maybe_self_update()
+    assert result == "spawned"
+
+
+def test_background_update_skips_local_ahead_commit(
+    monkeypatch, isolated_config_dir, fake_repo, tmp_path
+):
+    """The silent child must not update over clean local commits."""
+    _wire_remote(fake_repo, tmp_path)
+    local_sha = _commit_file(fake_repo, "LOCAL", "local\n", "local ahead")
+
+    result = selfupdate._run_background_update(fake_repo)
+
+    assert result == 0
+    assert _head(fake_repo) == local_sha
+    assert (fake_repo / "LOCAL").exists()
+
+
+# ---------- selfupdate_sync --------------------------------------------------
+
+
+def _wire_remote(repo: Path, tmp_path: Path) -> Path:
+    remote = tmp_path / "remote.git"
+    subprocess.run(["git", "init", "--quiet", "--bare", str(remote)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "remote", "add", "origin", str(remote)],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "push", "--quiet", "origin", "main"],
+        check=True,
+    )
+    return remote
+
+
+def test_selfupdate_sync_reports_up_to_date(
+    monkeypatch, isolated_config_dir, fake_repo, tmp_path
+):
+    _wire_remote(fake_repo, tmp_path)
+    result = selfupdate.selfupdate_sync(repo=fake_repo, check_only=True)
+    assert result["status"] == "up-to-date"
+
+
+def test_selfupdate_sync_detects_behind(
+    monkeypatch, isolated_config_dir, fake_repo, tmp_path
+):
+    """If the remote has a newer commit, check_only reports 'behind'."""
+    remote = _wire_remote(fake_repo, tmp_path)
+
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "--quiet", str(remote), str(other)], check=True)
+    subprocess.run(["git", "-C", str(other), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(other), "config", "user.name", "t"], check=True)
+    (other / "NEW").write_text("new\n")
+    subprocess.run(["git", "-C", str(other), "add", "NEW"], check=True)
+    subprocess.run(
+        ["git", "-C", str(other), "commit", "--quiet", "-m", "upstream advance"],
+        check=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(other), "push", "--quiet", "origin", "main"], check=True
+    )
+
+    result = selfupdate.selfupdate_sync(repo=fake_repo, check_only=True)
+    assert result["status"] == "behind"
+    assert result["head"] != result["upstream"]
+
+
+def test_selfupdate_sync_applies_fast_forward(
+    monkeypatch, isolated_config_dir, fake_repo, tmp_path
+):
+    remote = _wire_remote(fake_repo, tmp_path)
+
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "--quiet", str(remote), str(other)], check=True)
+    subprocess.run(["git", "-C", str(other), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(other), "config", "user.name", "t"], check=True)
+    remote_sha = _commit_file(other, "NEW", "new\n", "upstream advance")
+    subprocess.run(
+        ["git", "-C", str(other), "push", "--quiet", "origin", "main"], check=True
+    )
+
+    result = selfupdate.selfupdate_sync(repo=fake_repo)
+
+    assert result["status"] == "updated"
+    assert _head(fake_repo) == remote_sha
+    assert (fake_repo / "NEW").exists()
+
+
+def test_selfupdate_sync_skips_local_ahead_without_resetting(
+    monkeypatch, isolated_config_dir, fake_repo, tmp_path
+):
+    _wire_remote(fake_repo, tmp_path)
+    local_sha = _commit_file(fake_repo, "LOCAL", "local\n", "local ahead")
+
+    result = selfupdate.selfupdate_sync(repo=fake_repo)
+
+    assert result["status"] == "ahead"
+    assert _head(fake_repo) == local_sha
+    assert (fake_repo / "LOCAL").exists()
+
+
+def test_selfupdate_sync_skips_diverged_without_resetting(
+    monkeypatch, isolated_config_dir, fake_repo, tmp_path
+):
+    remote = _wire_remote(fake_repo, tmp_path)
+
+    other = tmp_path / "other"
+    subprocess.run(["git", "clone", "--quiet", str(remote), str(other)], check=True)
+    subprocess.run(["git", "-C", str(other), "config", "user.email", "t@t"], check=True)
+    subprocess.run(["git", "-C", str(other), "config", "user.name", "t"], check=True)
+    _commit_file(other, "REMOTE", "remote\n", "remote advance")
+    subprocess.run(
+        ["git", "-C", str(other), "push", "--quiet", "origin", "main"], check=True
+    )
+
+    local_sha = _commit_file(fake_repo, "LOCAL", "local\n", "local ahead")
+
+    result = selfupdate.selfupdate_sync(repo=fake_repo)
+
+    assert result["status"] == "diverged"
+    assert _head(fake_repo) == local_sha
+    assert (fake_repo / "LOCAL").exists()
+    assert not (fake_repo / "REMOTE").exists()
+
+
+def test_selfupdate_sync_force_does_not_override_branch_guard(
+    monkeypatch, isolated_config_dir, fake_repo, tmp_path
+):
+    """--force overrides the dirty-tree check but MUST NOT silently
+    rewrite a feature branch to origin/main — that would discard the
+    user's commits without warning."""
+    _wire_remote(fake_repo, tmp_path)
+    subprocess.run(
+        ["git", "-C", str(fake_repo), "checkout", "--quiet", "-b", "feature"],
+        check=True,
+    )
+    (fake_repo / "FEATURE").write_text("wip\n")
+    subprocess.run(["git", "-C", str(fake_repo), "add", "FEATURE"], check=True)
+    subprocess.run(
+        ["git", "-C", str(fake_repo), "commit", "--quiet", "-m", "feature wip"],
+        check=True,
+    )
+    feature_sha = subprocess.run(
+        ["git", "-C", str(fake_repo), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    result = selfupdate.selfupdate_sync(repo=fake_repo, force=True)
+    assert result["status"] == "branch-feature"
+
+    # Confirm the feature commit is still there — nothing was reset.
+    after = subprocess.run(
+        ["git", "-C", str(fake_repo), "rev-parse", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert after == feature_sha
+
+
+def test_selfupdate_sync_force_overrides_dirty(
+    monkeypatch, isolated_config_dir, fake_repo, tmp_path
+):
+    """--force on main with a dirty tree should proceed (and discard
+    the WIP) — the user explicitly asked for it."""
+    _wire_remote(fake_repo, tmp_path)
+    (fake_repo / "README").write_text("uncommitted change\n")
+
+    result = selfupdate.selfupdate_sync(repo=fake_repo, force=True, check_only=True)
+    # Either up-to-date or behind — the key assertion is that we got
+    # past the dirty guard.
+    assert result["status"] in {"up-to-date", "behind"}
+
+
+def test_cli_selfupdate_command_skips_pre_parse_auto_update():
+    from clawjournal.cli import _should_auto_update
+
+    assert _should_auto_update(["clawjournal", "selfupdate", "--check"]) is False
+    assert _should_auto_update(["clawjournal", "status"]) is True
+
+
+def test_cli_should_auto_update_ignores_selfupdate_in_arg_values():
+    """The subcommand sits at the first non-flag position. Matching
+    'selfupdate' anywhere in argv used to suppress auto-update for
+    legitimate commands like `export --output ./selfupdate` or notes
+    that contain the word."""
+    from clawjournal.cli import _should_auto_update
+
+    # 'selfupdate' as an option value, not the subcommand.
+    assert _should_auto_update(
+        ["clawjournal", "export", "--output", "./selfupdate"]
+    ) is True
+    # 'selfupdate' as part of a positional that comes after the real
+    # subcommand.
+    assert _should_auto_update(
+        ["clawjournal", "note", "add", "ran selfupdate"]
+    ) is True
+    # No args at all -> default export path -> auto-update fires.
+    assert _should_auto_update(["clawjournal"]) is True
+
+
+def test_cli_should_auto_update_skips_help_and_version():
+    """argparse prints and exits in milliseconds for -h/--help/--version;
+    a background fetch is wasted work."""
+    from clawjournal.cli import _should_auto_update
+
+    assert _should_auto_update(["clawjournal", "-h"]) is False
+    assert _should_auto_update(["clawjournal", "--help"]) is False
+    assert _should_auto_update(["clawjournal", "--version"]) is False
+    # But -h paired with a real subcommand still updates — the user is
+    # asking for subcommand help and may proceed to run it.
+    assert _should_auto_update(["clawjournal", "scan", "--help"]) is True


### PR DESCRIPTION
## Summary

- Every CLI invocation runs a silent, throttled (once/hour), background `git fetch && git merge --ff-only` from `rayward-external/clawjournal:main` so PhD-student contributors who never re-run the installer still end up on the latest code.
- Adds `clawjournal selfupdate [--check] [--force] [--json]` for an explicit synchronous update path. `--force` only overrides the dirty-tree guard, never the branch / local-commits / diverged guards — fast-forwards only.
- Swaps the canonical repo URL from `kai-rayward/clawjournal` to `rayward-external/clawjournal` across README, install scripts, plugin manifest, SKILL.md, and `pyproject`.

## Design highlights

- **Silent on the happy path.** Detached `python -c` child (POSIX `setsid` / Windows `DETACHED_PROCESS`); parent returns instantly. `stdout`/`stderr` are `DEVNULL`. Debug-only logging gated by `CLAWJOURNAL_AUTO_UPDATE_DEBUG=1`.
- **Cannot clobber WIP.** Guards skip when: opt-out env (`CLAWJOURNAL_NO_AUTO_UPDATE=1`), not a git checkout (wheel install), no `~/.clawjournal/` yet (fresh install), dirty tree, non-`main` branch, local-only commits, diverged history. The child re-runs every check post-fetch and only applies via `git merge --ff-only`.
- **Race-safe.** O_EXCL sidecar lock with atomic `os.link` stale-reclaim (60s window). Throttle stamp is written *before* the network call so a hung remote can't loop.
- **Clock-skew safe.** Negative deltas are treated as not-fresh, so a backward NTP step doesn't lock users out.
- **No shell.** `python -c` child + list-form argv — repo paths with spaces, `&`, `$`, quotes are all safe.

## Test plan

- [x] `pytest tests/test_selfupdate.py` — 27 unit tests covering opt-out, throttle, clock-skew, stale-lock reclaim under 8-thread contention, transient `git status` failure, dirty/non-main/local-ahead/diverged guards, `--force` semantics, help/version skip, and shell-metachar paths.
- [x] Full suite: 1797 passing on the rebased branch.
- [ ] Reviewer: install on a fresh machine, run `clawjournal status` twice within 5 seconds — second invocation should hit the throttle (verify with `CLAWJOURNAL_AUTO_UPDATE_DEBUG=1`).
- [ ] Reviewer: run `clawjournal selfupdate --check` on a clean checkout — should print `Already up to date` or `Update available: <sha> -> <sha>`.
- [ ] Reviewer: run on a feature branch — should print `Skipped: not on the main branch`.
- [ ] Reviewer: \`clawjournal -h\` should NOT trigger a background fetch (verify lock file absent in `~/.clawjournal/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)