### PR TITLE
Implement failure-value scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,15 +305,16 @@ AI-assisted scoring now records two labels in one pass: a legacy productivity sc
 
 **Just say to your AI:** *"Score my unscored ClawJournal sessions and auto-block the noise."*
 
-The agent batches the scoring over the v1 failure-source scope (`claude`, `codex`, `opencode`, `openclaw`). Productivity-1 sessions get auto-blocked when `--auto-triage` is set; high failure-value sessions stay visible for review and sharing.
+The agent batches the scoring over the v1 failure-source scope (`claude`, `codex`, `opencode`, `openclaw`). Productivity-1 sessions get auto-blocked when `--auto-triage` is set only if failure value is 1-2; failure value 3+ stays visible for review and sharing.
 
 <details>
 <summary><b>Show shell commands</b></summary>
 
 ```bash
-clawjournal score --batch --source failure-v1 --auto-triage  # score failure-value scope; auto-block productivity-1 noise
+clawjournal score --batch --source failure-v1 --auto-triage  # score failure-value scope; auto-block low-value productivity-1 noise
 clawjournal score-view <id>                          # show score details
-clawjournal set-score <id> --quality 4               # manual productivity override
+clawjournal set-score <id> --failure-value 4 --failure-evidence "User corrected a fabricated API call"
+clawjournal set-score <id> --quality 4               # legacy productivity override
 ```
 
 By default scoring uses the current agent's automation CLI (e.g. `codex exec` inside Codex, the Claude CLI inside Claude Code). Use `--backend` to override. For Codex specifically, `codex exec` reuses saved CLI authentication by default; for automation the recommended explicit credential is `CODEX_API_KEY`.
@@ -453,7 +454,7 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal serve` | Open workbench UI at localhost:8384 |
 | `clawjournal config --source all` | Select source scope (required) |
 | `clawjournal config --confirm-projects` | Confirm project selection (required before export) |
-| `clawjournal score --batch --source failure-v1 --auto-triage` | AI-score failure-value scope; auto-block productivity-1 noise |
+| `clawjournal score --batch --source failure-v1 --auto-triage` | AI-score failure-value scope; auto-block low-value productivity-1 noise |
 | `clawjournal bundle-create --status approved` | Bundle approved sessions |
 | `clawjournal bundle-export <bundle_id>` | Export bundle to disk as `sessions.jsonl` + `manifest.json` |
 
@@ -468,6 +469,7 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal shortlist <id> [id ...]` | Shortlist sessions |
 | `clawjournal score --batch --source failure-v1 --limit 20` | AI-score up to 20 in-scope sessions |
 | `clawjournal score-view <id>` | View score details |
+| `clawjournal set-score <id> --failure-value <1-5>` | Manually set the failure-value score; 4-5 requires `--failure-evidence` |
 | `clawjournal set-score <id> --quality <1-5>` | Manually set the legacy productivity score |
 
 ### Hold-state gate

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -1244,6 +1244,7 @@ def _run_inbox(
                 "outcome_badge": s.get("outcome_badge"),
                 "value_badges": value_badges,
                 "risk_badges": risk_badges,
+                "ai_failure_value_score": s.get("ai_failure_value_score"),
                 "ai_quality_score": s.get("ai_quality_score"),
                 "ai_score_reason": s.get("ai_score_reason"),
                 "review_status": s.get("review_status", "new"),
@@ -1993,7 +1994,7 @@ def _run_insights(args) -> None:
         if summary.get("most_efficient_model"):
             print(f"  Most efficient: {summary['most_efficient_model']}")
         if summary.get("highest_quality_model"):
-            print(f"  Highest quality: {summary['highest_quality_model']}")
+            print(f"  Highest productivity: {summary['highest_quality_model']}")
         savings = summary.get("potential_savings_usd", 0)
         if savings > 0:
             print(f"  Potential savings: {format_cost(savings)}/period")
@@ -2136,6 +2137,7 @@ def _extract_tool_uses(msg: dict) -> list[dict]:
 
 def _run_score_view(args) -> None:
     """Show condensed session view for AI scoring."""
+    from .scoring.overrides import failure_evidence_from_detail
     from .workbench.index import get_session_detail, open_index, query_sessions
 
     conn = open_index()
@@ -2269,11 +2271,48 @@ def _run_score_view(args) -> None:
 
         value_str = ", ".join(value_badges) if value_badges else "(none)"
         risk_str = ", ".join(risk_badges) if risk_badges else "(none)"
+        failure_score = detail.get("ai_failure_value_score")
+        quality_score = detail.get("ai_quality_score")
+        failure_modes = detail.get("ai_failure_modes", [])
+        if isinstance(failure_modes, str):
+            try:
+                failure_modes = json.loads(failure_modes)
+            except (json.JSONDecodeError, ValueError):
+                failure_modes = []
+        recovery_labels = detail.get("ai_recovery_labels", [])
+        if isinstance(recovery_labels, str):
+            try:
+                recovery_labels = json.loads(recovery_labels)
+            except (json.JSONDecodeError, ValueError):
+                recovery_labels = []
+        failure_attribution = detail.get("ai_failure_attribution")
+        learning_summary = detail.get("ai_learning_summary")
+        score_reason = detail.get("ai_score_reason")
+        failure_evidence = failure_evidence_from_detail(
+            detail.get("ai_scoring_detail")
+        )
 
         print(f"Session: {sid}")
         print(f"Source: {source} | Model: {model} | Project: {project}")
         print(f"Duration: {duration} | Tokens: {input_tok} in / {output_tok} out | Messages: {user_msgs} user / {asst_msgs} asst")
         print(f"Task type: {task_type} | Outcome: {outcome}")
+        failure_display = f"{failure_score}/5" if failure_score else "(unscored)"
+        productivity_display = f"{quality_score}/5" if quality_score else "(unscored)"
+        print(f"Failure value: {failure_display} | Productivity: {productivity_display}")
+        if failure_attribution:
+            print(f"Attribution: {failure_attribution}")
+        if failure_modes:
+            print(f"Failure modes: {', '.join(failure_modes)}")
+        if recovery_labels:
+            print(f"Recovery: {', '.join(recovery_labels)}")
+        if learning_summary:
+            print(f"Lesson: {learning_summary}")
+        elif score_reason:
+            print(f"Reason: {score_reason}")
+        if failure_evidence:
+            print("Evidence:")
+            for snippet in failure_evidence[:3]:
+                print(f"- {_truncate(snippet, 160)}")
         print(f"Value: {value_str} | Risk: {risk_str} | Sensitivity: {sensitivity}")
         print()
 
@@ -2354,35 +2393,97 @@ def _run_score_view(args) -> None:
 
 
 def _run_set_score(args) -> None:
-    """Record AI quality score for one or more sessions."""
-    from .workbench.index import open_index, update_session
+    """Record manual score overrides for one or more sessions."""
+    from .scoring.overrides import (
+        failure_evidence_from_detail,
+        merge_failure_evidence,
+        normalize_failure_evidence,
+        requires_failure_evidence,
+    )
+    from .workbench.index import get_session_detail, open_index, update_session
 
     session_ids = args.session_ids
     quality = args.quality
+    failure_value = args.failure_value
     reason = args.reason
+    failure_evidence = normalize_failure_evidence(
+        getattr(args, "failure_evidence", None)
+    )
 
     if not session_ids:
         print(json.dumps({"error": "No session IDs provided."}))
         sys.exit(1)
+    if quality is None and failure_value is None:
+        print(json.dumps({"error": "Provide --failure-value, --quality, or both."}))
+        sys.exit(1)
+    if failure_evidence and failure_value is None:
+        print(json.dumps({"error": "Provide --failure-value with --failure-evidence."}))
+        sys.exit(1)
 
     conn = open_index()
+    details: dict[str, dict[str, Any] | None] = {}
+    if requires_failure_evidence(failure_value):
+        missing_evidence: list[str] = []
+        for sid in session_ids:
+            detail = get_session_detail(conn, sid)
+            details[sid] = detail
+            if detail is None:
+                continue
+            existing_evidence = failure_evidence_from_detail(
+                detail.get("ai_scoring_detail")
+            )
+            if not failure_evidence and not existing_evidence:
+                missing_evidence.append(sid)
+        if missing_evidence:
+            conn.close()
+            print(json.dumps({
+                "error": "Failure-value 4-5 overrides require --failure-evidence.",
+                "session_ids": missing_evidence,
+            }))
+            sys.exit(1)
+
     results = []
     for sid in session_ids:
+        detail = details.get(sid)
+        if failure_evidence and sid not in details:
+            detail = get_session_detail(conn, sid)
+        updates: dict[str, Any] = {}
+        result: dict[str, Any] = {"session_id": sid}
+        if quality is not None:
+            updates["ai_quality_score"] = quality
+            result["ai_quality_score"] = quality
+        if failure_value is not None:
+            updates["ai_failure_value_score"] = failure_value
+            result["ai_failure_value_score"] = failure_value
+        if reason is not None:
+            updates["ai_score_reason"] = reason
+        if failure_evidence:
+            updates["ai_scoring_detail"] = merge_failure_evidence(
+                detail.get("ai_scoring_detail") if detail else None,
+                failure_evidence,
+            )
+            result["ai_failure_evidence"] = failure_evidence
         ok = update_session(
             conn, sid,
-            ai_quality_score=quality,
-            ai_score_reason=reason,
+            **updates,
         )
-        results.append({"session_id": sid, "ai_quality_score": quality, "ok": ok})
+        result["ok"] = ok
+        results.append(result)
     conn.close()
 
     success = sum(1 for r in results if r["ok"])
-    print(json.dumps({
+    payload: dict[str, Any] = {
         "action": "set-score",
         "updated": success,
-        "quality": quality,
         "results": results,
-    }, indent=2))
+    }
+    if failure_value is not None:
+        payload["failure_value"] = failure_value
+    if failure_evidence:
+        payload["failure_evidence"] = failure_evidence
+    if quality is not None:
+        payload["quality"] = quality
+    print(json.dumps(payload, indent=2))
 
 
 def _run_score_batch(args) -> None:
@@ -2602,6 +2703,16 @@ def _score_single_session(
     }
 
 
+def _is_auto_triage_noise(result: dict[str, Any]) -> bool:
+    """Return True when auto-triage should block a scored noise session."""
+    failure_value = result.get("ai_failure_value_score")
+    return (
+        result.get("ai_quality_score") == 1
+        and isinstance(failure_value, int)
+        and failure_value <= 2
+    )
+
+
 def _run_score(args) -> None:
     """Score sessions using the current agent's automation CLI or an explicit backend."""
     from .workbench.index import open_index, query_unscored_sessions, update_session
@@ -2632,9 +2743,9 @@ def _run_score(args) -> None:
             results.append(result)
             if result.get("ai_quality_score"):
                 failure = result.get("ai_failure_value_score")
-                failure_suffix = f", failure {failure}/5" if failure is not None else ""
+                failure_prefix = f"failure {failure}/5; " if failure is not None else ""
                 print(
-                    f"  -> quality {result['ai_quality_score']}/5{failure_suffix}: "
+                    f"  -> {failure_prefix}productivity {result['ai_quality_score']}/5: "
                     f"{result.get('reason', '')[:100]}",
                     file=sys.stderr,
                 )
@@ -2673,15 +2784,28 @@ def _run_score(args) -> None:
                     "none_1": sum(1 for q in failure_scores if q == 1),
                 }
 
-        # Auto-triage: archive noise (substance=1), leave everything else visible
+        # Auto-triage: archive productivity noise, but keep high failure-value
+        # traces visible even when the legacy productivity score is low.
         if auto_triage and scored and not dry_run:
-            noise_ids = [r["session_id"] for r in scored if r["ai_quality_score"] == 1]
+            noise_ids = [
+                r["session_id"]
+                for r in scored
+                if _is_auto_triage_noise(r)
+            ]
             triage = {"archived": 0, "visible": 0}
             if noise_ids:
                 for sid in noise_ids:
-                    update_session(conn, sid, status="blocked", reason="Auto-triage: noise session (productivity 1)")
+                    update_session(
+                        conn, sid,
+                        status="blocked",
+                        reason="Auto-triage: noise session (productivity 1, failure value 1-2)",
+                    )
                 triage["archived"] = len(noise_ids)
-                print(f"  Auto-archived {len(noise_ids)} noise sessions (productivity 1)", file=sys.stderr)
+                print(
+                    f"  Auto-archived {len(noise_ids)} noise sessions "
+                    "(productivity 1, failure value 1-2)",
+                    file=sys.stderr,
+                )
             triage["visible"] = len(scored) - len(noise_ids)
             summary["auto_triage"] = triage
 
@@ -2772,9 +2896,9 @@ def _run_rescore(args) -> None:
         results.append(result)
         if result.get("ai_quality_score"):
             failure = result.get("ai_failure_value_score")
-            failure_suffix = f", failure {failure}/5" if failure is not None else ""
+            failure_prefix = f"failure {failure}/5; " if failure is not None else ""
             print(
-                f"  -> quality {result['ai_quality_score']}/5{failure_suffix}: "
+                f"  -> {failure_prefix}productivity {result['ai_quality_score']}/5: "
                 f"{result.get('reason', '')[:100]}",
                 file=sys.stderr,
             )
@@ -3018,6 +3142,7 @@ def _run_recent(args: argparse.Namespace) -> None:
                 "source": s.get("source", ""),
                 "model": s.get("model"),
                 "duration_seconds": s.get("duration_seconds"),
+                "ai_failure_value_score": s.get("ai_failure_value_score"),
                 "ai_quality_score": s.get("ai_quality_score"),
                 "outcome_badge": s.get("outcome_badge"),
                 "start_time": s.get("start_time"),
@@ -3048,8 +3173,8 @@ def _run_recent(args: argparse.Namespace) -> None:
             dur_str = f"{dur // 60} min" if dur >= 60 else f"{dur}s"
         else:
             dur_str = ""
-        score = s.get("ai_quality_score")
-        score_str = f" · {score}/5" if score else ""
+        failure_score = s.get("ai_failure_value_score")
+        score_str = f" · FV {failure_score}/5" if failure_score else ""
         outcome = s.get("outcome_badge") or ""
         sid = s.get("session_id", "")
 
@@ -3793,9 +3918,16 @@ def main() -> None:
     sv.add_argument("--offset", type=int, default=0, help="Offset for batch")
     sv.add_argument("--source", choices=WORKBENCH_SOURCE_CHOICES, default=None)
 
-    ss = sub.add_parser("set-score", help="Record AI quality score for sessions")
+    ss = sub.add_parser("set-score", help="Record manual AI score overrides for sessions")
     ss.add_argument("session_ids", nargs="+", help="Session IDs")
-    ss.add_argument("--quality", type=int, required=True, choices=range(1, 6), help="Quality 1-5")
+    ss.add_argument("--failure-value", type=int, choices=range(1, 6), help="Failure value 1-5")
+    ss.add_argument(
+        "--failure-evidence",
+        action="append",
+        default=[],
+        help="Trace-backed evidence for manual failure-value 4-5 overrides; repeat for multiple snippets",
+    )
+    ss.add_argument("--quality", type=int, choices=range(1, 6), help="Legacy productivity quality 1-5")
     ss.add_argument("--reason", type=str, default=None, help="Reason for the score")
 
     sb = sub.add_parser("score-batch", help="List unscored sessions for AI scoring")

--- a/clawjournal/prompts/agents/scoring/rubric.md
+++ b/clawjournal/prompts/agents/scoring/rubric.md
@@ -50,8 +50,10 @@ Emit both `substance` and `ai_quality_score` with the same value.
 This is the primary score for failure-corpus capture. It answers: "how valuable
 is this trace for understanding and improving agent failure behavior?"
 
-5 = Clear, consequential SOTA-agent failure on real expert work, strong
-evidence, useful lesson.
+5 = Canonical high-value trace: consequential failure or recovery pattern on
+real expert work, where the agent's behavior is the lesson. Strong evidence
+and a reusable insight for evals, training, product design, or agent behavior
+analysis. Attribution may be agent-caused or non-agent-caused.
 4 = Meaningful failure or recovery pattern worth reviewing or turning into eval
 or training data.
 3 = Some failure signal, but ambiguous, minor, repeated, or mostly
@@ -61,8 +63,13 @@ environmental.
 or noise.
 
 A resolved session can be a 5 if it contains a valuable failure and recovery
-pattern. A failed session is not automatically valuable; it needs attributable,
-evidence-backed failure behavior.
+pattern. 5/5 does not require `agent_caused`; the teaching moment matters, not
+the source of the failure. A failed session is not automatically valuable; it
+needs attributable, evidence-backed failure behavior.
+
+Scores of 4 or 5 require at least one `ai_failure_evidence` snippet. If no
+snippet can be quoted or paraphrased from the trace, cap the failure-value score
+at 3.
 
 For multi-failure sessions, score by the highest single teaching moment, emit
 all applicable modes and recovery labels, and set attribution to the dominant
@@ -588,6 +595,8 @@ Before finalizing labels, confirm:
   agent's summary.
 - Each label is backed by concrete evidence (in `ai_failure_evidence`).
 - Your evidence quotes actually demonstrate the failure (not adjacent text).
+- If `ai_failure_value_score` is 4 or 5, `ai_failure_evidence` contains at
+  least one trace-backed snippet.
 - You did not infer a deep cause when the trace only supports a surface signal.
 - You considered whether an apparent failure is actually
   `evaluation_measurement` (eval artifact rather than agent behavior).

--- a/clawjournal/prompts/agents/scoring/rubric.md
+++ b/clawjournal/prompts/agents/scoring/rubric.md
@@ -50,22 +50,27 @@ Emit both `substance` and `ai_quality_score` with the same value.
 This is the primary score for failure-corpus capture. It answers: "how valuable
 is this trace for understanding and improving agent failure behavior?"
 
-5 = Canonical high-value trace: consequential failure or recovery pattern on
-real expert work, where the agent's behavior is the lesson. Strong evidence
-and a reusable insight for evals, training, product design, or agent behavior
+This is not a quality score, severity score, or user-satisfaction score. Rank
+the trace by the clearest trace-backed teaching moment.
+
+5 = Canonical failure trace: consequential, evidence-rich failure or recovery
+pattern on real expert work, where the agent's behavior is the lesson. Strong
+reusable insight for evals, training, product design, or agent behavior
 analysis. Attribution may be agent-caused or non-agent-caused.
