### PR TITLE
[codex] Add automatic failure-corpus scoring

### DIFF
--- a/.entire/settings.local.json
+++ b/.entire/settings.local.json
@@ -1,0 +1,3 @@
+{
+  "enabled": false
+}

--- a/README.md
+++ b/README.md
@@ -312,12 +312,15 @@ The agent batches the scoring over the `failure-corpus` source scope (`claude`, 
 
 ```bash
 clawjournal score --batch --source failure-corpus --auto-triage  # score failure-value scope; auto-block low-value productivity-1 noise
+clawjournal score --batch --source failure-corpus --window 7d     # restrict to traces from the last N days
 clawjournal score-view <id>                          # show score details
 clawjournal set-score <id> --failure-value 4 --failure-evidence "User corrected a fabricated API call"
 clawjournal set-score <id> --quality 4               # legacy productivity override
 ```
 
-By default scoring uses the current agent's automation CLI (e.g. `codex exec` inside Codex, the Claude CLI inside Claude Code). Use `--backend` to override. For Codex specifically, `codex exec` reuses saved CLI authentication by default; for automation the recommended explicit credential is `CODEX_API_KEY`.
+By default scoring uses the current agent's automation CLI (e.g. `codex exec` inside Codex, the Claude CLI inside Claude Code). Supported backends are `claude`, `codex`, `hermes`, and `openclaw`; use `--backend` to override. For Codex specifically, `codex exec` reuses saved CLI authentication by default; for automation the recommended explicit credential is `CODEX_API_KEY`.
+
+The browser workbench also keeps share-ready traces warm: on app load it offers to score the latest unscored `failure-corpus` traces in the background. It scores only after you confirm a backend once; the choice is persisted to `~/.clawjournal/config.json`. If you never open the workbench, confirm a backend headlessly with `clawjournal config --scorer-backend <claude|codex|hermes|openclaw>` (use `--scorer-backend none` to clear it).
 
 </details>
 
@@ -456,6 +459,7 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal serve` | Open workbench UI at localhost:8384 |
 | `clawjournal config --source all` | Select source scope (required) |
 | `clawjournal config --confirm-projects` | Confirm project selection (required before export) |
+| `clawjournal config --scorer-backend codex` | Confirm the AI scoring backend used for background workbench scoring (`none` clears it) |
 | `clawjournal score --batch --source failure-corpus --auto-triage` | AI-score failure-value scope; auto-block low-value productivity-1 noise |
 | `clawjournal bundle-create --status approved` | Bundle approved sessions |
 | `clawjournal bundle-export <bundle_id> --zip` | Export bundle to disk and write an uploadable zip |
@@ -470,6 +474,7 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal block <id> [id ...]` | Block sessions |
 | `clawjournal shortlist <id> [id ...]` | Shortlist sessions |
 | `clawjournal score --batch --source failure-corpus --limit 20` | AI-score up to 20 in-scope sessions |
+| `clawjournal score --batch --source failure-corpus --window 7d` | AI-score only in-scope sessions from the last N days |
 | `clawjournal score-view <id>` | View score details |
 | `clawjournal set-score <id> --failure-value <1-5>` | Manually set the failure-value score; 4-5 requires `--failure-evidence` |
 | `clawjournal set-score <id> --quality <1-5>` | Manually set the legacy productivity score |

--- a/README.md
+++ b/README.md
@@ -305,13 +305,13 @@ AI-assisted scoring now records two labels in one pass: a legacy productivity sc
 
 **Just say to your AI:** *"Score my unscored ClawJournal sessions and auto-block the noise."*
 
-The agent batches the scoring over the v1 failure-source scope (`claude`, `codex`, `opencode`, `openclaw`). Productivity-1 sessions get auto-blocked when `--auto-triage` is set only if failure value is 1-2; failure value 3+ stays visible for review and sharing.
+The agent batches the scoring over the `failure-corpus` source scope (`claude`, `codex`, `opencode`, `openclaw`). Productivity-1 sessions get auto-blocked when `--auto-triage` is set only if failure value is 1-2; failure value 3+ stays visible for review and sharing.
 
 <details>
 <summary><b>Show shell commands</b></summary>
 
 ```bash
-clawjournal score --batch --source failure-v1 --auto-triage  # score failure-value scope; auto-block low-value productivity-1 noise
+clawjournal score --batch --source failure-corpus --auto-triage  # score failure-value scope; auto-block low-value productivity-1 noise
 clawjournal score-view <id>                          # show score details
 clawjournal set-score <id> --failure-value 4 --failure-evidence "User corrected a fabricated API call"
 clawjournal set-score <id> --quality 4               # legacy productivity override
@@ -456,7 +456,7 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal serve` | Open workbench UI at localhost:8384 |
 | `clawjournal config --source all` | Select source scope (required) |
 | `clawjournal config --confirm-projects` | Confirm project selection (required before export) |
-| `clawjournal score --batch --source failure-v1 --auto-triage` | AI-score failure-value scope; auto-block low-value productivity-1 noise |
+| `clawjournal score --batch --source failure-corpus --auto-triage` | AI-score failure-value scope; auto-block low-value productivity-1 noise |
 | `clawjournal bundle-create --status approved` | Bundle approved sessions |
 | `clawjournal bundle-export <bundle_id> --zip` | Export bundle to disk and write an uploadable zip |
 
@@ -469,7 +469,7 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal approve <id> [id ...]` | Approve sessions |
 | `clawjournal block <id> [id ...]` | Block sessions |
 | `clawjournal shortlist <id> [id ...]` | Shortlist sessions |
-| `clawjournal score --batch --source failure-v1 --limit 20` | AI-score up to 20 in-scope sessions |
+| `clawjournal score --batch --source failure-corpus --limit 20` | AI-score up to 20 in-scope sessions |
 | `clawjournal score-view <id>` | View score details |
 | `clawjournal set-score <id> --failure-value <1-5>` | Manually set the failure-value score; 4-5 requires `--failure-evidence` |
 | `clawjournal set-score <id> --quality <1-5>` | Manually set the legacy productivity score |

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -7,7 +7,7 @@ import sys
 import urllib.error
 import urllib.request
 import zipfile
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Mapping, cast
 
@@ -65,7 +65,7 @@ WORKBENCH_SOURCE_CHOICES = ["claude", "codex", "opencode", "openclaw", "cursor",
 EVENT_SOURCE_CHOICES = ["auto", "claude", "codex", "openclaw", "all"]
 PII_PROVIDER_CHOICES = ("rules", "ai", "hybrid")
 FAILURE_VALUE_SOURCE_SCOPE = ("claude", "codex", "opencode", "openclaw")
-SCORE_SOURCE_CHOICES = set(WORKBENCH_SOURCE_CHOICES) | {"failure-v1", "all", "auto", "both"}
+SCORE_SOURCE_CHOICES = set(WORKBENCH_SOURCE_CHOICES) | {"failure-corpus", "failure-v1", "all", "auto", "both"}
 
 
 def _mask_secret(s: str) -> str:
@@ -89,12 +89,12 @@ def _normalize_score_source_filter(raw: str | None) -> str | list[str] | None:
     if raw is None:
         return list(FAILURE_VALUE_SOURCE_SCOPE)
     value = raw.strip().lower()
-    if value in ("", "failure-v1"):
+    if value in ("", "failure-corpus", "failure-v1"):
         return list(FAILURE_VALUE_SOURCE_SCOPE)
     if value == "both":
         print(
             "Warning: --source both is deprecated for scoring; use "
-            "--source failure-v1 or --source claude,codex,opencode,openclaw.",
+            "--source failure-corpus or --source claude,codex,opencode,openclaw.",
             file=sys.stderr,
         )
         return ["claude", "codex"]
@@ -363,6 +363,7 @@ def _merge_config_list(config: ClawJournalConfig, key: str, new_values: list[str
 def configure(
     repo: str | None = None,
     source: str | None = None,
+    scorer_backend: str | None = None,
     exclude: list[str] | None = None,
     redact: list[str] | None = None,
     redact_usernames: list[str] | None = None,
@@ -375,6 +376,13 @@ def configure(
         config["repo"] = repo
     if source is not None:
         config["source"] = source
+    if scorer_backend is not None:
+        if scorer_backend == "none":
+            config.pop("scorer_backend", None)
+            config.pop("scorer_backend_confirmed_at", None)
+        else:
+            config["scorer_backend"] = scorer_backend
+            config["scorer_backend_confirmed_at"] = datetime.now(timezone.utc).isoformat()
     if exclude is not None:
         if config.get("excluded_projects"):
             config["excluded_projects"] = normalize_excluded_project_names(
@@ -2587,7 +2595,13 @@ def _run_score_batch(args) -> None:
 
     conn = open_index()
     source_filter = _normalize_score_source_filter(args.source)
-    sessions = query_unscored_sessions(conn, limit=args.limit, source=source_filter)
+    window_days = getattr(args, "window", None)
+    since = (
+        (datetime.now(timezone.utc) - timedelta(days=window_days)).isoformat()
+        if window_days is not None
+        else None
+    )
+    sessions = query_unscored_sessions(conn, limit=args.limit, source=source_filter, since=since)
     conn.close()
 
     print(json.dumps(sessions, indent=2))
@@ -2820,10 +2834,16 @@ def _run_score(args) -> None:
     batch = args.batch
     auto_triage = getattr(args, "auto_triage", False)
     source_filter = _normalize_score_source_filter(args.source)
+    window_days = getattr(args, "window", None)
+    since = (
+        (datetime.now(timezone.utc) - timedelta(days=window_days)).isoformat()
+        if window_days is not None
+        else None
+    )
 
     if batch:
         # Batch mode: score unscored sessions
-        sessions = query_unscored_sessions(conn, limit=args.limit, source=source_filter)
+        sessions = query_unscored_sessions(conn, limit=args.limit, source=source_filter, since=since)
         if not sessions:
             print(json.dumps({"message": "No unscored sessions found.", "scored": 0}))
             conn.close()
@@ -3623,6 +3643,8 @@ def main() -> None:
     cfg.add_argument("--repo", type=str, help=argparse.SUPPRESS)
     cfg.add_argument("--source", choices=sorted(EXPLICIT_SOURCE_CHOICES),
                      help="Set export source scope explicitly: claude, codex, gemini, or all")
+    cfg.add_argument("--scorer-backend", choices=[b for b in SCORING_BACKEND_CHOICES if b != "auto"] + ["none"],
+                     help="Confirm the AI scoring backend for automatic workbench scoring")
     cfg.add_argument("--exclude", type=str, help="Comma-separated projects to exclude")
     cfg.add_argument("--redact", type=str,
                      help="Comma-separated strings to always redact (API keys, usernames, domains)")
@@ -4030,15 +4052,19 @@ def main() -> None:
 
     sb = sub.add_parser("score-batch", help="List unscored sessions for AI scoring")
     sb.add_argument("--limit", type=int, default=50)
-    sb.add_argument("--source", default="failure-v1",
-                    help="Source scope: failure-v1, comma list, all/auto, or a single source")
+    sb.add_argument("--source", default="failure-corpus",
+                    help="Source scope: failure-corpus, comma list, all/auto, or a single source")
+    sb.add_argument("--window", type=_parse_window_days, default=None,
+                    help="Only include unscored sessions from the last Nd days (e.g. 7d)")
 
     sc = sub.add_parser("score", help="Auto-score sessions via the current agent's automation CLI or an explicit backend")
     sc.add_argument("session_ids", nargs="*", help="Session IDs to score")
     sc.add_argument("--batch", action="store_true", help="Score all unscored sessions")
-    sc.add_argument("--limit", type=int, default=10, help="Max sessions for batch mode (default: 10)")
-    sc.add_argument("--source", default="failure-v1",
-                    help="Batch source scope: failure-v1, comma list, all/auto, or a single source")
+    sc.add_argument("--limit", type=int, default=20, help="Max sessions for batch mode (default: 20)")
+    sc.add_argument("--source", default="failure-corpus",
+                    help="Batch source scope: failure-corpus, comma list, all/auto, or a single source")
+    sc.add_argument("--window", type=_parse_window_days, default=None,
+                    help="Only score unscored sessions from the last Nd days (e.g. 7d)")
     sc.add_argument("--backend", choices=SCORING_BACKEND_CHOICES, default="auto",
                     help="Scoring backend (default: auto = current agent's automation CLI)")
     sc.add_argument("--model", type=str, default=None,
@@ -4059,8 +4085,8 @@ def main() -> None:
     )
     rs.add_argument(
         "--source",
-        default="failure-v1",
-        help="Source scope: failure-v1, comma list, all/auto, or a single source",
+        default="failure-corpus",
+        help="Source scope: failure-corpus, comma list, all/auto, or a single source",
     )
     rs.add_argument("--limit", type=int, default=200, help="Max sessions to rescore (default: 200)")
     rs.add_argument(
@@ -4525,6 +4551,7 @@ def _handle_config(args) -> None:
     has_changes = (
         args.repo
         or args.source
+        or args.scorer_backend
         or args.exclude
         or args.redact
         or args.redact_usernames
@@ -4537,6 +4564,7 @@ def _handle_config(args) -> None:
     configure(
         repo=args.repo,
         source=args.source,
+        scorer_backend=args.scorer_backend,
         exclude=_parse_csv_arg(args.exclude),
         redact=_parse_csv_arg(args.redact),
         redact_usernames=_parse_csv_arg(args.redact_usernames),

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -35,6 +35,8 @@ class ClawJournalConfig(TypedDict, total=False):
     pending_verification_email: str | None
     pending_verification_expires_at: str | int | None
     ai_pii_review_enabled: bool
+    scorer_backend: str | None
+    scorer_backend_confirmed_at: str | None
 
 
 DEFAULT_CONFIG: ClawJournalConfig = {

--- a/clawjournal/scoring/backends.py
+++ b/clawjournal/scoring/backends.py
@@ -18,21 +18,25 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-SUPPORTED_BACKENDS = ("claude", "codex", "openclaw")
+SUPPORTED_BACKENDS = ("claude", "codex", "hermes", "openclaw")
 BACKEND_CHOICES = ("auto", *SUPPORTED_BACKENDS)
+AUTO_BACKEND_FALLBACK_ORDER = ("codex", "claude", "hermes", "openclaw")
 BACKEND_COMMANDS: dict[str, str] = {
     "claude": "claude",
     "codex": "codex",
+    "hermes": "hermes",
     "openclaw": "openclaw",
 }
 BACKEND_ENV_MARKERS: dict[str, tuple[str, ...]] = {
     "claude": ("CLAUDECODE", "CLAUDE_CODE", "CLAUDECODE_SESSION_ID", "CLAUDE_PROJECT_DIR"),
     "codex": ("CODEX_THREAD_ID", "CODEX_SANDBOX", "CODEX_CI"),
+    "hermes": ("HERMES_HOME", "HERMES_CONFIG_PATH", "HERMES_SESSION_ID"),
     "openclaw": ("OPENCLAW_HOME", "OPENCLAW_STATE_DIR", "OPENCLAW_CONFIG_PATH"),
 }
 BACKEND_COMMAND_ALIASES: dict[str, tuple[str, ...]] = {
     "claude": ("claude",),
     "codex": ("codex",),
+    "hermes": ("hermes",),
     "openclaw": ("openclaw",),
 }
 
@@ -103,10 +107,23 @@ def detect_current_agent(env: dict[str, str] | None = None) -> str | None:
     return _detect_current_agent_from_env(env) or _detect_current_agent_from_process_tree()
 
 
+def detect_available_backend(env: dict[str, str] | None = None) -> str | None:
+    """Detect a usable backend, falling back to installed CLIs."""
+    detected = detect_current_agent(env)
+    if detected and shutil.which(BACKEND_COMMANDS[detected]) is not None:
+        return detected
+    for backend in AUTO_BACKEND_FALLBACK_ORDER:
+        command = BACKEND_COMMANDS[backend]
+        if shutil.which(command) is not None:
+            return backend
+    return None
+
+
 def resolve_backend(backend: str = "auto", env: dict[str, str] | None = None) -> str:
     """Resolve 'auto' backend selection to a concrete backend name.
 
-    Priority: explicit value > CLAWJOURNAL_SCORER_BACKEND env > auto-detect.
+    Priority: explicit value > CLAWJOURNAL_SCORER_BACKEND env >
+    current-agent detection > installed CLI fallback.
     """
     env = os.environ if env is None else env
     requested = (backend or "auto").strip().lower()
@@ -124,13 +141,13 @@ def resolve_backend(backend: str = "auto", env: dict[str, str] | None = None) ->
             )
         return override
 
-    detected = detect_current_agent(env)
+    detected = detect_available_backend(env)
     if detected:
         return detected
 
     raise RuntimeError(
-        "Could not detect the current agent. "
-        "Run clawjournal from a supported agent CLI, set CLAWJOURNAL_SCORER_BACKEND, "
+        "Could not detect a supported scoring backend. "
+        "Install a supported agent CLI, set CLAWJOURNAL_SCORER_BACKEND, "
         "or pass --backend explicitly."
     )
 
@@ -308,6 +325,19 @@ def _build_openclaw_cmd(
     ]
 
 
+def _build_hermes_cmd(
+    command: str,
+    *,
+    message: str,
+    model: str | None,
+) -> list[str]:
+    """Build a Hermes scripted one-shot invocation."""
+    cmd = [command, "-z", message]
+    if model:
+        cmd += ["--model", model]
+    return cmd
+
+
 def run_default_agent_task(
     *,
     backend: str = "auto",
@@ -330,12 +360,13 @@ def run_default_agent_task(
     parsing.
 
     Args:
-        backend: "auto", "claude", "codex", or "openclaw".
+        backend: "auto", "claude", "codex", "hermes", or "openclaw".
         cwd: Working directory for the subprocess.
         system_prompt_file: Path to system prompt (used by Claude's
             ``--system-prompt-file``; ignored by other backends).
         task_prompt: The task instruction. Delivered via stdin (Claude),
-            positional arg (Codex), or ``--message`` (OpenClaw).
+            positional arg (Codex), scripted one-shot (Hermes), or
+            ``--message`` (OpenClaw).
         model: Optional model override for Claude/Codex.
         timeout_seconds: Subprocess timeout.
         codex_sandbox: Codex sandbox mode ("read-only" or None for
@@ -461,6 +492,30 @@ def run_default_agent_task(
         if proc.returncode != 0:
             summary = summarize_process_error(proc.stderr, proc.stdout)
             raise RuntimeError(f"openclaw exited {proc.returncode}: {summary}")
+
+        return AgentResult(
+            stdout=proc.stdout or "",
+            stderr=proc.stderr or "",
+            returncode=proc.returncode,
+            cwd=cwd,
+        )
+
+    if resolved == "hermes":
+        cmd = _build_hermes_cmd(command, message=task_prompt, model=model)
+        try:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(cwd),
+                capture_output=True,
+                text=True,
+                timeout=timeout_seconds + 10,
+            )
+        except subprocess.TimeoutExpired:
+            raise RuntimeError(f"Timed out waiting for hermes ({timeout_seconds}s)")
+
+        if proc.returncode != 0:
+            summary = summarize_process_error(proc.stderr, proc.stdout)
+            raise RuntimeError(f"hermes exited {proc.returncode}: {summary}")
 
         return AgentResult(
             stdout=proc.stdout or "",

--- a/clawjournal/scoring/backends.py
+++ b/clawjournal/scoring/backends.py
@@ -21,6 +21,21 @@ logger = logging.getLogger(__name__)
 SUPPORTED_BACKENDS = ("claude", "codex", "hermes", "openclaw")
 BACKEND_CHOICES = ("auto", *SUPPORTED_BACKENDS)
 AUTO_BACKEND_FALLBACK_ORDER = ("codex", "claude", "hermes", "openclaw")
+
+# Prefix of the RuntimeError raised by resolve_backend() when no usable backend
+# can be found. Kept as a constant so callers (e.g. the daemon's auto-score
+# circuit breaker) can recognise the condition without duplicating the wording.
+NO_BACKEND_DETECTED_ERROR = "Could not detect a supported scoring backend"
+
+# Substrings of RuntimeError messages that mean "no scoring backend is usable" —
+# a permanent condition that should stop the daemon's auto-score loop rather than
+# be retried on every scan tick. Keep aligned with resolve_backend() and
+# require_backend_command() below.
+PERMANENT_BACKEND_FAILURE_MARKERS = (
+    NO_BACKEND_DETECTED_ERROR,
+    "CLI not found",
+    "Unsupported CLAWJOURNAL_SCORER_BACKEND",
+)
 BACKEND_COMMANDS: dict[str, str] = {
     "claude": "claude",
     "codex": "codex",
@@ -146,7 +161,7 @@ def resolve_backend(backend: str = "auto", env: dict[str, str] | None = None) ->
         return detected
 
     raise RuntimeError(
-        "Could not detect a supported scoring backend. "
+        f"{NO_BACKEND_DETECTED_ERROR}. "
         "Install a supported agent CLI, set CLAWJOURNAL_SCORER_BACKEND, "
         "or pass --backend explicitly."
     )

--- a/clawjournal/scoring/scoring.py
+++ b/clawjournal/scoring/scoring.py
@@ -778,6 +778,15 @@ def _extract_json_candidate_strings(value: Any) -> list[str]:
         text = value.strip()
         if text:
             candidates.append(text)
+            # Stdout-only backends (OpenClaw / Hermes) may wrap the JSON in
+            # markdown fences or surround it with prose despite instructions
+            # not to. Fall back to the outermost {...} span so the parse
+            # survives that.
+            start, end = text.find("{"), text.rfind("}")
+            if 0 <= start < end:
+                span = text[start:end + 1]
+                if span != text:
+                    candidates.append(span)
     elif isinstance(value, dict):
         priority_keys = (
             "text", "message", "result", "reply", "output", "content",

--- a/clawjournal/scoring/scoring.py
+++ b/clawjournal/scoring/scoring.py
@@ -873,7 +873,7 @@ def _read_scoring_output(result: AgentResult, backend: str) -> dict:
             return _validate_backend_judge_result(parsed)
         raise RuntimeError("scoring.json does not contain a JSON object")
 
-    # OpenClaw: parse from stdout
+    # OpenClaw / Hermes: parse from stdout
     stdout = result.stdout.strip()
     if not stdout:
         raise RuntimeError(f"{backend} did not produce scoring output")
@@ -910,10 +910,11 @@ def call_judge(
             rubric=rubric,
         )
 
-        # Build OpenClaw-specific message with absolute paths
-        openclaw_msg = None
-        if resolved == "openclaw":
-            openclaw_msg = (
+        # Build backend-specific messages for agents that do not consume
+        # Claude-style system prompts or Codex structured-output files.
+        file_based_msg = None
+        if resolved in ("openclaw", "hermes"):
+            file_based_msg = (
                 "Score the coding agent session using the files below.\n\n"
                 f"Read these absolute paths:\n"
                 f"- {tmp_path / 'judge_input.md'}\n"
@@ -924,8 +925,13 @@ def call_judge(
                 "Do not wrap it in markdown fences."
             )
 
-        # Codex uses structured output; give it a matching prompt
-        task_prompt = _SCORE_TASK_PROMPT_CODEX if resolved == "codex" else _SCORE_TASK_PROMPT
+        # Codex uses structured output; Hermes/OpenClaw get absolute paths.
+        if resolved == "codex":
+            task_prompt = _SCORE_TASK_PROMPT_CODEX
+        elif resolved == "hermes" and file_based_msg is not None:
+            task_prompt = file_based_msg
+        else:
+            task_prompt = _SCORE_TASK_PROMPT
 
         result = run_default_agent_task(
             backend=resolved,
@@ -937,7 +943,7 @@ def call_judge(
             codex_sandbox="read-only",
             codex_output_schema=JUDGE_SCHEMA,
             codex_output_file="scoring.json",
-            openclaw_message=openclaw_msg,
+            openclaw_message=file_based_msg if resolved == "openclaw" else None,
         )
 
         parsed = _read_scoring_output(result, resolved)

--- a/clawjournal/scoring/scoring.py
+++ b/clawjournal/scoring/scoring.py
@@ -586,8 +586,8 @@ JUDGE_SCHEMA = {
     "required": [
         "substance", "ai_quality_score", "ai_failure_value_score",
         "ai_recovery_labels", "ai_failure_attribution", "ai_failure_modes",
-        "ai_failure_evidence", "ai_learning_summary", "reasoning",
-        "display_title", "summary", "resolution", "effort_estimate",
+        "ai_meta_labels", "ai_failure_evidence", "ai_learning_summary",
+        "reasoning", "display_title", "summary", "resolution", "effort_estimate",
         "task_type", "session_tags", "privacy_flags", "project_areas",
     ],
 }

--- a/clawjournal/web/frontend/src/App.tsx
+++ b/clawjournal/web/frontend/src/App.tsx
@@ -117,6 +117,29 @@ function Sidebar() {
 }
 
 export default function App() {
+  useEffect(() => {
+    let cancelled = false;
+    const timer = window.setTimeout(async () => {
+      try {
+        const warmup = await api.scoringWarmup();
+        if (
+          !cancelled
+          && warmup.status === 'needs_confirmation'
+          && warmup.backend
+          && window.confirm(`Use ${warmup.display_name ?? warmup.backend} to score recent failure-corpus traces in the background?`)
+        ) {
+          await api.scoringWarmup({ confirm_backend: true, backend: warmup.backend });
+        }
+      } catch {
+        // Background scoring is opportunistic; the workbench stays usable.
+      }
+    }, 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(timer);
+    };
+  }, []);
+
   return (
     <BrowserRouter>
       <ToastProvider>

--- a/clawjournal/web/frontend/src/App.tsx
+++ b/clawjournal/web/frontend/src/App.tsx
@@ -116,19 +116,33 @@ function Sidebar() {
   );
 }
 
+const SCORING_WARMUP_DECLINED_KEY = 'cj.scoringWarmupDeclined';
+
 export default function App() {
   useEffect(() => {
     let cancelled = false;
     const timer = window.setTimeout(async () => {
       try {
         const warmup = await api.scoringWarmup();
-        if (
-          !cancelled
-          && warmup.status === 'needs_confirmation'
-          && warmup.backend
-          && window.confirm(`Use ${warmup.display_name ?? warmup.backend} to score recent failure-corpus traces in the background?`)
-        ) {
+        if (cancelled || warmup.status !== 'needs_confirmation' || !warmup.backend) {
+          return;
+        }
+        // Ask at most once. There is no server-side "declined" flag, so a
+        // browser that has already said no must remember it locally —
+        // otherwise this blocking dialog re-fires on every reload.
+        if (localStorage.getItem(SCORING_WARMUP_DECLINED_KEY)) {
+          return;
+        }
+        const accepted = window.confirm(
+          `Use ${warmup.display_name ?? warmup.backend} to score recent failure-corpus traces in the background?`,
+        );
+        if (cancelled) {
+          return;
+        }
+        if (accepted) {
           await api.scoringWarmup({ confirm_backend: true, backend: warmup.backend });
+        } else {
+          localStorage.setItem(SCORING_WARMUP_DECLINED_KEY, '1');
         }
       } catch {
         // Background scoring is opportunistic; the workbench stays usable.

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -242,8 +242,22 @@ export const api = {
     });
   },
 
-  scoringBackend(): Promise<{ backend: string | null; display_name: string | null }> {
+  scoringBackend(): Promise<{ backend: string | null; display_name: string | null; confirmed?: boolean; needs_confirmation?: boolean }> {
     return request('/scoring/backend');
+  },
+
+  scoringWarmup(body?: { confirm_backend?: boolean; backend?: string | null }): Promise<{
+    status: 'started' | 'already_running' | 'needs_confirmation' | 'disabled';
+    backend?: string | null;
+    display_name?: string | null;
+    reason?: string;
+    limit?: number;
+  }> {
+    return request('/scoring/warmup', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body ?? {}),
+    });
   },
 
   shares: {

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -15,7 +15,7 @@ import uuid
 import webbrowser
 import zipfile
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from functools import partial
 from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
@@ -26,6 +26,11 @@ from urllib.parse import parse_qs, unquote, urlparse
 from .. import __version__
 from ..redaction.anonymizer import Anonymizer
 from ..scoring.badges import compute_all_badges
+from ..scoring.backends import (
+    SUPPORTED_BACKENDS,
+    detect_available_backend,
+    require_backend_command,
+)
 from ..scoring.overrides import (
     failure_evidence_from_detail,
     merge_failure_evidence,
@@ -86,7 +91,13 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_PORT = 8384
 SCAN_INTERVAL = 60  # seconds
-AUTO_SCORE_BATCH_SIZE = 10
+AUTO_SCORE_BATCH_SIZE = 20
+SCORING_DISPLAY_NAMES = {
+    "claude": "Claude Code",
+    "codex": "Codex",
+    "hermes": "Hermes Agent",
+    "openclaw": "OpenClaw",
+}
 
 _SHARE_MAX_FILE_SIZE = 500 * 1024 * 1024  # 500 MB
 _SHARE_COOLDOWN_SECONDS = 10
@@ -143,6 +154,83 @@ def _persist_scoring_result(conn: sqlite3.Connection, session_id: str, result: A
         ai_rubric_git_sha=getattr(result, "rubric_git_sha", "") or None,
         ai_scored_at=getattr(result, "scored_at", "") or None,
     )
+
+
+def _env_scoring_backend() -> str | None:
+    backend = os.environ.get("CLAWJOURNAL_SCORER_BACKEND", "").strip().lower()
+    return backend if backend in SUPPORTED_BACKENDS else None
+
+
+def _confirmed_scoring_backend() -> str | None:
+    env_backend = _env_scoring_backend()
+    if env_backend:
+        return env_backend
+    config = load_config()
+    backend = str(config.get("scorer_backend") or "").strip().lower()
+    if backend in SUPPORTED_BACKENDS:
+        return backend
+    return None
+
+
+def _suggest_scoring_backend() -> str | None:
+    return detect_available_backend()
+
+
+def _save_confirmed_scoring_backend(backend: str) -> None:
+    config = load_config()
+    config["scorer_backend"] = backend
+    config["scorer_backend_confirmed_at"] = datetime.now(timezone.utc).isoformat()
+    save_config(config)
+
+
+def _scoring_backend_payload(backend: str | None) -> dict[str, Any]:
+    return {
+        "backend": backend,
+        "display_name": SCORING_DISPLAY_NAMES.get(backend or "", backend),
+    }
+
+
+def trigger_scoring_warmup(
+    scanner: "Scanner | None",
+    *,
+    confirm_backend: bool = False,
+    requested_backend: str | None = None,
+    limit: int = AUTO_SCORE_BATCH_SIZE,
+) -> dict[str, Any]:
+    """Start the share-readiness scoring warmup if it is allowed."""
+    if scanner is None:
+        return {"status": "disabled", "reason": "Background scanner is not running."}
+
+    backend = _confirmed_scoring_backend()
+    suggested = (requested_backend or "").strip().lower() or None
+    if suggested is not None and suggested not in SUPPORTED_BACKENDS:
+        return {"status": "disabled", "reason": f"Unsupported scoring backend: {suggested}"}
+
+    if backend is None:
+        backend = suggested or _suggest_scoring_backend()
+        if backend is None:
+            return {
+                "status": "disabled",
+                "reason": "No supported scoring backend CLI was detected.",
+            }
+        try:
+            require_backend_command(backend)
+        except RuntimeError as exc:
+            return {"status": "disabled", "reason": str(exc), **_scoring_backend_payload(backend)}
+        if not confirm_backend and _env_scoring_backend() is None:
+            return {
+                "status": "needs_confirmation",
+                "reason": "Confirm the detected AI scoring backend before background scoring starts.",
+                **_scoring_backend_payload(backend),
+            }
+        _save_confirmed_scoring_backend(backend)
+
+    try:
+        require_backend_command(backend)
+    except RuntimeError as exc:
+        return {"status": "disabled", "reason": str(exc), **_scoring_backend_payload(backend)}
+
+    return scanner.trigger_auto_score(limit=limit, backend=backend)
 
 
 def _maybe_create_trace_note(conn: sqlite3.Connection, session_id: str) -> None:
@@ -249,8 +337,14 @@ class Scanner:
         finally:
             conn.close()
 
-    def score_unscored_once(self, *, limit: int = AUTO_SCORE_BATCH_SIZE) -> int:
-        """Score a recent batch of unscored traces using the current agent."""
+    def score_unscored_once(
+        self,
+        *,
+        limit: int = AUTO_SCORE_BATCH_SIZE,
+        since: str | None = None,
+        backend: str = "auto",
+    ) -> int:
+        """Score the latest failure-corpus traces using the selected backend."""
         if self._auto_score_disabled_reason:
             return 0
         if not self._score_lock.acquire(blocking=False):
@@ -261,13 +355,11 @@ class Scanner:
         try:
             conn = open_index()
             try:
-                source_scope = self.source_filter or FAILURE_VALUE_SOURCE_SCOPE
-                recent_cutoff = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
                 sessions = query_unscored_sessions(
                     conn,
                     limit=limit,
-                    source=source_scope,
-                    since=recent_cutoff,
+                    source=FAILURE_VALUE_SOURCE_SCOPE,
+                    since=since,
                 )
                 if not sessions:
                     return 0
@@ -276,7 +368,7 @@ class Scanner:
                 for s in sessions:
                     sid = s["session_id"]
                     try:
-                        result = score_session(conn, sid, backend="auto")
+                        result = score_session(conn, sid, backend=backend)
                     except RuntimeError as exc:
                         message = str(exc)
                         if (
@@ -303,27 +395,34 @@ class Scanner:
         finally:
             self._score_lock.release()
 
-    def trigger_auto_score(self, *, limit: int = AUTO_SCORE_BATCH_SIZE) -> None:
-        """Start background scoring for recent unscored sessions if idle."""
+    def trigger_auto_score(
+        self,
+        *,
+        limit: int = AUTO_SCORE_BATCH_SIZE,
+        since: str | None = None,
+        backend: str = "auto",
+    ) -> dict[str, Any]:
+        """Start background scoring for the latest failure-corpus sessions if idle."""
         if self._auto_score_disabled_reason:
-            return
+            return {"status": "disabled", "reason": self._auto_score_disabled_reason}
         if self._score_thread and self._score_thread.is_alive():
-            return
+            return {"status": "already_running"}
 
         def _run() -> None:
-            scored = self.score_unscored_once(limit=limit)
+            scored = self.score_unscored_once(limit=limit, since=since, backend=backend)
             self.last_scored_count = scored
             if scored > 0:
                 logger.info("Auto-scored %d recent sessions", scored)
 
         self._score_thread = threading.Thread(target=_run, daemon=True)
         self._score_thread.start()
+        return {"status": "started", "limit": limit, "backend": backend}
 
     def _run(self) -> None:
         while not self._stop_event.is_set():
             try:
                 results = self.scan_once()
-                self.trigger_auto_score()
+                trigger_scoring_warmup(self)
                 total_new = sum(results.values())
                 if total_new > 0 or self.last_linked_count > 0:
                     logger.info(
@@ -1822,6 +1921,8 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             self._handle_add_allowlist()
         elif path == "/api/findings/allowlist":
             self._handle_add_findings_allowlist()
+        elif path == "/api/scoring/warmup":
+            self._handle_scoring_warmup()
         elif path == "/api/scan":
             force = parse_qs(parsed.query).get("force", [""])[0] in ("1", "true")
             self._handle_trigger_scan(force=force)
@@ -2448,17 +2549,24 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
 
     def _handle_scoring_backend(self) -> None:
         """Return the default AI scoring backend detected for this daemon."""
-        from ..scoring.backends import resolve_backend
-        display_names = {"claude": "Claude Code", "codex": "Codex", "openclaw": "OpenClaw"}
-        try:
-            backend = resolve_backend(backend="auto")
-        except RuntimeError:
-            _json_response(self, {"backend": None, "display_name": None})
-            return
+        backend = _confirmed_scoring_backend()
+        suggested = None if backend else _suggest_scoring_backend()
         _json_response(self, {
-            "backend": backend,
-            "display_name": display_names.get(backend, backend),
+            **_scoring_backend_payload(backend or suggested),
+            "confirmed": backend is not None,
+            "needs_confirmation": backend is None and suggested is not None,
         })
+
+    def _handle_scoring_warmup(self) -> None:
+        """Start background scoring for share-ready recommendations."""
+        body = _read_body(self) or {}
+        scanner = getattr(self.server, "_scanner", None)
+        payload = trigger_scoring_warmup(
+            scanner,
+            confirm_backend=bool(body.get("confirm_backend") or body.get("confirm")),
+            requested_backend=body.get("backend"),
+        )
+        _json_response(self, payload)
 
     def _handle_share_destination(self) -> None:
         """Return the optional hosted research-submission destination."""
@@ -3032,8 +3140,9 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         scanner = getattr(self.server, "_scanner", None)
         if scanner:
             results = scanner.scan_once()
-            scanner.trigger_auto_score()
+            warmup = trigger_scoring_warmup(scanner)
             payload: dict[str, Any] = {"ok": True, "new_sessions": results}
+            payload["scoring_warmup"] = warmup
             if force:
                 from ..config import load_config as _load_config
                 from .findings_pipeline import run_findings_pipeline
@@ -3298,7 +3407,7 @@ def run_server(
     def _initial_scan() -> None:
         logger.info("Running initial scan...")
         results = scanner.scan_once()
-        scanner.trigger_auto_score()
+        trigger_scoring_warmup(scanner)
         total = sum(results.values())
         logger.info(
             "Initial scan complete: %d sessions indexed, %d subagent relationships linked",

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -27,6 +27,7 @@ from .. import __version__
 from ..redaction.anonymizer import Anonymizer
 from ..scoring.badges import compute_all_badges
 from ..scoring.backends import (
+    PERMANENT_BACKEND_FAILURE_MARKERS,
     SUPPORTED_BACKENDS,
     detect_available_backend,
     require_backend_command,
@@ -376,11 +377,7 @@ class Scanner:
                         result = score_session(conn, sid, backend=backend)
                     except RuntimeError as exc:
                         message = str(exc)
-                        if (
-                            "Could not detect the current agent" in message
-                            or "CLI not found" in message
-                            or "Unsupported CLAWJOURNAL_SCORER_BACKEND" in message
-                        ):
+                        if any(marker in message for marker in PERMANENT_BACKEND_FAILURE_MARKERS):
                             self._auto_score_disabled_reason = message
                             logger.info("Automatic scoring disabled: %s", message)
                             break

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -355,6 +355,11 @@ class Scanner:
         try:
             conn = open_index()
             try:
+                # Warmup deliberately scores the latest `limit` unscored
+                # failure-corpus traces ordered by start_time DESC with no
+                # age cap (`since` is None for the background path). The
+                # `limit` bounds cost; callers that want a rolling window
+                # (CLI `--window`) pass `since` explicitly.
                 sessions = query_unscored_sessions(
                     conn,
                     limit=limit,

--- a/docs/automatic_failure_corpus_scoring.md
+++ b/docs/automatic_failure_corpus_scoring.md
@@ -40,9 +40,22 @@ If the user has not confirmed a backend before, warmup returns
 `needs_confirmation`. The frontend asks once, then stores the confirmed backend
 in `~/.clawjournal/config.json`.
 
+The background warmup never auto-confirms a backend — it only starts after an
+explicit confirmation. Users who never open the workbench (CLI-only) can confirm
+the headless equivalent so the daemon's background scoring can run:
+
+```bash
+clawjournal config --scorer-backend codex   # confirm; persists to config.json
+clawjournal config --scorer-backend none    # clear the confirmation
+```
+
+`CLAWJOURNAL_SCORER_BACKEND` is also honored and takes precedence over the
+stored confirmation.
+
 Hermes Agent (`https://github.com/NousResearch/hermes-agent`) is supported as a
 scoring backend only. ClawJournal invokes Hermes' scripted one-shot CLI mode and
-parses JSON from stdout.
+parses JSON from stdout. Stdout parsing tolerates markdown fences or surrounding
+prose by falling back to the outermost `{...}` span.
 
 ## Manual Commands
 

--- a/docs/automatic_failure_corpus_scoring.md
+++ b/docs/automatic_failure_corpus_scoring.md
@@ -1,0 +1,53 @@
+# Automatic Failure-Corpus Scoring
+
+## Summary
+
+ClawJournal should keep share-ready failure traces warm automatically. When a
+student opens the local workbench, the daemon starts a background scoring warmup
+for the latest 20 unscored `failure-corpus` sessions. The UI remains usable
+while scoring runs.
+
+`failure-corpus` is the public scoring source preset for `claude`, `codex`,
+`opencode`, and `openclaw`. The older `failure-v1` alias remains accepted for
+backward compatibility.
+
+## Behavior
+
+- `clawjournal serve` runs the normal initial scan, then triggers background
+  scoring.
+- The frontend also calls `POST /api/scoring/warmup` once on app load so an
+  already-running daemon can start scoring when the browser is opened or
+  reloaded.
+- Warmup scores the latest 20 unscored `failure-corpus` sessions by
+  `start_time DESC`.
+- Warmup uses the existing scorer lock, so repeated browser reloads cannot
+  start duplicate scoring jobs.
+- Share-ready recommendations continue to require `ai_failure_value_score`.
+  Unscored sessions are not recommended.
+- Bundle export and upload never run AI scoring inline.
+
+## Backend Selection
+
+Warmup detects the current agent context first. If no current agent is detected,
+it falls back to installed CLIs in this order:
+
+1. `codex`
+2. `claude`
+3. `hermes`
+4. `openclaw`
+
+If the user has not confirmed a backend before, warmup returns
+`needs_confirmation`. The frontend asks once, then stores the confirmed backend
+in `~/.clawjournal/config.json`.
+
+Hermes Agent (`https://github.com/NousResearch/hermes-agent`) is supported as a
+scoring backend only. ClawJournal invokes Hermes' scripted one-shot CLI mode and
+parses JSON from stdout.
+
+## Manual Commands
+
+```bash
+clawjournal score --batch --source failure-corpus --limit 20
+clawjournal score --batch --source failure-corpus --window 7d --limit 50
+clawjournal rescore --source failure-corpus --window 7d --limit 50
+```

--- a/skills/clawjournal-score/SKILL.md
+++ b/skills/clawjournal-score/SKILL.md
@@ -13,10 +13,10 @@ If no session ID was provided, suggest the automated approach first:
 
 ```bash
 # Score in-scope failure-value traces automatically (recommended)
-clawjournal score --batch --source failure-v1 --auto-triage --limit 20
+clawjournal score --batch --source failure-corpus --auto-triage --limit 20
 
 # Or without auto-triage:
-clawjournal score --batch --source failure-v1 --limit 20
+clawjournal score --batch --source failure-corpus --limit 20
 ```
 
 For hands-on scoring of a specific session, continue below.

--- a/skills/clawjournal-setup/SKILL.md
+++ b/skills/clawjournal-setup/SKILL.md
@@ -94,10 +94,10 @@ Ask: "Would you like me to auto-score your sessions? Each session gets two AI ra
 If yes:
 
 ```bash
-~/.clawjournal-venv/bin/clawjournal score --batch --source failure-v1 --auto-triage
+~/.clawjournal-venv/bin/clawjournal score --batch --source failure-corpus --auto-triage
 ```
 
-`--source failure-v1` scopes to the supported sources (claude, codex, opencode, openclaw); auto-triage archives productivity-1 sessions only when failure value is 1-2.
+`--source failure-corpus` scopes to the supported sources (claude, codex, opencode, openclaw); auto-triage archives productivity-1 sessions only when failure value is 1-2.
 
 Show summary: "N sessions scored. Failure-value distribution: ... M productivity-1 low-failure-value sessions auto-archived as noise."
 

--- a/skills/clawjournal/SKILL.md
+++ b/skills/clawjournal/SKILL.md
@@ -74,10 +74,10 @@ Present the traces to the user as a numbered list showing title, source, badges,
 
 ```bash
 clawjournal scan
-clawjournal score --batch --source failure-v1 --auto-triage
+clawjournal score --batch --source failure-corpus --auto-triage
 ```
 
-`--source failure-v1` scopes scoring to claude / codex / opencode / openclaw. Each session gets two AI ratings: failure value (the primary signal for teachable agent failures) and productivity (legacy compatibility).
+`--source failure-corpus` scopes scoring to claude / codex / opencode / openclaw. Each session gets two AI ratings: failure value (the primary signal for teachable agent failures) and productivity (legacy compatibility).
 
 Present summary:
 
@@ -272,8 +272,8 @@ clawjournal shortlist <id> [id ...]
 clawjournal search <query> [--json] [--limit 20]
 
 # Scoring
-clawjournal score --batch [--source failure-v1] [--auto-triage] [--limit 20]
-clawjournal rescore --window 7d [--source failure-v1] [--limit 200]
+clawjournal score --batch [--source failure-corpus] [--auto-triage] [--limit 20]
+clawjournal rescore --window 7d [--source failure-corpus] [--limit 200]
 clawjournal score-view <id>
 clawjournal set-score <id> --failure-value <1-5> [--failure-evidence "..."] [--reason "..."]
 clawjournal set-score <id> --quality <1-5> [--reason "..."]  # legacy productivity only

--- a/tests/scoring/test_backends.py
+++ b/tests/scoring/test_backends.py
@@ -13,12 +13,14 @@ from clawjournal.scoring.backends import (
     SUPPORTED_BACKENDS,
     _build_claude_cmd,
     _build_codex_cmd,
+    _build_hermes_cmd,
     _build_openclaw_cmd,
     _classify_process_command,
     _detect_current_agent_from_env,
     _detect_current_agent_from_process_tree,
     _get_process_field,
     check_backend_runtime,
+    detect_available_backend,
     format_codex_runtime_error,
     require_backend_command,
     resolve_backend,
@@ -29,10 +31,10 @@ from clawjournal.scoring.backends import (
 
 class TestConstants:
     def test_backend_choices_include_auto(self):
-        assert BACKEND_CHOICES == ("auto", "claude", "codex", "openclaw")
+        assert BACKEND_CHOICES == ("auto", "claude", "codex", "hermes", "openclaw")
 
     def test_supported_backends(self):
-        assert set(SUPPORTED_BACKENDS) == {"claude", "codex", "openclaw"}
+        assert set(SUPPORTED_BACKENDS) == {"claude", "codex", "hermes", "openclaw"}
 
 
 class TestDetection:
@@ -44,6 +46,9 @@ class TestDetection:
 
     def test_detect_from_env_openclaw(self):
         assert _detect_current_agent_from_env({"OPENCLAW_STATE_DIR": "/tmp"}) == "openclaw"
+
+    def test_detect_from_env_hermes(self):
+        assert _detect_current_agent_from_env({"HERMES_HOME": "/tmp/hermes"}) == "hermes"
 
     def test_detect_from_env_empty(self):
         assert _detect_current_agent_from_env({}) is None
@@ -59,6 +64,9 @@ class TestDetection:
     def test_classify_process_command_openclaw(self):
         assert _classify_process_command("openclaw", "") == "openclaw"
 
+    def test_classify_process_command_hermes(self):
+        assert _classify_process_command("hermes", "") == "hermes"
+
     def test_classify_process_command_unknown(self):
         assert _classify_process_command("bash", "/bin/bash") is None
 
@@ -67,6 +75,7 @@ class TestResolveBackend:
     def test_explicit_backend(self):
         assert resolve_backend("codex", {}) == "codex"
         assert resolve_backend("claude", {}) == "claude"
+        assert resolve_backend("hermes", {}) == "hermes"
         assert resolve_backend("openclaw", {}) == "openclaw"
 
     def test_explicit_unsupported_raises(self):
@@ -84,7 +93,8 @@ class TestResolveBackend:
 
     def test_auto_detects_from_env(self):
         env = {"CODEX_THREAD_ID": "thread-123"}
-        assert resolve_backend("auto", env) == "codex"
+        with patch("clawjournal.scoring.backends.shutil.which", return_value="/usr/bin/codex"):
+            assert resolve_backend("auto", env) == "codex"
 
 
 class TestErrorFormatting:
@@ -128,10 +138,26 @@ class TestRequireBackendCommand:
             require_backend_command("codex")
 
 
-class TestResolveBackendAutoNoAgent:
-    def test_raises_when_no_agent(self, monkeypatch):
+class TestResolveBackendAutoFallback:
+    def test_falls_back_when_detected_agent_cli_is_missing(self, monkeypatch):
+        monkeypatch.setattr(
+            "clawjournal.scoring.backends.shutil.which",
+            lambda cmd: "/usr/bin/claude" if cmd == "claude" else None,
+        )
+        assert resolve_backend("auto", {"CODEX_THREAD_ID": "thread-123"}) == "claude"
+
+    def test_uses_installed_backend_when_no_agent(self, monkeypatch):
         monkeypatch.setattr("clawjournal.scoring.backends._detect_current_agent_from_process_tree", lambda **kw: None)
-        with pytest.raises(RuntimeError, match="Could not detect the current agent"):
+        monkeypatch.setattr(
+            "clawjournal.scoring.backends.shutil.which",
+            lambda cmd: "/usr/bin/hermes" if cmd == "hermes" else None,
+        )
+        assert resolve_backend("auto", {}) == "hermes"
+
+    def test_raises_when_no_agent_or_installed_backend(self, monkeypatch):
+        monkeypatch.setattr("clawjournal.scoring.backends._detect_current_agent_from_process_tree", lambda **kw: None)
+        monkeypatch.setattr("clawjournal.scoring.backends.shutil.which", lambda cmd: None)
+        with pytest.raises(RuntimeError, match="Could not detect a supported scoring backend"):
             resolve_backend("auto", {})
 
 
@@ -259,6 +285,17 @@ class TestBuildOpenclawCmd:
             "--json",
             "--timeout", "60",
         ]
+
+
+class TestBuildHermesCmd:
+    def test_basic(self):
+        assert _build_hermes_cmd("hermes", message="score this", model=None) == [
+            "hermes", "-z", "score this",
+        ]
+
+    def test_with_model(self):
+        cmd = _build_hermes_cmd("hermes", message="score this", model="nous/hermes")
+        assert cmd == ["hermes", "-z", "score this", "--model", "nous/hermes"]
 
 
 # ---------------------------------------------------------------------------
@@ -486,6 +523,39 @@ class TestRunDefaultAgentTaskOpenclaw:
         )
         idx = captured_cmd.index("--message")
         assert captured_cmd[idx + 1] == "fallback prompt"
+
+
+class TestRunDefaultAgentTaskHermes:
+    def test_success(self, monkeypatch, tmp_path):
+        _stub_which(monkeypatch)
+        _stub_subprocess(monkeypatch, stdout='{"quality": 4}')
+        result = run_default_agent_task(
+            backend="hermes", cwd=tmp_path, task_prompt="score",
+        )
+        assert result.stdout == '{"quality": 4}'
+        assert result.returncode == 0
+
+    def test_nonzero_exit_raises(self, monkeypatch, tmp_path):
+        _stub_which(monkeypatch)
+        _stub_subprocess(monkeypatch, returncode=1, stderr="error: failed")
+        with pytest.raises(RuntimeError, match="hermes exited 1"):
+            run_default_agent_task(
+                backend="hermes", cwd=tmp_path, task_prompt="score",
+            )
+
+    def test_model_override_forwarded(self, monkeypatch, tmp_path):
+        _stub_which(monkeypatch)
+        captured_cmd = []
+
+        def spy_run(cmd, **kw):
+            captured_cmd.extend(cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("clawjournal.scoring.backends.subprocess.run", spy_run)
+        run_default_agent_task(
+            backend="hermes", cwd=tmp_path, task_prompt="score", model="nous/hermes",
+        )
+        assert captured_cmd == ["hermes", "-z", "score", "--model", "nous/hermes"]
 
 
 class TestRunDefaultAgentTaskUnsupportedBackend:

--- a/tests/scoring/test_scoring.py
+++ b/tests/scoring/test_scoring.py
@@ -517,7 +517,7 @@ class TestValidateJudgeResultBackwardCompat:
 
 class TestBackendSelection:
     def test_backend_choices_include_auto(self):
-        assert SCORING_BACKEND_CHOICES == ("auto", "claude", "codex", "openclaw")
+        assert SCORING_BACKEND_CHOICES == ("auto", "claude", "codex", "hermes", "openclaw")
 
     def test_detect_current_agent_from_env_codex(self):
         env = {"CODEX_THREAD_ID": "thread-123"}
@@ -551,7 +551,8 @@ class TestBackendSelection:
 
     def test_resolve_backend_raises_without_current_agent(self, monkeypatch):
         monkeypatch.setattr("clawjournal.scoring.backends._detect_current_agent_from_process_tree", lambda **kw: None)
-        with pytest.raises(RuntimeError, match="Could not detect the current agent"):
+        monkeypatch.setattr("clawjournal.scoring.backends.shutil.which", lambda cmd: None)
+        with pytest.raises(RuntimeError, match="Could not detect a supported scoring backend"):
             resolve_backend("auto", {})
 
     def test_call_judge_dispatches_to_codex(self, monkeypatch):
@@ -709,6 +710,43 @@ class TestBackendSelection:
         assert captured["openclaw_message"] is not None
         assert "absolute paths" in captured["openclaw_message"].lower()
 
+    def test_call_judge_dispatches_to_hermes_and_reads_stdout_json(self, monkeypatch):
+        monkeypatch.setattr("clawjournal.scoring.scoring.load_scoring_rubric", lambda: "rubric")
+
+        scoring = {
+            "substance": 5,
+            **_failure_fields(ai_quality_score=5, ai_failure_value_score=5),
+            "reasoning": "Excellent failure trace",
+            "display_title": "Recover broken migration",
+            "summary": "Recovered a broken migration after tool failures.",
+            "resolution": "resolved",
+            "effort_estimate": 0.6,
+            "task_type": "debugging",
+            "session_tags": ["backend"],
+            "privacy_flags": [],
+            "project_areas": ["db/"],
+        }
+        captured = {}
+
+        def fake_run(*, backend, task_prompt=None, openclaw_message=None, **kw):
+            captured["backend"] = backend
+            captured["task_prompt"] = task_prompt
+            captured["openclaw_message"] = openclaw_message
+            return AgentResult(stdout=json.dumps(scoring), stderr="", returncode=0, cwd=kw["cwd"])
+
+        monkeypatch.setattr("clawjournal.scoring.scoring.run_default_agent_task", fake_run)
+        result = call_judge(
+            "prompt",
+            session_data={"messages": []},
+            metadata={"total_steps": 1},
+            backend="hermes",
+        )
+        assert result["substance"] == 5
+        assert result["task_type"] == "debugging"
+        assert captured["backend"] == "hermes"
+        assert captured["openclaw_message"] is None
+        assert "absolute paths" in captured["task_prompt"].lower()
+
     def test_extract_judge_result_from_nested_openclaw_json(self):
         payload = {
             "reply": {
@@ -773,6 +811,13 @@ class TestReadScoringOutput:
             stdout=json.dumps(_VALID_JUDGE), stderr="", returncode=0, cwd=tmp_path,
         )
         parsed = _read_scoring_output(result, "openclaw")
+        assert parsed["substance"] == 4
+
+    def test_hermes_reads_from_stdout(self, tmp_path):
+        result = AgentResult(
+            stdout=json.dumps(_VALID_JUDGE), stderr="", returncode=0, cwd=tmp_path,
+        )
+        parsed = _read_scoring_output(result, "hermes")
         assert parsed["substance"] == 4
 
     def test_live_backend_output_requires_failure_fields(self, tmp_path):

--- a/tests/scoring/test_scoring.py
+++ b/tests/scoring/test_scoring.py
@@ -820,6 +820,18 @@ class TestReadScoringOutput:
         parsed = _read_scoring_output(result, "hermes")
         assert parsed["substance"] == 4
 
+    def test_stdout_json_in_markdown_fences_is_parsed(self, tmp_path):
+        fenced = "```json\n" + json.dumps(_VALID_JUDGE) + "\n```"
+        result = AgentResult(stdout=fenced, stderr="", returncode=0, cwd=tmp_path)
+        parsed = _read_scoring_output(result, "hermes")
+        assert parsed["substance"] == 4
+
+    def test_stdout_json_with_surrounding_prose_is_parsed(self, tmp_path):
+        noisy = "Here is the score:\n" + json.dumps(_VALID_JUDGE) + "\nDone."
+        result = AgentResult(stdout=noisy, stderr="", returncode=0, cwd=tmp_path)
+        parsed = _read_scoring_output(result, "openclaw")
+        assert parsed["substance"] == 4
+
     def test_live_backend_output_requires_failure_fields(self, tmp_path):
         legacy_payload = {
             "substance": 4,

--- a/tests/scoring/test_scoring.py
+++ b/tests/scoring/test_scoring.py
@@ -645,6 +645,7 @@ class TestBackendSelection:
     def test_codex_judge_schema_forbids_additional_properties(self):
         assert JUDGE_SCHEMA["type"] == "object"
         assert JUDGE_SCHEMA["additionalProperties"] is False
+        assert set(JUDGE_SCHEMA["required"]) == set(JUDGE_SCHEMA["properties"])
 
     def test_check_backend_runtime_codex_is_non_blocking(self):
         env = {"CODEX_SANDBOX_NETWORK_DISABLED": "1"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,6 +17,7 @@ from clawjournal.cli import (
     _format_token_count,
     _has_session_sources,
     _merge_config_list,
+    _normalize_score_source_filter,
     _parse_csv_arg,
     _scan_for_text_occurrences,
     _scan_high_entropy_strings,
@@ -1899,13 +1900,54 @@ class TestScore:
         assert result["session_id"] == "sess-1"
         assert "Judge failed: backend auth failed" in result["error"]
 
-    def test_score_help_includes_default_limit_10(self, capsys, monkeypatch):
+    def test_score_help_includes_default_limit_20(self, capsys, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["clawjournal", "score", "--help"])
         with pytest.raises(SystemExit) as excinfo:
             main()
         assert excinfo.value.code == 0
         out = capsys.readouterr().out
-        assert "Max sessions for batch mode (default: 10)" in out
+        assert "Max sessions for batch mode (default: 20)" in out
+        assert "failure-corpus" in out
+
+    def test_failure_corpus_alias_matches_legacy_failure_v1(self):
+        assert _normalize_score_source_filter("failure-corpus") == _normalize_score_source_filter("failure-v1")
+
+    def test_score_batch_window_filters_recent_sessions(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+        monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+        monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "clawjournal_config")
+
+        from clawjournal.cli import _run_score_batch
+        from clawjournal.workbench.index import open_index, upsert_sessions
+
+        now = datetime.now(timezone.utc)
+        conn = open_index()
+        upsert_sessions(conn, [
+            {
+                "session_id": "old-sess",
+                "project": "test-project",
+                "source": "claude",
+                "model": "claude-sonnet-4",
+                "start_time": (now - timedelta(days=30)).isoformat(),
+                "messages": [{"role": "user", "content": "Old"}],
+                "stats": {"user_messages": 1, "assistant_messages": 0, "tool_uses": 0},
+            },
+            {
+                "session_id": "recent-sess",
+                "project": "test-project",
+                "source": "codex",
+                "model": "gpt-5",
+                "start_time": (now - timedelta(days=1)).isoformat(),
+                "messages": [{"role": "user", "content": "Recent"}],
+                "stats": {"user_messages": 1, "assistant_messages": 0, "tool_uses": 0},
+            },
+        ])
+        conn.close()
+
+        _run_score_batch(MagicMock(limit=50, source="failure-corpus", window=7))
+
+        output = json.loads(capsys.readouterr().out)
+        assert [row["session_id"] for row in output] == ["recent-sess"]
 
     def test_share_preview_json(self, bundle_index, capsys):
         """share --preview --json outputs session list as JSON."""

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -602,6 +602,43 @@ class TestScanner:
         assert row["ai_score_reason"] == "Strong trace"
         assert row["ai_summary"] == "Useful fix"
 
+    def test_score_unscored_once_disables_on_no_backend_error(self, tmp_path, monkeypatch):
+        """A 'no usable backend' RuntimeError must trip the circuit breaker so the
+        scan loop stops retrying. Guards against the disable sentinel drifting away
+        from resolve_backend's message."""
+        from clawjournal.scoring.backends import NO_BACKEND_DETECTED_ERROR
+
+        monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+        monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+        monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "clawjournal_config")
+        monkeypatch.setattr("clawjournal.workbench.daemon.CONFIG_DIR", tmp_path / "clawjournal_config")
+
+        now = datetime.now(timezone.utc)
+        conn = open_index()
+        upsert_sessions(conn, [{
+            "session_id": "sess-nb",
+            "project": "test-project",
+            "source": "claude",
+            "model": "claude-sonnet-4",
+            "start_time": now.isoformat(),
+            "messages": [{"role": "user", "content": "Fix it", "tool_uses": []}],
+            "stats": {"user_messages": 1, "assistant_messages": 0, "tool_uses": 0},
+        }])
+        conn.close()
+
+        def boom(conn, session_id, model=None, backend="auto"):
+            raise RuntimeError(
+                f"{NO_BACKEND_DETECTED_ERROR}. Install a supported agent CLI, "
+                "set CLAWJOURNAL_SCORER_BACKEND, or pass --backend explicitly."
+            )
+
+        monkeypatch.setattr("clawjournal.scoring.scoring.score_session", boom)
+
+        scanner = Scanner(source_filter="claude")
+        assert scanner.score_unscored_once(limit=5) == 0
+        assert scanner._auto_score_disabled_reason is not None
+        assert NO_BACKEND_DETECTED_ERROR in scanner._auto_score_disabled_reason
+
     def test_score_unscored_once_respects_since_window(self, tmp_path, monkeypatch):
         monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
         monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -19,6 +19,7 @@ from clawjournal.workbench.daemon import (
     run_server,
     _SHARE_COOLDOWN_SECONDS,
     _apply_upload_pii_redactions,
+    trigger_scoring_warmup,
 )
 from clawjournal.workbench.index import open_index, upsert_sessions
 
@@ -71,6 +72,27 @@ def server(index_setup):
     thread = Thread(target=srv.serve_forever, daemon=True)
     thread.start()
     yield port
+    srv.shutdown()
+
+
+@pytest.fixture
+def server_with_scanner(index_setup):
+    """Start a test HTTP server with a controllable background scanner."""
+    from http.server import ThreadingHTTPServer
+
+    scanner = SimpleNamespace(calls=[], status="started")
+
+    def trigger_auto_score(**kwargs):
+        scanner.calls.append(kwargs)
+        return {"status": scanner.status, **kwargs}
+
+    scanner.trigger_auto_score = trigger_auto_score
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), WorkbenchHandler)
+    srv._scanner = scanner
+    port = srv.server_address[1]
+    thread = Thread(target=srv.serve_forever, daemon=True)
+    thread.start()
+    yield port, scanner
     srv.shutdown()
 
 
@@ -580,7 +602,7 @@ class TestScanner:
         assert row["ai_score_reason"] == "Strong trace"
         assert row["ai_summary"] == "Useful fix"
 
-    def test_score_unscored_once_skips_sessions_outside_recent_window(self, tmp_path, monkeypatch):
+    def test_score_unscored_once_respects_since_window(self, tmp_path, monkeypatch):
         monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
         monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
         monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "clawjournal_config")
@@ -615,8 +637,138 @@ class TestScanner:
         monkeypatch.setattr("clawjournal.scoring.scoring.score_session", fake_score)
 
         scanner = Scanner(source_filter="claude")
-        assert scanner.score_unscored_once(limit=5) == 0
+        since = (datetime.now(timezone.utc) - timedelta(days=7)).isoformat()
+        assert scanner.score_unscored_once(limit=5, since=since) == 0
         assert calls["count"] == 0
+
+    def test_score_unscored_once_uses_failure_corpus_even_with_scan_filter(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+        monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+        monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "clawjournal_config")
+        monkeypatch.setattr("clawjournal.workbench.daemon.CONFIG_DIR", tmp_path / "clawjournal_config")
+
+        now = datetime.now(timezone.utc)
+        conn = open_index()
+        upsert_sessions(conn, [
+            {
+                "session_id": "cursor-sess",
+                "project": "test-project",
+                "source": "cursor",
+                "model": "cursor",
+                "start_time": now.isoformat(),
+                "messages": [{"role": "user", "content": "Cursor task"}],
+                "stats": {"user_messages": 1, "assistant_messages": 0, "tool_uses": 0},
+            },
+            {
+                "session_id": "codex-sess",
+                "project": "test-project",
+                "source": "codex",
+                "model": "gpt-5",
+                "start_time": (now - timedelta(minutes=1)).isoformat(),
+                "messages": [{"role": "user", "content": "Codex task"}],
+                "stats": {"user_messages": 1, "assistant_messages": 0, "tool_uses": 0},
+            },
+        ])
+        conn.close()
+
+        scored_ids = []
+
+        def fake_score(conn, session_id, model=None, backend="auto"):
+            scored_ids.append(session_id)
+            return SimpleNamespace(
+                quality=4,
+                reason="Good trace",
+                detail_json='{"substance": 4}',
+                task_type="debugging",
+                outcome_label="resolved",
+                value_labels=[],
+                risk_level=[],
+                display_title="Good trace",
+                effort_estimate=0.5,
+                summary="Useful trace",
+                failure_value_score=4,
+                recovery_labels=[],
+                failure_attribution="agent_caused",
+                failure_modes=[],
+                learning_summary="Useful failure trace",
+                scorer_backend="test",
+                scorer_model="test-model",
+                rubric_git_sha="test-sha",
+                scored_at=now.isoformat(),
+            )
+
+        monkeypatch.setattr("clawjournal.scoring.scoring.score_session", fake_score)
+
+        scanner = Scanner(source_filter="cursor")
+        assert scanner.score_unscored_once(limit=5) == 1
+        assert scored_ids == ["codex-sess"]
+
+
+class TestScoringWarmupAPI:
+    def test_endpoint_returns_disabled_without_scanner(self, server):
+        status, data = _post(server, "/api/scoring/warmup")
+
+        assert status == 200
+        assert data["status"] == "disabled"
+
+    def test_endpoint_requires_confirmation_for_detected_backend(self, server_with_scanner, monkeypatch):
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {})
+        monkeypatch.setattr("clawjournal.workbench.daemon.detect_available_backend", lambda: "codex")
+        monkeypatch.setattr("clawjournal.workbench.daemon.require_backend_command", lambda backend: backend)
+        port, scanner = server_with_scanner
+
+        status, data = _post(port, "/api/scoring/warmup")
+
+        assert status == 200
+        assert data["status"] == "needs_confirmation"
+        assert data["backend"] == "codex"
+        assert scanner.calls == []
+
+    def test_endpoint_starts_after_confirmation_and_persists_backend(self, server_with_scanner, monkeypatch):
+        config: dict[str, object] = {}
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: dict(config))
+        monkeypatch.setattr("clawjournal.workbench.daemon.save_config", lambda cfg: config.update(cfg))
+        monkeypatch.setattr("clawjournal.workbench.daemon.detect_available_backend", lambda: "codex")
+        monkeypatch.setattr("clawjournal.workbench.daemon.require_backend_command", lambda backend: backend)
+        port, scanner = server_with_scanner
+
+        status, data = _post(
+            port,
+            "/api/scoring/warmup",
+            {"confirm_backend": True, "backend": "codex"},
+        )
+
+        assert status == 200
+        assert data["status"] == "started"
+        assert data["backend"] == "codex"
+        assert data["limit"] == 20
+        assert scanner.calls == [{"limit": 20, "backend": "codex"}]
+        assert config["scorer_backend"] == "codex"
+        assert "scorer_backend_confirmed_at" in config
+
+    def test_endpoint_reports_already_running_from_scanner(self, server_with_scanner, monkeypatch):
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: {"scorer_backend": "codex"},
+        )
+        monkeypatch.setattr("clawjournal.workbench.daemon.require_backend_command", lambda backend: backend)
+        port, scanner = server_with_scanner
+        scanner.status = "already_running"
+
+        status, data = _post(port, "/api/scoring/warmup")
+
+        assert status == 200
+        assert data["status"] == "already_running"
+        assert scanner.calls == [{"limit": 20, "backend": "codex"}]
+
+    def test_helper_disables_when_no_backend_detected(self, monkeypatch):
+        scanner = SimpleNamespace(trigger_auto_score=lambda **kw: {"status": "started"})
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {})
+        monkeypatch.setattr("clawjournal.workbench.daemon.detect_available_backend", lambda: None)
+
+        result = trigger_scoring_warmup(scanner)
+
+        assert result["status"] == "disabled"
 
 
 class TestProjectsAPI:


### PR DESCRIPTION
## Summary

- adds `failure-corpus` as the public scoring preset while keeping `failure-v1` as a compatibility alias
- adds automatic background warmup for the latest 20 unscored failure-corpus traces via the daemon and workbench app load
- adds backend confirmation persistence plus Hermes Agent scoring backend support
- adds `--window` support for score batch flows and documents the agreed plan

## Notes

This branch was rebased onto `origin/main` after `Make AI PII review opt-in for share packaging (#49)` landed. The only rebase conflict was in `clawjournal/config.py`; both the new `ai_pii_review_enabled` config field and the scorer backend confirmation fields are retained.

## Validation

- `PYTHONPATH=. pytest -q` -> `1873 passed`
- `npm run build` -> passed
- `git diff --check` -> clean