### PR TITLE
[codex] Rank share queue by failure value

### DIFF
--- a/clawjournal/web/frontend/src/views/Share.tsx
+++ b/clawjournal/web/frontend/src/views/Share.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
-import { Link, useSearchParams } from 'react-router-dom';
+import { Link, useLocation, useSearchParams } from 'react-router-dom';
 import type { Session, Share as ShareType, ToolUse } from '../types.ts';
 import { api } from '../api.ts';
 import { useToast } from '../components/Toast.tsx';
@@ -172,6 +172,24 @@ interface ShareReadyStats {
   models: string[];
   recommended_session_ids: string[];
   sessions: ReadySession[];
+}
+
+const DEFAULT_SHARE_QUEUE_SIZE = 10;
+
+function queueFromStats(stats: ShareReadyStats): string[] {
+  const validIds = new Set(stats.sessions.map((s) => s.session_id));
+  return (stats.recommended_session_ids || [])
+    .filter((id) => validIds.has(id))
+    .slice(0, DEFAULT_SHARE_QUEUE_SIZE);
+}
+
+function completedKeysForStep(step: StepKey): Set<string> {
+  const idx = STEPS.findIndex((s) => s.key === step);
+  return new Set(STEPS.slice(0, Math.max(0, idx)).map((s) => s.key));
+}
+
+function parseStep(value: string | null): StepKey {
+  return STEPS.some((s) => s.key === value) ? value as StepKey : 'queue';
 }
 
 interface RedactedReviewMessage {
@@ -478,15 +496,17 @@ function StatusDot({ status }: { status: 'checking' | 'clear' | 'review' }) {
 
 export function Share() {
   const { toast } = useToast();
+  const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
+  const internalSearchRef = useRef<string | null>(null);
+  const skipNextUrlSyncRef = useRef(false);
 
   const [activeStep, setActiveStep] = useState<StepKey>(
-    () => (searchParams.get('step') as StepKey) || 'queue',
+    () => parseStep(searchParams.get('step')),
   );
   const [completedKeys, setCompletedKeys] = useState<Set<string>>(() => {
-    const step = (searchParams.get('step') as StepKey) || 'queue';
-    const idx = STEPS.findIndex((s) => s.key === step);
-    return new Set(STEPS.slice(0, Math.max(0, idx)).map((s) => s.key));
+    const step = parseStep(searchParams.get('step'));
+    return completedKeysForStep(step);
   });
 
   const [readyStats, setReadyStats] = useState<ShareReadyStats | null>(null);
@@ -550,13 +570,10 @@ export function Share() {
       setShares(shareList);
       setScoringBackend(backend);
       if (!selectionInitialized && stats.sessions.length > 0) {
-        // Server recommendation is approved high-value failure traces, capped
-        // at 5. Trust it and only filter out ids the
-        // client can't resolve (eg. excluded projects).
-        const validIds = new Set(stats.sessions.map((s) => s.session_id));
-        const recommended = (stats.recommended_session_ids || [])
-          .filter((id) => validIds.has(id))
-          .slice(0, 5);
+        // Server recommendation is an ordered, reviewable default package.
+        // Trust it and only filter out ids the client can't resolve
+        // (eg. excluded projects).
+        const recommended = queueFromStats(stats);
         setQueueOrder(recommended);
         setSelectionInitialized(true);
       }
@@ -578,6 +595,52 @@ export function Share() {
   // =================================================
 
   useEffect(() => {
+    if (selectionInitialized || !readyStats || searchParams.get('ids')) return;
+    setQueueOrder(queueFromStats(readyStats));
+    setSelectionInitialized(true);
+  }, [readyStats, searchParams, selectionInitialized]);
+
+  useEffect(() => {
+    const currentSearch = location.search.startsWith('?') ? location.search.slice(1) : location.search;
+    if (internalSearchRef.current === currentSearch) return;
+
+    internalSearchRef.current = currentSearch;
+    skipNextUrlSyncRef.current = true;
+
+    const idsParam = searchParams.get('ids');
+    const ids = idsParam ? idsParam.split(',').filter(Boolean) : null;
+    const step = parseStep(searchParams.get('step'));
+
+    setActiveStep(step);
+    setCompletedKeys(completedKeysForStep(step));
+    setNote(searchParams.get('note') || '');
+    setPackagedShareId(searchParams.get('share'));
+    setRedactedSessions({});
+    setApprovedIds(new Set());
+    setExpandedReviewIds(new Set());
+    setBundleInfo(null);
+    setPackageProgress(0);
+    setPackageLog('');
+    setPackagingFailed(null);
+
+    if (ids) {
+      setQueueOrder(ids);
+      setSelectionInitialized(true);
+      return;
+    }
+
+    const recommended = readyStats && readyStats.sessions.length > 0
+      ? queueFromStats(readyStats)
+      : [];
+    setQueueOrder(recommended);
+    setSelectionInitialized(!!readyStats);
+  }, [location.search, readyStats, searchParams]);
+
+  useEffect(() => {
+    if (skipNextUrlSyncRef.current) {
+      skipNextUrlSyncRef.current = false;
+      return;
+    }
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
       if (activeStep === 'queue') next.delete('step'); else next.set('step', activeStep);
@@ -585,6 +648,7 @@ export function Share() {
       if (csv) next.set('ids', csv); else next.delete('ids');
       if (note) next.set('note', note); else next.delete('note');
       if (packagedShareId) next.set('share', packagedShareId); else next.delete('share');
+      internalSearchRef.current = next.toString();
       return next;
     }, { replace: true });
   }, [activeStep, queueOrder, note, packagedShareId, setSearchParams]);

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -34,6 +34,7 @@ WIDENED_MESSAGE_SCHEMA_VERSION = 4
 WORKBENCH_SCHEMA_VERSION = WIDENED_MESSAGE_SCHEMA_VERSION
 BACKFILL_WINDOW = 100
 FAILURE_VALUE_SOURCE_SCOPE = ("claude", "codex", "opencode", "openclaw")
+SHARE_RECOMMENDATION_LIMIT = 10
 
 # Display-only normalization from the mixed AI/heuristic outcome vocabulary
 # onto a single coherent label set. Prevents the duplicate-meaning rows we
@@ -3362,9 +3363,9 @@ def get_share_ready_stats(
 
     By default returns only `review_status='approved'` sessions; pass
     `include_unapproved=True` to widen the pool so the Preview UI can
-    offer non-approved sessions for explicit review. Approved high-value
-    failure traces are recommended first; unapproved high-value failures
-    remain visible but are never auto-approved by this API.
+    offer non-approved sessions for explicit review. Recommendations are
+    ranked by failure value first so the share wizard starts with the best
+    failure examples.
     """
     where_status = "" if include_unapproved else " WHERE review_status = 'approved'"
     rows = conn.execute(
@@ -3389,9 +3390,9 @@ def get_share_ready_stats(
         "     WHERE b.shared_at IS NOT NULL"
         "   )"
         " )"
-        " ORDER BY (review_status = 'approved') DESC,"
-        " (ai_failure_value_score IS NULL), ai_failure_value_score DESC,"
-        " start_time DESC, ai_quality_score DESC"
+        " ORDER BY (ai_failure_value_score IS NULL),"
+        " ai_failure_value_score DESC, start_time DESC,"
+        " (review_status = 'approved') DESC, ai_quality_score DESC"
     ).fetchall()
     cols = ["session_id", "project", "model", "source", "display_title",
             "ai_quality_score", "ai_failure_value_score", "ai_recovery_labels",
@@ -3419,76 +3420,26 @@ def get_share_ready_stats(
             projects.add(s["project"])
         if s.get("model"):
             models.add(s["model"])
-    approved_sessions = [s for s in sessions if s.get("review_status") == "approved"]
-    # Default recommendation: approved high-value failure traces from in-scope
-    # sources. Recent rows dominate, with older approved high-value failures as
-    # backfill. Unapproved failures are shown to the user for review, not added
-    # to the package by default.
-    recent_cutoff = datetime.now(timezone.utc) - timedelta(days=7)
-
-    def _is_recent(start_time: str | None) -> bool:
-        if not start_time:
-            return False
-        try:
-            ts = datetime.fromisoformat(start_time.replace("Z", "+00:00"))
-        except ValueError:
-            return False
-        if ts.tzinfo is None:
-            ts = ts.replace(tzinfo=timezone.utc)
-        return ts >= recent_cutoff
-
-    recent_sessions = sorted(
-        (s for s in sessions if _is_recent(s.get("start_time"))),
-        key=lambda s: (
-            s.get("ai_failure_value_score") or 0,
-            s.get("start_time") or "",
-        ),
-        reverse=True,
-    )
-
-    recommended_pool: list[dict] = []
+    recommended_pool: list[dict[str, Any]] = []
     seen_ids: set[str] = set()
 
-    def _is_high_value_failure(session: dict[str, Any]) -> bool:
-        score = session.get("ai_failure_value_score")
-        return (
-            session.get("review_status") == "approved"
-            and session.get("source") in FAILURE_VALUE_SOURCE_SCOPE
-            and (score or 0) >= 4
-        )
-
-    # Tier 1: recent approved high-value failures.
-    for session in recent_sessions:
-        if len(recommended_pool) >= 5:
-            break
+    def _add_recommendation(session: dict[str, Any]) -> None:
         sid = session.get("session_id")
         if not sid or sid in seen_ids:
-            continue
-        if not _is_high_value_failure(session):
-            continue
+            return
         recommended_pool.append(session)
         seen_ids.add(sid)
 
-    # Tier 2: older approved high-value failures.
-    if len(recommended_pool) < 5:
-        older_high_value = sorted(
-            (s for s in approved_sessions if not _is_recent(s.get("start_time")) and _is_high_value_failure(s)),
-            key=lambda s: (
-                s.get("ai_failure_value_score") or 0,
-                s.get("start_time") or "",
-            ),
-            reverse=True,
-        )
-        for session in older_high_value:
-            if len(recommended_pool) >= 5:
-                break
-            sid = session.get("session_id")
-            if not sid or sid in seen_ids:
-                continue
-            recommended_pool.append(session)
-            seen_ids.add(sid)
+    for session in sessions:
+        if len(recommended_pool) >= SHARE_RECOMMENDATION_LIMIT:
+            break
+        if session.get("source") not in FAILURE_VALUE_SOURCE_SCOPE:
+            continue
+        if session.get("ai_failure_value_score") is None:
+            continue
+        _add_recommendation(session)
 
-    recommended_ids = [s["session_id"] for s in recommended_pool[:5]]
+    recommended_ids = [s["session_id"] for s in recommended_pool[:SHARE_RECOMMENDATION_LIMIT]]
 
     return {
         "count": len(sessions),

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -812,6 +812,89 @@ class TestShares:
         assert [s["session_id"] for s in stats["sessions"]] == ["failure", "legacy"]
         assert stats["recommended_session_ids"] == ["failure"]
 
+    def test_share_ready_fills_default_queue_with_lower_failure_value_scores(self, index_conn):
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        sessions = [
+            _make_session(
+                f"s{i}",
+                start_time=(now - timedelta(minutes=i)).isoformat(),
+                end_time=(now - timedelta(minutes=i - 10)).isoformat(),
+            )
+            for i in range(1, 13)
+        ]
+        upsert_sessions(index_conn, sessions)
+        scores = {
+            "s1": 5,
+            "s2": 4,
+            "s3": 3,
+            "s4": 2,
+            "s5": 1,
+            "s6": 1,
+            "s7": 1,
+            "s8": 1,
+            "s9": 1,
+            "s10": 1,
+            "s11": 1,
+            "s12": 1,
+        }
+        for sid, score in scores.items():
+            update_session(
+                index_conn,
+                sid,
+                status="approved",
+                ai_quality_score=5,
+                ai_failure_value_score=score,
+            )
+
+        stats = get_share_ready_stats(index_conn)
+
+        assert stats["recommended_session_ids"] == [
+            "s1", "s2", "s3", "s4", "s5", "s6", "s7", "s8", "s9", "s10",
+        ]
+
+    def test_share_ready_widened_pool_ranks_best_failure_examples_first(self, index_conn):
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        upsert_sessions(index_conn, [
+            _make_session(
+                f"s{i}",
+                start_time=(now - timedelta(minutes=i)).isoformat(),
+                end_time=(now - timedelta(minutes=i - 10)).isoformat(),
+            )
+            for i in range(1, 12)
+        ])
+        for sid in ("s1", "s2"):
+            update_session(
+                index_conn,
+                sid,
+                status="approved",
+                ai_quality_score=5,
+                ai_failure_value_score=3,
+            )
+        for i in range(3, 6):
+            update_session(
+                index_conn,
+                f"s{i}",
+                status="new",
+                ai_quality_score=4,
+                ai_failure_value_score=4,
+            )
+        for i in range(6, 12):
+            update_session(
+                index_conn,
+                f"s{i}",
+                status="new",
+                ai_quality_score=4,
+                ai_failure_value_score=2,
+            )
+
+        stats = get_share_ready_stats(index_conn, include_unapproved=True)
+
+        assert stats["recommended_session_ids"] == [
+            "s3", "s4", "s5", "s1", "s2", "s6", "s7", "s8", "s9", "s10",
+        ]
+
     def test_share_ready_respects_excluded_project_rules(self, index_conn):
         from datetime import datetime, timedelta, timezone
         now = datetime.now(timezone.utc)


### PR DESCRIPTION
## Summary

- Rank Share wizard recommendations by `ai_failure_value_score` first so the draft queue starts with the best failure examples.
- Increase the default Share queue from 5 to 10 traces and keep URL state from resurrecting stale one-trace selections.
- Add regression coverage for 10-trace queue filling and failure-score-first ordering across approved and new traces.

## Root Cause

The Share page preserved old `ids` state when navigating back to `/share`, and the backend recommendation logic prioritized approved sessions before higher-value failure examples. That made the package look stuck on old selections and hid better failure traces behind lower-value approved ones.

## Validation

- `PYTHONPATH=. pytest -q` (`1811 passed`)
- `cd clawjournal/web/frontend && npm run build`
- `git diff --check`
- Verified locally in the workbench that Share opens with 10 traces ordered by failure value first.