-4 = Meaningful failure or recovery pattern worth reviewing or turning into eval
-or training data.
-3 = Some failure signal, but ambiguous, minor, repeated, or mostly
-environmental.
-2 = Weak signal: routine retry, expected debugging, or unclear attribution.
+4 = Strong pattern: meaningful trace-backed agent failure or recovery behavior
+worth reviewing and likely worth turning into eval or training data.
+3 = Usable signal: real failure signal, but minor, ambiguous, repeated, mostly
+environmental, or only partly attributable.
+2 = Weak signal: routine retry, expected debugging, unclear attribution, or
+little reusable lesson.
 1 = No useful failure signal: smooth success, trivial session, control sample,
 or noise.
 
 A resolved session can be a 5 if it contains a valuable failure and recovery
 pattern. 5/5 does not require `agent_caused`; the teaching moment matters, not
-the source of the failure. A failed session is not automatically valuable; it
-needs attributable, evidence-backed failure behavior.
+the source of the failure. A failed or blocked session is not automatically
+valuable; score by visible agent behavior, evidence clarity, consequence,
+recovery signal, and reusable lesson.
 
 Scores of 4 or 5 require at least one `ai_failure_evidence` snippet. If no
 snippet can be quoted or paraphrased from the trace, cap the failure-value score

