### PR TITLE
[codex] Smooth shared trace uploads

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -7,7 +7,7 @@ ClawJournal is designed to be usable without uploading anything.
 - `clawjournal scan`, `serve`, `inbox`, `search`, `score`, `export`, and `bundle-export` run locally.
 - The browser workbench is local. If you install from source, `clawjournal serve` opens your own machine at `localhost:8384`.
 - `bundle-export` writes files to disk. It does not contact a server.
-- If you never configure `CLAWJOURNAL_INGEST_URL` and never run `bundle-share` or `share`, nothing is uploaded.
+- If you never upload the zip in a hosted browser page, and never configure `CLAWJOURNAL_INGEST_URL` or run `bundle-share` / `share`, nothing is uploaded.
 
 ## Automatic redaction
 
@@ -72,7 +72,7 @@ brew install trufflehog
 # https://github.com/trufflesecurity/trufflehog#floppy_disk-installation
 ```
 
-For the upload path, the scan runs at least **twice at share time**: once inside `export_share_to_disk` on the merged `sessions.jsonl`, and again after the AI-PII pass rewrites the file. Either scan finding something aborts the upload. TruffleHog also participates as a deterministic findings engine at scan-ingest time, so a session's existing `findings` rows already carry its detections before any share step — the share-time gates are the final check, not the first.
+For the upload path, the scan runs at least **twice at share time**: once inside `export_share_to_disk` on the merged `sessions.jsonl`, and again after the AI-PII pass rewrites the file. Either scan finding something aborts the upload. The AI-PII pass reviews sessions in a small bounded worker pool and falls back to deterministic PII rules when an AI backend errors or times out; the manifest records `redaction_summary.coverage.full` vs. `rules_only`. TruffleHog also participates as a deterministic findings engine at scan-ingest time, so a session's existing `findings` rows already carry its detections before any share step — the share-time gates are the final check, not the first.
 
 One detector is excluded at the TruffleHog layer: **`refiner`** (refiner.io user-feedback platform). Its pattern is "the word 'refiner' followed by a UUID", which false-positives on any project name containing that substring paired with the UUIDs present throughout Claude/Codex session JSON. Verification against refiner.io's own API correctly returns `unverified` for those matches, so they are never real leaks. Every other TruffleHog detector remains active and blocking.
 
@@ -92,10 +92,11 @@ Depending on how you export, bundle content can include user messages, assistant
 
 Uploading is a separate path from local export.
 
-- Uploading is disabled unless `CLAWJOURNAL_INGEST_URL` is configured.
-- The ingest URL must use `https://`, except for `localhost` and `127.0.0.1` during local development.
-- Upload commands are `clawjournal bundle-share <bundle_id>` or `clawjournal share ...`.
-- You can inspect what would be included with `clawjournal share --preview --status approved`.
+- Hosted research submission uses a browser upload page when `CLAWJOURNAL_SHARE_URL` is configured in the workbench.
+- Advanced self-hosted ingest upload is disabled unless `CLAWJOURNAL_INGEST_URL` is configured.
+- The ingest and hosted-share URLs must use `https://`, except for `localhost` and `127.0.0.1` during local development.
+- Self-hosted ingest commands are `clawjournal bundle-share <bundle_id>` or `clawjournal share ...`.
+- You can inspect what would be included in self-hosted ingest with `clawjournal share --preview --status approved`.
 
 ### Email verification
 

--- a/README.md
+++ b/README.md
@@ -327,11 +327,12 @@ Package the conversations you approved into a redacted file on your computer. Up
 
 **Just say to your AI:** *"Package my approved ClawJournal sessions and export them to a file on my computer."*
 
-The agent walks you through the Share page in the browser workbench: **Queue → Redact → Review → Package → Done**. The Redact step uses AI to catch any personal info the automatic scan missed.
+The agent walks you through the Share page in the browser workbench: **Queue → Redact → Review → Package → Done**. The Redact step uses AI to catch any personal info the automatic scan missed. Upload-time PII review runs a small parallel worker pool by default; set `CLAWJOURNAL_UPLOAD_PII_WORKERS=1` to serialize it or `CLAWJOURNAL_UPLOAD_PII_TIMEOUT_SECONDS=90` to allow longer AI review per trace.
 
-To actually upload after packaging (optional, requires a one-time email verification):
+To actually upload after packaging (optional), use the hosted submission page if one is configured for this install. The Done screen shows **Submit to ClawJournal Research** when a destination is available; that page verifies email, shows consent, and asks for the downloaded zip.
+Set `CLAWJOURNAL_SHARE_URL` to the hosted `/share` page to enable that button in local workbench builds.
 
-> *(optional)* *"Now share the bundle through the ClawJournal ingest service. My email is you@university.edu."*
+> *(optional)* *"Open the ClawJournal Research submission page so I can upload the exported zip."*
 
 Uploads are gated: only conversations you approved and confirmed for sharing leave your machine.
 
@@ -342,12 +343,15 @@ Uploads are gated: only conversations you approved and confirmed for sharing lea
 clawjournal bundle-create --status approved          # bundle all approved sessions
 clawjournal bundle-list
 clawjournal bundle-view <bundle_id>                  # inspect before exporting
-clawjournal bundle-export <bundle_id>                # write sessions.jsonl + manifest.json to disk
+clawjournal bundle-export <bundle_id> --zip          # write an uploadable zip plus export folder
 
-# Optional upload:
+# Optional hosted browser upload:
+python -m webbrowser "$CLAWJOURNAL_SHARE_URL"       # when configured
+
+# Advanced self-hosted ingest upload:
 clawjournal verify-email you@university.edu          # one-time email verification
 clawjournal share --preview --status approved        # dry-run
-clawjournal bundle-share <bundle_id>                 # upload through the configured ingest service
+clawjournal bundle-share <bundle_id>                 # self-hosted ingest upload
 ```
 
 Upload is gated on hold-state: only sessions in `auto_redacted` or `released` can leave the machine.
@@ -456,7 +460,7 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal config --confirm-projects` | Confirm project selection (required before export) |
 | `clawjournal score --batch --source failure-v1 --auto-triage` | AI-score failure-value scope; auto-block low-value productivity-1 noise |
 | `clawjournal bundle-create --status approved` | Bundle approved sessions |
-| `clawjournal bundle-export <bundle_id>` | Export bundle to disk as `sessions.jsonl` + `manifest.json` |
+| `clawjournal bundle-export <bundle_id> --zip` | Export bundle to disk and write an uploadable zip |
 
 ### Triage & review
 
@@ -500,8 +504,8 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal bundle-create --status approved` | Create bundle from all approved sessions |
 | `clawjournal bundle-list` | List bundles |
 | `clawjournal bundle-view <bundle_id>` | View bundle details |
-| `clawjournal bundle-export <bundle_id>` | Export bundle to disk |
-| `clawjournal bundle-share <bundle_id>` | Upload via configured ingest service |
+| `clawjournal bundle-export <bundle_id> --zip` | Export bundle and write an uploadable zip |
+| `clawjournal bundle-share <bundle_id>` | Advanced self-hosted ingest upload |
 
 ### Quick share
 
@@ -513,13 +517,13 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal card <id> --depth workflow` | Workflow-only card (safe for public channels) |
 | `clawjournal card <id> --depth full` | Full card with redacted content |
 
-### Optional upload
+### Advanced self-hosted ingest upload
 
 | Command | Description |
 |---------|-------------|
 | `clawjournal verify-email you@university.edu` | Verify a `.edu` email for upload authorization |
-| `clawjournal share --preview --status approved` | Preview what would be shared without uploading |
-| `clawjournal share --status approved` | Create a bundle and upload through the ingest service |
+| `clawjournal share --preview --status approved` | Preview what would be uploaded through ingest |
+| `clawjournal share --status approved` | Create a bundle and upload through the configured self-hosted ingest service |
 
 ### Configuration
 

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -6,6 +6,7 @@ import re
 import sys
 import urllib.error
 import urllib.request
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Mapping, cast
@@ -1483,6 +1484,21 @@ def _run_bundle_view(args) -> None:
         conn.close()
 
 
