### PR TITLE
release: 0.1.14 — default hosted share URL

### DIFF
--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -95,7 +95,11 @@ _UPLOAD_PII_DEFAULT_TIMEOUT_SECONDS = 60
 _UPLOAD_PII_MIN_TIMEOUT_SECONDS = 10
 _UPLOAD_PII_MAX_TIMEOUT_SECONDS = 180
 _SHARE_INGEST_URL = os.environ.get("CLAWJOURNAL_INGEST_URL", "")
-_HOSTED_SHARE_URL = os.environ.get("CLAWJOURNAL_SHARE_URL", "").strip()
+# The hosted research submission page. Self-hosters can override via the
+# CLAWJOURNAL_SHARE_URL env var; explicitly setting it to an empty value
+# disables the workbench's "Submit to ClawJournal Research" button.
+_HOSTED_SHARE_URL_DEFAULT = "https://data.rayward.ai/share"
+_HOSTED_SHARE_URL = os.environ.get("CLAWJOURNAL_SHARE_URL", _HOSTED_SHARE_URL_DEFAULT).strip()
 _SHARE_GCS_BUCKET = os.environ.get("CLAWJOURNAL_GCS_BUCKET", "clawjournal-traces")
 _SHARE_GCS_PREFIX = os.environ.get("CLAWJOURNAL_GCS_PREFIX", "clawjournal")
 _SHARE_UPLOAD_TIMEOUT = 120

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawjournal"
-version = "0.1.13"
+version = "0.1.14"
 description = "Review, score, and curate your coding agent conversation traces locally"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -627,6 +627,11 @@ class TestProjectsAPI:
 
 
 class TestShareDestinationAPI:
+    def test_packaged_default_points_to_rayward_research(self):
+        from clawjournal.workbench.daemon import _HOSTED_SHARE_URL_DEFAULT
+
+        assert _HOSTED_SHARE_URL_DEFAULT == "https://data.rayward.ai/share"
+
     def test_unconfigured_share_destination(self, server, monkeypatch):
         monkeypatch.setattr("clawjournal.workbench.daemon._HOSTED_SHARE_URL", "")
 


### PR DESCRIPTION
## Summary

- Bumps `clawjournal` version to **0.1.14**.
- Defaults `_HOSTED_SHARE_URL` to `https://data.rayward.ai/share` so the workbench's "Submit to ClawJournal Research" button shows up out of the box after upgrade.
- Adds a small test asserting the packaged default.

Self-hosters can still override via the `CLAWJOURNAL_SHARE_URL` env var; setting it to an empty string disables the hosted button.

## Why now

PR #45 shipped the hosted-zip flow, and PR #12 deployed the matching server side to `data.rayward.ai`. Without this default, end users would have to know the URL and configure the env var themselves to see the new button.

## Test plan

- [x] `pytest -q` (1822 passed locally)
- [x] `npm run build` (frontend dist clean)
- [ ] CI green
- [ ] Tag `v0.1.14` and publish wheel to PyPI after merge