--- a/clawjournal/scoring/insights.py
+++ b/clawjournal/scoring/insights.py
@@ -50,7 +50,7 @@ def collect_advisor_stats(
     # export path already filters them at `cli.py:479`; mirror that here.
     # Same-model traffic at different reasoning-effort tiers (e.g.
     # `gpt-5.4 @ high` vs `gpt-5.4 @ xhigh`) is split into separate rows
-    # so "Most efficient" and "Highest quality" picks a specific tier.
+    # so "Most efficient" and "Highest productivity" picks a specific tier.
     # Numerator matches the normalized `resolved` bucket in
     # workbench.index (AI `resolved` or heuristic `tests_passed`).
     # Dropping heuristic `completed` from the success set — it's the
@@ -289,9 +289,9 @@ def generate_recommendations(stats: dict[str, Any]) -> dict[str, Any]:
                 recommendations.append({
                     "type": "high_roi",
                     "priority": "low",
-                    "title": f"{best['type'].title()} work has the best quality score",
+                    "title": f"{best['type'].title()} work has the best productivity score",
                     "detail": (
-                        f"{best['type'].title()} sessions: {best['avg_score']:.1f}/5 avg score "
+                        f"{best['type'].title()} sessions: {best['avg_score']:.1f}/5 avg productivity "
                         f"at {format_cost(best['cost'])} total cost ({best['sessions']} sessions)."
                     ),
                 })
@@ -307,9 +307,9 @@ def generate_recommendations(stats: dict[str, Any]) -> dict[str, Any]:
                 recommendations.append({
                     "type": "model_comparison",
                     "priority": "low",
-                    "title": "Model quality vs cost trade-off",
+                    "title": "Model productivity vs cost trade-off",
                     "detail": (
-                        f"Highest quality: {best_quality['model']} ({best_quality['avg_score']:.1f}/5 avg, "
+                        f"Highest productivity: {best_quality['model']} ({best_quality['avg_score']:.1f}/5 avg, "
                         f"{format_cost(best_quality['cost'])} total). "
                         f"Most cost-effective: {cheapest['model']} "
                         f"({cheapest['avg_score']:.1f}/5 avg, "

--- a/clawjournal/scoring/overrides.py
+++ b/clawjournal/scoring/overrides.py
@@ -1,0 +1,69 @@
+"""Helpers for manual scoring overrides."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+
+def normalize_failure_evidence(value: Any) -> list[str]:
+    """Return non-empty failure-evidence snippets from a string or sequence."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        candidates: list[Any] = [value]
+    elif isinstance(value, (list, tuple)):
+        candidates = list(value)
+    else:
+        return []
+
+    snippets: list[str] = []
+    seen: set[str] = set()
+    for item in candidates:
+        if not isinstance(item, str):
+            continue
+        snippet = item.strip()
+        if not snippet or snippet in seen:
+            continue
+        snippets.append(snippet)
+        seen.add(snippet)
+    return snippets
+
+
+def parse_scoring_detail(raw: Any) -> dict[str, Any]:
+    """Parse an ``ai_scoring_detail`` payload into a mutable dict."""
+    if isinstance(raw, dict):
+        return dict(raw)
+    if isinstance(raw, str) and raw.strip():
+        try:
+            parsed = json.loads(raw)
+        except (json.JSONDecodeError, ValueError):
+            return {}
+        if isinstance(parsed, dict):
+            return dict(parsed)
+    return {}
+
+
+def failure_evidence_from_detail(raw: Any) -> list[str]:
+    """Extract normalized ``ai_failure_evidence`` from scoring detail."""
+    detail = parse_scoring_detail(raw)
+    return normalize_failure_evidence(detail.get("ai_failure_evidence"))
+
+
+def merge_failure_evidence(raw: Any, evidence: list[str]) -> str:
+    """Merge failure evidence into scoring detail and serialize it."""
+    detail = parse_scoring_detail(raw)
+    merged = normalize_failure_evidence(
+        [*failure_evidence_from_detail(detail), *evidence]
+    )
+    if merged:
+        detail["ai_failure_evidence"] = merged
+    return json.dumps(detail, sort_keys=True)
+
+
+def requires_failure_evidence(score: Any) -> bool:
+    """Return whether a failure-value score requires evidence."""
+    try:
+        return int(score) >= 4
+    except (TypeError, ValueError):
+        return False

--- a/clawjournal/scoring/scoring.py
+++ b/clawjournal/scoring/scoring.py
@@ -1087,6 +1087,8 @@ def _validate_judge_result(result: dict) -> dict:
         _VALID_META_LABELS,
     )
     failure_evidence = _validate_bounded_string_list(result.get("ai_failure_evidence", []))
+    if failure_value_score is not None and failure_value_score >= 4 and not failure_evidence:
+        failure_value_score = 3
 
     learning_summary = result.get("ai_learning_summary", "")
     if not isinstance(learning_summary, str):

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -104,7 +104,7 @@ export const api = {
       return request(`/sessions/${encodeURIComponent(id)}/redaction-report${q}`);
     },
 
-    update(id: string, body: { status?: string; notes?: string; reason?: string; ai_quality_score?: number; ai_score_reason?: string; ai_failure_value_score?: number; ai_recovery_labels?: string[]; ai_failure_attribution?: string; ai_failure_modes?: string[]; ai_learning_summary?: string; hold_state?: HoldState; embargo_until?: string | null }): Promise<{ ok: boolean }> {
+    update(id: string, body: { status?: string; notes?: string; reason?: string; ai_quality_score?: number; ai_score_reason?: string; ai_failure_value_score?: number; ai_failure_evidence?: string[]; ai_recovery_labels?: string[]; ai_failure_attribution?: string; ai_failure_modes?: string[]; ai_learning_summary?: string; hold_state?: HoldState; embargo_until?: string | null }): Promise<{ ok: boolean }> {
       return request(`/sessions/${encodeURIComponent(id)}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
@@ -160,7 +160,7 @@ export const api = {
     return request(`/dashboard${qs(params)}`);
   },
 
-  highlights(params: { days?: number; top?: number; min_quality?: number } = {}): Promise<HighlightsData> {
+  highlights(params: { days?: number; top?: number; min_quality?: number; min_failure_value?: number } = {}): Promise<HighlightsData> {
     return request(`/dashboard/highlights${qs(params)}`);
   },
 

--- a/clawjournal/web/frontend/src/components/FilterBar.tsx
+++ b/clawjournal/web/frontend/src/components/FilterBar.tsx
@@ -76,10 +76,10 @@ export function FilterBar({ filters, onChange }: FilterBarProps) {
         <option value="start_time:desc">Newest first</option>
         <option value="start_time:asc">Oldest first</option>
         <option value="ai_failure_value_score:desc">Top failures</option>
+        <option value="ai_quality_score:desc">Highest productivity</option>
         <option value="sensitivity_score:desc">Highest risk</option>
         <option value="input_tokens:desc">Most tokens</option>
         <option value="tool_uses:desc">Most tool use</option>
-        <option value="ai_quality_score:desc">Highest productivity</option>
       </select>
 
       <select

--- a/clawjournal/web/frontend/src/components/TraceCard.tsx
+++ b/clawjournal/web/frontend/src/components/TraceCard.tsx
@@ -49,12 +49,6 @@ interface TraceCardProps {
   quickActionMode?: 'full' | 'share';
 }
 
-function scoreStyle(score: number): { background: string; color: string } {
-  if (score >= 4) return { background: '#dcfce7', color: '#166534' };
-  if (score === 3) return { background: '#fef3c7', color: '#92400e' };
-  return { background: '#fee2e2', color: '#991b1b' };
-}
-
 export function TraceCard({
   session,
   selected = false,
@@ -125,22 +119,6 @@ export function TraceCard({
           <span style={{ fontWeight: 600, fontSize: 15, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
             {session.display_title}
           </span>
-          {session.ai_quality_score != null && (
-            <span style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              width: 22,
-              height: 22,
-              borderRadius: '50%',
-              fontSize: 12,
-              fontWeight: 700,
-              flexShrink: 0,
-              ...scoreStyle(session.ai_quality_score),
-            }}>
-              {session.ai_quality_score}
-            </span>
-          )}
           {session.ai_failure_value_score != null && (
             <span style={{
               display: 'inline-flex',
@@ -155,6 +133,25 @@ export function TraceCard({
               flexShrink: 0,
             }}>
               {session.ai_failure_value_score} failure value
+            </span>
+          )}
+          {session.ai_quality_score != null && (
+            <span
+              title="Legacy productivity score"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '2px 6px',
+                borderRadius: 9999,
+                fontSize: 11,
+                fontWeight: 600,
+                color: '#6b7280',
+                background: '#f3f4f6',
+                flexShrink: 0,
+              }}
+            >
+              P {session.ai_quality_score}/5
             </span>
           )}
           <span style={{ fontSize: 12, color: '#9ca3af', flexShrink: 0 }}>

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -304,7 +304,7 @@ export interface InsightsFocusRow {
 export interface InsightsModelEffectivenessRow {
   model: string;
   sessions: number;
-  avg_score: number;
+  avg_failure_value_score: number;
   resolve_rate: number;
   avg_cost: number;
   total_cost: number;
@@ -332,6 +332,7 @@ export interface InsightsDurationVsScoreRow {
   session_id: string;
   duration_seconds: number;
   ai_quality_score: number;
+  ai_failure_value_score: number | null;
   resolution: string | null;
   cost: number | null;
 }
@@ -346,6 +347,7 @@ export interface HighlightItem {
   end_time: string | null;
   duration_seconds: number | null;
   ai_quality_score: number | null;
+  ai_failure_value_score: number | null;
   ai_effort_estimate: number | null;
   outcome: string | null;
   summary_teaser: string;
@@ -356,6 +358,7 @@ export interface HighlightsData {
   highlights: HighlightItem[];
   window_days: number;
   min_quality: number;
+  min_failure_value?: number;
   candidate_count: number;
 }
 

--- a/clawjournal/web/frontend/src/views/Dashboard.tsx
+++ b/clawjournal/web/frontend/src/views/Dashboard.tsx
@@ -103,8 +103,9 @@ interface TriageStats {
   by_status: Record<string, number>;
 }
 
-const SCORE_COLORS = ['', colors.red400, colors.yellow400, colors.gray400, colors.blue400, colors.green400];
-const SCORE_LABELS = ['', 'Noise', 'Minimal', 'Light', 'Solid', 'Major'];
+const SCORE_COLORS = ['', colors.gray400, colors.yellow400, colors.blue400, colors.red400, colors.red500];
+const SCORE_LABELS = ['', 'No signal', 'Weak signal', 'Usable signal', 'Strong pattern', 'Canonical'];
+const PRODUCTIVITY_COLORS = ['', colors.red400, colors.yellow400, colors.gray400, colors.blue400, colors.green400];
 
 // Keep as many trailing dash-segments as fit in the label column; full id stays in the hover title.
 // Path separators and dashes-inside-folder-names look identical here, so we err on the side of
@@ -205,7 +206,7 @@ export function Dashboard() {
 
   if (!data) return null;
 
-  const { summary, weekly_activity, by_outcome_label, by_value_label, by_risk_level, by_task_type, by_model, by_agent, tokens_by_source, by_quality_score, unscored_count, resolve_rate, resolve_rate_previous, read_edit_ratio, top_tools, avg_interrupts } = data;
+  const { summary, weekly_activity, by_outcome_label, by_value_label, by_risk_level, by_task_type, by_model, by_agent, tokens_by_source, by_quality_score, by_failure_value_score = [], resolve_rate, resolve_rate_previous, read_edit_ratio, top_tools, avg_interrupts } = data;
 
   // Sort outcomes by count descending
   const sortedOutcomes = [...by_outcome_label].sort((a, b) => b.count - a.count);
@@ -227,12 +228,20 @@ export function Dashboard() {
   const approved = triage?.by_status['approved'] ?? 0;
   const skipped = triage?.by_status['blocked'] ?? 0;
 
-  // Quality score stats
-  const totalScored = by_quality_score.reduce((s, q) => s + q.count, 0);
-  const qualityMax = Math.max(...by_quality_score.map(q => q.count), 0);
-  const avgScore = totalScored > 0
-    ? (by_quality_score.reduce((s, q) => s + q.score * q.count, 0) / totalScored).toFixed(1)
+  const totalProductivityScored = by_quality_score.reduce((s, q) => s + q.count, 0);
+  const productivityMax = Math.max(...by_quality_score.map(q => q.count), 0);
+  const avgProductivity = totalProductivityScored > 0
+    ? (by_quality_score.reduce((s, q) => s + q.score * q.count, 0) / totalProductivityScored).toFixed(1)
     : null;
+  const productivityUnscored = Math.max(0, summary.total_sessions - totalProductivityScored);
+
+  // Failure-value score stats
+  const totalFailureScored = by_failure_value_score.reduce((s, q) => s + q.count, 0);
+  const failureMax = Math.max(...by_failure_value_score.map(q => q.count), 0);
+  const avgFailureValue = totalFailureScored > 0
+    ? (by_failure_value_score.reduce((s, q) => s + q.score * q.count, 0) / totalFailureScored).toFixed(1)
+    : null;
+  const failureUnscored = Math.max(0, summary.total_sessions - totalFailureScored);
 
   return (
     <div style={{ padding: '16px 20px', maxWidth: 1200 }}>
@@ -244,7 +253,7 @@ export function Dashboard() {
         <StatCard label="Sessions" value={formatNumber(summary.total_sessions)} sub={`${approved} approved`} />
         <StatCard label="Tokens" value={formatNumber(summary.total_tokens)} sub={`${tokens_by_source.length} sources`} />
         <StatCard label="API Equivalent" value={formatCost(summary.total_cost)} sub={`${summary.unique_projects} projects`} color={colors.emerald400} />
-        <StatCard label="Avg Productivity" value={avgScore ?? '--'} sub={totalScored > 0 ? `${totalScored} scored` : 'none scored'} color={avgScore && parseFloat(avgScore) >= 4 ? colors.green500 : avgScore ? colors.yellow400 : colors.gray400} />
+        <StatCard label="Avg Failure Value" value={avgFailureValue ?? '--'} sub={totalFailureScored > 0 ? `${totalFailureScored} scored` : 'none scored'} color={avgFailureValue && parseFloat(avgFailureValue) >= 4 ? colors.red500 : avgFailureValue ? colors.yellow400 : colors.gray400} />
         {resolve_rate != null && (() => {
           const pct = Math.round(resolve_rate * 100);
           const trend = resolve_rate_previous != null
@@ -254,7 +263,7 @@ export function Dashboard() {
             : null;
           const arrow = trend === 'up' ? ' \u2191' : trend === 'down' ? ' \u2193' : trend === 'stable' ? ' \u2192' : '';
           const trendColor = trend === 'up' ? colors.green500 : trend === 'down' ? colors.red400 : colors.gray500;
-          return <StatCard label="Resolve Rate" value={`${pct}%${arrow}`} sub={totalScored > 0 ? `${totalScored} scored` : 'not scored'} color={trendColor} />;
+          return <StatCard label="Resolve Rate" value={`${pct}%${arrow}`} sub={totalProductivityScored > 0 ? `${totalProductivityScored} scored` : 'not scored'} color={trendColor} />;
         })()}
       </div>
 
@@ -383,30 +392,34 @@ export function Dashboard() {
       {/* Model effectiveness */}
       {insights && insights.model_effectiveness.length > 0 && (
         <div style={{ marginBottom: 12 }}>
-          <Section title="Model Effectiveness" subtitle="Quality and cost comparison across models">
+          <Section title="Model Effectiveness" subtitle="Failure value and cost comparison across models">
             <div style={{ overflowX: 'auto' }}>
               <table style={{ width: '100%', borderCollapse: 'collapse', fontSize: 13 }}>
                 <thead>
                   <tr style={{ borderBottom: `1px solid ${colors.gray200}`, color: colors.gray500, fontSize: 12 }}>
                     <th style={{ textAlign: 'left', padding: '6px 8px', fontWeight: 600 }}>Model</th>
                     <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: 600 }}>Sessions</th>
-                    <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: 600 }}>Avg Score</th>
+                    <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: 600 }}>Avg FV</th>
                     <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: 600 }}>Resolve Rate</th>
                     <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: 600 }} title="Average API cost per session (total cost ÷ sessions)">Avg Cost / Session</th>
                     <th style={{ textAlign: 'right', padding: '6px 8px', fontWeight: 600 }}>Total API Cost</th>
                   </tr>
                 </thead>
                 <tbody>
-                  {insights.model_effectiveness.slice(0, 10).map(m => (
-                    <tr key={m.model} style={{ borderBottom: `1px solid ${colors.gray100}` }}>
-                      <td style={{ padding: '6px 8px', color: colors.gray700, fontWeight: 500 }}>{shortModel(m.model)}</td>
-                      <td style={{ padding: '6px 8px', textAlign: 'right', color: colors.gray600 }}>{m.sessions}</td>
-                      <td style={{ padding: '6px 8px', textAlign: 'right', color: (m.avg_score ?? 0) >= 4 ? colors.green500 : (m.avg_score ?? 0) >= 3 ? colors.yellow400 : colors.red400, fontWeight: 600 }}>{(m.avg_score ?? 0).toFixed(1)}</td>
-                      <td style={{ padding: '6px 8px', textAlign: 'right', color: colors.gray600 }}>{((m.resolve_rate ?? 0) * 100).toFixed(0)}%</td>
-                      <td style={{ padding: '6px 8px', textAlign: 'right', color: colors.gray600 }}>{formatCost(m.avg_cost)}</td>
-                      <td style={{ padding: '6px 8px', textAlign: 'right', color: colors.gray700, fontWeight: 500 }}>{formatCost(m.total_cost)}</td>
-                    </tr>
-                  ))}
+                  {insights.model_effectiveness.slice(0, 10).map(m => {
+                    const avgFailure = m.avg_failure_value_score ?? 0;
+                    const failureColor = avgFailure >= 4 ? colors.red500 : avgFailure >= 3 ? colors.yellow400 : colors.gray500;
+                    return (
+                      <tr key={m.model} style={{ borderBottom: `1px solid ${colors.gray100}` }}>
+                        <td style={{ padding: '6px 8px', color: colors.gray700, fontWeight: 500 }}>{shortModel(m.model)}</td>
+                        <td style={{ padding: '6px 8px', textAlign: 'right', color: colors.gray600 }}>{m.sessions}</td>
+                        <td style={{ padding: '6px 8px', textAlign: 'right', color: failureColor, fontWeight: 600 }}>{avgFailure > 0 ? avgFailure.toFixed(1) : '--'}</td>
+                        <td style={{ padding: '6px 8px', textAlign: 'right', color: colors.gray600 }}>{((m.resolve_rate ?? 0) * 100).toFixed(0)}%</td>
+                        <td style={{ padding: '6px 8px', textAlign: 'right', color: colors.gray600 }}>{formatCost(m.avg_cost)}</td>
+                        <td style={{ padding: '6px 8px', textAlign: 'right', color: colors.gray700, fontWeight: 500 }}>{formatCost(m.total_cost)}</td>
+                      </tr>
+                    );
+                  })}
                 </tbody>
               </table>
             </div>
@@ -457,7 +470,7 @@ export function Dashboard() {
         </div>
       )}
 
-      {/* Row 1: Activity + Quality Score + Models */}
+      {/* Row 1: Activity + Failure Value + Models */}
       <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr 1fr', gap: 12, marginBottom: 12 }}>
         {/* Weekly activity */}
         <Section title="Activity" subtitle="Sessions per week">
@@ -469,19 +482,19 @@ export function Dashboard() {
           )}
         </Section>
 
-        {/* Quality score distribution */}
-        <Section title="Productivity Score" subtitle={totalScored > 0 ? `${totalScored} scored, ${unscored_count} pending` : 'No sessions scored yet'}>
-          {totalScored > 0 ? (
+        {/* Failure-value score distribution */}
+        <Section title="Failure Value" subtitle={totalFailureScored > 0 ? `${totalFailureScored} scored, ${failureUnscored} pending` : 'No sessions scored yet'}>
+          {totalFailureScored > 0 ? (
             <>
               {[5, 4, 3, 2, 1].map(score => {
-                const entry = by_quality_score.find(q => q.score === score);
+                const entry = by_failure_value_score.find(q => q.score === score);
                 const count = entry?.count ?? 0;
-                const pct = qualityMax > 0 ? (count / qualityMax) * 100 : 0;
-                const pctTotal = totalScored > 0 ? ((count / totalScored) * 100).toFixed(0) : '0';
+                const pct = failureMax > 0 ? (count / failureMax) * 100 : 0;
+                const pctTotal = totalFailureScored > 0 ? ((count / totalFailureScored) * 100).toFixed(0) : '0';
                 return (
                   <div key={score} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '3px 0' }}>
                     <div style={{ width: 80, fontSize: 13, color: colors.gray700, flexShrink: 0 }}>
-                      <span style={{ color: SCORE_COLORS[score], fontWeight: 600 }}>{'★'.repeat(score)}{'☆'.repeat(5 - score)}</span>
+                      <span style={{ color: SCORE_COLORS[score], fontWeight: 700 }}>FV {score}</span>
                     </div>
                     <div style={{ flex: 1, background: colors.gray100, borderRadius: 3, height: 16 }}>
                       <div style={{
@@ -499,8 +512,8 @@ export function Dashboard() {
                 );
               })}
               <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 6, fontSize: 12, color: colors.gray400, borderTop: `1px solid ${colors.gray100}`, paddingTop: 6 }}>
-                <span>Avg: <strong style={{ color: colors.gray700 }}>{avgScore}</strong>/5</span>
-                <span>{SCORE_LABELS[Math.round(parseFloat(avgScore!))]}</span>
+                <span>Avg: <strong style={{ color: colors.gray700 }}>{avgFailureValue}</strong>/5</span>
+                <span>{SCORE_LABELS[Math.round(parseFloat(avgFailureValue!))]}</span>
               </div>
             </>
           ) : (
@@ -541,6 +554,44 @@ export function Dashboard() {
             ))}
           </Section>
         )}
+
+        {/* Legacy productivity distribution */}
+        <Section title="Productivity" subtitle={totalProductivityScored > 0 ? `${totalProductivityScored} scored, ${productivityUnscored} pending` : 'No productivity scores yet'}>
+          {totalProductivityScored > 0 ? (
+            <>
+              {[5, 4, 3, 2, 1].map(score => {
+                const entry = by_quality_score.find(q => q.score === score);
+                const count = entry?.count ?? 0;
+                const pct = productivityMax > 0 ? (count / productivityMax) * 100 : 0;
+                const pctTotal = totalProductivityScored > 0 ? ((count / totalProductivityScored) * 100).toFixed(0) : '0';
+                return (
+                  <div key={score} style={{ display: 'flex', alignItems: 'center', gap: 6, padding: '3px 0' }}>
+                    <div style={{ width: 54, fontSize: 13, color: colors.gray700, flexShrink: 0 }}>
+                      <span style={{ color: PRODUCTIVITY_COLORS[score], fontWeight: 700 }}>P {score}</span>
+                    </div>
+                    <div style={{ flex: 1, background: colors.gray100, borderRadius: 3, height: 14 }}>
+                      <div style={{
+                        width: `${pct}%`, background: PRODUCTIVITY_COLORS[score], borderRadius: 3, height: 14,
+                        minWidth: count > 0 ? 2 : 0, transition: 'width 0.3s ease',
+                      }} />
+                    </div>
+                    <div style={{ width: 56, fontSize: 12, color: colors.gray500, textAlign: 'right', flexShrink: 0 }}>
+                      {count} <span style={{ color: colors.gray400, fontSize: 11 }}>({pctTotal}%)</span>
+                    </div>
+                  </div>
+                );
+              })}
+              <div style={{ display: 'flex', justifyContent: 'space-between', marginTop: 6, fontSize: 12, color: colors.gray400, borderTop: `1px solid ${colors.gray100}`, paddingTop: 6 }}>
+                <span>Avg: <strong style={{ color: colors.gray700 }}>{avgProductivity}</strong>/5</span>
+                <span>secondary lens</span>
+              </div>
+            </>
+          ) : (
+            <div style={{ fontSize: 13, color: colors.gray400, padding: '16px 0', textAlign: 'center' }}>
+              Run <code style={{ background: colors.gray100, padding: '2px 6px', borderRadius: 3 }}>clawjournal score</code> to score sessions
+            </div>
+          )}
+        </Section>
 
         {/* Tokens by source */}
         {tokenSources.length > 0 && (

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -10,11 +10,6 @@ import { colors, selectStyle } from '../theme.ts';
 
 const PAGE_SIZE = 10;
 
-function scoreBadge(score: number | null): string {
-  if (score == null) return '\u2014';
-  return '\u2605'.repeat(Math.min(score, 5));
-}
-
 function failureBadge(score: number | null): string {
   if (score == null) return '\u2014';
   return `${score} failure`;
@@ -502,10 +497,17 @@ export function Inbox() {
               }} onClick={() => handleExpand(s.session_id)}>
                 {/* Failure + productivity scores */}
                 <div style={{
-                  fontSize: '12px', color: colors.red500, whiteSpace: 'nowrap', minWidth: '74px',
-                  fontWeight: 700,
+                  display: 'flex', flexDirection: 'column', gap: 1,
+                  fontSize: '12px', whiteSpace: 'nowrap', minWidth: '74px',
                 }}>
-                  {failureBadge(s.ai_failure_value_score)}
+                  <span style={{ color: colors.red500, fontWeight: 700 }}>
+                    {failureBadge(s.ai_failure_value_score)}
+                  </span>
+                  {s.ai_quality_score != null && (
+                    <span style={{ color: colors.gray400, fontSize: 11, fontWeight: 600 }}>
+                      P {s.ai_quality_score}/5
+                    </span>
+                  )}
                 </div>
 
                 {/* Title + meta */}
@@ -547,7 +549,6 @@ export function Inbox() {
                     <span>
                       {s.project} &middot; {s.user_messages + s.assistant_messages} msgs
                       {s.outcome_label ? ` · ${outcomeText(s.outcome_label)}` : ''}
-                      {s.ai_quality_score != null ? ` · productivity ${s.ai_quality_score}/5` : ''}
                       {s.ai_failure_attribution ? ` · ${s.ai_failure_attribution.replace(/_/g, ' ')}` : ''}
                     </span>
                   </div>

--- a/clawjournal/web/frontend/src/views/Insights.tsx
+++ b/clawjournal/web/frontend/src/views/Insights.tsx
@@ -147,7 +147,8 @@ const RESOLUTION_COLORS: Record<string, string> = {
 };
 
 function ScatterPlot({ data }: { data: InsightsDurationVsScoreRow[] }) {
-  if (data.length < 3) {
+  const scored = data.filter(d => d.ai_failure_value_score != null);
+  if (scored.length < 3) {
     return <div style={{ fontSize: 13, color: colors.gray400, padding: '12px 0' }}>Not enough scored sessions for scatter plot</div>;
   }
 
@@ -155,20 +156,21 @@ function ScatterPlot({ data }: { data: InsightsDurationVsScoreRow[] }) {
   const plotH = SCATTER_H - SPAD.top - SPAD.bottom;
 
   // X axis: duration in minutes, capped at 95th percentile for legibility
-  const durations = data.map(d => (d.duration_seconds || 0) / 60).sort((a, b) => a - b);
+  const durations = scored.map(d => (d.duration_seconds || 0) / 60).sort((a, b) => a - b);
   const p95Idx = Math.floor(durations.length * 0.95);
   const maxMinutes = Math.max(durations[p95Idx] || 60, 10);
 
-  // Y axis: productivity score 1-5
+  // Y axis: failure-value score 1-5
   const minScore = 1;
   const maxScore = 5;
 
-  const dots = data.map(d => {
+  const dots = scored.map(d => {
     const mins = Math.min((d.duration_seconds || 0) / 60, maxMinutes);
     const x = SPAD.left + (mins / maxMinutes) * plotW;
-    const y = SPAD.top + plotH - ((d.ai_quality_score - minScore) / (maxScore - minScore)) * plotH;
+    const score = d.ai_failure_value_score ?? 1;
+    const y = SPAD.top + plotH - ((score - minScore) / (maxScore - minScore)) * plotH;
     const color = RESOLUTION_COLORS[d.resolution ?? ''] ?? colors.gray400;
-    return { x, y, color, d };
+    return { x, y, color, score, d };
   });
 
   return (
@@ -194,13 +196,13 @@ function ScatterPlot({ data }: { data: InsightsDurationVsScoreRow[] }) {
       {/* Dots */}
       {dots.map((dot, i) => (
         <circle key={i} cx={dot.x} cy={dot.y} r={4} fill={dot.color} opacity={0.6}>
-          <title>{Math.round(dot.d.duration_seconds / 60)}min, score {dot.d.ai_quality_score}, {dot.d.resolution ?? 'unknown'}{dot.d.cost ? `, ${formatCost(dot.d.cost)}` : ''}</title>
+          <title>{Math.round(dot.d.duration_seconds / 60)}min, failure value {dot.score}, {dot.d.resolution ?? 'unknown'}{dot.d.cost ? `, ${formatCost(dot.d.cost)}` : ''}</title>
         </circle>
       ))}
 
       {/* Axis labels */}
       <text x={SPAD.left + plotW / 2} y={SCATTER_H - 14} textAnchor="middle" fontSize={10} fill={colors.gray500}>Duration (minutes)</text>
-      <text x={12} y={SPAD.top + plotH / 2} textAnchor="middle" fontSize={10} fill={colors.gray500} transform={`rotate(-90, 12, ${SPAD.top + plotH / 2})`}>Productivity</text>
+      <text x={12} y={SPAD.top + plotH / 2} textAnchor="middle" fontSize={10} fill={colors.gray500} transform={`rotate(-90, 12, ${SPAD.top + plotH / 2})`}>Failure Value</text>
     </svg>
   );
 }
@@ -242,10 +244,10 @@ function labelFor(outcome: string): string {
 }
 
 function HighlightCard({ item }: { item: HighlightItem }) {
-  const scoreColor = item.ai_quality_score && item.ai_quality_score >= 5
-    ? colors.green500
-    : item.ai_quality_score && item.ai_quality_score >= 4
-    ? colors.blue400
+  const scoreColor = item.ai_failure_value_score && item.ai_failure_value_score >= 5
+    ? colors.red500
+    : item.ai_failure_value_score && item.ai_failure_value_score >= 4
+    ? colors.red400
     : colors.gray400;
 
   return (
@@ -275,12 +277,12 @@ function HighlightCard({ item }: { item: HighlightItem }) {
     >
       <div style={{ display: 'flex', justifyContent: 'space-between', gap: 6, marginBottom: 6 }}>
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
-          {item.ai_quality_score != null && (
+          {item.ai_failure_value_score != null && (
             <span style={{
               fontSize: 11, fontWeight: 600, color: scoreColor,
               background: `${scoreColor}18`, padding: '2px 7px', borderRadius: 10,
             }}>
-              {item.ai_quality_score}/5
+              FV {item.ai_failure_value_score}/5
             </span>
           )}
           {item.outcome && (
@@ -401,7 +403,7 @@ export function Insights() {
       const [adv, ins, hl] = await Promise.all([
         api.advisor({ days }),
         api.insights({ start, end }),
-        api.highlights({ days, top: 3, min_quality: 4 }).catch(() => null),
+        api.highlights({ days, top: 3, min_failure_value: 4 }).catch(() => null),
       ]);
       setAdvisor(adv);
       setInsights(ins);
@@ -501,23 +503,14 @@ export function Insights() {
             <div style={{ fontSize: 14, color: colors.green500, marginTop: 2 }}>{stats.most_efficient_model}</div>
           </div>
         )}
-        {stats.highest_quality_model && (
-          <div style={{
-            flex: 1, background: colors.blue50, border: `1px solid ${colors.blue100}`, borderRadius: 8,
-            padding: '10px 14px',
-          }}>
-            <div style={{ fontSize: 12, color: colors.blue700, fontWeight: 600 }}>Highest Productivity</div>
-            <div style={{ fontSize: 14, color: colors.blue600, marginTop: 2 }}>{stats.highest_quality_model}</div>
-          </div>
-        )}
       </div>
 
-      {/* Highlights — top 3 recent high-productivity sessions across different agents,
+      {/* Highlights — top 3 recent high-failure-value sessions across different agents,
           matched to the tab's `days` window. */}
       {highlights && highlights.highlights.length > 0 && (
         <Section
           title="Highlights"
-          subtitle={`Top ${highlights.highlights.length} recent high-productivity sessions across agents`}
+          subtitle={`Top ${highlights.highlights.length} recent high-failure-value sessions across agents`}
         >
           <div style={{ display: 'flex', gap: 10, flexWrap: 'wrap' }}>
             {highlights.highlights.map((item) => (
@@ -527,7 +520,7 @@ export function Insights() {
         </Section>
       )}
       {highlights && highlights.highlights.length === 0 && (
-        <Section title="Highlights" subtitle={`No 4+ productivity sessions in the last ${highlights.window_days} days`}>
+        <Section title="Highlights" subtitle={`No 4+ failure-value sessions in the last ${highlights.window_days} days`}>
           <div style={{ fontSize: 12, color: colors.gray500, padding: 8 }}>
             Run <code style={{ background: colors.gray100, padding: '1px 5px', borderRadius: 3 }}>clawjournal score</code> on recent sessions to populate this panel.
           </div>
@@ -542,9 +535,9 @@ export function Insights() {
         </Section>
       )}
 
-      {/* Duration vs Quality scatter */}
+      {/* Duration vs Failure Value scatter */}
       {insights && insights.duration_vs_score && insights.duration_vs_score.length >= 3 && (
-        <Section title="Duration vs Quality" subtitle="Longer sessions aren't always better">
+        <Section title="Duration vs Failure Value" subtitle="Longer sessions are not automatically higher value">
           <ScatterPlot data={insights.duration_vs_score} />
           <ScatterLegend />
         </Section>

--- a/clawjournal/web/frontend/src/views/SessionDetail.tsx
+++ b/clawjournal/web/frontend/src/views/SessionDetail.tsx
@@ -64,6 +64,34 @@ function truncate(text: string, max: number): string {
   return text.slice(0, max) + '...';
 }
 
+function failureValueLabel(score: number): string {
+  return score === 5 ? 'Canonical'
+    : score === 4 ? 'Strong pattern'
+    : score === 3 ? 'Usable signal'
+    : score === 2 ? 'Weak signal'
+    : 'No signal';
+}
+
+function failureEvidenceText(detail: string | null | undefined): string {
+  if (!detail) return '';
+  try {
+    const parsed = JSON.parse(detail);
+    if (!Array.isArray(parsed.ai_failure_evidence)) return '';
+    return parsed.ai_failure_evidence
+      .filter((item: unknown): item is string => typeof item === 'string' && item.trim().length > 0)
+      .join('\n');
+  } catch {
+    return '';
+  }
+}
+
+function splitEvidence(text: string): string[] {
+  return text
+    .split('\n')
+    .map(item => item.trim())
+    .filter(Boolean);
+}
+
 /** Render text with [REDACTED] spans highlighted. */
 /* ------------------------------------------------------------------ */
 /*  Sub-components                                                    */
@@ -189,7 +217,8 @@ export default function SessionDetail() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const [userRating, setUserRating] = useState<number | null>(null);
+  const [failureValueOverride, setFailureValueOverride] = useState<number | null>(null);
+  const [failureValueEvidence, setFailureValueEvidence] = useState('');
   const [scoring, setScoring] = useState(false);
 
   // Refs for scroll targets
@@ -213,7 +242,8 @@ export default function SessionDetail() {
       .get(id)
       .then((data) => {
         setSession(data);
-        setUserRating(data.ai_quality_score);
+        setFailureValueOverride(data.ai_failure_value_score);
+        setFailureValueEvidence(failureEvidenceText(data.ai_scoring_detail));
       })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
@@ -539,28 +569,29 @@ export default function SessionDetail() {
           background: colors.white,
         }}
       >
-        <Section title="Productivity Score">
-          {(userRating ?? session.ai_quality_score) != null ? (() => {
-            const displayScore = userRating ?? session.ai_quality_score!;
+        <Section title="Failure Value">
+          {(failureValueOverride ?? session.ai_failure_value_score) != null ? (() => {
+            const displayScore = failureValueOverride ?? session.ai_failure_value_score!;
             return (
             <div>
-              <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 4 }}>
+              <div style={{ display: 'flex', alignItems: 'baseline', gap: 8, marginBottom: 6 }}>
                 <span style={{
-                  fontSize: 22,
-                  letterSpacing: '-1px',
-                  color: colors.yellow400,
+                  fontSize: 24,
+                  fontWeight: 700,
+                  color: colors.red500,
                 }}>
-                  {'\u2605'.repeat(displayScore)}{'\u2606'.repeat(5 - displayScore)}
+                  FV {displayScore}/5
                 </span>
                 <span style={{ fontSize: 13, fontWeight: 600, color: colors.gray700 }}>
-                  {displayScore === 5 ? 'Major'
-                    : displayScore === 4 ? 'Solid'
-                    : displayScore === 3 ? 'Light'
-                    : displayScore === 2 ? 'Minimal'
-                    : 'Noise'}
+                  {failureValueLabel(displayScore)}
                 </span>
               </div>
-              {session.ai_summary && (
+              {session.ai_learning_summary && (
+                <div style={{ fontSize: 12, color: colors.gray700, lineHeight: 1.5, marginBottom: 6 }}>
+                  {session.ai_learning_summary}
+                </div>
+              )}
+              {session.ai_summary && !session.ai_learning_summary && (
                 <div style={{ fontSize: 12, color: colors.gray700, lineHeight: 1.5, marginBottom: 6 }}>
                   {session.ai_summary}
                 </div>
@@ -570,10 +601,15 @@ export default function SessionDetail() {
                   {session.ai_score_reason}
                 </div>
               )}
+              {session.ai_quality_score != null && (
+                <div style={{ fontSize: 11, color: colors.gray400, lineHeight: 1.4, marginBottom: 8 }}>
+                  Legacy productivity {session.ai_quality_score}/5
+                </div>
+              )}
             </div>
             );
           })() : (
-            <div style={{ fontSize: 12, color: colors.gray400, marginBottom: 8 }}>Not scored yet</div>
+            <div style={{ fontSize: 12, color: colors.gray400, marginBottom: 8 }}>Failure value not scored yet</div>
           )}
 
           <button
@@ -585,7 +621,8 @@ export default function SessionDetail() {
                 await api.sessions.score(id);
                 const fresh = await api.sessions.get(id);
                 setSession(fresh);
-                setUserRating(fresh.ai_quality_score);
+                setFailureValueOverride(fresh.ai_failure_value_score);
+                setFailureValueEvidence(failureEvidenceText(fresh.ai_scoring_detail));
                 toast('Scored', 'success');
               } catch (e) {
                 toast(e instanceof Error ? e.message : 'Scoring failed', 'error');
@@ -606,38 +643,70 @@ export default function SessionDetail() {
               cursor: scoring ? 'wait' : 'pointer',
             }}
           >
-            {scoring ? 'Scoring…' : (session.ai_quality_score ? 'Re-score with AI' : 'Score with AI')}
+            {scoring ? 'Scoring…' : (session.ai_failure_value_score ? 'Re-score with AI' : 'Score with AI')}
           </button>
 
-          <div style={{ fontSize: 12, fontWeight: 600, color: colors.gray700, marginBottom: 4 }}>Override rating</div>
-          <div style={{ display: 'flex', gap: 2, marginBottom: 4 }}>
+          <div style={{ fontSize: 12, fontWeight: 600, color: colors.gray700, marginBottom: 4 }}>Override failure value</div>
+          <textarea
+            value={failureValueEvidence}
+            onChange={e => setFailureValueEvidence(e.target.value)}
+            placeholder="Evidence for 4-5 overrides"
+            rows={3}
+            style={{
+              width: '100%',
+              boxSizing: 'border-box',
+              resize: 'vertical',
+              border: `1px solid ${colors.gray200}`,
+              borderRadius: 4,
+              padding: '6px 8px',
+              marginBottom: 6,
+              fontSize: 12,
+              lineHeight: 1.4,
+              color: colors.gray700,
+            }}
+          />
+          <div style={{ display: 'grid', gridTemplateColumns: 'repeat(5, 1fr)', gap: 4, marginBottom: 4 }}>
             {[1, 2, 3, 4, 5].map((n) => {
-              const currentScore = userRating ?? session.ai_quality_score ?? 0;
+              const currentScore = failureValueOverride ?? session.ai_failure_value_score ?? 0;
+              const active = n === currentScore;
               return (
                 <button
                   key={n}
                   onClick={async () => {
-                    setUserRating(n);
+                    const evidence = splitEvidence(failureValueEvidence);
+                    if (n >= 4 && evidence.length === 0) {
+                      toast('Evidence is required for failure value 4-5', 'error');
+                      return;
+                    }
                     if (id) {
                       try {
-                        await api.sessions.update(id, { ai_quality_score: n });
-                        toast(`Rating set to ${n}`, 'success');
+                        await api.sessions.update(id, {
+                          ai_failure_value_score: n,
+                          ...(evidence.length > 0 ? { ai_failure_evidence: evidence } : {}),
+                        });
+                        const fresh = await api.sessions.get(id);
+                        setSession(fresh);
+                        setFailureValueOverride(n);
+                        setFailureValueEvidence(failureEvidenceText(fresh.ai_scoring_detail));
+                        toast(`Failure value set to ${n}`, 'success');
                       } catch (e) {
-                        toast(e instanceof Error ? e.message : 'Failed to save rating', 'error');
+                        toast(e instanceof Error ? e.message : 'Failed to save failure value', 'error');
                       }
                     }
                   }}
                   style={{
-                    padding: '4px 2px',
-                    border: 'none',
-                    background: 'transparent',
-                    color: n <= currentScore ? colors.yellow400 : colors.gray300,
-                    fontSize: 20,
+                    padding: '5px 0',
+                    border: `1px solid ${active ? colors.red500 : colors.gray200}`,
+                    background: active ? colors.red500 : colors.white,
+                    color: active ? colors.white : colors.gray700,
+                    borderRadius: 4,
+                    fontSize: 12,
+                    fontWeight: 700,
                     cursor: 'pointer',
                     lineHeight: 1,
                   }}
                 >
-                  {n <= currentScore ? '\u2605' : '\u2606'}
+                  {n}
                 </button>
               );
             })}

--- a/clawjournal/web/frontend/src/views/Share.tsx
+++ b/clawjournal/web/frontend/src/views/Share.tsx
@@ -78,11 +78,6 @@ function formatDate(iso: string): string {
   return d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }
 
-function scoreBadge(score: number | null): string {
-  if (score == null) return '';
-  return '\u2605'.repeat(Math.min(score, 5));
-}
-
 function outcomeBadge(outcome: string | null): string {
   if (!outcome) return '';
   const b = outcome.toLowerCase();
@@ -1434,20 +1429,28 @@ function QueueStep(p: QueueStepProps) {
                         <span style={{ opacity: 0.5 }}>&middot;</span>
                         <span style={{ color: '#991b1b', fontWeight: 700 }}>{s.ai_failure_value_score} failure value</span>
                       </>)}
+                      {s.ai_quality_score != null && (<>
+                        <span style={{ opacity: 0.5 }}>&middot;</span>
+                        <span
+                          style={{ color: colors.gray500 }}
+                          title="Legacy productivity score"
+                        >
+                          productivity {s.ai_quality_score}/5
+                        </span>
+                      </>)}
                       {s.ai_failure_attribution && (<>
                         <span style={{ opacity: 0.5 }}>&middot;</span>
                         <span>{s.ai_failure_attribution.replace(/_/g, ' ')}</span>
                       </>)}
-                      {s.ai_quality_score != null ? (<>
-                        <span style={{ opacity: 0.5 }}>&middot;</span>
-                        <span style={{ color: '#c08a1a', letterSpacing: -1 }}>{scoreBadge(s.ai_quality_score)}</span>
-                      </>) : (<>
+                      {s.ai_failure_value_score == null && (<>
                         <span style={{ opacity: 0.5 }}>&middot;</span>
                         <span
                           style={{ color: colors.gray500, fontStyle: 'italic' }}
-                          title="This session hasn't been scored yet. Click Preview → Score with AI, or run `clawjournal score` from a terminal."
+                          title={s.ai_quality_score == null
+                            ? "This session hasn't been scored yet. Click Preview → Score with AI, or run `clawjournal score` from a terminal."
+                            : "This legacy-scored session is missing failure value. Re-score it with AI before sharing."}
                         >
-                          unscored
+                          {s.ai_quality_score == null ? 'unscored' : 'failure value missing'}
                         </span>
                       </>)}
                       {s.outcome_badge && (<>

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -25,6 +25,12 @@ from urllib.parse import parse_qs, unquote, urlparse
 from .. import __version__
 from ..redaction.anonymizer import Anonymizer
 from ..scoring.badges import compute_all_badges
+from ..scoring.overrides import (
+    failure_evidence_from_detail,
+    merge_failure_evidence,
+    normalize_failure_evidence,
+    requires_failure_evidence,
+)
 from ..config import CONFIG_DIR, load_config, save_config
 from .findings_pipeline import (
     drain_findings_backfill,
@@ -1183,6 +1189,43 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         body = _read_body(self)
         conn = open_index()
         try:
+            if "ai_failure_value_score" in body or "ai_failure_evidence" in body:
+                detail = get_session_detail(conn, session_id)
+                if detail is None:
+                    _json_response(self, {"error": "Session not found"}, 404)
+                    return
+
+                failure_value = body.get("ai_failure_value_score")
+                if failure_value is not None:
+                    try:
+                        failure_value = int(failure_value)
+                    except (TypeError, ValueError):
+                        _json_response(self, {"error": "Invalid failure value"}, 400)
+                        return
+                    body["ai_failure_value_score"] = failure_value
+
+                provided_evidence = normalize_failure_evidence(
+                    body.get("ai_failure_evidence")
+                )
+                raw_detail = body.get(
+                    "ai_scoring_detail",
+                    detail.get("ai_scoring_detail"),
+                )
+                if requires_failure_evidence(failure_value):
+                    existing_evidence = failure_evidence_from_detail(raw_detail)
+                    if not provided_evidence and not existing_evidence:
+                        _json_response(
+                            self,
+                            {"error": "Failure-value 4-5 overrides require evidence."},
+                            400,
+                        )
+                        return
+                if provided_evidence:
+                    body["ai_scoring_detail"] = merge_failure_evidence(
+                        raw_detail,
+                        provided_evidence,
+                    )
+
             ok = update_session(
                 conn, session_id,
                 status=body.get("status"),
@@ -1492,11 +1535,16 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         days = _int_param("days", 7, 1, 90)
         top_n = _int_param("top", 3, 1, 12)
         min_quality = _int_param("min_quality", 4, 1, 5)
+        min_failure_value = _int_param("min_failure_value", min_quality, 1, 5)
 
         conn = open_index()
         try:
             data = get_highlights(
-                conn, days=days, top_n=top_n, min_quality=min_quality
+                conn,
+                days=days,
+                top_n=top_n,
+                min_quality=min_quality,
+                min_failure_value=min_failure_value,
             )
             _json_response(self, data)
         finally:

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -2876,22 +2876,24 @@ def get_highlights(
     days: int = 7,
     top_n: int = 3,
     min_quality: int = 4,
+    min_failure_value: int | None = None,
 ) -> dict[str, Any]:
     """Pick a small curated set of 'worth a look' sessions for the dashboard.
 
     Selection recipe:
     1. Candidates have `end_time` within the last `days`, are fully scored
-       (`ai_quality_score IS NOT NULL`), and meet `ai_quality_score >= min_quality`.
-    2. Order by `ai_quality_score DESC, end_time DESC`.
+       (`ai_failure_value_score IS NOT NULL`), and meet the failure-value threshold.
+    2. Order by `ai_failure_value_score DESC, end_time DESC`.
     3. Diversify across `source` — prefer one from each distinct agent
        (claude / codex / openclaw / etc.) before taking a second from any.
     4. If fewer than `top_n` distinct sources have candidates, fill from the
        remaining sorted list.
 
     Each result carries enough metadata for the dashboard card plus a
-    one-line rationale string ("5-star · 3 days ago") so the UI doesn't
+    one-line rationale string ("FV 5/5 · 3 days ago") so the UI doesn't
     have to re-derive it.
     """
+    threshold = min_failure_value if min_failure_value is not None else min_quality
     cutoff = datetime.now(timezone.utc) - timedelta(days=days)
     cutoff_iso = cutoff.isoformat()
 
@@ -2900,16 +2902,17 @@ def get_highlights(
         SELECT session_id, project, source, model,
                start_time, end_time, duration_seconds,
                display_title, ai_display_title, ai_summary,
-               ai_quality_score, ai_effort_estimate,
+               ai_quality_score, ai_failure_value_score,
+               ai_learning_summary, ai_effort_estimate,
                outcome_badge, ai_outcome_badge
         FROM sessions
         WHERE end_time IS NOT NULL
           AND end_time >= ?
-          AND ai_quality_score IS NOT NULL
-          AND ai_quality_score >= ?
-        ORDER BY ai_quality_score DESC, end_time DESC
+          AND ai_failure_value_score IS NOT NULL
+          AND ai_failure_value_score >= ?
+        ORDER BY ai_failure_value_score DESC, end_time DESC, ai_quality_score DESC
         """,
-        (cutoff_iso, min_quality),
+        (cutoff_iso, threshold),
     ).fetchall()
 
     candidates = [dict(r) for r in rows]
@@ -2938,7 +2941,7 @@ def get_highlights(
     now = datetime.now(timezone.utc)
 
     def _rationale(s: dict[str, Any]) -> str:
-        score = s.get("ai_quality_score")
+        score = s.get("ai_failure_value_score")
         end_time = s.get("end_time") or ""
         try:
             end_dt = datetime.fromisoformat(end_time.replace("Z", "+00:00"))
@@ -2956,7 +2959,7 @@ def get_highlights(
                 when = f"{delta.days} days ago"
         except (ValueError, AttributeError):
             when = "recently"
-        score_label = f"{score}-star" if score else "scored"
+        score_label = f"FV {score}/5" if score else "failure-value scored"
         return f"{score_label} · {when}"
 
     def _truncate(text: str | None, limit: int = 200) -> str:
@@ -2981,9 +2984,10 @@ def get_highlights(
             "end_time": s.get("end_time"),
             "duration_seconds": s.get("duration_seconds"),
             "ai_quality_score": s.get("ai_quality_score"),
+            "ai_failure_value_score": s.get("ai_failure_value_score"),
             "ai_effort_estimate": s.get("ai_effort_estimate"),
             "outcome": outcome,
-            "summary_teaser": _truncate(s.get("ai_summary")),
+            "summary_teaser": _truncate(s.get("ai_learning_summary") or s.get("ai_summary")),
             "rationale": _rationale(s),
         })
 
@@ -2991,6 +2995,7 @@ def get_highlights(
         "highlights": highlights,
         "window_days": days,
         "min_quality": min_quality,
+        "min_failure_value": threshold,
         "candidate_count": len(candidates),
     }
 
@@ -3189,18 +3194,18 @@ def get_insights(
         focus.append(proj)
     result["focus"] = focus
 
-    # Productivity: duration vs score. Returns the normalized resolution
+    # Failure value: duration vs score. Returns the normalized resolution
     # (`resolved` / `failed` / `partial` / etc.) so the frontend scatter
     # plot only has to color-code one vocabulary. Before normalization,
     # heuristic badges like `tests_failed` / `build_failed` / `errored`
     # fell into the color map's default gray "Other" bucket instead of
     # red failures.
     rows = conn.execute(
-        f"SELECT session_id, duration_seconds, ai_quality_score, "
+        f"SELECT session_id, duration_seconds, ai_quality_score, ai_failure_value_score, "
         f"({_OUTCOME_NORMALIZE_SQL}) as resolution, "
         f"estimated_cost_usd as cost "
         f"FROM sessions {where} "
-        f"AND duration_seconds IS NOT NULL AND ai_quality_score IS NOT NULL "
+        f"AND duration_seconds IS NOT NULL AND ai_failure_value_score IS NOT NULL "
         f"ORDER BY start_time DESC LIMIT 200",
         params_base,
     ).fetchall()
@@ -3213,7 +3218,7 @@ def get_insights(
         f"SELECT CASE WHEN model_effort IS NOT NULL AND model_effort != '' "
         f"       THEN model || ' @ ' || model_effort ELSE model END as model, "
         f"COUNT(*) as sessions, "
-        f"AVG(ai_quality_score) as avg_score, "
+        f"AVG(ai_failure_value_score) as avg_failure_value_score, "
         f"SUM(CASE WHEN ({_OUTCOME_NORMALIZE_SQL}) = 'resolved' THEN 1 ELSE 0 END) * 1.0 / COUNT(*) as resolve_rate, "
         f"AVG(estimated_cost_usd) as avg_cost, "
         f"SUM(estimated_cost_usd) as total_cost "
@@ -3222,7 +3227,7 @@ def get_insights(
         params_base,
     ).fetchall()
     result["model_effectiveness"] = [
-        {**dict(r), "avg_score": round(r["avg_score"] or 0, 1), "resolve_rate": round(r["resolve_rate"] or 0, 2), "avg_cost": round(r["avg_cost"] or 0, 4), "total_cost": round(r["total_cost"] or 0, 2)}
+        {**dict(r), "avg_failure_value_score": round(r["avg_failure_value_score"] or 0, 1), "resolve_rate": round(r["resolve_rate"] or 0, 2), "avg_cost": round(r["avg_cost"] or 0, 4), "total_cost": round(r["total_cost"] or 0, 2)}
         for r in rows
     ]
 
@@ -3415,8 +3420,6 @@ def get_share_ready_stats(
         if s.get("model"):
             models.add(s["model"])
     approved_sessions = [s for s in sessions if s.get("review_status") == "approved"]
-    has_failure_scores = any(s.get("ai_failure_value_score") is not None for s in sessions)
-
     # Default recommendation: approved high-value failure traces from in-scope
     # sources. Recent rows dominate, with older approved high-value failures as
     # backfill. Unapproved failures are shown to the user for review, not added
@@ -3448,11 +3451,6 @@ def get_share_ready_stats(
 
     def _is_high_value_failure(session: dict[str, Any]) -> bool:
         score = session.get("ai_failure_value_score")
-        if score is None and not has_failure_scores:
-            # Transitional fallback for pre-migration databases. Once any
-            # failure-value scores exist in the visible pool, recommendations
-            # are strictly failure-value based.
-            score = session.get("ai_quality_score")
         return (
             session.get("review_status") == "approved"
             and session.get("source") in FAILURE_VALUE_SOURCE_SCOPE

--- a/redefine-ai-score.md
+++ b/redefine-ai-score.md
@@ -6,8 +6,16 @@ Last updated: 2026-05-26
 Target decisions:
 - 5/5 does not require `agent_caused`; gate on whether agent behavior is the lesson.
 - Scores of 4 or 5 require at least one `ai_failure_evidence` snippet.
-- Hide the legacy `ai_quality_score` from primary UI surfaces; keep it in the
-  data model, CLI, and exports for compatibility.
+- Show `ai_failure_value_score` as the primary score. Keep the legacy
+  productivity `ai_quality_score` visible as a secondary score and sortable
+  lens.
+- Default review sorting uses failure value. Productivity sort remains
+  available when the reviewer wants that lens.
+- `--auto-triage` only auto-blocks productivity-1 sessions when failure value
+  is 1-2. Failure value 3 stays reviewable.
+- Human 4-5 failure-value overrides require trace-backed evidence.
+- Legacy traces with productivity score but no failure-value score should be
+  rescored, not treated as fully scored.
 
 ## Problem
 
@@ -42,7 +50,7 @@ Target field split:
 | Field | Meaning | Product role |
 | --- | --- | --- |
 | `ai_failure_value_score` | 1-5 value for failure-corpus review | Primary score |
-| `ai_quality_score` | 1-5 productivity/substance legacy score | Hidden from primary UI surfaces; kept in data model, CLI, and exports |
+| `ai_quality_score` | 1-5 productivity/substance legacy score | Secondary score; visible and sortable but not the default lens |
 | `ai_failure_modes` | What kind of failure happened | Failure reason labels |
 | `ai_failure_attribution` | Dominant cause of the key failure | Failure reason context |
 | `ai_recovery_labels` | Whether and how recovery happened | Failure/recovery context |
@@ -64,19 +72,18 @@ Current repo state:
   `clawjournal/scoring/scoring.py:1090`: a failure-value score of 4 or 5 with
   no `ai_failure_evidence` is downgraded to 3.
 - `set-score --failure-value` exists for manual failure-value overrides.
+  Overrides to 4-5 require stored `ai_failure_evidence`.
 - The workbench list (`TraceCard.tsx`), session detail score panel, share
   recommendations, and recent highlights now use failure value as the primary
   review score.
-- The legacy `ai_quality_score` is still visible on four UI surfaces that
-  need follow-up migration:
+- The legacy `ai_quality_score` remains visible as a secondary lens:
   - `web/frontend/src/views/SessionDetail.tsx:582-587` renders
     `Legacy productivity {score}/5` next to the failure-value panel.
   - `web/frontend/src/views/Dashboard.tsx:230` computes
     `totalProductivityScored` and renders a `by_quality_score` histogram
-    alongside `by_failure_value_score`.
-  - `web/frontend/src/views/Insights.tsx:169` falls back to
-    `ai_quality_score` when `ai_failure_value_score` is null, so quality
-    still drives ranking on legacy traces.
+    alongside `by_failure_value_score` as broader analytics.
+  - `web/frontend/src/views/Insights.tsx` uses failure value for the primary
+    score lens; legacy productivity-only traces should be rescored.
   - `web/frontend/src/views/Share.tsx` (and the `api.ts` / `types.ts`
     contracts) keep `ai_quality_score` in the share-ready payload.
 
@@ -141,22 +148,25 @@ Recommended UI changes:
 2. Show `ai_failure_value_score` as the primary 1-5 score in session detail.
 3. Place failure modes, attribution, recovery labels, evidence, and learning
    summary directly under the failure score.
-4. Hide the legacy productivity score (`ai_quality_score`) from primary UI
-   surfaces. Keep it in the data model and CLI/exports for backwards
-   compatibility; showing two 1-5 scores with different meanings side-by-side
-   confuses reviewers.
+4. Keep the legacy productivity score (`ai_quality_score`) visible but
+   subordinate. It should read as a secondary analytics/review lens, not as the
+   main score.
 5. In list views, sort by failure value by default and label the sort as "Top
    failure value" or "Most valuable failures".
-6. In CLI output, lead with failure value:
+6. Keep productivity sort available for reviewers who need the older
+   productivity/substance lens.
+7. In CLI output, lead with failure value:
    `failure value 4/5; productivity 3/5`.
-7. Avoid presenting failure value as generic gold stars if that makes it feel
+8. Avoid presenting failure value as generic gold stars if that makes it feel
    like praise. Consider `FV 4/5`, a severity-style badge, or a compact numeric
    meter instead.
 
 ## Dashboard And List View
 
-The dashboard and list view are the primary review surfaces. Their job is
-triage — "what should I review next?" — not a leaderboard.
+The list view is the primary review queue. The dashboard is a broader
+analytics surface: it should still make failure value prominent, but it can
+also show productivity, model/source mix, cost, token, outcome, and activity
+context.
 
 Reframing first: under the new score, "best cases" and "failure cases" overlap.
 A canonical 5/5 trace *is* a best case (best for the corpus). There is no
@@ -165,15 +175,18 @@ counter, not a parallel ranked surface.
 
 ### Dashboard
 
-Four tiles, nothing more:
+Dashboard priorities:
 
 1. Failure-value distribution — small 1-5 histogram of recent traces.
 2. Top failure modes — top 5 by count.
 3. Top recovery patterns — top 5 by count.
-4. Recent 4-5s — the review inbox.
+4. Recent 4-5s — a review lane, not the only dashboard content.
+5. Secondary analytics — productivity distribution, outcomes, model/source
+   summaries, cost/tokens, activity, and similar operational context.
 
-Plus one ambient line at the top: `N sessions this week, M smooth successes`.
-Baseline activity, no ranked board.
+The dashboard should not make productivity the headline score, but keeping it
+visible is useful because it answers a different question: whether a trace was
+substantive/productive rather than whether it is valuable for failure analysis.
 
 ### List view
 
@@ -186,19 +199,19 @@ One default surface, sorted by failure value desc. Each row shows four things:
 
 Filters: failure value, failure mode, recovery label, outcome.
 
-Anything denser turns the list into a spreadsheet.
+Anything denser turns the review queue into a spreadsheet.
 
 ### What to resist
 
 Trying to make the list view serve every lens at once — recency, productivity,
-failure, outcome. Lock failure-value as the default lens and let timeline /
-outcome live as filters or alternate sorts, not parallel default surfaces. Two
-ranked boards always splits attention and never pays for the complexity.
+failure, outcome. Lock failure-value as the default lens and let timeline,
+productivity, and outcome live as filters or alternate sorts, not parallel
+default surfaces.
 
 Sharp tradeoff: a user who wants "what happened this week, all of it" needs a
 separate timeline view. Fine to build, but keep it clearly marked as a second
-lens — don't let it leak into the dashboard default. The dashboard's job is
-"what should I review next," not "what did I do."
+lens. The dashboard can answer "what happened this week" as analytics; the
+review list should answer "what should I inspect next."
 
 ## CLI And Data Model Direction
 
@@ -213,12 +226,15 @@ Near-term behavior:
 - `set-score --quality` should remain a legacy productivity override.
 - Use the manual failure-value override when human review needs to correct the
   score:
-  `set-score --failure-value 4`.
+  `set-score --failure-value 4 --failure-evidence "..."`.
 - Auto-triage should not hide a trace solely because productivity is low if
-  failure value is high. `--auto-triage` should only auto-block productivity-1
-  sessions when failure value is below 4. Rationale: failure value 3 is
-  "usable signal" worth keeping reviewable; 4-5 is share-worthy. So 4 is the
-  cutoff between "could be reviewed later" and "definitely keep in the queue."
+  failure value is at least usable. `--auto-triage` should only auto-block
+  productivity-1 sessions when failure value is 1-2. Rationale: failure value
+  3 is "usable signal" worth keeping reviewable; 4-5 is share-worthy. The
+  cutoff is between 2 and 3, not between 3 and 4.
+- Batch scoring should include legacy traces missing `ai_failure_value_score`,
+  even if they already have the old productivity score. Rescoring is the
+  migration path for legacy traces.
 
 Provenance remains important when changing score meaning:
 
@@ -272,11 +288,7 @@ Evidence and attribution rules:
    unless explicitly marked as evaluation data?
 3. Should we derive a `corpus_ready` state from failure value, evidence, hold
    state, and privacy gates?
-4. Is "below 4" the right auto-triage cutoff? The current proposal keeps
-   productivity-1 + failure-value-3 traces reviewable; an alternative is
-   "below 3" (only auto-block productivity-1 + failure-value 1-2). Trade-off:
-   reviewer queue size vs. capturing 3/5 "usable but minor" signals.
-5. Should the dashboard scope to "all time" or "last 7 days" by default? A
+4. Should the dashboard scope to "all time" or "last 7 days" by default? A
    7-day default makes the histogram and recent feed feel alive; all-time is
    stable but may underweight recent regressions and starve low-volume users.
 
@@ -294,48 +306,43 @@ Evidence and attribution rules:
 3. Session Detail leads with the failure-value panel; failure modes,
    attribution, recovery, evidence, and learning summary surface directly
    under it.
-4. Manual failure-value override: `set-score --failure-value <n>`.
+4. Manual failure-value override: `set-score --failure-value <n>`; 4-5
+   overrides require `--failure-evidence`.
 5. Workbench list (`TraceCard.tsx`), share recommendations, and recent
    highlights rank by failure value.
+6. Auto-triage only blocks productivity-1 sessions when failure value is 1-2.
+7. Legacy productivity-only traces are considered unscored for the new failure
+   lens and can be filled by `clawjournal score --batch`.
 
 ### Remaining
 
-1. **Hide the legacy productivity score from primary UI surfaces.** Four
-   concrete touch-points (see "Current repo state" above for exact line
-   refs):
-   - Remove or gate the `Legacy productivity {score}/5` badge in
-     `SessionDetail.tsx:582-587`.
-   - Drop or relabel the `by_quality_score` histogram in
-     `Dashboard.tsx:230` (and stop computing `totalProductivityScored` for
-     the primary surface).
-   - In `Insights.tsx:169`, stop falling back to `ai_quality_score` for
-     the primary score lens — render "no failure score yet" for legacy
-     traces instead.
-   - In `Share.tsx`, drop `ai_quality_score` from the share-ready UI;
-     keep it in the API contract (`api.ts` / `types.ts`) for backwards
-     compatibility.
-2. **Update CLI text and README language** so "quality" is no longer the
-   main score; lead with failure value in `score-view` output.
-3. **Auto-triage gate.** Implement the "below 4" rule so productivity-1
-   sessions with high failure value are not auto-blocked.
-4. **Migrate "quality" copy in the Insights recommendations engine.** The
-   recommendation cards rendered on the Insights view still read "best
-   quality score", "Model quality vs cost trade-off", and "Highest quality:
-   …". Source:
+1. **Keep productivity visibly secondary.** The session detail and dashboard
+   can show productivity, but the default list/review/share lens should
+   remain failure value.
+2. **Rename "quality" copy to "productivity" in the Insights recommendations
+   engine.** The recommendation cards still emit "best quality score",
+   "Model quality vs cost trade-off", and "Highest quality:". Touch-points:
    - `clawjournal/scoring/insights.py:292` — `"{type} work has the best
      quality score"` title.
    - `clawjournal/scoring/insights.py:310` — `"Model quality vs cost
      trade-off"` title.
    - `clawjournal/scoring/insights.py:312` — `"Highest quality: {model}
      ({avg_score:.1f}/5 avg, ...)"` body.
-   - `clawjournal/cli.py:1997` — matching CLI line `Highest quality:
-     {summary['highest_quality_model']}`.
+   - `clawjournal/cli.py:1997` — matching CLI line
+     `Highest quality: {summary['highest_quality_model']}`.
 
-   Decide whether the recommendation should switch to failure-value
-   framing or to a neutral "score" framing, and whether the underlying
-   metric should still be `ai_quality_score` or move to
-   `ai_failure_value_score` (the recommendation logic likely needs the
-   same migration, not just the label).
-5. **Re-run the frontend build** once the UI surfaces above are reworked —
+   The recommendation logic operates on `ai_quality_score` (productivity) and
+   that is fine — only the copy needs to switch from "quality" to
+   "productivity" so the term does not conflate with the failure-value
+   framing.
+3. **Remove the legacy-quality fallback in the Insights "Duration vs Failure
+   Value" scatter.** `clawjournal/web/frontend/src/views/Insights.tsx:169`
+   reads `const score = d.ai_failure_value_score ?? d.ai_quality_score`, so
+   legacy productivity-only traces get silently plotted on the failure-value
+   axis. Per Target decisions, legacy traces with no failure-value score
+   should be rescored, not coerced into the failure-value slot. Either omit
+   those traces from the scatter or render them with a visual treatment that
+   marks them as "rescore needed."
+4. **Re-run the frontend build** once the UI surfaces above are reworked —
    the CI smoke job verifies the built wheel ships
    `clawjournal/web/frontend/dist/index.html`.

--- a/redefine-ai-score.md
+++ b/redefine-ai-score.md
@@ -318,6 +318,24 @@ Evidence and attribution rules:
    main score; lead with failure value in `score-view` output.
 3. **Auto-triage gate.** Implement the "below 4" rule so productivity-1
    sessions with high failure value are not auto-blocked.
-4. **Re-run the frontend build** once the four UI surfaces above are
-   reworked — the CI smoke job verifies the built wheel ships
+4. **Migrate "quality" copy in the Insights recommendations engine.** The
+   recommendation cards rendered on the Insights view still read "best
+   quality score", "Model quality vs cost trade-off", and "Highest quality:
+   …". Source:
+   - `clawjournal/scoring/insights.py:292` — `"{type} work has the best
+     quality score"` title.
+   - `clawjournal/scoring/insights.py:310` — `"Model quality vs cost
+     trade-off"` title.
+   - `clawjournal/scoring/insights.py:312` — `"Highest quality: {model}
+     ({avg_score:.1f}/5 avg, ...)"` body.
+   - `clawjournal/cli.py:1997` — matching CLI line `Highest quality:
+     {summary['highest_quality_model']}`.
+
+   Decide whether the recommendation should switch to failure-value
+   framing or to a neutral "score" framing, and whether the underlying
+   metric should still be `ai_quality_score` or move to
+   `ai_failure_value_score` (the recommendation logic likely needs the
+   same migration, not just the label).
+5. **Re-run the frontend build** once the UI surfaces above are reworked —
+   the CI smoke job verifies the built wheel ships
    `clawjournal/web/frontend/dist/index.html`.

--- a/redefine-ai-score.md
+++ b/redefine-ai-score.md
@@ -57,13 +57,28 @@ Current repo state:
   `ai_failure_evidence` and `ai_meta_labels` live inside `ai_scoring_detail`
   and are included in export/share payloads.
 - The scorer already emits both `ai_quality_score` and
-  `ai_failure_value_score`.
-- The workbench list and share flow already use failure value in important
-  places, but session detail, dashboard, insights, and some compact cards still
-  surface the legacy productivity score. Hiding productivity is remaining UI
-  work, not a completed state.
-- `set-score --quality` exists; a manual `--failure-value` override does not
-  exist yet.
+  `ai_failure_value_score`. The canonical rubric prompt
+  (`clawjournal/prompts/agents/scoring/rubric.md`) reflects the new semantics
+  (5/5 does not require `agent_caused`; 4-5 require evidence).
+- Scorer validation enforces the evidence cap at
+  `clawjournal/scoring/scoring.py:1090`: a failure-value score of 4 or 5 with
+  no `ai_failure_evidence` is downgraded to 3.
+- `set-score --failure-value` exists for manual failure-value overrides.
+- The workbench list (`TraceCard.tsx`), session detail score panel, share
+  recommendations, and recent highlights now use failure value as the primary
+  review score.
+- The legacy `ai_quality_score` is still visible on four UI surfaces that
+  need follow-up migration:
+  - `web/frontend/src/views/SessionDetail.tsx:582-587` renders
+    `Legacy productivity {score}/5` next to the failure-value panel.
+  - `web/frontend/src/views/Dashboard.tsx:230` computes
+    `totalProductivityScored` and renders a `by_quality_score` histogram
+    alongside `by_failure_value_score`.
+  - `web/frontend/src/views/Insights.tsx:169` falls back to
+    `ai_quality_score` when `ai_failure_value_score` is null, so quality
+    still drives ranking on legacy traces.
+  - `web/frontend/src/views/Share.tsx` (and the `api.ts` / `types.ts`
+    contracts) keep `ai_quality_score` in the share-ready payload.
 
 ## Score Semantics
 
@@ -89,7 +104,8 @@ Important implications:
   about the agent's handling of constraints, uncertainty, collaboration, or
   recovery.
 - Scores of `4` or `5` require at least one `ai_failure_evidence` snippet. If no
-  snippet can be quoted, fall back to `3`.
+  snippet can be quoted, fall back to `3`. The scorer validation path enforces
+  this cap after parsing judge output.
 - `5/5` does not require `agent_caused` attribution. A non-agent-caused trace
   can score `5/5` if the agent's behavior (recovery, uncertainty handling,
   collaboration, escalation) is itself the lesson. Treat `agent_caused` as a
@@ -184,12 +200,6 @@ separate timeline view. Fine to build, but keep it clearly marked as a second
 lens — don't let it leak into the dashboard default. The dashboard's job is
 "what should I review next," not "what did I do."
 
-### Open question
-
-- Should the dashboard scope to "all time" or "last 7 days" by default? A
-  7-day default makes the histogram and recent feed feel alive; all-time is
-  stable but may underweight recent regressions and starve low-volume users.
-
 ## CLI And Data Model Direction
 
 Keep the current columns and add behavior around them rather than renaming the
@@ -201,12 +211,14 @@ Near-term behavior:
   `ai_quality_score`.
 - `score-view` should lead with failure value and failure reasons.
 - `set-score --quality` should remain a legacy productivity override.
-- Add or consider a manual failure-value override, for example:
+- Use the manual failure-value override when human review needs to correct the
+  score:
   `set-score --failure-value 4`.
 - Auto-triage should not hide a trace solely because productivity is low if
-  failure value is high. Current `--auto-triage` only auto-blocks
-  productivity-1 sessions, so this needs a pass before changing the UI defaults
-  further.
+  failure value is high. `--auto-triage` should only auto-block productivity-1
+  sessions when failure value is below 4. Rationale: failure value 3 is
+  "usable signal" worth keeping reviewable; 4-5 is share-worthy. So 4 is the
+  cutoff between "could be reviewed later" and "definitely keep in the queue."
 
 Provenance remains important when changing score meaning:
 
@@ -260,22 +272,52 @@ Evidence and attribution rules:
    unless explicitly marked as evaluation data?
 3. Should we derive a `corpus_ready` state from failure value, evidence, hold
    state, and privacy gates?
-4. Should low-productivity/high-failure-value traces bypass productivity-based
-   auto-blocking? This becomes more important once the legacy score is hidden
-   from primary UI surfaces.
+4. Is "below 4" the right auto-triage cutoff? The current proposal keeps
+   productivity-1 + failure-value-3 traces reviewable; an alternative is
+   "below 3" (only auto-block productivity-1 + failure-value 1-2). Trade-off:
+   reviewer queue size vs. capturing 3/5 "usable but minor" signals.
+5. Should the dashboard scope to "all time" or "last 7 days" by default? A
+   7-day default makes the histogram and recent feed feel alive; all-time is
+   stable but may underweight recent regressions and starve low-volume users.
 
 ## Implementation Sketch
 
-The smallest useful remaining path is:
+### Already shipped
 
-1. Update the canonical scoring rubric so the live judge prompt matches these
-   semantics.
-2. Update Session Detail so `ai_failure_value_score` is the primary score panel.
-3. Hide the legacy productivity score from primary UI surfaces. Keep it in the
-   data model and CLI for backwards compatibility.
-4. Update CLI text and README language to stop treating "quality" as the main
-   score.
-5. Add manual override support for failure value.
-6. Review share recommendations, dashboard averages, and insights so they rank
-   by failure value where appropriate.
-7. Re-run frontend build if frontend files change.
+1. Canonical rubric prompt updated
+   (`clawjournal/prompts/agents/scoring/rubric.md`) — the failure-value
+   section, the 5/5 no-`agent_caused` rule, and the 4-5 evidence requirement
+   are all in the live judge prompt.
+2. Scorer validation enforces the evidence cap at
+   `clawjournal/scoring/scoring.py:1090`: a score of 4 or 5 with no
+   `ai_failure_evidence` is downgraded to 3.
+3. Session Detail leads with the failure-value panel; failure modes,
+   attribution, recovery, evidence, and learning summary surface directly
+   under it.
+4. Manual failure-value override: `set-score --failure-value <n>`.
+5. Workbench list (`TraceCard.tsx`), share recommendations, and recent
+   highlights rank by failure value.
+
+### Remaining
+
+1. **Hide the legacy productivity score from primary UI surfaces.** Four
+   concrete touch-points (see "Current repo state" above for exact line
+   refs):
+   - Remove or gate the `Legacy productivity {score}/5` badge in
+     `SessionDetail.tsx:582-587`.
+   - Drop or relabel the `by_quality_score` histogram in
+     `Dashboard.tsx:230` (and stop computing `totalProductivityScored` for
+     the primary surface).
+   - In `Insights.tsx:169`, stop falling back to `ai_quality_score` for
+     the primary score lens — render "no failure score yet" for legacy
+     traces instead.
+   - In `Share.tsx`, drop `ai_quality_score` from the share-ready UI;
+     keep it in the API contract (`api.ts` / `types.ts`) for backwards
+     compatibility.
+2. **Update CLI text and README language** so "quality" is no longer the
+   main score; lead with failure value in `score-view` output.
+3. **Auto-triage gate.** Implement the "below 4" rule so productivity-1
+   sessions with high failure value are not auto-blocked.
+4. **Re-run the frontend build** once the four UI surfaces above are
+   reworked — the CI smoke job verifies the built wheel ships
+   `clawjournal/web/frontend/dist/index.html`.

--- a/redefine-ai-score.md
+++ b/redefine-ai-score.md
@@ -1,12 +1,13 @@
 # Redefine AI Score
 
-Status: draft for iteration
+Status: implementation proposal
 Last updated: 2026-05-26
 
-Recent decisions:
+Target decisions:
 - 5/5 does not require `agent_caused`; gate on whether agent behavior is the lesson.
 - Scores of 4 or 5 require at least one `ai_failure_evidence` snippet.
-- Hide the legacy `ai_quality_score` in the UI; keep it in the data model and CLI.
+- Hide the legacy `ai_quality_score` from primary UI surfaces; keep it in the
+  data model, CLI, and exports for compatibility.
 
 ## Problem
 
@@ -36,18 +37,33 @@ Make the primary user-facing 1-5 score the failure-value score:
 Keep the existing productivity score as a secondary/legacy field. Do not reuse
 one field for both meanings.
 
-Current field split:
+Target field split:
 
 | Field | Meaning | Product role |
 | --- | --- | --- |
 | `ai_failure_value_score` | 1-5 value for failure-corpus review | Primary score |
-| `ai_quality_score` | 1-5 productivity/substance legacy score | Hidden in UI; kept in data model and CLI |
+| `ai_quality_score` | 1-5 productivity/substance legacy score | Hidden from primary UI surfaces; kept in data model, CLI, and exports |
 | `ai_failure_modes` | What kind of failure happened | Failure reason labels |
 | `ai_failure_attribution` | Dominant cause of the key failure | Failure reason context |
 | `ai_recovery_labels` | Whether and how recovery happened | Failure/recovery context |
-| `ai_failure_evidence` | Trace-backed evidence snippets | Label support |
+| `ai_failure_evidence` | Trace-backed evidence snippets | Label support in `ai_scoring_detail` and exports |
 | `ai_learning_summary` | One concise lesson from the trace | Human review summary |
-| `ai_meta_labels` | Evaluation/scoring artifacts | Meta-level caveats |
+| `ai_meta_labels` | Evaluation/scoring artifacts | Meta-level caveats in `ai_scoring_detail` and exports |
+
+Current repo state:
+
+- The schema already stores `ai_failure_value_score`, `ai_failure_modes`,
+  `ai_failure_attribution`, `ai_recovery_labels`, and `ai_learning_summary`.
+  `ai_failure_evidence` and `ai_meta_labels` live inside `ai_scoring_detail`
+  and are included in export/share payloads.
+- The scorer already emits both `ai_quality_score` and
+  `ai_failure_value_score`.
+- The workbench list and share flow already use failure value in important
+  places, but session detail, dashboard, insights, and some compact cards still
+  surface the legacy productivity score. Hiding productivity is remaining UI
+  work, not a completed state.
+- `set-score --quality` exists; a manual `--failure-value` override does not
+  exist yet.
 
 ## Score Semantics
 
@@ -59,7 +75,7 @@ The 1-5 scale should rank traces by corpus value, not by how badly the agent did
 | 2 | Weak signal | A possible failure exists, but it is routine, unclear, expected debugging, or low-value. |
 | 3 | Usable signal | There is a real failure signal, but it is minor, ambiguous, repeated, mostly environmental, or only partly attributable. |
 | 4 | Strong pattern | Meaningful agent failure or recovery pattern with clear evidence and a useful lesson. Worth review and likely share/export consideration. |
-| 5 | Canonical failure trace | Consequential, evidence-rich failure on real expert work. Strong lesson for evals, training data, product design, or agent behavior analysis. |
+| 5 | Canonical failure trace | Consequential, evidence-rich failure or recovery pattern on real expert work. Strong lesson for evals, training data, product design, or agent behavior analysis. |
 
 Important implications:
 
@@ -103,15 +119,16 @@ reason from:
 
 The product surface should make failure value the primary review lens.
 
-Recommended changes:
+Recommended UI changes:
 
 1. Rename the main score panel from "Productivity Score" to "Failure Value".
 2. Show `ai_failure_value_score` as the primary 1-5 score in session detail.
 3. Place failure modes, attribution, recovery labels, evidence, and learning
    summary directly under the failure score.
-4. Hide the legacy productivity score (`ai_quality_score`) in the UI. Keep it
-   in the data model and CLI/exports for backwards compatibility — showing two
-   1-5 scores with different meanings side-by-side confuses reviewers.
+4. Hide the legacy productivity score (`ai_quality_score`) from primary UI
+   surfaces. Keep it in the data model and CLI/exports for backwards
+   compatibility; showing two 1-5 scores with different meanings side-by-side
+   confuses reviewers.
 5. In list views, sort by failure value by default and label the sort as "Top
    failure value" or "Most valuable failures".
 6. In CLI output, lead with failure value:
@@ -187,7 +204,9 @@ Near-term behavior:
 - Add or consider a manual failure-value override, for example:
   `set-score --failure-value 4`.
 - Auto-triage should not hide a trace solely because productivity is low if
-  failure value is high.
+  failure value is high. Current `--auto-triage` only auto-blocks
+  productivity-1 sessions, so this needs a pass before changing the UI defaults
+  further.
 
 Provenance remains important when changing score meaning:
 
@@ -242,20 +261,21 @@ Evidence and attribution rules:
 3. Should we derive a `corpus_ready` state from failure value, evidence, hold
    state, and privacy gates?
 4. Should low-productivity/high-failure-value traces bypass productivity-based
-   auto-blocking? (Largely moot for the UI now that the legacy score is hidden,
-   but the underlying auto-triage logic may still need a pass.)
+   auto-blocking? This becomes more important once the legacy score is hidden
+   from primary UI surfaces.
 
 ## Implementation Sketch
 
-If we implement this direction, the smallest useful path is:
+The smallest useful remaining path is:
 
-1. Update Session Detail so `ai_failure_value_score` is the primary score panel.
-2. Hide the legacy productivity score in the UI. Keep it in the data model and
-   CLI for backwards compatibility.
-3. Update CLI text and README language to stop treating "quality" as the main
+1. Update the canonical scoring rubric so the live judge prompt matches these
+   semantics.
+2. Update Session Detail so `ai_failure_value_score` is the primary score panel.
+3. Hide the legacy productivity score from primary UI surfaces. Keep it in the
+   data model and CLI for backwards compatibility.
+4. Update CLI text and README language to stop treating "quality" as the main
    score.
-4. Add manual override support for failure value.
-5. Review share recommendations, dashboard averages, and insights so they rank
+5. Add manual override support for failure value.
+6. Review share recommendations, dashboard averages, and insights so they rank
    by failure value where appropriate.
-6. Re-run frontend build if frontend files change.
-
+7. Re-run frontend build if frontend files change.

--- a/redefine-ai-score.md
+++ b/redefine-ai-score.md
@@ -313,36 +313,19 @@ Evidence and attribution rules:
 6. Auto-triage only blocks productivity-1 sessions when failure value is 1-2.
 7. Legacy productivity-only traces are considered unscored for the new failure
    lens and can be filled by `clawjournal score --batch`.
+8. Productivity remains visible as a secondary lens in session detail, list
+   cards, share review rows, dashboard analytics, and productivity sort
+   options.
+9. Insights recommendation copy uses "productivity" when it is analyzing
+   `ai_quality_score`, and the duration scatter no longer falls back from
+   missing failure value to productivity.
 
 ### Remaining
 
-1. **Keep productivity visibly secondary.** The session detail and dashboard
-   can show productivity, but the default list/review/share lens should
-   remain failure value.
-2. **Rename "quality" copy to "productivity" in the Insights recommendations
-   engine.** The recommendation cards still emit "best quality score",
-   "Model quality vs cost trade-off", and "Highest quality:". Touch-points:
-   - `clawjournal/scoring/insights.py:292` — `"{type} work has the best
-     quality score"` title.
-   - `clawjournal/scoring/insights.py:310` — `"Model quality vs cost
-     trade-off"` title.
-   - `clawjournal/scoring/insights.py:312` — `"Highest quality: {model}
-     ({avg_score:.1f}/5 avg, ...)"` body.
-   - `clawjournal/cli.py:1997` — matching CLI line
-     `Highest quality: {summary['highest_quality_model']}`.
-
-   The recommendation logic operates on `ai_quality_score` (productivity) and
-   that is fine — only the copy needs to switch from "quality" to
-   "productivity" so the term does not conflate with the failure-value
-   framing.
-3. **Remove the legacy-quality fallback in the Insights "Duration vs Failure
-   Value" scatter.** `clawjournal/web/frontend/src/views/Insights.tsx:169`
-   reads `const score = d.ai_failure_value_score ?? d.ai_quality_score`, so
-   legacy productivity-only traces get silently plotted on the failure-value
-   axis. Per Target decisions, legacy traces with no failure-value score
-   should be rescored, not coerced into the failure-value slot. Either omit
-   those traces from the scatter or render them with a visual treatment that
-   marks them as "rescore needed."
-4. **Re-run the frontend build** once the UI surfaces above are reworked —
-   the CI smoke job verifies the built wheel ships
-   `clawjournal/web/frontend/dist/index.html`.
+1. **Choose the final visual language for failure value.** Current UI uses
+   compact `FV n/5` badges; keep or refine that after seeing real reviewer use.
+2. **Decide whether to derive `corpus_ready`.** It would likely combine
+   failure value, evidence, hold state, and privacy gates.
+3. **Choose the dashboard default window.** The current dashboard supports
+   multiple ranges, but the product default may still need tuning after more
+   scored traces exist.

--- a/redefine-ai-score.md
+++ b/redefine-ai-score.md
@@ -1,0 +1,261 @@
+# Redefine AI Score
+
+Status: draft for iteration
+Last updated: 2026-05-26
+
+Recent decisions:
+- 5/5 does not require `agent_caused`; gate on whether agent behavior is the lesson.
+- Scores of 4 or 5 require at least one `ai_failure_evidence` snippet.
+- Hide the legacy `ai_quality_score` in the UI; keep it in the data model and CLI.
+
+## Problem
+
+ClawJournal originally used a 1-5 AI score as a productivity/substance rating:
+"is this session worth keeping as a work trace?"
+
+Our current focus is different. We care most about why agents fail, how they
+recover, and which traces are valuable for improving frontier coding agents. A
+generic "quality" or "productivity" star rating is now misleading because:
+
+- a failed session can be extremely valuable;
+- a recovered session can be more valuable than a smooth success;
+- a long productive session can have little failure-reason value;
+- a low-quality session is not automatically useful if the cause is unclear;
+- failure reasons should be evidence-backed labels, not vague dissatisfaction.
+
+The visible 1-5 score should therefore mean "failure value", not "agent quality"
+or "user satisfaction".
+
+## Proposed Decision
+
+Make the primary user-facing 1-5 score the failure-value score:
+
+> How useful is this trace for understanding and improving agent failure
+> behavior on real work?
+
+Keep the existing productivity score as a secondary/legacy field. Do not reuse
+one field for both meanings.
+
+Current field split:
+
+| Field | Meaning | Product role |
+| --- | --- | --- |
+| `ai_failure_value_score` | 1-5 value for failure-corpus review | Primary score |
+| `ai_quality_score` | 1-5 productivity/substance legacy score | Hidden in UI; kept in data model and CLI |
+| `ai_failure_modes` | What kind of failure happened | Failure reason labels |
+| `ai_failure_attribution` | Dominant cause of the key failure | Failure reason context |
+| `ai_recovery_labels` | Whether and how recovery happened | Failure/recovery context |
+| `ai_failure_evidence` | Trace-backed evidence snippets | Label support |
+| `ai_learning_summary` | One concise lesson from the trace | Human review summary |
+| `ai_meta_labels` | Evaluation/scoring artifacts | Meta-level caveats |
+
+## Score Semantics
+
+The 1-5 scale should rank traces by corpus value, not by how badly the agent did.
+
+| Score | Label | Meaning |
+| --- | --- | --- |
+| 1 | No signal | No useful failure signal: smooth success, trivial session, control sample, or noise. |
+| 2 | Weak signal | A possible failure exists, but it is routine, unclear, expected debugging, or low-value. |
+| 3 | Usable signal | There is a real failure signal, but it is minor, ambiguous, repeated, mostly environmental, or only partly attributable. |
+| 4 | Strong pattern | Meaningful agent failure or recovery pattern with clear evidence and a useful lesson. Worth review and likely share/export consideration. |
+| 5 | Canonical failure trace | Consequential, evidence-rich failure on real expert work. Strong lesson for evals, training data, product design, or agent behavior analysis. |
+
+Important implications:
+
+- A resolved session can be `5/5` if it contains a valuable failure and recovery
+  pattern.
+- A failed session can be `2/5` if the trace does not show a clear, useful, or
+  attributable failure reason.
+- A smooth success should usually be `1/5` for failure value, even if it is
+  `5/5` productivity.
+- A blocked session is not automatically valuable. It needs to reveal something
+  about the agent's handling of constraints, uncertainty, collaboration, or
+  recovery.
+- Scores of `4` or `5` require at least one `ai_failure_evidence` snippet. If no
+  snippet can be quoted, fall back to `3`.
+- `5/5` does not require `agent_caused` attribution. A non-agent-caused trace
+  can score `5/5` if the agent's behavior (recovery, uncertainty handling,
+  collaboration, escalation) is itself the lesson. Treat `agent_caused` as a
+  category inside `ai_failure_attribution`, not a gate on the score.
+
+## Failure Reasons Are Separate From The Score
+
+The score answers: "How valuable is this trace for the failure corpus?"
+
+Failure reasons answer: "What happened, based on trace evidence?"
+
+That distinction matters. The score should not become a disguised category. A
+trace can have the same failure reason as another trace but a different score
+because one has clearer evidence, stronger consequences, better recovery signal,
+or more reusable lessons.
+
+Failure reason labels should require concrete trace evidence. Do not label a
+reason from:
+
+- benchmark rank alone;
+- aggregate metrics alone;
+- "the user seemed unhappy" without a specific trace signal;
+- final bad outcome without visible agent behavior;
+- normal iteration that caused no meaningful burden, harm, or misleading output.
+
+## UI Direction
+
+The product surface should make failure value the primary review lens.
+
+Recommended changes:
+
+1. Rename the main score panel from "Productivity Score" to "Failure Value".
+2. Show `ai_failure_value_score` as the primary 1-5 score in session detail.
+3. Place failure modes, attribution, recovery labels, evidence, and learning
+   summary directly under the failure score.
+4. Hide the legacy productivity score (`ai_quality_score`) in the UI. Keep it
+   in the data model and CLI/exports for backwards compatibility — showing two
+   1-5 scores with different meanings side-by-side confuses reviewers.
+5. In list views, sort by failure value by default and label the sort as "Top
+   failure value" or "Most valuable failures".
+6. In CLI output, lead with failure value:
+   `failure value 4/5; productivity 3/5`.
+7. Avoid presenting failure value as generic gold stars if that makes it feel
+   like praise. Consider `FV 4/5`, a severity-style badge, or a compact numeric
+   meter instead.
+
+## Dashboard And List View
+
+The dashboard and list view are the primary review surfaces. Their job is
+triage — "what should I review next?" — not a leaderboard.
+
+Reframing first: under the new score, "best cases" and "failure cases" overlap.
+A canonical 5/5 trace *is* a best case (best for the corpus). There is no
+separate "top successes" ranking. Smooth successes appear only as an ambient
+counter, not a parallel ranked surface.
+
+### Dashboard
+
+Four tiles, nothing more:
+
+1. Failure-value distribution — small 1-5 histogram of recent traces.
+2. Top failure modes — top 5 by count.
+3. Top recovery patterns — top 5 by count.
+4. Recent 4-5s — the review inbox.
+
+Plus one ambient line at the top: `N sessions this week, M smooth successes`.
+Baseline activity, no ranked board.
+
+### List view
+
+One default surface, sorted by failure value desc. Each row shows four things:
+
+- failure value badge (primary);
+- outcome chip (success / partial / fail / blocked);
+- one top `ai_failure_modes` tag;
+- one-line `ai_learning_summary` excerpt.
+
+Filters: failure value, failure mode, recovery label, outcome.
+
+Anything denser turns the list into a spreadsheet.
+
+### What to resist
+
+Trying to make the list view serve every lens at once — recency, productivity,
+failure, outcome. Lock failure-value as the default lens and let timeline /
+outcome live as filters or alternate sorts, not parallel default surfaces. Two
+ranked boards always splits attention and never pays for the complexity.
+
+Sharp tradeoff: a user who wants "what happened this week, all of it" needs a
+separate timeline view. Fine to build, but keep it clearly marked as a second
+lens — don't let it leak into the dashboard default. The dashboard's job is
+"what should I review next," not "what did I do."
+
+### Open question
+
+- Should the dashboard scope to "all time" or "last 7 days" by default? A
+  7-day default makes the histogram and recent feed feel alive; all-time is
+  stable but may underweight recent regressions and starve low-volume users.
+
+## CLI And Data Model Direction
+
+Keep the current columns and add behavior around them rather than renaming the
+schema immediately.
+
+Near-term behavior:
+
+- `score` should continue emitting both `ai_failure_value_score` and
+  `ai_quality_score`.
+- `score-view` should lead with failure value and failure reasons.
+- `set-score --quality` should remain a legacy productivity override.
+- Add or consider a manual failure-value override, for example:
+  `set-score --failure-value 4`.
+- Auto-triage should not hide a trace solely because productivity is low if
+  failure value is high.
+
+Provenance remains important when changing score meaning:
+
+- preserve scorer backend;
+- preserve scorer model;
+- preserve rubric revision;
+- preserve scoring timestamp;
+- make rescoring explicit when the rubric meaning changes materially.
+
+## Candidate Rubric Text
+
+This can replace or sharpen the current failure-value section:
+
+```text
+Failure value score (1-5) measures how useful the trace is for understanding
+and improving coding-agent failure behavior. It is not a quality score and not a
+severity score.
+
+5 = Canonical high-value trace: consequential failure or recovery pattern on
+real expert work, where the agent's behavior is the lesson. Strong trace-backed
+evidence and a reusable insight for evals, training, product design, or agent
+behavior analysis. Attribution may be agent-caused or non-agent-caused.
+
+4 = Strong failure or recovery pattern: meaningful trace-backed agent behavior
+worth reviewing and likely worth sharing/exporting.
+
+3 = Usable failure signal: real signal exists, but it is minor, ambiguous,
+common, mostly environmental, or only partly attributable.
+
+2 = Weak signal: routine retry, expected debugging, unclear attribution, or
+little reusable lesson.
+
+1 = No useful failure signal: smooth success, trivial session, control sample,
+or noise.
+
+Evidence and attribution rules:
+- Scores of 4 or 5 must be backed by at least one `ai_failure_evidence` snippet.
+  If no snippet can be quoted, fall back to 3.
+- 5/5 does not require `agent_caused`. The teaching moment matters, not the
+  source of the failure.
+- Do not infer failure value from bad outcome alone. Score by the clearest
+  trace-backed teaching moment. A resolved session can score high; a failed
+  session can score low.
+```
+
+## Open Questions
+
+1. Should the visible score use stars at all, or should failure value use a
+   different visual language?
+2. Should high failure value require real user work, excluding synthetic evals
+   unless explicitly marked as evaluation data?
+3. Should we derive a `corpus_ready` state from failure value, evidence, hold
+   state, and privacy gates?
+4. Should low-productivity/high-failure-value traces bypass productivity-based
+   auto-blocking? (Largely moot for the UI now that the legacy score is hidden,
+   but the underlying auto-triage logic may still need a pass.)
+
+## Implementation Sketch
+
+If we implement this direction, the smallest useful path is:
+
+1. Update Session Detail so `ai_failure_value_score` is the primary score panel.
+2. Hide the legacy productivity score in the UI. Keep it in the data model and
+   CLI for backwards compatibility.
+3. Update CLI text and README language to stop treating "quality" as the main
+   score.
+4. Add manual override support for failure value.
+5. Review share recommendations, dashboard averages, and insights so they rank
+   by failure value where appropriate.
+6. Re-run frontend build if frontend files change.
+

--- a/skills/clawjournal-score/RUBRIC.md
+++ b/skills/clawjournal-score/RUBRIC.md
@@ -50,8 +50,10 @@ Emit both `substance` and `ai_quality_score` with the same value.
 This is the primary score for failure-corpus capture. It answers: "how valuable
 is this trace for understanding and improving agent failure behavior?"
 
-5 = Clear, consequential SOTA-agent failure on real expert work, strong
-evidence, useful lesson.
+5 = Canonical high-value trace: consequential failure or recovery pattern on
+real expert work, where the agent's behavior is the lesson. Strong evidence
+and a reusable insight for evals, training, product design, or agent behavior
+analysis. Attribution may be agent-caused or non-agent-caused.
 4 = Meaningful failure or recovery pattern worth reviewing or turning into eval
 or training data.
 3 = Some failure signal, but ambiguous, minor, repeated, or mostly
@@ -61,8 +63,13 @@ environmental.
 or noise.
 
 A resolved session can be a 5 if it contains a valuable failure and recovery
-pattern. A failed session is not automatically valuable; it needs attributable,
-evidence-backed failure behavior.
+pattern. 5/5 does not require `agent_caused`; the teaching moment matters, not
+the source of the failure. A failed session is not automatically valuable; it
+needs attributable, evidence-backed failure behavior.
+
+Scores of 4 or 5 require at least one `ai_failure_evidence` snippet. If no
+snippet can be quoted or paraphrased from the trace, cap the failure-value score
+at 3.
 
 For multi-failure sessions, score by the highest single teaching moment, emit
 all applicable modes and recovery labels, and set attribution to the dominant
@@ -588,6 +595,8 @@ Before finalizing labels, confirm:
   agent's summary.
 - Each label is backed by concrete evidence (in `ai_failure_evidence`).
 - Your evidence quotes actually demonstrate the failure (not adjacent text).
+- If `ai_failure_value_score` is 4 or 5, `ai_failure_evidence` contains at
+  least one trace-backed snippet.
 - You did not infer a deep cause when the trace only supports a surface signal.
 - You considered whether an apparent failure is actually
   `evaluation_measurement` (eval artifact rather than agent behavior).

--- a/skills/clawjournal-score/RUBRIC.md
+++ b/skills/clawjournal-score/RUBRIC.md
@@ -50,22 +50,27 @@ Emit both `substance` and `ai_quality_score` with the same value.
 This is the primary score for failure-corpus capture. It answers: "how valuable
 is this trace for understanding and improving agent failure behavior?"
 
-5 = Canonical high-value trace: consequential failure or recovery pattern on
-real expert work, where the agent's behavior is the lesson. Strong evidence
-and a reusable insight for evals, training, product design, or agent behavior
+This is not a quality score, severity score, or user-satisfaction score. Rank
+the trace by the clearest trace-backed teaching moment.
+
+5 = Canonical failure trace: consequential, evidence-rich failure or recovery
+pattern on real expert work, where the agent's behavior is the lesson. Strong
+reusable insight for evals, training, product design, or agent behavior
 analysis. Attribution may be agent-caused or non-agent-caused.
-4 = Meaningful failure or recovery pattern worth reviewing or turning into eval
-or training data.
-3 = Some failure signal, but ambiguous, minor, repeated, or mostly
-environmental.
-2 = Weak signal: routine retry, expected debugging, or unclear attribution.
+4 = Strong pattern: meaningful trace-backed agent failure or recovery behavior
+worth reviewing and likely worth turning into eval or training data.
+3 = Usable signal: real failure signal, but minor, ambiguous, repeated, mostly
+environmental, or only partly attributable.
+2 = Weak signal: routine retry, expected debugging, unclear attribution, or
+little reusable lesson.
 1 = No useful failure signal: smooth success, trivial session, control sample,
 or noise.
 
 A resolved session can be a 5 if it contains a valuable failure and recovery
 pattern. 5/5 does not require `agent_caused`; the teaching moment matters, not
-the source of the failure. A failed session is not automatically valuable; it
-needs attributable, evidence-backed failure behavior.
+the source of the failure. A failed or blocked session is not automatically
+valuable; score by visible agent behavior, evidence clarity, consequence,
+recovery signal, and reusable lesson.
 
 Scores of 4 or 5 require at least one `ai_failure_evidence` snippet. If no
 snippet can be quoted or paraphrased from the trace, cap the failure-value score

--- a/skills/clawjournal-score/SKILL.md
+++ b/skills/clawjournal-score/SKILL.md
@@ -20,6 +20,8 @@ clawjournal score --batch --source failure-v1 --limit 20
 ```
 
 For hands-on scoring of a specific session, continue below.
+With `--auto-triage`, only productivity-1 sessions with failure value 1-2 are
+auto-blocked; failure value 3+ stays reviewable.
 
 ## Session Data
 
@@ -82,9 +84,11 @@ See `RUBRIC.md` in this directory for the full scoring rubric with examples. In 
 
 ## Store the Score
 
-Manual score setting only updates the legacy productivity score. Prefer
-`clawjournal score` for failure-value annotations.
+Manual score setting can override failure value directly. Keep `--quality` for
+legacy productivity compatibility only. Failure-value overrides to 4-5 require
+trace-backed evidence.
 
 ```bash
-clawjournal set-score <session-id> --quality <score> --reason "<1-2 sentence explanation>"
+clawjournal set-score <session-id> --failure-value <score> --failure-evidence "<trace-backed snippet>" --reason "<1-2 sentence explanation>"
+clawjournal set-score <session-id> --quality <score> --reason "<legacy productivity note>"
 ```

--- a/skills/clawjournal-score/SKILL.md
+++ b/skills/clawjournal-score/SKILL.md
@@ -40,11 +40,13 @@ clawjournal score --batch --limit 10
 ClawJournal now records two scores in one pass:
 
 - `ai_quality_score`: legacy productivity/substance score.
-- `ai_failure_value_score`: primary capture score for SOTA-agent failure behavior.
+- `ai_failure_value_score`: primary capture score for understanding
+  frontier-agent failure and recovery behavior.
 
 Failure value:
 
-**5 = Clear consequential failure** — Real expert work, strong evidence, useful lesson.
+**5 = Canonical high-value trace** — Consequential failure or recovery pattern
+on real expert work, where the agent behavior is the lesson.
 
 **4 = Meaningful failure/recovery** — Worth reviewing or turning into eval/training data.
 
@@ -63,6 +65,11 @@ Failure attribution: `agent_caused`, `environment`, `preexisting_problem`, `user
 Failure modes (`ai_failure_modes`): `task_framing`, `method_selection`, `context_handling`, `execution_error`, `reasoning_fabrication`, `revision_failure`, `verification_skipped`, `deliverable_defect`, `communication_error`, `collaboration_error`, `safety_security`, `efficiency_waste`.
 
 Meta labels (`ai_meta_labels`): `evaluation_measurement` only — emit when the evaluation/measurement setup itself misjudges the agent, not when the agent failed.
+
+Scores of 4 or 5 require at least one `ai_failure_evidence` snippet. A 5/5
+does not require `agent_caused`; non-agent-caused traces can be high value when
+the agent's recovery, uncertainty handling, escalation, or collaboration is the
+lesson.
 
 ### Detailed rubric
 

--- a/skills/clawjournal-setup/SKILL.md
+++ b/skills/clawjournal-setup/SKILL.md
@@ -89,7 +89,7 @@ If zero sessions found:
 
 ## 3. Score & Auto-Triage (optional but recommended)
 
-Ask: "Would you like me to auto-score your sessions? Each session gets two AI ratings: a productivity score (1-5, legacy) and a failure-value score (1-5, the new primary signal for finding teachable agent failures on real work)."
+Ask: "Would you like me to auto-score your sessions? Each session gets two AI ratings: a failure-value score (1-5, the primary signal for finding teachable agent failures on real work) and a productivity score (1-5, legacy compatibility)."
 
 If yes:
 
@@ -97,9 +97,9 @@ If yes:
 ~/.clawjournal-venv/bin/clawjournal score --batch --source failure-v1 --auto-triage
 ```
 
-`--source failure-v1` scopes to the supported sources (claude, codex, opencode, openclaw); auto-triage archives productivity-1 noise sessions.
+`--source failure-v1` scopes to the supported sources (claude, codex, opencode, openclaw); auto-triage archives productivity-1 sessions only when failure value is 1-2.
 
-Show summary: "N sessions scored. Productivity distribution: ... Failure-value distribution: ... M auto-archived as productivity-1 noise."
+Show summary: "N sessions scored. Failure-value distribution: ... M productivity-1 low-failure-value sessions auto-archived as noise."
 
 If no: skip to Step 4.
 

--- a/skills/clawjournal/SKILL.md
+++ b/skills/clawjournal/SKILL.md
@@ -77,11 +77,11 @@ clawjournal scan
 clawjournal score --batch --source failure-v1 --auto-triage
 ```
 
-`--source failure-v1` scopes scoring to claude / codex / opencode / openclaw. Each session gets two AI ratings: productivity (legacy) and failure-value (the new primary signal for finding teachable agent failures).
+`--source failure-v1` scopes scoring to claude / codex / opencode / openclaw. Each session gets two AI ratings: failure value (the primary signal for teachable agent failures) and productivity (legacy compatibility).
 
 Present summary:
 
-> Found 47 sessions. 23 scored. Productivity 4-5: 14, productivity 1-2: 8 (auto-archived). Failure-value 4-5: 9 (high-value failure traces — review first). 16 still need review.
+> Found 47 sessions. 23 scored. Failure-value 4-5: 9 (high-value failure traces — review first). Productivity-1 low-failure-value noise: 8 auto-archived. 16 still need review.
 
 Ask:
 > How would you like to review?
@@ -274,7 +274,8 @@ clawjournal search <query> [--json] [--limit 20]
 clawjournal score --batch [--source failure-v1] [--auto-triage] [--limit 20]
 clawjournal rescore --window 7d [--source failure-v1] [--limit 200]
 clawjournal score-view <id>
-clawjournal set-score <id> <1-5> [--reason "..."]  # legacy productivity only
+clawjournal set-score <id> --failure-value <1-5> [--failure-evidence "..."] [--reason "..."]
+clawjournal set-score <id> --quality <1-5> [--reason "..."]  # legacy productivity only
 
 # Share
 clawjournal share --status approved [--note "..."] [--preview] [--json]

--- a/tests/scoring/test_scoring.py
+++ b/tests/scoring/test_scoring.py
@@ -465,6 +465,50 @@ class TestValidateJudgeResultBackwardCompat:
         assert validated["summary"] == "Added a feature."
         assert validated["effort_estimate"] == 0.7
 
+    def test_high_failure_value_without_evidence_is_capped(self):
+        result = {
+            "substance": 4,
+            **_failure_fields(
+                ai_quality_score=4,
+                ai_failure_value_score=5,
+                ai_failure_evidence=[],
+            ),
+            "reasoning": "High value, but no concrete evidence was returned.",
+            "display_title": "Review failed session",
+            "summary": "Reviewed a failed session.",
+            "resolution": "failed",
+            "task_type": "review",
+            "session_tags": [],
+            "privacy_flags": [],
+            "project_areas": [],
+        }
+
+        validated = _validate_judge_result(result)
+
+        assert validated["ai_failure_value_score"] == 3
+
+    def test_high_failure_value_with_evidence_is_preserved(self):
+        result = {
+            "substance": 4,
+            **_failure_fields(
+                ai_quality_score=4,
+                ai_failure_value_score=5,
+                ai_failure_evidence=["User corrected the agent's unsupported claim."],
+            ),
+            "reasoning": "Evidence-backed high-value failure.",
+            "display_title": "Review failed session",
+            "summary": "Reviewed a failed session.",
+            "resolution": "failed",
+            "task_type": "review",
+            "session_tags": [],
+            "privacy_flags": [],
+            "project_areas": [],
+        }
+
+        validated = _validate_judge_result(result)
+
+        assert validated["ai_failure_value_score"] == 5
+
 
 # ---------------------------------------------------------------------------
 # Backend selection

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -977,6 +977,34 @@ class TestWorkbenchSourceChoices:
         assert seen["source"] == "aider"
 
 
+class TestRecentOutput:
+    def test_recent_prints_failure_value_as_visible_score(self, monkeypatch, capsys):
+        from clawjournal.cli import _run_recent
+
+        conn = MagicMock()
+
+        def fake_query_sessions(conn, **kwargs):
+            if kwargs.get("sort") == "indexed_at":
+                return [{"indexed_at": "2999-01-01T00:00:00+00:00"}]
+            return [{
+                "session_id": "sess-1",
+                "display_title": "Investigate flaky parser",
+                "duration_seconds": 90,
+                "outcome_badge": "failed",
+                "ai_failure_value_score": 4,
+                "ai_quality_score": 1,
+            }]
+
+        monkeypatch.setattr("clawjournal.workbench.index.open_index", lambda: conn)
+        monkeypatch.setattr("clawjournal.workbench.index.query_sessions", fake_query_sessions)
+
+        _run_recent(MagicMock(source=None, since=None, limit=5, json=False))
+
+        out = capsys.readouterr().out
+        assert "FV 4/5" in out
+        assert "1/5" not in out
+
+
 class TestEventsCLI:
     def test_events_capabilities_outputs_json(self, capsys):
         with patch.object(sys, "argv", ["clawjournal", "events", "capabilities"]):
@@ -1517,6 +1545,160 @@ class TestVerifyEmail:
 
 
 class TestScore:
+    def test_set_score_can_override_failure_value(self, monkeypatch, capsys):
+        from clawjournal.cli import _run_set_score
+
+        conn = MagicMock()
+        calls = []
+
+        monkeypatch.setattr("clawjournal.workbench.index.open_index", lambda: conn)
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.get_session_detail",
+            lambda conn_arg, sid: {"ai_scoring_detail": "{}"},
+        )
+
+        def fake_update_session(conn_arg, session_id, **updates):
+            calls.append((conn_arg, session_id, updates))
+            return True
+
+        monkeypatch.setattr("clawjournal.workbench.index.update_session", fake_update_session)
+
+        args = MagicMock(
+            session_ids=["sess-1"],
+            quality=None,
+            failure_value=4,
+            failure_evidence=["Trace-backed failure evidence."],
+            reason="Trace-backed failure pattern.",
+        )
+        _run_set_score(args)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["failure_value"] == 4
+        assert output["failure_evidence"] == ["Trace-backed failure evidence."]
+        assert output["results"][0]["ai_failure_value_score"] == 4
+        assert len(calls) == 1
+        assert calls[0][0] is conn
+        assert calls[0][1] == "sess-1"
+        assert calls[0][2]["ai_failure_value_score"] == 4
+        assert calls[0][2]["ai_score_reason"] == "Trace-backed failure pattern."
+        assert json.loads(calls[0][2]["ai_scoring_detail"]) == {
+            "ai_failure_evidence": ["Trace-backed failure evidence."],
+        }
+        conn.close.assert_called_once()
+
+    def test_set_score_requires_evidence_for_high_failure_value(self, monkeypatch, capsys):
+        from clawjournal.cli import _run_set_score
+
+        conn = MagicMock()
+        monkeypatch.setattr("clawjournal.workbench.index.open_index", lambda: conn)
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.get_session_detail",
+            lambda conn_arg, sid: {"ai_scoring_detail": "{}"},
+        )
+
+        args = MagicMock(
+            session_ids=["sess-1"],
+            quality=None,
+            failure_value=4,
+            failure_evidence=[],
+            reason="Needs promotion.",
+        )
+
+        with pytest.raises(SystemExit):
+            _run_set_score(args)
+
+        output = json.loads(capsys.readouterr().out)
+        assert "require --failure-evidence" in output["error"]
+        assert output["session_ids"] == ["sess-1"]
+        conn.close.assert_called_once()
+
+    def test_set_score_requires_at_least_one_score(self, monkeypatch, capsys):
+        from clawjournal.cli import _run_set_score
+
+        args = MagicMock(
+            session_ids=["sess-1"],
+            quality=None,
+            failure_value=None,
+            failure_evidence=[],
+            reason=None,
+        )
+
+        with pytest.raises(SystemExit):
+            _run_set_score(args)
+
+        output = json.loads(capsys.readouterr().out)
+        assert "Provide --failure-value" in output["error"]
+
+    def test_score_view_prints_failure_value_first(self, monkeypatch, capsys):
+        from clawjournal.cli import _run_score_view
+
+        conn = MagicMock()
+        monkeypatch.setattr("clawjournal.workbench.index.open_index", lambda: conn)
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.get_session_detail",
+            lambda conn_arg, sid: {
+                "session_id": sid,
+                "source": "codex",
+                "model": "gpt-5",
+                "project": "demo",
+                "duration_seconds": 120,
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "user_messages": 1,
+                "assistant_messages": 1,
+                "task_type": "debugging",
+                "outcome_badge": "resolved",
+                "sensitivity_score": 0.0,
+                "value_badges": [],
+                "risk_badges": [],
+                "ai_failure_value_score": 4,
+                "ai_quality_score": 2,
+                "ai_failure_modes": ["reasoning_fabrication"],
+                "ai_recovery_labels": ["user_corrected_recovery"],
+                "ai_failure_attribution": "agent_caused",
+                "ai_learning_summary": "The user corrected a fabricated API call.",
+                "ai_scoring_detail": json.dumps({
+                    "ai_failure_evidence": ["User corrected the nonexistent call."],
+                }),
+                "messages": [],
+                "files_touched": [],
+                "commands_run": [],
+            },
+        )
+
+        _run_score_view(MagicMock(batch=False, session_ids=["sess-1"]))
+
+        output = capsys.readouterr().out
+        assert "Failure value: 4/5 | Productivity: 2/5" in output
+        assert "Failure modes: reasoning_fabrication" in output
+        assert "Evidence:" in output
+        assert "User corrected the nonexistent call." in output
+        conn.close.assert_called_once()
+
+    def test_auto_triage_only_blocks_low_failure_value_productivity_noise(self):
+        from clawjournal.cli import _is_auto_triage_noise
+
+        assert _is_auto_triage_noise({
+            "ai_quality_score": 1,
+            "ai_failure_value_score": 1,
+        })
+        assert _is_auto_triage_noise({
+            "ai_quality_score": 1,
+            "ai_failure_value_score": 2,
+        })
+        assert not _is_auto_triage_noise({
+            "ai_quality_score": 1,
+            "ai_failure_value_score": 3,
+        })
+        assert not _is_auto_triage_noise({
+            "ai_quality_score": 1,
+            "ai_failure_value_score": 4,
+        })
+        assert not _is_auto_triage_noise({
+            "ai_quality_score": 1,
+            "ai_failure_value_score": None,
+        })
+
     def test_score_single_session_returns_error_on_judge_failure(self, monkeypatch):
         from clawjournal.cli import _score_single_session
 

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -412,6 +412,27 @@ class TestSessionsAPI:
         status, detail = _get(server, "/api/sessions/sess-0")
         assert detail["review_status"] == "approved"
 
+    def test_update_session_requires_evidence_for_high_failure_value(self, server):
+        status, data = _post(server, "/api/sessions/sess-0", {"ai_failure_value_score": 4})
+
+        assert status == 400
+        assert "require evidence" in data["error"]
+
+    def test_update_session_stores_failure_evidence_for_high_failure_value(self, server):
+        status, data = _post(server, "/api/sessions/sess-0", {
+            "ai_failure_value_score": 4,
+            "ai_failure_evidence": ["The user corrected a fabricated API call."],
+        })
+        assert status == 200
+        assert data["ok"] is True
+
+        status, detail = _get(server, "/api/sessions/sess-0")
+        assert status == 200
+        assert detail["ai_failure_value_score"] == 4
+        assert json.loads(detail["ai_scoring_detail"]) == {
+            "ai_failure_evidence": ["The user corrected a fabricated API call."],
+        }
+
     def test_score_session_endpoint_updates_session(self, server, monkeypatch):
         monkeypatch.setattr(
             "clawjournal.scoring.scoring.score_session",

--- a/tests/workbench/test_highlights.py
+++ b/tests/workbench/test_highlights.py
@@ -29,6 +29,7 @@ def _insert(
     source="claude",
     project="proj-1",
     quality=5,
+    failure_value=None,
     ended_hours_ago=24,
     duration=1000,
     title=None,
@@ -57,11 +58,15 @@ def _insert(
         ),
     )
     conn.commit()
-    if quality is not None:
+    if quality is not None or failure_value is not None:
+        if failure_value is None:
+            failure_value = quality
         update_session(
             conn, session_id,
             ai_quality_score=quality,
+            ai_failure_value_score=failure_value,
             ai_summary=summary or f"Summary for {session_id}",
+            ai_learning_summary=summary or f"Summary for {session_id}",
             ai_outcome_badge="resolved",
             ai_effort_estimate=0.5,
         )
@@ -155,16 +160,16 @@ class TestSourceDiversification:
         assert {h["source"] for h in data["highlights"]} == {"claude"}
 
 
-class TestQualityTieBreaker:
-    def test_higher_quality_beats_more_recent_at_same_source(self, index_conn):
-        _insert(index_conn, session_id="solid", quality=4, ended_hours_ago=1)
-        _insert(index_conn, session_id="major", quality=5, ended_hours_ago=24)
+class TestFailureValueTieBreaker:
+    def test_higher_failure_value_beats_more_recent_at_same_source(self, index_conn):
+        _insert(index_conn, session_id="solid", quality=5, failure_value=4, ended_hours_ago=1)
+        _insert(index_conn, session_id="canonical", quality=3, failure_value=5, ended_hours_ago=24)
 
         data = get_highlights(index_conn, days=7, top_n=3, min_quality=4)
 
         ids = [h["session_id"] for h in data["highlights"]]
-        # Both are from the same source; quality tier wins.
-        assert ids == ["major", "solid"]
+        # Both are from the same source; failure-value tier wins.
+        assert ids == ["canonical", "solid"]
 
 
 class TestMetadataFields:
@@ -182,9 +187,10 @@ class TestMetadataFields:
         assert card["project"] == "proj-1"
         assert card["source"] == "claude"
         assert card["ai_quality_score"] == 5
+        assert card["ai_failure_value_score"] == 5
         assert card["outcome"] == "resolved"
         assert "rationale" in card
-        assert card["rationale"].startswith("5-star")
+        assert card["rationale"].startswith("FV 5/5")
 
     def test_summary_teaser_truncates(self, index_conn):
         long_summary = "word " * 200  # far more than 200 chars
@@ -217,13 +223,14 @@ class TestEndpointResponseShape:
         data = get_highlights(index_conn, days=7, top_n=3, min_quality=4)
 
         assert set(data.keys()) == {
-            "highlights", "window_days", "min_quality", "candidate_count"
+            "highlights", "window_days", "min_quality", "min_failure_value", "candidate_count"
         }
         assert data["window_days"] == 7
         assert data["min_quality"] == 4
+        assert data["min_failure_value"] == 4
 
     def test_unscored_sessions_excluded(self, index_conn):
-        # Session with NULL ai_quality_score (not yet scored) must not appear
+        # Session with NULL ai_failure_value_score (not yet scored) must not appear
         # even if end_time is in range.
         _insert(index_conn, session_id="unscored", quality=None, ended_hours_ago=1)
         _insert(index_conn, session_id="scored", quality=5, ended_hours_ago=2)
@@ -232,3 +239,12 @@ class TestEndpointResponseShape:
 
         ids = [h["session_id"] for h in data["highlights"]]
         assert ids == ["scored"]
+
+    def test_high_quality_low_failure_value_excluded(self, index_conn):
+        _insert(index_conn, session_id="productive", quality=5, failure_value=2, ended_hours_ago=1)
+        _insert(index_conn, session_id="failure", quality=3, failure_value=4, ended_hours_ago=2)
+
+        data = get_highlights(index_conn, days=7, top_n=3, min_quality=4)
+
+        ids = [h["session_id"] for h in data["highlights"]]
+        assert ids == ["failure"]

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -735,7 +735,7 @@ class TestShares:
         assert share["session_count"] == 0
 
     def test_share_history_and_share_ready_recommendations(self, index_conn):
-        # Recommendations require 5-star quality in the last 7 days. Use
+        # Recommendations require high failure value in the last 7 days. Use
         # `datetime.now()` so the window is always satisfied; the existing
         # in-memory DB has no clock dependency otherwise.
         from datetime import datetime, timedelta, timezone
@@ -758,7 +758,12 @@ class TestShares:
             ),
         ])
         for sid in ("s1", "s2", "s3"):
