### PR TITLE
fix: rebalance search and share layouts

### DIFF
--- a/clawjournal/web/frontend/src/views/Search.tsx
+++ b/clawjournal/web/frontend/src/views/Search.tsx
@@ -7,6 +7,8 @@ import { EmptyState } from '../components/Spinner.tsx';
 import { useToast } from '../components/Toast.tsx';
 import { colors } from '../theme.ts';
 
+const SEARCH_SHELL_WIDTH = 1120;
+
 export function Search() {
   const { toast } = useToast();
   const [query, setQuery] = useState('');
@@ -44,11 +46,16 @@ export function Search() {
   };
 
   return (
-    <div style={{ maxWidth: 960, margin: '0 auto', padding: '24px 16px' }}>
+    <div style={{ maxWidth: SEARCH_SHELL_WIDTH, margin: '0 auto', padding: '32px 24px 48px' }}>
       <h1 style={{ fontSize: 22, fontWeight: 700, margin: '0 0 4px 0', color: colors.gray900 }}>Search</h1>
       <p style={{ fontSize: 14, color: colors.gray500, margin: '0 0 16px 0' }}>Full-text search across all session content</p>
 
-      <div style={{ marginBottom: 20 }}>
+      <div style={{
+        marginBottom: 24,
+        padding: '18px',
+        borderRadius: 14,
+        background: colors.gray50,
+      }}>
         <input
           type="text"
           value={query}
@@ -63,6 +70,7 @@ export function Search() {
             outline: 'none',
             boxSizing: 'border-box',
             background: colors.white,
+            boxShadow: '0 1px 2px rgba(0,0,0,0.03)',
           }}
         />
       </div>
@@ -90,11 +98,18 @@ export function Search() {
       )}
 
       {!loading && !searched && (
-        <div style={{ textAlign: 'center', padding: '40px 20px' }}>
+        <div style={{
+          textAlign: 'center',
+          padding: '40px 20px',
+          minHeight: 280,
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'center',
+        }}>
           <div style={{ fontSize: 32, marginBottom: 12 }}>&#128269;</div>
           <h3 style={{ margin: '0 0 6px', fontSize: 16, fontWeight: 600, color: colors.gray500 }}>Search sessions</h3>
           <p style={{ margin: '0 0 20px', fontSize: 14, color: colors.gray400 }}>Type to search, or try a suggested query:</p>
-          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'center', maxWidth: 600, margin: '0 auto' }}>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap', justifyContent: 'center', maxWidth: 720, margin: '0 auto' }}>
             {PRESET_SEARCHES.map(preset => (
               <button
                 key={preset.query}

--- a/clawjournal/web/frontend/src/views/Share.tsx
+++ b/clawjournal/web/frontend/src/views/Share.tsx
@@ -130,6 +130,7 @@ interface BucketCounts {
 }
 
 const emptyBuckets = (): BucketCounts => ({ tokens: 0, emails: 0, paths: 0, timestamps: 0, urls: 0, other: 0 });
+const SHARE_SHELL_WIDTH = '1120px';
 
 // ============================================================
 // Types
@@ -1038,7 +1039,7 @@ export function Share() {
   // =================================================
 
   if (loading) {
-    return <div style={{ padding: '24px', maxWidth: '720px', margin: '0 auto' }}>
+    return <div style={{ padding: '32px 24px 48px', maxWidth: SHARE_SHELL_WIDTH, margin: '0 auto' }}>
       <Spinner text="Loading share data..." />
     </div>;
   }
@@ -1266,7 +1267,7 @@ function QueueStep(p: QueueStepProps) {
   const historyShares = p.shares.filter(b => b.status === 'shared' || b.status === 'exported');
 
   return (
-    <div style={{ padding: '24px', maxWidth: '960px', margin: '0 auto' }}>
+    <div style={{ padding: '32px 24px 48px', maxWidth: SHARE_SHELL_WIDTH, margin: '0 auto' }}>
       {p.globalStyles}
       {p.stepperHeader}
 
@@ -1277,9 +1278,10 @@ function QueueStep(p: QueueStepProps) {
             Build a redacted bundle of your traces to share for model evaluation and training.
           </p>
           <div style={{
-            padding: '60px 28px', textAlign: 'center',
+            minHeight: 280, padding: '60px 28px', textAlign: 'center',
             background: colors.gray50, border: `1px dashed ${colors.gray300}`,
             borderRadius: 12, color: colors.gray500,
+            display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center',
           }}>
             <div style={{
               width: 52, height: 52, borderRadius: 12, background: colors.white,
@@ -1333,9 +1335,10 @@ function QueueStep(p: QueueStepProps) {
             </>
           ) : (
             <div style={{
-              padding: '48px 28px', textAlign: 'center',
+              minHeight: 280, padding: '48px 28px', textAlign: 'center',
               background: colors.gray50, border: `1px dashed ${colors.gray300}`,
               borderRadius: 12, color: colors.gray500,
+              display: 'flex', flexDirection: 'column', justifyContent: 'center', alignItems: 'center',
             }}>
               <div style={{
                 width: 52, height: 52, borderRadius: 12, background: colors.white,
@@ -1736,7 +1739,7 @@ function RedactStep(p: RedactStepProps) {
   );
 
   return (
-    <div style={{ padding: '24px', maxWidth: '960px', margin: '0 auto' }}>
+    <div style={{ padding: '32px 24px 48px', maxWidth: SHARE_SHELL_WIDTH, margin: '0 auto' }}>
       {p.globalStyles}
       {p.stepperHeader}
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
@@ -1955,7 +1958,7 @@ function ReviewStep(p: ReviewStepProps) {
   )).length;
 
   return (
-    <div style={{ padding: '24px', maxWidth: '960px', margin: '0 auto' }}>
+    <div style={{ padding: '32px 24px 48px', maxWidth: SHARE_SHELL_WIDTH, margin: '0 auto' }}>
       {p.globalStyles}
       {p.stepperHeader}
       <div style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 6 }}>
@@ -2402,11 +2405,11 @@ function PackageStep(p: PackageStepProps) {
   }, [flying]);
 
   return (
-    <div style={{ padding: '24px', maxWidth: '720px', margin: '0 auto' }}>
+    <div style={{ padding: '32px 24px 48px', maxWidth: SHARE_SHELL_WIDTH, margin: '0 auto' }}>
       {p.globalStyles}
       {p.stepperHeader}
       <div style={{
-        padding: '40px 24px 24px', maxWidth: 520, margin: '0 auto', textAlign: 'center',
+        padding: '56px 24px 24px', maxWidth: 680, margin: '0 auto', textAlign: 'center',
       }}>
         <div style={{ width: 180, height: 240, margin: '0 auto 24px', position: 'relative' }}>
           {flying.map((f) => (
@@ -2515,10 +2518,10 @@ function DoneStep(p: DoneStepProps) {
   const traces = p.bundle?.traces ?? 0;
 
   return (
-    <div style={{ padding: '24px', maxWidth: '720px', margin: '0 auto' }}>
+    <div style={{ padding: '32px 24px 48px', maxWidth: SHARE_SHELL_WIDTH, margin: '0 auto' }}>
       {p.globalStyles}
       {p.stepperHeader}
-      <div style={{ position: 'relative', padding: '48px 24px 24px', maxWidth: 600, margin: '0 auto', textAlign: 'center' }}>
+      <div style={{ position: 'relative', padding: '56px 24px 24px', maxWidth: 680, margin: '0 auto', textAlign: 'center' }}>
         <div style={{ position: 'absolute', inset: 0, pointerEvents: 'none', overflow: 'hidden' }}>
           {confettiPieces.map((c) => (
             <span key={c.id} style={{


### PR DESCRIPTION
## Summary
- rebalance the `/search` shell so the input and empty state read correctly on desktop
- widen the `/share` flow and keep the outer shell stable across steps while preserving narrow package/done cards
- center the empty queue states without stretching the CTA controls

## Verification
- `npm run build` in `clawjournal/web/frontend`
- manually checked `http://127.0.0.1:8384/search`
- manually checked `http://127.0.0.1:8384/share`

## Claude Review
- initial Claude diff review flagged two real layout issues: the brittle search empty-state height and the share step-shell width jump
- both issues were fixed before opening/updating this PR
- final Claude pass left one non-blocking note: the queue empty-state cards use centered flex-column layout, which could be fragile if future children need full-width block layout
- manually verified the current queue empty-state content in-browser; the current icon, copy, and CTA render correctly, so this is not a blocking issue for the present UI

## Notes
- no new tests added for this change set