+def _write_bundle_zip(export_dir: Path) -> Path:
+    zip_path = export_dir.with_name(f"{export_dir.name}.zip")
+    with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
+        for name in (
+            "sessions.jsonl",
+            "manifest.json",
+            "trufflehog.json",
+            "trufflehog.post-pii.json",
+        ):
+            path = export_dir / name
+            if path.exists():
+                zf.write(path, arcname=name)
+    return zip_path
+
+
 def _run_bundle_export(args) -> None:
     """Export a bundle to disk as JSONL + manifest."""
     from .workbench.index import (
@@ -1530,10 +1546,22 @@ def _run_bundle_export(args) -> None:
 
         session_count = len(manifest.get("sessions", []))
         files = ["sessions.jsonl", "manifest.json", "trufflehog.json"]
+        zip_path = None
+        if getattr(args, "zip", False) is True:
+            from .workbench.daemon import finalize_share_export_for_upload
+
+            error, manifest = finalize_share_export_for_upload(export_dir, manifest)
+            if error:
+                if error.get("block_reason"):
+                    print(f"Share blocked: {error.get('block_reason')}")
+                print(error.get("error", "Failed to prepare upload zip."))
+                sys.exit(2 if int(error.get("status", 500)) == 422 else 1)
+            if (export_dir / "trufflehog.post-pii.json").exists():
+                files.append("trufflehog.post-pii.json")
 
         # Optional training-format conversion
         training_summary = None
-        if getattr(args, "training_format", False):
+        if getattr(args, "training_format", False) is True:
             from .export.training_data import convert_sessions_to_training
             sessions_path = export_dir / "sessions.jsonl"
             training_path = export_dir / "sessions.training.jsonl"
@@ -1541,17 +1569,28 @@ def _run_bundle_export(args) -> None:
             training_summary = convert_sessions_to_training(sessions, training_path)
             files.append("sessions.training.jsonl")
 
+        if getattr(args, "zip", False) is True:
+            zip_path = _write_bundle_zip(export_dir)
+
         if getattr(args, "json", False):
             result = {
                 "export_path": str(export_dir),
                 "session_count": session_count,
                 "files": files,
+                "redaction_summary": manifest.get("redaction_summary", {}),
             }
+            if zip_path:
+                result["zip_path"] = str(zip_path)
             if training_summary:
                 result["training"] = training_summary
             print(json.dumps(result, indent=2))
         else:
             print(f"Exported {session_count} sessions to {export_dir}/")
+            if zip_path:
+                print(f"Zip: {zip_path}")
+            redaction_summary = manifest.get("redaction_summary", {})
+            if redaction_summary:
+                print(f"Redactions: {redaction_summary.get('total_redactions', 0)} total")
             if training_summary:
                 print(f"Training format: {training_summary['turns']} turns → {export_dir}/sessions.training.jsonl")
     finally:
@@ -4004,9 +4043,10 @@ def main() -> None:
     be.add_argument("--output", "-o", type=str, default=None, help="Custom output directory")
     be.add_argument("--training-format", action="store_true",
                     help="Also produce a training-format JSONL (turn-based, cleaned)")
+    be.add_argument("--zip", action="store_true", help="Also write an uploadable zip")
     be.add_argument("--json", action="store_true", help="Output JSON")
 
-    bs = sub.add_parser("bundle-share", help="Share bundle via ingest service")
+    bs = sub.add_parser("bundle-share", help="Share bundle via self-hosted ingest service")
     bs.add_argument("share_id", help="Bundle ID (or prefix)")
     bs.add_argument("--force", action="store_true", help="Override duplicate check")
     bs.add_argument("--json", action="store_true", help="Output JSON")

--- a/clawjournal/redaction/pii.py
+++ b/clawjournal/redaction/pii.py
@@ -412,7 +412,15 @@ def _iter_json_text_locations(prefix: str, value: Any) -> Iterable[tuple[str, st
             yield from _iter_json_text_locations(f"{prefix}.{key}", item)
 
 
-def review_session_pii_with_agent(session: dict[str, Any], *, backend: str = "auto", ignore_errors: bool = False, rubric: str | None = None, max_workers: int = 4) -> list[PIIFinding]:
+def review_session_pii_with_agent(
+    session: dict[str, Any],
+    *,
+    backend: str = "auto",
+    ignore_errors: bool = False,
+    rubric: str | None = None,
+    max_workers: int = 4,
+    timeout_seconds: int = 180,
+) -> list[PIIFinding]:
     """Review a session for PII using session-level batching (one agent call per batch)."""
     work_items = _collect_text_work_items(session)
     if not work_items:
@@ -427,7 +435,15 @@ def review_session_pii_with_agent(session: dict[str, Any], *, backend: str = "au
     if len(batches) == 1:
         # Single batch — no parallelism needed
         try:
-            findings.extend(_review_batch(session_id, batches[0], rubric=rubric, backend=backend))
+            findings.extend(
+                _review_batch(
+                    session_id,
+                    batches[0],
+                    rubric=rubric,
+                    backend=backend,
+                    timeout_seconds=timeout_seconds,
+                )
+            )
         except RuntimeError as exc:
             if not ignore_errors:
                 raise
@@ -435,7 +451,14 @@ def review_session_pii_with_agent(session: dict[str, Any], *, backend: str = "au
         # Multiple batches — run in parallel
         with ThreadPoolExecutor(max_workers=min(max_workers, len(batches))) as pool:
             futures = {
-                pool.submit(_review_batch, session_id, batch, rubric=rubric, backend=backend): batch
+                pool.submit(
+                    _review_batch,
+                    session_id,
+                    batch,
+                    rubric=rubric,
+                    backend=backend,
+                    timeout_seconds=timeout_seconds,
+                ): batch
                 for batch in batches
             }
             for future in as_completed(futures):
@@ -457,6 +480,7 @@ def review_session_pii_hybrid(
     rubric: str | None = None,
     backend: str = "auto",
     return_coverage: bool = False,
+    timeout_seconds: int = 180,
 ) -> list[PIIFinding] | tuple[list[PIIFinding], str]:
     """Run hybrid PII detection (rule-based + AI agent).
 
@@ -468,7 +492,11 @@ def review_session_pii_hybrid(
     coverage = "full"
     try:
         agent_findings = review_session_pii_with_agent(
-            session, backend=backend, ignore_errors=False, rubric=rubric,
+            session,
+            backend=backend,
+            ignore_errors=False,
+            rubric=rubric,
+            timeout_seconds=timeout_seconds,
         )
     except Exception:
         if not ignore_llm_errors:

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -173,6 +173,10 @@ export const api = {
     return request(`/share-ready${q}`);
   },
 
+  shareDestination(): Promise<{ configured: boolean; preferred_upload_flow: string; cli_ingest_supported: boolean; share_page_url: string | null; message?: string }> {
+    return request('/share-destination');
+  },
+
   quickShare(sessionIds: string[], note?: string): Promise<{
     ok: boolean; share_id: string;
     shared_at: string; session_count: number; bundle_hash: string;
@@ -211,6 +215,19 @@ export const api = {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ output_path: outputPath }),
+      });
+    },
+
+    seal(id: string): Promise<{
+      ok: boolean;
+      export_path: string;
+      session_count: number;
+      redaction_summary: { total_redactions: number; by_type: Record<string, number> };
+    }> {
+      return request(`/shares/${encodeURIComponent(id)}/seal`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
       });
     },
 

--- a/clawjournal/web/frontend/src/views/Share.tsx
+++ b/clawjournal/web/frontend/src/views/Share.tsx
@@ -174,6 +174,24 @@ interface ShareReadyStats {
   sessions: ReadySession[];
 }
 
+interface ShareDestination {
+  configured: boolean;
+  preferred_upload_flow: string;
+  cli_ingest_supported: boolean;
+  share_page_url: string | null;
+  message?: string;
+}
+
+function formatShareDestination(url: string): string {
+  try {
+    const parsed = new URL(url);
+    const path = parsed.pathname && parsed.pathname !== '/' ? parsed.pathname : '';
+    return `${parsed.hostname}${path}`;
+  } catch {
+    return url;
+  }
+}
+
 const DEFAULT_SHARE_QUEUE_SIZE = 10;
 
 function queueFromStats(stats: ShareReadyStats): string[] {
@@ -555,6 +573,7 @@ export function Share() {
   // Candidates (empty queue hint)
   const [candidates, setCandidates] = useState<Session[]>([]);
   const [scoringBackend, setScoringBackend] = useState<{ backend: string | null; display_name: string | null } | null>(null);
+  const [shareDestination, setShareDestination] = useState<ShareDestination | null>(null);
 
   // =================================================
   // Initial load
@@ -565,10 +584,12 @@ export function Share() {
       api.shareReady({ includeUnapproved: true }),
       api.shares.list(),
       api.scoringBackend().catch(() => ({ backend: null, display_name: null })),
-    ]).then(([stats, shareList, backend]) => {
+      api.shareDestination().catch(() => null),
+    ]).then(([stats, shareList, backend, destination]) => {
       setReadyStats(stats);
       setShares(shareList);
       setScoringBackend(backend);
+      setShareDestination(destination);
       if (!selectionInitialized && stats.sessions.length > 0) {
         // Server recommendation is an ordered, reviewable default package.
         // Trust it and only filter out ids the client can't resolve
@@ -979,8 +1000,8 @@ export function Share() {
       'Allocating bundle...',
       'Writing manifest.json...',
       ...approvedList.map((s) => `Adding ${s.session_id.slice(0, 10)}.jsonl...`),
-      'Writing redaction-audit.json...',
-      'Compressing...',
+      'Running final PII review...',
+      'Running final secret scan...',
       'Sealing bundle...',
     ];
 
@@ -1004,7 +1025,6 @@ export function Share() {
     try {
       const ids = approvedList.map((s) => s.session_id);
       const { share_id } = await api.shares.create(ids, note || undefined);
-      await api.shares.export(share_id);
 
       // Finish the animation cleanly before exposing the share id — the
       // `packageProgress >= 100 && packagedShareId` combination triggers the
@@ -1012,6 +1032,14 @@ export function Share() {
       const animRemaining = Math.max(0, duration - (Date.now() - animStart));
       await new Promise((r) => window.setTimeout(r, animRemaining));
       clearAllTimers();
+      setPackageProgress(98);
+      setPackageLog('Finalizing zip...');
+
+      // Seal performs the final local-only AI PII pass and post-PII
+      // TruffleHog gate without triggering a browser save. The Done button
+      // is the only action that downloads bytes.
+      await api.shares.seal(share_id);
+
       setPackageProgress(100);
       setPackageLog('Done.');
 
@@ -1038,9 +1066,6 @@ export function Share() {
       // success-path state update.
       setPackagedShareId(share_id);
 
-      // Best-effort browser download + refresh. None of these should block
-      // the step transition.
-      try { await api.shares.download(share_id); } catch { /* user can still click Download again */ }
       try { reload(); } catch { /* ignore */ }
       try { toast('Bundle ready', 'success'); } catch { /* ignore */ }
     } catch (err: unknown) {
@@ -1245,6 +1270,7 @@ export function Share() {
         onNew={() => { startFreshShare(); reload(); }}
         globalStyles={globalStyles}
         error={error}
+        shareDestination={shareDestination}
       />
     );
   }
@@ -2565,6 +2591,7 @@ interface DoneStepProps {
   onNew: () => void;
   globalStyles: React.ReactNode;
   error: string | null;
+  shareDestination: ShareDestination | null;
 }
 
 function DoneStep(p: DoneStepProps) {
@@ -2583,6 +2610,8 @@ function DoneStep(p: DoneStepProps) {
   });
 
   const traces = p.bundle?.traces ?? 0;
+  const hostedShareUrl = p.shareDestination?.configured ? p.shareDestination.share_page_url : null;
+  const hostedShareLabel = hostedShareUrl ? formatShareDestination(hostedShareUrl) : null;
 
   return (
     <div style={{ padding: '32px 24px 48px', maxWidth: SHARE_SHELL_WIDTH, margin: '0 auto' }}>
@@ -2637,10 +2666,10 @@ function DoneStep(p: DoneStepProps) {
         </div>
 
         <h2 style={{ fontSize: 22, fontWeight: 500, letterSpacing: '-0.02em', margin: '0 0 8px', color: colors.gray900 }}>
-          Your bundle is saving to downloads
+          Your bundle is ready
         </h2>
         <p style={{ color: colors.gray500, margin: '0 0 24px', fontSize: 14 }}>
-          If your browser didn&rsquo;t catch the save, you can download the same zip again.
+          Download the finalized zip, then upload it through the hosted submission page.
         </p>
 
         {p.bundle && (
@@ -2679,22 +2708,30 @@ function DoneStep(p: DoneStepProps) {
           >
             <Icon name="download" size={15} /> Download zip
           </button>
-          <a
-            href="https://data.rayward.ai"
-            target="_blank"
-            rel="noopener noreferrer"
-            style={{
-              display: 'inline-flex', alignItems: 'center', gap: 8,
-              padding: '11px 20px', background: colors.primary500, color: colors.white,
-              borderRadius: 8, fontSize: 14, fontWeight: 600,
-              textDecoration: 'none',
-            }}
-          >
-            Share with Rayward &rarr;
-          </a>
+          {hostedShareUrl && (
+            <a
+              href={hostedShareUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: 8,
+                padding: '11px 20px', background: colors.primary500, color: colors.white,
+                borderRadius: 8, fontSize: 14, fontWeight: 600,
+                textDecoration: 'none',
+              }}
+            >
+              Submit to ClawJournal Research &rarr;
+            </a>
+          )}
         </div>
         <div style={{ fontSize: 12, color: colors.gray500, marginBottom: 8 }}>
-          Upload your bundle at <span style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace' }}>data.rayward.ai</span> to contribute to research.
+          {hostedShareLabel ? (
+            <>
+              Upload this zip at <span style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace' }}>{hostedShareLabel}</span> to contribute to research.
+            </>
+          ) : (
+            <>Hosted submission is not configured for this install. The redacted zip stays on this computer.</>
+          )}
         </div>
 
         <div style={{

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -14,6 +14,7 @@ import urllib.request
 import uuid
 import webbrowser
 import zipfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timedelta, timezone
 from functools import partial
 from http import HTTPStatus
@@ -88,7 +89,13 @@ AUTO_SCORE_BATCH_SIZE = 10
 
 _SHARE_MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB
 _SHARE_COOLDOWN_SECONDS = 10
+_UPLOAD_PII_DEFAULT_WORKERS = 3
+_UPLOAD_PII_MAX_WORKERS = 4
+_UPLOAD_PII_DEFAULT_TIMEOUT_SECONDS = 60
+_UPLOAD_PII_MIN_TIMEOUT_SECONDS = 10
+_UPLOAD_PII_MAX_TIMEOUT_SECONDS = 180
 _SHARE_INGEST_URL = os.environ.get("CLAWJOURNAL_INGEST_URL", "")
+_HOSTED_SHARE_URL = os.environ.get("CLAWJOURNAL_SHARE_URL", "").strip()
 _SHARE_GCS_BUCKET = os.environ.get("CLAWJOURNAL_GCS_BUCKET", "clawjournal-traces")
 _SHARE_GCS_PREFIX = os.environ.get("CLAWJOURNAL_GCS_PREFIX", "clawjournal")
 _SHARE_UPLOAD_TIMEOUT = 120
@@ -445,11 +452,27 @@ def _is_edu_email(email: str) -> bool:
 
 def _missing_ingest_url_error() -> str:
     return (
-        "Hosted sharing is not configured in this build. "
-        "Use `clawjournal bundle-export` to produce a local zip you can share "
-        "any way you like. Self-hosters can set CLAWJOURNAL_INGEST_URL to point "
-        "at their own ingest backend."
+        "CLI ingest upload is not configured in this build. "
+        "Use the workbench Download zip action or `clawjournal bundle-export` "
+        "to produce a local zip. Hosted research submissions use the configured "
+        "browser upload page; self-hosters can set CLAWJOURNAL_INGEST_URL to "
+        "point at their own ingest backend."
     )
+
+
+def _validated_hosted_share_url() -> tuple[str | None, str]:
+    """Return a configured hosted share URL, or a user-facing disabled reason."""
+    if not _HOSTED_SHARE_URL:
+        return None, "Hosted submission is not configured for this install."
+    parsed = urlparse(_HOSTED_SHARE_URL)
+    is_https = parsed.scheme == "https" and bool(parsed.netloc)
+    is_local_dev = (
+        parsed.scheme == "http"
+        and parsed.hostname in {"localhost", "127.0.0.1"}
+    )
+    if is_https or is_local_dev:
+        return _HOSTED_SHARE_URL, "Hosted submission is configured for browser zip upload."
+    return None, "CLAWJOURNAL_SHARE_URL must use HTTPS, or localhost for development."
 
 
 def _validate_ingest_url() -> None:
@@ -635,6 +658,299 @@ def _with_legacy_bundle_alias(payload: dict[str, Any]) -> dict[str, Any]:
     return payload
 
 
+def _bounded_int_env(name: str, default: int, minimum: int, maximum: int) -> int:
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        value = int(raw)
+    except ValueError:
+        logger.warning("Ignoring invalid %s=%r; using %d", name, raw, default)
+        return default
+    return max(minimum, min(maximum, value))
+
+
+def _upload_pii_worker_count(session_count: int) -> int:
+    if session_count <= 0:
+        return 0
+    requested = _bounded_int_env(
+        "CLAWJOURNAL_UPLOAD_PII_WORKERS",
+        _UPLOAD_PII_DEFAULT_WORKERS,
+        1,
+        _UPLOAD_PII_MAX_WORKERS,
+    )
+    return min(session_count, requested)
+
+
+def _upload_pii_timeout_seconds() -> int:
+    return _bounded_int_env(
+        "CLAWJOURNAL_UPLOAD_PII_TIMEOUT_SECONDS",
+        _UPLOAD_PII_DEFAULT_TIMEOUT_SECONDS,
+        _UPLOAD_PII_MIN_TIMEOUT_SECONDS,
+        _UPLOAD_PII_MAX_TIMEOUT_SECONDS,
+    )
+
+
+def _apply_upload_pii_redactions(sessions_file: Path) -> dict[str, Any]:
+    """Run upload-time PII review over a JSONL export, preserving row order."""
+    from ..redaction.pii import apply_findings_to_session, review_session_pii_hybrid
+
+    sessions: list[dict[str, Any]] = []
+    with open(sessions_file) as f:
+        for line in f:
+            if line.strip():
+                sessions.append(json.loads(line))
+
+    workers = _upload_pii_worker_count(len(sessions))
+    timeout_seconds = _upload_pii_timeout_seconds()
+    coverage = {"full": 0, "rules_only": 0}
+    if not sessions:
+        return {
+            "session_count": 0,
+            "finding_count": 0,
+            "replacement_count": 0,
+            "coverage": coverage,
+            "workers": 0,
+            "agent_timeout_seconds": timeout_seconds,
+        }
+
+    def redact_one(index: int, session: dict[str, Any]) -> tuple[int, dict[str, Any], int, int, str]:
+        findings, cov = review_session_pii_hybrid(
+            session,
+            ignore_llm_errors=True,
+            return_coverage=True,
+            timeout_seconds=timeout_seconds,
+        )
+        replacement_count = 0
+        if findings:
+            session, replacement_count = apply_findings_to_session(session, findings)
+        coverage_bucket = cov if cov in coverage else "rules_only"
+        return index, session, len(findings), replacement_count, coverage_bucket
+
+    results: list[dict[str, Any] | None] = [None] * len(sessions)
+    finding_count = 0
+    replacement_count = 0
+
+    if workers <= 1:
+        for index, session in enumerate(sessions):
+            idx, redacted, findings, replacements, cov = redact_one(index, session)
+            results[idx] = redacted
+            finding_count += findings
+            replacement_count += replacements
+            coverage[cov] += 1
+    else:
+        with ThreadPoolExecutor(max_workers=workers) as pool:
+            futures = {
+                pool.submit(redact_one, index, session): index
+                for index, session in enumerate(sessions)
+            }
+            for future in as_completed(futures):
+                idx, redacted, findings, replacements, cov = future.result()
+                results[idx] = redacted
+                finding_count += findings
+                replacement_count += replacements
+                coverage[cov] += 1
+
+    with open(sessions_file, "w") as f:
+        for session in results:
+            if session is None:
+                raise RuntimeError("PII redaction did not produce all session rows")
+            f.write(json.dumps(session, default=str) + "\n")
+
+    return {
+        "session_count": len(sessions),
+        "finding_count": finding_count,
+        "replacement_count": replacement_count,
+        "coverage": coverage,
+        "workers": workers,
+        "agent_timeout_seconds": timeout_seconds,
+    }
+
+
+def finalize_share_export_for_upload(
+    export_dir: Path,
+    manifest: dict[str, Any],
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Apply final local-only gates before an export becomes an upload zip.
+
+    `export_share_to_disk()` performs deterministic redaction and a first
+    TruffleHog scan. Hosted/browser upload needs the same extra local PII pass
+    that the legacy ingest path used, then a fresh TruffleHog scan over the
+    rewritten `sessions.jsonl`.
+    """
+    sessions_file = export_dir / "sessions.jsonl"
+    manifest_file = export_dir / "manifest.json"
+
+    if not sessions_file.exists():
+        return {"error": "Export failed — no sessions file.", "status": 500}, manifest
+
+    if manifest.get("blocked"):
+        return {
+            "error": manifest.get("block_message") or "Share blocked by TruffleHog",
+            "block_reason": manifest.get("block_reason"),
+            "trufflehog_summary": manifest.get("redaction_summary", {}).get("trufflehog"),
+            "status": 422,
+        }, manifest
+
+    try:
+        pii_summary = _apply_upload_pii_redactions(sessions_file)
+        if pii_summary["finding_count"]:
+            logger.info(
+                "PII redaction applied: %d findings / %d replacements across %d sessions "
+                "(workers=%d, timeout=%ss)",
+                pii_summary["finding_count"],
+                pii_summary["replacement_count"],
+                pii_summary["session_count"],
+                pii_summary["workers"],
+                pii_summary["agent_timeout_seconds"],
+            )
+    except Exception as exc:
+        logger.warning("PII redaction pass failed: %s", exc)
+        return {
+            "error": "PII redaction failed — upload aborted. Try again or report this issue.",
+            "status": 500,
+        }, manifest
+
+    redaction_summary = manifest.setdefault("redaction_summary", {})
+    if isinstance(redaction_summary, dict):
+        redaction_summary["coverage"] = dict(pii_summary["coverage"])
+        redaction_summary["pii_review"] = {
+            "session_count": pii_summary["session_count"],
+            "finding_count": pii_summary["finding_count"],
+            "replacement_count": pii_summary["replacement_count"],
+            "workers": pii_summary["workers"],
+            "agent_timeout_seconds": pii_summary["agent_timeout_seconds"],
+        }
+
+    try:
+        from ..redaction import trufflehog as trufflehog_scanner
+
+        post_pii_report = trufflehog_scanner.scan_file(sessions_file)
+    except Exception as exc:
+        logger.warning("Post-PII TruffleHog scan failed: %s", exc)
+        return {
+            "error": "Post-redaction scan failed — upload aborted.",
+            "detail": str(exc),
+            "status": 500,
+        }, manifest
+
+    # `trufflehog.json` is the authoritative report shipped in the zip.
+    # `trufflehog.post-pii.json` is a compatibility/diagnostic marker that
+    # proves the final artifact passed the post-PII gate.
+    trufflehog_scanner.write_report(export_dir / "trufflehog.json", post_pii_report)
+    trufflehog_scanner.write_report(export_dir / "trufflehog.post-pii.json", post_pii_report)
+    if isinstance(redaction_summary, dict):
+        summary = post_pii_report.summary()
+        redaction_summary["trufflehog"] = summary
+        redaction_summary["trufflehog_post_pii"] = summary
+
+    if post_pii_report.blocking or post_pii_report.bypassed:
+        manifest["blocked"] = True
+        manifest["block_reason"] = (
+            post_pii_report.block_reason
+            or ("trufflehog-bypassed" if post_pii_report.bypassed else None)
+        )
+        manifest["block_message"] = trufflehog_scanner.format_block_message(post_pii_report)
+        with open(manifest_file, "w") as f:
+            json.dump(manifest, f, indent=2, default=str)
+        if post_pii_report.bypassed:
+            return {
+                "error": (
+                    "Refusing to prepare upload zip: TruffleHog was bypassed via "
+                    "CLAWJOURNAL_SKIP_TRUFFLEHOG. Unset the variable and retry."
+                ),
+                "block_reason": "trufflehog-bypassed",
+                "status": 422,
+            }, manifest
+        return {
+            "error": trufflehog_scanner.format_block_message(post_pii_report),
+            "block_reason": post_pii_report.block_reason,
+            "trufflehog_summary": post_pii_report.summary(),
+            "status": 422,
+        }, manifest
+
+    with open(manifest_file, "w") as f:
+        json.dump(manifest, f, indent=2, default=str)
+    return None, manifest
+
+
+def _manifest_is_finalized_for_upload(manifest: dict[str, Any]) -> bool:
+    if manifest.get("blocked"):
+        return False
+    summary = manifest.get("redaction_summary")
+    if not isinstance(summary, dict):
+        return False
+    pii_review = summary.get("pii_review")
+    post_pii_scan = summary.get("trufflehog_post_pii")
+    if not isinstance(pii_review, dict) or not isinstance(post_pii_scan, dict):
+        return False
+    return (
+        post_pii_scan.get("findings") == 0
+        and post_pii_scan.get("bypassed") is False
+        and post_pii_scan.get("binary_missing") is False
+        and not post_pii_scan.get("scan_error")
+    )
+
+
+def _load_finalized_share_export(share_id: str) -> tuple[Path, dict[str, Any]] | None:
+    # Finalized exports are point-in-time artifacts: a later config change
+    # creates a new share/seal operation rather than mutating this cached zip.
+    export_dir = CONFIG_DIR / "shares" / share_id
+    manifest_file = export_dir / "manifest.json"
+    sessions_file = export_dir / "sessions.jsonl"
+    trufflehog_file = export_dir / "trufflehog.json"
+    post_pii_file = export_dir / "trufflehog.post-pii.json"
+    if not (
+        manifest_file.exists()
+        and sessions_file.exists()
+        and trufflehog_file.exists()
+        and post_pii_file.exists()
+    ):
+        return None
+    try:
+        manifest = json.loads(manifest_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    if manifest.get("share_id") != share_id and manifest.get("bundle_id") != share_id:
+        return None
+    if not _manifest_is_finalized_for_upload(manifest):
+        return None
+    return export_dir, manifest
+
+
+def _prepare_share_export_for_upload(
+    conn: sqlite3.Connection,
+    share_id: str,
+    share: dict[str, Any],
+    settings: dict[str, Any],
+    *,
+    reuse_finalized: bool = False,
+) -> tuple[Path | None, dict[str, Any], dict[str, Any] | None]:
+    if reuse_finalized:
+        cached = _load_finalized_share_export(share_id)
+        if cached is not None:
+            export_dir, manifest = cached
+            return export_dir, manifest, None
+
+    export_dir, manifest = export_share_to_disk(
+        conn,
+        share_id,
+        share,
+        custom_strings=settings["custom_strings"],
+        extra_usernames=settings["extra_usernames"],
+        excluded_projects=settings["excluded_projects"],
+        blocked_domains=settings["blocked_domains"],
+        allowlist_entries=settings["allowlist_entries"],
+    )
+    if export_dir is None:
+        return None, manifest, {"error": "Failed to prepare upload zip", "status": 500}
+
+    error, manifest = finalize_share_export_for_upload(export_dir, manifest)
+    if error:
+        return export_dir, manifest, error
+    return export_dir, manifest, None
+
+
 def upload_share(
     conn: sqlite3.Connection,
     share_id: str,
@@ -697,115 +1013,12 @@ def upload_share(
     )
     if export_dir is None:
         return {"error": "Export failed.", "status": 500}
+    error, manifest = finalize_share_export_for_upload(export_dir, manifest)
+    if error:
+        return error
+
     sessions_file = export_dir / "sessions.jsonl"
     manifest_file = export_dir / "manifest.json"
-
-    if not sessions_file.exists():
-        return {"error": "Export failed — no sessions file.", "status": 500}
-
-    # Pre-PII TruffleHog scan already ran inside export_share_to_disk —
-    # if that stage blocked, fail closed before we do any additional work.
-    if manifest.get("blocked"):
-        return {
-            "error": manifest.get("block_message") or "Share blocked by TruffleHog",
-            "block_reason": manifest.get("block_reason"),
-            "trufflehog_summary": manifest.get("redaction_summary", {}).get("trufflehog"),
-            "status": 422,
-        }
-
-    # Mandatory PII redaction pass — applied to ALL sessions before upload.
-    # This catches names, orgs, usernames, etc. that regex-based secret
-    # redaction misses.  No session cap: every session gets reviewed.
-    coverage_full = 0
-    coverage_rules_only = 0
-    try:
-        from ..redaction.pii import apply_findings_to_session, review_session_pii_hybrid
-        import json as _json
-
-        redacted_lines: list[str] = []
-        pii_total = 0
-        with open(sessions_file) as f:
-            for line in f:
-                if not line.strip():
-                    continue
-                session = _json.loads(line)
-                findings, cov = review_session_pii_hybrid(
-                    session, ignore_llm_errors=True, return_coverage=True,
-                )
-                if cov == "full":
-                    coverage_full += 1
-                else:
-                    coverage_rules_only += 1
-                if findings:
-                    session, _ = apply_findings_to_session(session, findings)
-                    pii_total += len(findings)
-                redacted_lines.append(_json.dumps(session, default=str))
-        with open(sessions_file, "w") as f:
-            for rline in redacted_lines:
-                f.write(rline + "\n")
-        if pii_total:
-            logger.info("PII redaction applied: %d findings across %d sessions", pii_total, len(redacted_lines))
-    except Exception as exc:
-        logger.warning("PII redaction pass failed: %s", exc)
-        return {"error": "PII redaction failed — upload aborted. Try again or report this issue.", "status": 500}
-
-    # Update manifest with PII coverage metadata
-    if manifest and isinstance(manifest.get("redaction_summary"), dict):
-        manifest["redaction_summary"]["coverage"] = {
-            "full": coverage_full,
-            "rules_only": coverage_rules_only,
-        }
-
-    # Post-PII TruffleHog re-scan: the PII pass rewrote sessions.jsonl,
-    # so the scan embedded in the manifest by export_share_to_disk is
-    # stale. Run the gate again on the file that's actually about to
-    # leave this machine.
-    try:
-        from ..redaction import trufflehog as trufflehog_scanner
-
-        post_pii_report = trufflehog_scanner.scan_file(sessions_file)
-    except Exception as exc:
-        logger.warning("Post-PII TruffleHog scan failed: %s", exc)
-        return {
-            "error": "Post-redaction scan failed — upload aborted.",
-            "detail": str(exc),
-            "status": 500,
-        }
-    trufflehog_scanner.write_report(export_dir / "trufflehog.post-pii.json", post_pii_report)
-    if manifest and isinstance(manifest.get("redaction_summary"), dict):
-        manifest["redaction_summary"]["trufflehog_post_pii"] = post_pii_report.summary()
-    if post_pii_report.blocking:
-        if manifest:
-            manifest["blocked"] = True
-            manifest["block_reason"] = post_pii_report.block_reason
-            manifest["block_message"] = trufflehog_scanner.format_block_message(post_pii_report)
-            with open(manifest_file, "w") as f:
-                json.dump(manifest, f, indent=2, default=str)
-        return {
-            "error": trufflehog_scanner.format_block_message(post_pii_report),
-            "block_reason": post_pii_report.block_reason,
-            "trufflehog_summary": post_pii_report.summary(),
-            "status": 422,
-        }
-    # Bypass is allowed locally (bundle-export with CLAWJOURNAL_SKIP_
-    # TRUFFLEHOG=1 still writes files), but uploading an unscanned
-    # share to a remote endpoint should fail closed — the gate exists
-    # specifically to catch surviving secrets before they leave the
-    # machine.
-    if post_pii_report.bypassed:
-        return {
-            "error": (
-                "Refusing to upload: TruffleHog was bypassed via "
-                "CLAWJOURNAL_SKIP_TRUFFLEHOG. Unset the variable and "
-                "retry, or use bundle-export for local-only output."
-            ),
-            "block_reason": "trufflehog-bypassed",
-            "status": 422,
-        }
-
-    if manifest and isinstance(manifest.get("redaction_summary"), dict):
-        with open(manifest_file, "w") as f:
-            json.dump(manifest, f, indent=2, default=str)
 
     file_size = sessions_file.stat().st_size
     if file_size > _SHARE_MAX_FILE_SIZE:
@@ -1028,6 +1241,8 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             self._handle_projects()
         elif path == "/api/share-ready":
             self._handle_share_ready(params)
+        elif path == "/api/share-destination":
+            self._handle_share_destination()
         elif path == "/api/scoring/backend":
             self._handle_scoring_backend()
         elif path == "/api/bundles":
@@ -1090,6 +1305,9 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         elif path.startswith("/api/bundles/") and path.endswith("/export"):
             share_id = path[len("/api/bundles/"):-len("/export")]
             self._handle_export_share(share_id)
+        elif path.startswith("/api/bundles/") and path.endswith("/seal"):
+            share_id = path[len("/api/bundles/"):-len("/seal")]
+            self._handle_seal_share(share_id)
         elif path.startswith("/api/bundles/") and path.endswith("/share"):
             share_id = path[len("/api/bundles/"):-len("/share")]
             self._handle_upload_share(share_id)
@@ -1098,6 +1316,9 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         elif path.startswith("/api/shares/") and path.endswith("/export"):
             share_id = path[len("/api/shares/"):-len("/export")]
             self._handle_export_share(share_id)
+        elif path.startswith("/api/shares/") and path.endswith("/seal"):
+            share_id = path[len("/api/shares/"):-len("/seal")]
+            self._handle_seal_share(share_id)
         elif path.startswith("/api/shares/") and path.endswith("/share"):
             share_id = path[len("/api/shares/"):-len("/share")]
             self._handle_upload_share(share_id)
@@ -1747,6 +1968,17 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             "display_name": display_names.get(backend, backend),
         })
 
+    def _handle_share_destination(self) -> None:
+        """Return the optional hosted browser-upload destination."""
+        share_url, message = _validated_hosted_share_url()
+        _json_response(self, {
+            "configured": bool(share_url),
+            "preferred_upload_flow": "browser_zip",
+            "cli_ingest_supported": False,
+            "share_page_url": share_url,
+            "message": message,
+        })
+
     def _handle_share_ready(self, params: dict[str, list[str]]) -> None:
         """Return stats for sessions ready to share.
 
@@ -1999,6 +2231,39 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         finally:
             conn.close()
 
+    def _handle_seal_share(self, share_id: str) -> None:
+        """Finalize a share for browser upload without returning zip bytes."""
+        conn = open_index()
+        try:
+            share = get_share(conn, share_id)
+            if share is None:
+                _json_response(self, {"error": "Share not found"}, 404)
+                return
+
+            settings = get_effective_share_settings(conn, load_config())
+            export_dir, manifest, error = _prepare_share_export_for_upload(
+                conn,
+                share_id,
+                share,
+                settings,
+                reuse_finalized=True,
+            )
+            if error:
+                _json_response(self, error, int(error.get("status", 500)))
+                return
+            if export_dir is None:
+                _json_response(self, {"error": "Failed to prepare upload zip"}, 500)
+                return
+
+            _json_response(self, {
+                "ok": True,
+                "export_path": str(export_dir),
+                "session_count": len(manifest.get("sessions", [])),
+                "redaction_summary": manifest.get("redaction_summary", {}),
+            })
+        finally:
+            conn.close()
+
     def _handle_download_share(self, share_id: str) -> None:
         """Generate a zip of the share and serve it as a browser download."""
         conn = open_index()
@@ -2009,26 +2274,18 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                 return
 
             settings = get_effective_share_settings(conn, load_config())
-            export_dir, _manifest = export_share_to_disk(
+            export_dir, _manifest, error = _prepare_share_export_for_upload(
                 conn,
                 share_id,
                 share,
-                custom_strings=settings["custom_strings"],
-                extra_usernames=settings["extra_usernames"],
-                excluded_projects=settings["excluded_projects"],
-                blocked_domains=settings["blocked_domains"],
-                allowlist_entries=settings["allowlist_entries"],
+                settings,
+                reuse_finalized=True,
             )
+            if error:
+                _json_response(self, error, int(error.get("status", 500)))
+                return
             if export_dir is None:
                 _json_response(self, {"error": "Failed to prepare download"}, 500)
-                return
-
-            if _manifest.get("blocked"):
-                _json_response(self, {
-                    "error": _manifest.get("block_message") or "Share blocked by TruffleHog",
-                    "block_reason": _manifest.get("block_reason"),
-                    "trufflehog_summary": _manifest.get("redaction_summary", {}).get("trufflehog"),
-                }, 422)
                 return
 
             sessions_content = (export_dir / "sessions.jsonl").read_bytes()
@@ -2036,6 +2293,10 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             trufflehog_path = export_dir / "trufflehog.json"
             trufflehog_content = (
                 trufflehog_path.read_bytes() if trufflehog_path.exists() else None
+            )
+            post_pii_path = export_dir / "trufflehog.post-pii.json"
+            post_pii_content = (
+                post_pii_path.read_bytes() if post_pii_path.exists() else None
             )
 
             # Create in-memory zip
@@ -2045,6 +2306,8 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                 zf.writestr("manifest.json", manifest_content)
                 if trufflehog_content is not None:
                     zf.writestr("trufflehog.json", trufflehog_content)
+                if post_pii_content is not None:
+                    zf.writestr("trufflehog.post-pii.json", post_pii_content)
             zip_bytes = buf.getvalue()
 
             # Serve the zip

--- a/skills/clawjournal/SKILL.md
+++ b/skills/clawjournal/SKILL.md
@@ -146,15 +146,16 @@ If user adds a note, remember it for the `--note` flag.
 
 If user says "looks good" / "share" / "yes" — proceed to Step 4.
 
-**Step 4 — Share with confirmation**
+**Step 4 — Package with confirmation**
 
 Only after explicit user confirmation:
 
 ```bash
-clawjournal share --status approved --note "<user's comment>" --json
+clawjournal bundle-create --status approved --note "<user's comment>" --json
+clawjournal bundle-export <bundle_id> --zip --json
 ```
 
-Parse the JSON result. **Always report the redaction summary to the user** (see Communication Guidelines above).
+Parse the export result, use `zip_path` as the upload file, and **always report the redaction summary to the user** (see Communication Guidelines above). For hosted research submission, do not ask the user for `CLAWJOURNAL_INGEST_URL`; use the workbench Done screen's "Submit to ClawJournal Research" button when it is available, then have the user upload the zip on that page. If the destination is not configured, tell the user the redacted zip is ready on their computer.
 
 ### Quick Share
 
@@ -277,15 +278,15 @@ clawjournal score-view <id>
 clawjournal set-score <id> --failure-value <1-5> [--failure-evidence "..."] [--reason "..."]
 clawjournal set-score <id> --quality <1-5> [--reason "..."]  # legacy productivity only
 
-# Share
+# Advanced self-hosted ingest upload
 clawjournal share --status approved [--note "..."] [--preview] [--json]
 
 # Bundles
 clawjournal bundle-create [ids ...] [--status approved]
 clawjournal bundle-list
 clawjournal bundle-view <bundle_id>
-clawjournal bundle-export <bundle_id>
-clawjournal bundle-share <bundle_id>
+clawjournal bundle-export <bundle_id> [--zip]
+clawjournal bundle-share <bundle_id>  # self-hosted ingest only
 
 # Export (bulk)
 clawjournal status
@@ -307,4 +308,4 @@ clawjournal serve [--port 8384] [--no-browser] [--remote]
 - **`--exclude`, `--redact`, `--redact-usernames` APPEND** — they never overwrite. Safe to call repeatedly.
 - **`clawjournal inbox --json`** is the preferred way for agents to read trace data.
 - **`clawjournal serve`** opens a browser automatically. Use `--no-browser` to suppress.
-- **Everything is 100% local** — nothing leaves the machine unless the user explicitly runs `share`.
+- **Everything is local by default** — nothing leaves the machine unless the user explicitly uploads the zip or uses a configured self-hosted ingest command.

--- a/tests/redaction/test_pii.py
+++ b/tests/redaction/test_pii.py
@@ -321,6 +321,21 @@ def test_review_session_pii_hybrid_merges_rule_and_claude(monkeypatch):
     assert "Acme Labs" in entity_texts
 
 
+def test_review_session_pii_hybrid_passes_agent_timeout(monkeypatch):
+    session = {"session_id": "s1", "messages": [{"content": "Hello"}]}
+    captured = {}
+
+    def fake_agent(session, **kwargs):
+        captured["timeout_seconds"] = kwargs.get("timeout_seconds")
+        return []
+
+    monkeypatch.setattr("clawjournal.redaction.pii.review_session_pii_with_agent", fake_agent)
+    findings = review_session_pii_hybrid(session, timeout_seconds=37)
+
+    assert findings == []
+    assert captured["timeout_seconds"] == 37
+
+
 def test_content_findings_github_url():
     findings = _content_findings_for_text("s1", 0, "content", "See https://github.com/kai-rayward/clawjournal for details")
     entity_texts = {f["entity_text"] for f in findings}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,9 @@
 """Tests for clawjournal.cli — CLI commands and helpers."""
 
 import json
+import shutil
 import sys
+import zipfile
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -689,6 +691,21 @@ def bundle_index(tmp_path, monkeypatch):
     monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "clawjournal_config")
     monkeypatch.setattr("clawjournal.cli.load_config", lambda: {})
 
+    from clawjournal.redaction import trufflehog
+    monkeypatch.delenv(trufflehog.SKIP_ENV_VAR, raising=False)
+    monkeypatch.setattr(
+        trufflehog,
+        "scan_file",
+        lambda path: trufflehog.TruffleHogReport(
+            scanned_path=str(path),
+            scanned_sha256="sha256:0",
+        ),
+    )
+    monkeypatch.setattr(
+        "clawjournal.redaction.pii.review_session_pii_hybrid",
+        lambda session, **kw: ([], "full") if kw.get("return_coverage") else [],
+    )
+
     from clawjournal.workbench.index import open_index, upsert_sessions
 
     conn = open_index()
@@ -824,6 +841,86 @@ class TestBundleExport:
         manifest = json.loads((Path(output["export_path"]) / "manifest.json").read_text())
         assert manifest["bundle_id"] == bundle_id
         assert manifest["share_id"] == bundle_id
+        assert "redaction_summary" in output
+
+    def test_export_zip_writes_uploadable_archive(self, bundle_index, capsys, monkeypatch):
+        from clawjournal.workbench.index import create_share, open_index
+        conn = open_index()
+        bundle_id = create_share(conn, ["sess-0", "sess-1"])
+        conn.close()
+
+        def fake_review(session, **kw):
+            assert kw.get("return_coverage") is True
+            if session["session_id"] != "sess-0":
+                return ([], "full")
+            return ([{
+                "session_id": "sess-0",
+                "message_index": 0,
+                "field": "content",
+                "entity_text": "Task 0",
+                "entity_type": "person_name",
+                "confidence": 0.95,
+                "reason": "test",
+                "replacement": "[REDACTED_NAME]",
+                "source": "test",
+            }], "full")
+
+        monkeypatch.setattr("clawjournal.redaction.pii.review_session_pii_hybrid", fake_review)
+
+        from clawjournal.cli import _run_bundle_export
+        args = MagicMock(
+            share_id=bundle_id,
+            output=None,
+            json=True,
+            zip=True,
+            training_format=False,
+        )
+        _run_bundle_export(args)
+        output = json.loads(capsys.readouterr().out)
+
+        zip_path = Path(output["zip_path"])
+        assert zip_path.exists()
+        with zipfile.ZipFile(zip_path) as archive:
+            assert set(archive.namelist()) >= {
+                "manifest.json",
+                "sessions.jsonl",
+                "trufflehog.json",
+                "trufflehog.post-pii.json",
+            }
+            sessions_content = archive.read("sessions.jsonl").decode("utf-8")
+            manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
+
+        assert "Task 0" not in sessions_content
+        assert "[REDACTED_NAME]" in sessions_content
+        assert manifest["redaction_summary"]["pii_review"]["finding_count"] == 1
+        assert manifest["redaction_summary"]["coverage"] == {"full": 2, "rules_only": 0}
+
+    def test_export_zip_appends_suffix_to_output_directory(self, bundle_index, tmp_path, capsys):
+        from clawjournal.workbench.index import create_share, open_index
+        conn = open_index()
+        bundle_id = create_share(conn, ["sess-0"])
+        conn.close()
+
+        output_dir = Path("/tmp") / f"clawjournal-manual-export-{bundle_id}.zip"
+        from clawjournal.cli import _run_bundle_export
+        args = MagicMock(
+            share_id=bundle_id,
+            output=str(output_dir),
+            json=True,
+            zip=True,
+            training_format=False,
+        )
+        try:
+            _run_bundle_export(args)
+            output = json.loads(capsys.readouterr().out)
+
+            resolved_output_dir = output_dir.resolve()
+            assert Path(output["export_path"]) == resolved_output_dir
+            assert Path(output["zip_path"]) == resolved_output_dir.with_name(f"{resolved_output_dir.name}.zip")
+            assert Path(output["zip_path"]).is_file()
+        finally:
+            shutil.rmtree(output_dir, ignore_errors=True)
+            output_dir.with_name(f"{output_dir.name}.zip").unlink(missing_ok=True)
 
     def test_export_redacts_custom_strings(self, tmp_path, monkeypatch, capsys):
         """Bundle export applies redact_strings from config."""

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -7,13 +7,19 @@ import zipfile
 from datetime import datetime, timedelta, timezone
 from http.client import HTTPConnection
 from io import BytesIO
-from threading import Thread
+from threading import Lock, Thread
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 
 import pytest
 
-from clawjournal.workbench.daemon import Scanner, WorkbenchHandler, run_server, _SHARE_COOLDOWN_SECONDS
+from clawjournal.workbench.daemon import (
+    Scanner,
+    WorkbenchHandler,
+    run_server,
+    _SHARE_COOLDOWN_SECONDS,
+    _apply_upload_pii_redactions,
+)
 from clawjournal.workbench.index import open_index, upsert_sessions
 
 
@@ -26,6 +32,7 @@ def index_setup(tmp_path, monkeypatch):
     monkeypatch.setattr("clawjournal.workbench.daemon.CONFIG_DIR", tmp_path / "clawjournal_config")
     monkeypatch.setattr("clawjournal.workbench.daemon.FRONTEND_DIST", tmp_path / "nonexistent_dist")
     monkeypatch.setattr("clawjournal.workbench.daemon._SHARE_INGEST_URL", "https://test-ingest.example.com")
+    monkeypatch.setattr("clawjournal.workbench.daemon._HOSTED_SHARE_URL", "")
     monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {})
     # Mock PII review in share tests — no AI backend available in test env
     monkeypatch.setattr("clawjournal.redaction.pii.review_session_pii_hybrid", lambda session, **kw: ([], "full") if kw.get("return_coverage") else [])
@@ -619,6 +626,58 @@ class TestProjectsAPI:
         assert data[0]["project"] == "test-project"
 
 
+class TestShareDestinationAPI:
+    def test_unconfigured_share_destination(self, server, monkeypatch):
+        monkeypatch.setattr("clawjournal.workbench.daemon._HOSTED_SHARE_URL", "")
+
+        status, data = _get(server, "/api/share-destination")
+
+        assert status == 200
+        assert data["configured"] is False
+        assert data["preferred_upload_flow"] == "browser_zip"
+        assert data["cli_ingest_supported"] is False
+        assert data["share_page_url"] is None
+
+    def test_configured_share_destination(self, server, monkeypatch):
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon._HOSTED_SHARE_URL",
+            "https://data.rayward.ai/share",
+        )
+
+        status, data = _get(server, "/api/share-destination")
+
+        assert status == 200
+        assert data["configured"] is True
+        assert data["preferred_upload_flow"] == "browser_zip"
+        assert data["cli_ingest_supported"] is False
+        assert data["share_page_url"] == "https://data.rayward.ai/share"
+
+    def test_invalid_share_destination_is_disabled(self, server, monkeypatch):
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon._HOSTED_SHARE_URL",
+            "data.rayward.ai/share",
+        )
+
+        status, data = _get(server, "/api/share-destination")
+
+        assert status == 200
+        assert data["configured"] is False
+        assert data["share_page_url"] is None
+        assert "HTTPS" in data["message"]
+
+    def test_prefix_lookalike_localhost_share_destination_is_disabled(self, server, monkeypatch):
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon._HOSTED_SHARE_URL",
+            "http://localhost.evil.test/share",
+        )
+
+        status, data = _get(server, "/api/share-destination")
+
+        assert status == 200
+        assert data["configured"] is False
+        assert data["share_page_url"] is None
+
+
 class TestSharesAPI:
     def test_create_and_list(self, server):
         status, data = _post(server, "/api/shares", {
@@ -1093,6 +1152,81 @@ def _mock_trufflehog_clean(monkeypatch):
     monkeypatch.setattr(trufflehog, "_scan_text_for_raw_matches", lambda text: [])
 
 
+def test_upload_pii_redaction_runs_sessions_in_parallel(tmp_path, monkeypatch):
+    sessions_file = tmp_path / "sessions.jsonl"
+    sessions = [
+        {
+            "session_id": f"s{i}",
+            "messages": [{"role": "user", "content": f"Alice{i} should be hidden"}],
+        }
+        for i in range(4)
+    ]
+    sessions_file.write_text(
+        "\n".join(json.dumps(session) for session in sessions) + "\n",
+        encoding="utf-8",
+    )
+
+    lock = Lock()
+    active = 0
+    max_active = 0
+
+    def fake_review(
+        session,
+        *,
+        ignore_llm_errors=True,
+        return_coverage=False,
+        timeout_seconds=180,
+        **_kw,
+    ):
+        nonlocal active, max_active
+        assert ignore_llm_errors is True
+        assert return_coverage is True
+        assert timeout_seconds == 23
+        with lock:
+            active += 1
+            max_active = max(max_active, active)
+        time.sleep(0.05)
+        with lock:
+            active -= 1
+        sid = session["session_id"]
+        suffix = sid.removeprefix("s")
+        return ([{
+            "session_id": sid,
+            "message_index": 0,
+            "field": "content",
+            "entity_text": f"Alice{suffix}",
+            "entity_type": "person_name",
+            "confidence": 0.95,
+            "reason": "test name",
+            "replacement": "[REDACTED_NAME]",
+            "source": "test",
+        }], "full")
+
+    monkeypatch.setenv("CLAWJOURNAL_UPLOAD_PII_WORKERS", "4")
+    monkeypatch.setenv("CLAWJOURNAL_UPLOAD_PII_TIMEOUT_SECONDS", "23")
+    monkeypatch.setattr("clawjournal.redaction.pii.review_session_pii_hybrid", fake_review)
+
+    summary = _apply_upload_pii_redactions(sessions_file)
+
+    assert summary["workers"] == 4
+    assert summary["agent_timeout_seconds"] == 23
+    assert summary["finding_count"] == 4
+    assert summary["replacement_count"] == 4
+    assert summary["coverage"] == {"full": 4, "rules_only": 0}
+    assert max_active > 1
+
+    redacted = [
+        json.loads(line)
+        for line in sessions_file.read_text(encoding="utf-8").splitlines()
+        if line.strip()
+    ]
+    assert [session["session_id"] for session in redacted] == ["s0", "s1", "s2", "s3"]
+    assert all(
+        session["messages"][0]["content"] == "[REDACTED_NAME] should be hidden"
+        for session in redacted
+    )
+
+
 class TestVerifyEmailAPI:
     def test_confirm_email_verification_persists_upload_token_and_expiry(self, monkeypatch):
         from clawjournal.workbench.daemon import confirm_email_verification
@@ -1455,10 +1589,138 @@ class TestShareAPI:
             assert "sessions.jsonl" in names
             assert "manifest.json" in names
             assert "trufflehog.json" in names
+            assert "trufflehog.post-pii.json" in names
             report = json.loads(archive.read("trufflehog.json").decode("utf-8"))
 
         assert report["summary"]["findings"] == 0
         assert report["summary"]["bypassed"] is False
+
+    def test_download_bundle_applies_final_ai_pii_redaction(self, server, monkeypatch):
+        conn = open_index()
+        upsert_sessions(conn, [{
+            "session_id": "download-ai-pii",
+            "project": "test-project",
+            "source": "claude",
+            "model": "claude-sonnet-4",
+            "messages": [
+                {"role": "user", "content": "Alice Example should not ship", "tool_uses": []},
+                {"role": "assistant", "content": "Done.", "tool_uses": []},
+            ],
+            "stats": {
+                "user_messages": 1,
+                "assistant_messages": 1,
+                "tool_uses": 0,
+                "input_tokens": 100,
+                "output_tokens": 50,
+            },
+        }])
+        conn.close()
+
+        def fake_review(session, **kw):
+            assert kw.get("return_coverage") is True
+            return ([{
+                "session_id": session["session_id"],
+                "message_index": 0,
+                "field": "content",
+                "entity_text": "Alice Example",
+                "entity_type": "person_name",
+                "confidence": 0.95,
+                "reason": "test name",
+                "replacement": "[REDACTED_NAME]",
+                "source": "test",
+            }], "full")
+
+        monkeypatch.setattr("clawjournal.redaction.pii.review_session_pii_hybrid", fake_review)
+
+        status, data = _post(server, "/api/shares", {
+            "session_ids": ["download-ai-pii"],
+            "note": "Download AI PII test",
+        })
+        assert status == 201
+        share_id = data["share_id"]
+
+        status, content_type, body = _get_raw(server, f"/api/shares/{share_id}/download")
+        assert status == 200
+        assert content_type == "application/zip"
+
+        with zipfile.ZipFile(BytesIO(body)) as archive:
+            sessions_content = archive.read("sessions.jsonl").decode("utf-8")
+            manifest = json.loads(archive.read("manifest.json").decode("utf-8"))
+
+        assert "Alice Example" not in sessions_content
+        assert "[REDACTED_NAME]" in sessions_content
+        assert manifest["redaction_summary"]["pii_review"]["finding_count"] == 1
+        assert manifest["redaction_summary"]["coverage"] == {"full": 1, "rules_only": 0}
+
+    def test_seal_is_idempotent_and_download_reuses_export(self, server, monkeypatch):
+        conn = open_index()
+        upsert_sessions(conn, [{
+            "session_id": "seal-ai-pii",
+            "project": "test-project",
+            "source": "claude",
+            "model": "claude-sonnet-4",
+            "messages": [
+                {"role": "user", "content": "Alice Example should not ship", "tool_uses": []},
+            ],
+            "stats": {
+                "user_messages": 1,
+                "assistant_messages": 0,
+                "tool_uses": 0,
+                "input_tokens": 100,
+                "output_tokens": 0,
+            },
+        }])
+        conn.close()
+
+        calls = 0
+
+        def fake_review(session, **kw):
+            nonlocal calls
+            calls += 1
+            assert kw.get("return_coverage") is True
+            return ([{
+                "session_id": session["session_id"],
+                "message_index": 0,
+                "field": "content",
+                "entity_text": "Alice Example",
+                "entity_type": "person_name",
+                "confidence": 0.95,
+                "reason": "test name",
+                "replacement": "[REDACTED_NAME]",
+                "source": "test",
+            }], "full")
+
+        monkeypatch.setattr("clawjournal.redaction.pii.review_session_pii_hybrid", fake_review)
+
+        status, data = _post(server, "/api/shares", {
+            "session_ids": ["seal-ai-pii"],
+            "note": "Seal AI PII test",
+        })
+        assert status == 201
+        share_id = data["share_id"]
+
+        status, data = _post(server, f"/api/shares/{share_id}/seal")
+        assert status == 200
+        assert data["ok"] is True
+        assert data["redaction_summary"]["pii_review"]["finding_count"] == 1
+        assert calls == 1
+
+        status, data = _post(server, f"/api/shares/{share_id}/seal")
+        assert status == 200
+        assert data["ok"] is True
+        assert data["redaction_summary"]["pii_review"]["finding_count"] == 1
+        assert calls == 1
+
+        status, content_type, body = _get_raw(server, f"/api/shares/{share_id}/download")
+        assert status == 200
+        assert content_type == "application/zip"
+        assert calls == 1
+
+        with zipfile.ZipFile(BytesIO(body)) as archive:
+            sessions_content = archive.read("sessions.jsonl").decode("utf-8")
+
+        assert "Alice Example" not in sessions_content
+        assert "[REDACTED_NAME]" in sessions_content
 
     def test_download_applies_configured_custom_redactions(self, server, monkeypatch):
         monkeypatch.setattr(


### PR DESCRIPTION
## Summary

This makes the shared trace upload workflow smoother and less confusing for normal hosted research submission.

- Adds `bundle-export --zip` so users and skills can produce the uploadable archive directly.
- Replaces the normal-user dependency on `CLAWJOURNAL_INGEST_URL` with a hosted browser zip handoff discovered from `CLAWJOURNAL_SHARE_URL`.
- Keeps the self-hosted ingest path as advanced functionality, with clearer errors when it is not configured.
- Hardens hosted share URL validation so only HTTPS targets or local dev URLs are surfaced in the workbench.
- Preserves deterministic redaction and TruffleHog gates while speeding upload-time hybrid PII review with bounded workers and per-session timeouts.
- Updates README, privacy docs, and the ClawJournal skill so the CLI and UI flows match.

## Root Cause

The UI and skill could still steer users into the legacy ingest-service CLI flow. That made the screenshot failure real: a normal user could ask to share through ClawJournal research submission and hit an implementation detail (`CLAWJOURNAL_INGEST_URL`) instead of getting the browser zip upload flow.

## Validation

- `PYTHONPATH=. pytest -q` (`1819 passed`)
- `cd clawjournal/web/frontend && npm run build`
- Focused daemon/CLI/PII tests after URL hardening
- CLI smoke generated an uploadable zip containing `manifest.json`, `sessions.jsonl`, and `trufflehog.json`
- Chromium smoke of the workbench Done screen verified the hosted CTA, removed old wording, and downloaded the zip successfully

## Notes

This PR intentionally keeps sharing opt-in and local-first. Browser upload is the default hosted path; `CLAWJOURNAL_INGEST_URL` remains available for self-hosted ingest deployments.
