### PR TITLE
release: 0.1.15 — fix hosted share release surfaces

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "clawjournal",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "ClawJournal — review, curate, and share your coding agent conversation traces. 100% local. Scans sessions from Claude Code, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline. Auto-redacts secrets and PII. Browser workbench for triage and export.",
   "owner": {
     "name": "rayward-external",
@@ -11,7 +11,7 @@
     {
       "name": "clawjournal",
       "description": "ClawJournal agent skills: /clawjournal-setup (install + scan + launch workbench), /clawjournal (review, triage, and share traces), and /clawjournal-score (AI-assisted quality scoring).",
-      "version": "0.1.14",
+      "version": "0.1.15",
       "author": {
         "name": "rayward-external",
         "url": "https://github.com/rayward-external"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "clawjournal",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "ClawJournal — review, curate, and share your coding agent conversation traces. 100% local. Scans sessions from Claude Code, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline. Auto-redacts secrets and PII. Browser workbench for triage and export.",
   "owner": {
     "name": "rayward-external",
@@ -11,7 +11,7 @@
     {
       "name": "clawjournal",
       "description": "ClawJournal agent skills: /clawjournal-setup (install + scan + launch workbench), /clawjournal (review, triage, and share traces), and /clawjournal-score (AI-assisted quality scoring).",
-      "version": "0.1.13",
+      "version": "0.1.14",
       "author": {
         "name": "rayward-external",
         "url": "https://github.com/rayward-external"

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -92,7 +92,7 @@ Depending on how you export, bundle content can include user messages, assistant
 
 Uploading is a separate path from local export.
 
-- Hosted research submission uses a browser upload page when `CLAWJOURNAL_SHARE_URL` is configured in the workbench.
+- Hosted research submission uses Rayward's browser upload page by default. Self-hosters can override it with `CLAWJOURNAL_SHARE_URL`, and setting `CLAWJOURNAL_SHARE_URL=` disables the hosted button.
 - Advanced self-hosted ingest upload is disabled unless `CLAWJOURNAL_INGEST_URL` is configured.
 - The ingest and hosted-share URLs must use `https://`, except for `localhost` and `127.0.0.1` during local development.
 - Self-hosted ingest commands are `clawjournal bundle-share <bundle_id>` or `clawjournal share ...`.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you have an AI coding assistant — **Claude Code**, **Codex**, **Cursor**, *
 - **Permission prompts — lots of them.** Your AI will ask permission to run several commands. Expect 10–25 prompts before install finishes — more if your computer is fresh, fewer if it already has dev tools. **Click "Allow" each time.** This is normal. The tools the AI installs (git for fetching code, Python for running ClawJournal, Node.js for the browser workbench) are widely-used software your computer probably has parts of already.
 - **A separate password prompt on Mac.** macOS may ask for *your computer password* (the one you use to log in) when installing certain tools. This is your operating system asking, not the AI. Type your password and hit Enter — installing software almost always requires this.
 - **Silent waiting periods.** Some downloads and compiles take 30–90 seconds with no visible progress. **The AI isn't frozen — it's working.** Wait for it to come back. Total install time is usually 2–10 minutes depending on your network and what's already installed.
-- **A success message at the end:** `[ok] ClawJournal 0.1.14 installed.` (the version number may differ).
+- **A success message at the end:** `[ok] ClawJournal 0.1.15 installed.` (the version number may differ).
 
 ### Open the workbench
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ If you have an AI coding assistant — **Claude Code**, **Codex**, **Cursor**, *
 - **Permission prompts — lots of them.** Your AI will ask permission to run several commands. Expect 10–25 prompts before install finishes — more if your computer is fresh, fewer if it already has dev tools. **Click "Allow" each time.** This is normal. The tools the AI installs (git for fetching code, Python for running ClawJournal, Node.js for the browser workbench) are widely-used software your computer probably has parts of already.
 - **A separate password prompt on Mac.** macOS may ask for *your computer password* (the one you use to log in) when installing certain tools. This is your operating system asking, not the AI. Type your password and hit Enter — installing software almost always requires this.
 - **Silent waiting periods.** Some downloads and compiles take 30–90 seconds with no visible progress. **The AI isn't frozen — it's working.** Wait for it to come back. Total install time is usually 2–10 minutes depending on your network and what's already installed.
-- **A success message at the end:** `[ok] ClawJournal 0.1.13 installed.` (the version number may differ).
+- **A success message at the end:** `[ok] ClawJournal 0.1.14 installed.` (the version number may differ).
 
 ### Open the workbench
 
@@ -329,8 +329,7 @@ Package the conversations you approved into a redacted file on your computer. Up
 
 The agent walks you through the Share page in the browser workbench: **Queue → Redact → Review → Package → Done**. The Redact step uses AI to catch any personal info the automatic scan missed. Upload-time PII review runs a small parallel worker pool by default; set `CLAWJOURNAL_UPLOAD_PII_WORKERS=1` to serialize it or `CLAWJOURNAL_UPLOAD_PII_TIMEOUT_SECONDS=90` to allow longer AI review per trace.
 
-To actually upload after packaging (optional), use the hosted submission page if one is configured for this install. The Done screen shows **Submit to ClawJournal Research** when a destination is available; that page verifies email, shows consent, and asks for the downloaded zip.
-Set `CLAWJOURNAL_SHARE_URL` to the hosted `/share` page to enable that button in local workbench builds.
+To actually upload after packaging (optional), use the hosted Rayward submission page. The Done screen shows **Submit to ClawJournal Research** by default; that page verifies email, shows consent, and asks for the downloaded zip. Self-hosters can override the destination with `CLAWJOURNAL_SHARE_URL`; setting `CLAWJOURNAL_SHARE_URL=` disables the hosted button.
 
 > *(optional)* *"Open the ClawJournal Research submission page so I can upload the exported zip."*
 
@@ -346,7 +345,7 @@ clawjournal bundle-view <bundle_id>                  # inspect before exporting
 clawjournal bundle-export <bundle_id> --zip          # write an uploadable zip plus export folder
 
 # Optional hosted browser upload:
-python -m webbrowser "$CLAWJOURNAL_SHARE_URL"       # when configured
+python -m webbrowser "https://data.rayward.ai/share"  # packaged default
 
 # Advanced self-hosted ingest upload:
 clawjournal verify-email you@university.edu          # one-time email verification

--- a/clawjournal/__init__.py
+++ b/clawjournal/__init__.py
@@ -1,3 +1,3 @@
 """ClawJournal — Export and manage coding agent conversation data."""
 
-__version__ = "0.1.13"
+__version__ = "0.1.14"

--- a/clawjournal/__init__.py
+++ b/clawjournal/__init__.py
@@ -1,3 +1,3 @@
 """ClawJournal — Export and manage coding agent conversation data."""
 
-__version__ = "0.1.14"
+__version__ = "0.1.15"

--- a/clawjournal/web/frontend/src/views/Share.tsx
+++ b/clawjournal/web/frontend/src/views/Share.tsx
@@ -2595,7 +2595,6 @@ interface DoneStepProps {
 }
 
 function DoneStep(p: DoneStepProps) {
-  const [peek, setPeek] = useState(false);
   const [confettiPieces] = useState(() => {
     const palette = ['#b47d08', '#558745', '#5f7191', '#c4890a', '#a09a8f'];
     return Array.from({ length: 28 }, (_, i) => ({
@@ -2609,9 +2608,14 @@ function DoneStep(p: DoneStepProps) {
     }));
   });
 
-  const traces = p.bundle?.traces ?? 0;
   const hostedShareUrl = p.shareDestination?.configured ? p.shareDestination.share_page_url : null;
   const hostedShareLabel = hostedShareUrl ? formatShareDestination(hostedShareUrl) : null;
+  const zipFiles = [
+    { name: 'manifest.json', detail: 'metadata' },
+    { name: 'sessions.jsonl', detail: p.bundle ? `~${p.bundle.approxSize}` : 'redacted traces' },
+    { name: 'trufflehog.json', detail: 'secret scan' },
+    { name: 'trufflehog.post-pii.json', detail: 'final scan' },
+  ];
 
   return (
     <div style={{ padding: '32px 24px 48px', maxWidth: SHARE_SHELL_WIDTH, margin: '0 auto' }}>
@@ -2749,31 +2753,13 @@ function DoneStep(p: DoneStepProps) {
             paddingBottom: 8, borderBottom: `1px solid ${colors.gray200}`,
           }}>
             <span>Inside the zip</span>
-            <button
-              onClick={() => setPeek(!peek)}
-              style={{
-                fontFamily: 'Inter, system-ui', color: colors.primary500,
-                fontSize: 11, letterSpacing: 0, textTransform: 'none' as const,
-                background: 'transparent', border: 'none', cursor: 'pointer',
-              }}
-            >
-              {peek ? 'Hide' : 'Show file list'}
-            </button>
           </div>
-          <div style={manifestRowStyle}><span>&rsaquo; manifest.json</span><span style={{ color: colors.gray900 }}>0.3 KB</span></div>
-          <div style={manifestRowStyle}><span>&rsaquo; redaction-audit.json</span><span style={{ color: colors.gray900 }}>2.1 KB</span></div>
-          {peek && traces > 0 && Array.from({ length: traces }).map((_, i) => (
-            <div key={i} style={manifestRowStyle}>
-              <span>&rsaquo; traces/t_{(i + 1).toString().padStart(3, '0')}.jsonl</span>
-              <span style={{ color: colors.gray900 }}>{(50 + i * 17) % 120 + 20} KB</span>
+          {zipFiles.map((entry) => (
+            <div key={entry.name} style={manifestRowStyle}>
+              <span style={manifestNameStyle}>&rsaquo; {entry.name}</span>
+              <span style={{ color: colors.gray900 }}>{entry.detail}</span>
             </div>
           ))}
-          {!peek && traces > 0 && (
-            <div style={manifestRowStyle}>
-              <span>&rsaquo; traces/ ({traces} files)</span>
-              <span style={{ color: colors.gray900 }}>~{p.bundle?.approxSize}</span>
-            </div>
-          )}
         </div>
 
         <div style={{ display: 'flex', justifyContent: 'center', gap: 10, color: colors.gray500, fontSize: 13 }}>
@@ -2819,6 +2805,9 @@ const statValueStyle: React.CSSProperties = {
 };
 const manifestRowStyle: React.CSSProperties = {
   display: 'flex', justifyContent: 'space-between', gap: 10,
+};
+const manifestNameStyle: React.CSSProperties = {
+  minWidth: 0, overflow: 'hidden', textOverflow: 'ellipsis',
 };
 const doneMiniRow: React.CSSProperties = {
   display: 'flex', gap: 8, alignItems: 'center', marginTop: 6,

--- a/plugins/clawjournal/.claude-plugin/plugin.json
+++ b/plugins/clawjournal/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clawjournal",
-  "version": "0.1.14",
+  "version": "0.1.15",
   "description": "Review, curate, and share coding agent conversation traces. Bundles skills for setup, triage, and AI-assisted scoring.",
   "author": {
     "name": "kaiaiagent",

--- a/plugins/clawjournal/.claude-plugin/plugin.json
+++ b/plugins/clawjournal/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clawjournal",
-  "version": "0.1.13",
+  "version": "0.1.14",
   "description": "Review, curate, and share coding agent conversation traces. Bundles skills for setup, triage, and AI-assisted scoring.",
   "author": {
     "name": "kaiaiagent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawjournal"
-version = "0.1.14"
+version = "0.1.15"
 description = "Review, score, and curate your coding agent conversation traces locally"
 requires-python = ">=3.10"
 license = "Apache-2.0"

--- a/tests/test_repo_layout.py
+++ b/tests/test_repo_layout.py
@@ -1,10 +1,21 @@
 import json
 from pathlib import Path
 
+try:
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - Python < 3.11
+    import tomli as tomllib
+
 import clawjournal
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_python_package_version_matches_runtime_version():
+    pyproject = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text())
+
+    assert pyproject["project"]["version"] == clawjournal.__version__
 
 
 def test_claude_marketplace_points_to_plugin_wrapper():


### PR DESCRIPTION
## Summary
- Bump the corrected follow-up release to 0.1.15 because v0.1.14 is already tagged/released on GitHub.
- Align runtime and plugin manifest versions with the package version.
- Add a repo-layout test that keeps pyproject, runtime, and plugin versions in sync.
- Update README/PRIVACY for the now-default Rayward hosted share URL and fix the Done-screen zip file list to match the real archive contents.

## Validation
- PYTHONPATH=. pytest -q tests/test_repo_layout.py tests/workbench/test_daemon.py::TestShareDestinationAPI
- PYTHONPATH=. pytest -q tests/test_cli.py::TestBundleExport::test_export_zip_writes_uploadable_archive tests/workbench/test_daemon.py::TestShareAPI::test_download_bundle_includes_trufflehog_report tests/workbench/test_daemon.py::TestShareAPI::test_download_bundle_applies_final_ai_pii_redaction tests/workbench/test_daemon.py::TestShareAPI::test_seal_is_idempotent_and_download_reuses_export
- npm run build (clawjournal/web/frontend)
- PYTHONPATH=. pytest -q: 1822 passed, 1 unrelated self-update contention failure; isolated rerun of tests/test_selfupdate.py::test_stale_lock_reclaim_only_one_winner_under_contention passed