-            update_session(index_conn, sid, status="approved", ai_quality_score=5)
+            update_session(
+                index_conn, sid,
+                status="approved",
+                ai_quality_score=5,
+                ai_failure_value_score=5,
+            )
 
         shared_share_id = create_share(index_conn, ["s1"])
         index_conn.execute(
@@ -776,8 +781,36 @@ class TestShares:
 
         stats = get_share_ready_stats(index_conn)
         assert [s["session_id"] for s in stats["sessions"]] == ["s3", "s2"]
-        # Recommendation is the same ordered list (recent 5-star, capped 5).
+        # Recommendation is the same ordered list (recent high failure value, capped 5).
         assert stats["recommended_session_ids"] == ["s3", "s2"]
+
+    def test_share_ready_does_not_recommend_legacy_productivity_only_scores(self, index_conn):
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        upsert_sessions(index_conn, [
+            _make_session(
+                "legacy",
+                start_time=(now - timedelta(days=1)).isoformat(),
+                end_time=(now - timedelta(days=1, minutes=-10)).isoformat(),
+            ),
+            _make_session(
+                "failure",
+                start_time=now.isoformat(),
+                end_time=(now + timedelta(minutes=10)).isoformat(),
+            ),
+        ])
+        update_session(index_conn, "legacy", status="approved", ai_quality_score=5)
+        update_session(
+            index_conn, "failure",
+            status="approved",
+            ai_quality_score=3,
+            ai_failure_value_score=4,
+        )
+
+        stats = get_share_ready_stats(index_conn)
+
+        assert [s["session_id"] for s in stats["sessions"]] == ["failure", "legacy"]
+        assert stats["recommended_session_ids"] == ["failure"]
 
     def test_share_ready_respects_excluded_project_rules(self, index_conn):
         from datetime import datetime, timedelta, timezone
@@ -792,8 +825,18 @@ class TestShares:
                 start_time=(now - timedelta(days=1)).isoformat(),
             ),
         ])
-        update_session(index_conn, "private", status="approved", ai_quality_score=5)
-        update_session(index_conn, "public", status="approved", ai_quality_score=5)
+        update_session(
+            index_conn, "private",
+            status="approved",
+            ai_quality_score=5,
+            ai_failure_value_score=5,
+        )
+        update_session(
+            index_conn, "public",
+            status="approved",
+            ai_quality_score=5,
+            ai_failure_value_score=5,
+        )
         add_policy(index_conn, "exclude_project", "private-repo")
 
         settings = get_effective_share_settings(index_conn, {"excluded_projects": []})


### PR DESCRIPTION
## Summary

Adds `redefine-ai-score.md` — a design doc for shifting the primary user-facing 1-5 AI score from productivity/quality to **failure value**: how useful a trace is for understanding and improving agent failure behavior on real expert work.

### Current decisions

- Show `ai_failure_value_score` as the primary 1-5 score. Keep the legacy productivity `ai_quality_score` visible as a **secondary score and sortable lens** — it answers a different question (substance) that still has signal.
- 5/5 does not require `agent_caused`; the gate is whether agent behavior (recovery, uncertainty handling, collaboration, escalation) is the lesson.
- Scores of 4 or 5 require at least one `ai_failure_evidence` snippet; if no snippet can be quoted, the score falls back to 3. Manual `set-score --failure-value` overrides to 4-5 require `--failure-evidence`.
- `--auto-triage` only auto-blocks productivity-1 sessions when failure value is 1-2. Failure value 3 stays reviewable.
- Legacy traces with productivity score but no failure-value score are treated as unscored for the new failure lens; the migration path is rescoring via `clawjournal score --batch`.

### Design evolution during the PR

The doc went through three positions on the legacy productivity score before landing on the current one:

1. First draft: hide `ai_quality_score` from the UI entirely.
2. Mid-iteration: hide from primary UI surfaces only.
3. **Current:** keep visible as a secondary lens. Productivity and failure value answer different questions; hiding productivity loses signal.

The commit history reflects this trajectory — reviewers scanning the diff will see the swing.

### Status

Most of the underlying work is already on `main` (see Implementation Sketch → "Already shipped" — all 7 items verified against the code on this branch).

Remaining: keep productivity visibly secondary on the surfaces that need a small tweak, rename "quality" copy to "productivity" in the Insights recommendations engine (four file refs in the doc), and remove a legacy-quality fallback in `Insights.tsx:169` that silently coerces productivity into the failure-value slot.

## Test plan

- [x] Docs-only change; no code paths touched.
- [x] All "Already shipped" claims verified against the code on `origin/main`.
- [x] UI verification — built frontend and walked the four migrated surfaces (Sessions list, Dashboard, Session Detail, Insights, Share).
