### PR TITLE
Harden the PhD-student share/submission workflow

### DIFF
--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -1734,6 +1734,7 @@ def _run_verify_email(args) -> None:
     """Handle the verify-email CLI command."""
     from .workbench.daemon import (
         _expiry_is_valid,
+        _hosted_is_local_dev,
         _is_edu_email,
         confirm_email_verification,
         request_email_verification,
@@ -1809,7 +1810,9 @@ def _run_verify_email(args) -> None:
             "message": "You will receive a verification code by email.",
             "next_command": f"clawjournal verify-email {email} --code <CODE>",
         }
-        if result.get("dev_code"):
+        # `dev_code` is a local-development convenience; only surface it when the
+        # hosted service is a local/dev deployment, never against production.
+        if result.get("dev_code") and _hosted_is_local_dev():
             payload["dev_code"] = result["dev_code"]
         print(json.dumps(payload, indent=2))
 

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -720,6 +720,27 @@ export function Share() {
     }
   }, [activeStep, packagedShareId, packageProgress, packagingFailed, shareDestination]);
 
+  // Reload/deep-link robustness: a page reload or bookmark can land directly on
+  // Submit. If hosted submission isn't available (disabled, closed, or the
+  // destination failed to load) and the share hasn't already been submitted,
+  // fall back to the download-only Done view instead of stranding the user on a
+  // Submit step they can't complete. Gated on `loading` so we wait for the
+  // initial destination fetch (a still-null destination after load means
+  // not-submittable). Mirrors the package→done branch above.
+  useEffect(() => {
+    if (activeStep !== 'submit' || receiptId || loading) return;
+    const canSubmit = !!shareDestination?.daemon_upload_supported && !!shareDestination?.submissions_open;
+    if (!canSubmit) setActiveStep('done');
+  }, [activeStep, shareDestination, receiptId, loading]);
+
+  // A Submit deep-link with no packaged share has nothing to act on; send the
+  // user back to the start rather than rendering a dead-end Submit bound to a
+  // null share id. In the normal flow `packagedShareId` is always set before we
+  // advance to Submit, so this only fires on a stale/partial deep-link.
+  useEffect(() => {
+    if (activeStep === 'submit' && !packagedShareId) setActiveStep('queue');
+  }, [activeStep, packagedShareId]);
+
   // =================================================
   // Step 5: Done actions
   // =================================================

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -638,6 +638,21 @@ def _hosted_api_base() -> str:
     return f"{parsed.scheme}://{parsed.netloc}"
 
 
+def _hosted_is_local_dev() -> bool:
+    """True when the hosted submission API points at a local/dev host.
+
+    Used to gate developer-only fields (e.g. ``dev_code``) so they are never
+    forwarded to the browser when talking to a production deployment, even if a
+    misconfigured server were to return them.
+    """
+    try:
+        parsed = urlparse(_hosted_api_base())
+    except RuntimeError:
+        return False
+    host = (parsed.hostname or "").lower()
+    return host in {"localhost", "127.0.0.1", "::1"} or parsed.scheme == "http"
+
+
 def _json_request(
     url: str,
     *,
@@ -790,7 +805,15 @@ def request_email_verification(email: str) -> dict:
     Returns the response dict from the server (contains status info).
     """
     normalized = _normalize_email(email)
-    capabilities = _fetch_hosted_share_capabilities()
+    try:
+        capabilities = _fetch_hosted_share_capabilities()
+    except (OSError, ValueError, RuntimeError, urllib.error.URLError):
+        # The capabilities doc is only a best-effort source for the institution
+        # email policy. If it is momentarily unreachable, fall back to the
+        # built-in default suffixes rather than blocking the student from
+        # requesting a code; a genuine outage still surfaces on the verify-email
+        # POST below.
+        capabilities = None
     if not _email_domain_allowed(normalized, capabilities):
         raise ValueError("Enter a valid academic email address.")
 
@@ -808,6 +831,17 @@ def request_email_verification(email: str) -> dict:
     if not isinstance(verification_id, str) or not verification_id:
         raise ValueError("Verification service did not return a verification id.")
     config = load_config()
+    prior_verified = (config.get("verified_email") or "").strip().lower()
+    if prior_verified and prior_verified != normalized:
+        # Switching identities: drop the previously verified email's upload
+        # token so a later submit cannot upload under the old identity while
+        # the UI shows the new email being verified.
+        for key in (
+            "verified_email",
+            "verified_email_token",
+            "verified_email_token_expires_at",
+        ):
+            config.pop(key, None)
     config["pending_verification_id"] = verification_id
     config["pending_verification_email"] = normalized
     config["pending_verification_expires_at"] = result.get("expires_at")
@@ -1206,6 +1240,42 @@ def finalize_share_export_for_upload(
     return None, manifest
 
 
+def _redaction_settings_fingerprint(settings: dict[str, Any]) -> str:
+    """Stable hash of the redaction inputs that shape an exported bundle.
+
+    A finalized export is a point-in-time artifact, but it must only be reused
+    while these inputs are unchanged. Editing the allowlist, custom redaction
+    strings/usernames, excluded projects, or blocked domains must force a
+    rebuild so a later seal/submit/download can never ship content redacted
+    under stale settings. `ai_pii` is intentionally excluded — it is gated
+    separately by ``_manifest_is_finalized_for_upload``.
+
+    Order-independent: each list is normalized (handles str and dict entries)
+    and sorted, so config/policy ordering differences do not change the hash.
+
+    MAINTENANCE: these keys must stay in sync with the redaction-affecting
+    inputs produced by ``get_effective_share_settings`` (index.py). If a new
+    redaction input is added there, add it here too — otherwise a change to it
+    would not invalidate the cache and a stale-redacted bundle could be reused.
+    """
+
+    def _norm(values: Any) -> list[str]:
+        return sorted(
+            json.dumps(item, sort_keys=True, default=str) for item in (values or [])
+        )
+
+    payload = {
+        "custom_strings": _norm(settings.get("custom_strings")),
+        "extra_usernames": _norm(settings.get("extra_usernames")),
+        "excluded_projects": _norm(settings.get("excluded_projects")),
+        "blocked_domains": _norm(settings.get("blocked_domains")),
+        "allowlist_entries": _norm(settings.get("allowlist_entries")),
+    }
+    return hashlib.sha256(
+        json.dumps(payload, sort_keys=True).encode("utf-8")
+    ).hexdigest()
+
+
 def _manifest_is_finalized_for_upload(
     manifest: dict[str, Any],
     *,
@@ -1234,6 +1304,7 @@ def _load_finalized_share_export(
     share_id: str,
     *,
     ai_pii: bool | None = None,
+    expected_fingerprint: str | None = None,
 ) -> tuple[Path, dict[str, Any]] | None:
     # Finalized exports are point-in-time artifacts: a later config change
     # creates a new share/seal operation rather than mutating this cached zip.
@@ -1257,6 +1328,15 @@ def _load_finalized_share_export(
         return None
     if not _manifest_is_finalized_for_upload(manifest, ai_pii=ai_pii):
         return None
+    if (
+        expected_fingerprint is not None
+        and manifest.get("redaction_settings_fingerprint") != expected_fingerprint
+    ):
+        # Redaction settings (allowlist / custom strings / excluded projects /
+        # blocked domains) changed since this export was sealed. Force a
+        # rebuild rather than reuse a stale-redacted artifact. Exports sealed
+        # before this field existed have no fingerprint and so also rebuild once.
+        return None
     return export_dir, manifest
 
 
@@ -1274,14 +1354,21 @@ def _prepare_share_export_for_upload(
         if ai_pii_review_enabled is None
         else ai_pii_review_enabled
     )
+    settings_fingerprint = _redaction_settings_fingerprint(settings)
     if reuse_finalized:
         # Pass the RAW override (not effective_ai_pii) on purpose: a finalized
         # export is a point-in-time artifact. With an explicit ai_pii override
         # the cache is only reused when its recorded ai_enabled matches; with no
         # override (None) we reuse whatever was sealed (history re-download),
         # rather than letting a later config-default flip rebuild the artifact.
+        # The fingerprint additionally forces a rebuild when the redaction
+        # settings changed since seal, so we never reuse stale-redacted bytes.
         # A cache miss still finalizes with effective_ai_pii below.
-        cached = _load_finalized_share_export(share_id, ai_pii=ai_pii_review_enabled)
+        cached = _load_finalized_share_export(
+            share_id,
+            ai_pii=ai_pii_review_enabled,
+            expected_fingerprint=settings_fingerprint,
+        )
         if cached is not None:
             export_dir, manifest = cached
             return export_dir, manifest, None
@@ -1298,6 +1385,12 @@ def _prepare_share_export_for_upload(
     )
     if export_dir is None:
         return None, manifest, {"error": "Failed to prepare upload zip", "status": 500}
+
+    # Stamp the redaction-settings fingerprint so a later reuse can detect when
+    # the allowlist / custom redactions changed and rebuild instead of shipping
+    # stale bytes. Set before finalize so it is persisted to manifest.json.
+    if isinstance(manifest, dict):
+        manifest["redaction_settings_fingerprint"] = settings_fingerprint
 
     error, manifest = finalize_share_export_for_upload(
         export_dir,
@@ -1652,12 +1745,33 @@ def submit_share_to_hosted(
         method="POST",
     )
 
+    ambiguous_timeout_error = {
+        "error": (
+            "Your bundle was uploaded but the server did not confirm before the "
+            "connection timed out. It may already have been received — check for a "
+            "confirmation email before retrying, since re-submitting could create a "
+            "duplicate."
+        ),
+        "ambiguous": True,
+        "status": 504,
+    }
     try:
         with urllib.request.urlopen(req, timeout=_SHARE_UPLOAD_TIMEOUT) as resp:
             hosted_result = json.loads(resp.read())
     except urllib.error.HTTPError as exc:
         return _hosted_http_error_result(exc)
-    except (urllib.error.URLError, TimeoutError, OSError):
+    except TimeoutError:
+        # The bundle bytes were already sent; a timeout means we never learned
+        # whether the server accepted it. Do NOT clear the token or mark the
+        # share shared, and warn against a blind retry that could duplicate a
+        # submission that actually landed.
+        return dict(ambiguous_timeout_error)
+    except (urllib.error.URLError, OSError) as exc:
+        # A URLError may wrap a timeout raised while writing the request body.
+        if isinstance(getattr(exc, "reason", None), TimeoutError):
+            return dict(ambiguous_timeout_error)
+        # Connection refused / DNS failure: the request never reached the
+        # server, so an immediate retry is safe.
         return {"error": "Could not reach hosted submission service. Please try again.", "status": 502}
 
     receipt_id = hosted_result.get("receipt_id")
@@ -2646,7 +2760,10 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             "email": _normalize_email(email),
             "expires_at": result.get("expires_at"),
         }
-        if result.get("dev_code"):
+        # `dev_code` is a local-development convenience only. Never forward it to
+        # the browser when pointed at a production hosted deployment, even if the
+        # server returns it.
+        if result.get("dev_code") and _hosted_is_local_dev():
             response["dev_code"] = result["dev_code"]
         _json_response(self, response)
 
@@ -2721,6 +2838,19 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         try:
             settings = get_effective_share_settings(conn, load_config())
             ai_pii_override = _optional_bool(body.get("ai_pii")) if "ai_pii" in body else None
+            # Fail fast on hold-state BEFORE creating the share row: quick-share
+            # leads straight to submit, so there is no point creating/packaging a
+            # share for sessions the release gate would later block — and a gate
+            # placed after create_share would orphan the draft share on rejection.
+            # submit_share_to_hosted re-checks this at upload time.
+            from .index import release_gate_blockers
+            blockers = release_gate_blockers(conn, session_ids)
+            if blockers:
+                _json_response(self, {
+                    "error": "Some selected sessions are on hold and cannot be shared.",
+                    "blockers": blockers,
+                }, 409)
+                return
             share_id = create_share(conn, session_ids, note=note)
             share = get_share(conn, share_id)
             if share is None:
@@ -3042,15 +3172,9 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
 
     def _handle_upload_share(self, share_id: str) -> None:
         """Submit a share to hosted research after consent."""
-        with _share_rate_lock:
-            now = time.time()
-            elapsed = now - WorkbenchHandler._last_share_time
-            if elapsed < _SHARE_COOLDOWN_SECONDS:
-                _json_response(self, {
-                    "error": f"Rate limited. Try again in {int(_SHARE_COOLDOWN_SECONDS - elapsed)}s.",
-                }, 429)
-                return
-
+        # Validate the request BEFORE the rate-limit gate so a malformed request
+        # (missing consent fields) doesn't consume the 10s cooldown — only a real
+        # submission attempt should start it.
         body = _read_body(self)
         force = _body_bool(body.get("force", False))
         ai_pii_override = _optional_bool(body.get("ai_pii")) if "ai_pii" in body else None
@@ -3070,6 +3194,20 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                 "missing": missing,
             }, 400)
             return
+
+        with _share_rate_lock:
+            now = time.time()
+            elapsed = now - WorkbenchHandler._last_share_time
+            if elapsed < _SHARE_COOLDOWN_SECONDS:
+                _json_response(self, {
+                    "error": f"Rate limited. Try again in {int(_SHARE_COOLDOWN_SECONDS - elapsed)}s.",
+                }, 429)
+                return
+            # Mark in-flight atomically (like _handle_quick_share) so a second
+            # tab / double-click cannot also pass this check and reach the
+            # hosted POST concurrently, and so a failed attempt still starts the
+            # cooldown instead of allowing an immediate retry loop.
+            WorkbenchHandler._last_share_time = now
 
         conn = open_index()
         try:

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -3406,7 +3406,7 @@ def get_share_ready_stats(
         " ai_failure_attribution, ai_failure_modes, ai_learning_summary,"
         " user_messages, assistant_messages, tool_uses,"
         " input_tokens, output_tokens, outcome_badge, client_origin,"
-        " runtime_channel, start_time, review_status"
+        " runtime_channel, start_time, review_status, hold_state, embargo_until"
         " FROM sessions"
         f"{where_status}"
         f"{' AND' if where_status else ' WHERE'} session_id NOT IN ("
@@ -3431,7 +3431,7 @@ def get_share_ready_stats(
             "ai_failure_attribution", "ai_failure_modes", "ai_learning_summary",
             "user_messages", "assistant_messages", "tool_uses", "input_tokens",
             "output_tokens", "outcome_badge", "client_origin", "runtime_channel",
-            "start_time", "review_status"]
+            "start_time", "review_status", "hold_state", "embargo_until"]
     sessions = [dict(zip(cols, r)) for r in rows]
     for session in sessions:
         for field in ("ai_recovery_labels", "ai_failure_modes"):
@@ -3440,6 +3440,22 @@ def get_share_ready_stats(
                     session[field] = json.loads(session[field])
                 except (json.JSONDecodeError, ValueError):
                     session[field] = []
+    # Only offer sessions that are actually shareable: drop explicit holds
+    # (`pending_review`, active `embargoed`) so the student cannot pick a
+    # session that the submit-time release gate would later reject. Auto-expired
+    # embargoes pass through via `effective_hold_state`. The two helper columns
+    # are consumed here and removed so the response shape is unchanged.
+    # NOTE: this runs before the recommendation pool and the projects/models
+    # sets are computed below, so all of those are derived from the shareable
+    # subset only (a project whose sessions are all held won't be offered).
+    shareable_sessions: list[dict[str, Any]] = []
+    for session in sessions:
+        effective = effective_hold_state(
+            session.pop("hold_state", None), session.pop("embargo_until", None)
+        )
+        if effective in SHAREABLE_HOLD_STATES:
+            shareable_sessions.append(session)
+    sessions = shareable_sessions
     if excluded_projects:
         sessions = [
             session for session in sessions

--- a/skills/clawjournal-setup/SKILL.md
+++ b/skills/clawjournal-setup/SKILL.md
@@ -158,6 +158,26 @@ Tell the user:
 - "Score sessions with `/clawjournal-score`"
 - "Everything stays 100% local until you explicitly choose to share"
 
+## Before sharing: source scope + project confirmation
+
+Sharing/exporting is gated until two one-time confirmations are set — this
+prevents accidentally contributing traces from a source or project the user
+didn't intend. Local review and scoring do **not** need these; only the first
+share does. The workbench Share flow and `clawjournal` export both block until
+both are in place:
+
+- **Source scope** — explicitly choose which agents' traces are in scope:
+  ```bash
+  ~/.clawjournal-venv/bin/clawjournal config --source <claude|codex|gemini|all>
+  ```
+- **Project confirmation** — confirm the projects whose traces may be shared:
+  ```bash
+  ~/.clawjournal-venv/bin/clawjournal config --confirm-projects
+  ```
+
+It's fine to defer this until the user is ready to contribute — if they try to
+share first, ClawJournal prints the exact command to run.
+
 ## Troubleshooting
 
 **clawjournal command not found after install:** Use `~/.clawjournal-venv/bin/clawjournal` directly, or add the venv bin directory to your shell PATH.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1732,6 +1732,32 @@ class TestVerifyEmail:
         assert payload["status"] == "verification_sent"
         assert payload["next_command"] == "clawjournal verify-email test@university.edu --code <CODE>"
 
+    def test_verify_email_request_suppresses_dev_code_on_prod(self, monkeypatch, capsys):
+        monkeypatch.setattr("clawjournal.cli.load_config", lambda: {})
+        monkeypatch.setattr("clawjournal.workbench.daemon._is_edu_email", lambda email: True)
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.request_email_verification",
+            lambda email: {"status": "ok", "dev_code": "424242"},
+        )
+        monkeypatch.setattr("clawjournal.workbench.daemon._hosted_is_local_dev", lambda: False)
+        monkeypatch.setattr("sys.argv", ["clawjournal", "verify-email", "test@university.edu"])
+        main()
+        payload = json.loads(capsys.readouterr().out)
+        assert "dev_code" not in payload
+
+    def test_verify_email_request_surfaces_dev_code_on_local(self, monkeypatch, capsys):
+        monkeypatch.setattr("clawjournal.cli.load_config", lambda: {})
+        monkeypatch.setattr("clawjournal.workbench.daemon._is_edu_email", lambda email: True)
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.request_email_verification",
+            lambda email: {"status": "ok", "dev_code": "424242"},
+        )
+        monkeypatch.setattr("clawjournal.workbench.daemon._hosted_is_local_dev", lambda: True)
+        monkeypatch.setattr("sys.argv", ["clawjournal", "verify-email", "test@university.edu"])
+        main()
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["dev_code"] == "424242"
+
 
 class TestScore:
     def test_set_score_can_override_failure_value(self, monkeypatch, capsys):

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -1427,6 +1427,41 @@ def _mock_trufflehog_clean(monkeypatch):
     monkeypatch.setattr(trufflehog, "_scan_text_for_raw_matches", lambda text: [])
 
 
+def test_redaction_settings_fingerprint_covers_all_inputs():
+    """Every redaction-affecting input changes the fingerprint; ai_pii does not;
+    and list order within a field does not — guards against a typo dropping a
+    field from the hash or making it order-sensitive."""
+    from clawjournal.workbench.daemon import _redaction_settings_fingerprint
+
+    base = {
+        "custom_strings": ["a"],
+        "extra_usernames": ["u"],
+        "excluded_projects": ["/p"],
+        "blocked_domains": ["x.com"],
+        "allowlist_entries": [{"value": "v"}],
+    }
+    base_fp = _redaction_settings_fingerprint(base)
+
+    for key, changed in [
+        ("custom_strings", ["a", "b"]),
+        ("extra_usernames", ["u", "w"]),
+        ("excluded_projects", ["/p", "/q"]),
+        ("blocked_domains", ["x.com", "y.com"]),
+        ("allowlist_entries", [{"value": "v2"}]),
+    ]:
+        assert _redaction_settings_fingerprint({**base, key: changed}) != base_fp, \
+            f"changing {key} must invalidate the fingerprint"
+
+    # ai_pii is intentionally NOT part of the fingerprint (gated separately).
+    assert _redaction_settings_fingerprint({**base, "ai_pii_review_enabled": True}) == base_fp
+
+    # Order within a list field does not change the hash.
+    assert (
+        _redaction_settings_fingerprint({**base, "custom_strings": ["b", "a", "c"]})
+        == _redaction_settings_fingerprint({**base, "custom_strings": ["c", "a", "b"]})
+    )
+
+
 def test_upload_pii_redaction_runs_sessions_in_parallel(tmp_path, monkeypatch):
     sessions_file = tmp_path / "sessions.jsonl"
     sessions = [
@@ -1634,6 +1669,113 @@ class TestVerifyEmailAPI:
         assert status == 429
         assert data["error"] == "Too many verification attempts"
 
+    def test_request_verification_falls_back_when_capabilities_unavailable(self, monkeypatch):
+        """A momentarily unreachable capabilities doc must not block requesting a
+        code: domain validation falls back to the built-in default suffixes and
+        the verify-email POST still proceeds."""
+        from clawjournal.workbench.daemon import request_email_verification
+
+        saved = {}
+        monkeypatch.setattr("clawjournal.workbench.daemon._HOSTED_SHARE_URL", "https://hosted.example.test/share")
+        monkeypatch.setattr("clawjournal.workbench.daemon._hosted_capabilities_cache", None)
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {})
+        monkeypatch.setattr("clawjournal.workbench.daemon.save_config", lambda config: saved.update(config))
+
+        def mock_urlopen(req, **kwargs):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            if "/.well-known/clawjournal-share.json" in url:
+                raise urllib.error.URLError("capabilities down")
+            if "/api/verify-email" in url:
+                resp = MagicMock()
+                resp.read.return_value = json.dumps({
+                    "verification_id": "verify-123",
+                    "expires_at": "2026-01-01T00:00:00+00:00",
+                }).encode()
+                resp.__enter__ = lambda s: s
+                resp.__exit__ = MagicMock(return_value=False)
+                return resp
+            raise ValueError(f"Unexpected URL: {url}")
+
+        with patch("clawjournal.workbench.daemon.urllib.request.urlopen", side_effect=mock_urlopen):
+            result = request_email_verification("test@university.edu")
+
+        assert result["verification_id"] == "verify-123"
+        assert saved["pending_verification_id"] == "verify-123"
+
+    def test_request_verification_still_rejects_bad_domain_when_capabilities_down(self, monkeypatch):
+        """The capabilities fallback must not weaken domain validation: a
+        non-academic address is still rejected using the default suffixes."""
+        from clawjournal.workbench.daemon import request_email_verification
+
+        monkeypatch.setattr("clawjournal.workbench.daemon._HOSTED_SHARE_URL", "https://hosted.example.test/share")
+        monkeypatch.setattr("clawjournal.workbench.daemon._hosted_capabilities_cache", None)
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {})
+
+        def mock_urlopen(req, **kwargs):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            if "/.well-known/clawjournal-share.json" in url:
+                raise urllib.error.URLError("capabilities down")
+            raise AssertionError("verify-email POST should not be reached for a rejected domain")
+
+        with patch("clawjournal.workbench.daemon.urllib.request.urlopen", side_effect=mock_urlopen):
+            with pytest.raises(ValueError):
+                request_email_verification("someone@gmail.com")
+
+    def test_request_verification_clears_stale_token_on_email_switch(self, monkeypatch):
+        """Requesting a code for a different email must drop the previously
+        verified email's upload token, so a later submit cannot upload under
+        the old identity while the UI shows the new email."""
+        from clawjournal.workbench.daemon import request_email_verification
+
+        state = {
+            "verified_email": "old@university.edu",
+            "verified_email_token": "old-token",
+            "verified_email_token_expires_at": int(time.time()) + 3600,
+        }
+        monkeypatch.setattr("clawjournal.workbench.daemon._HOSTED_SHARE_URL", "https://hosted.example.test/share")
+        monkeypatch.setattr("clawjournal.workbench.daemon._hosted_capabilities_cache", None)
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: dict(state))
+
+        def save_state(updated):
+            state.clear()
+            state.update(updated)
+
+        monkeypatch.setattr("clawjournal.workbench.daemon.save_config", save_state)
+
+        with patch("clawjournal.workbench.daemon.urllib.request.urlopen", side_effect=_mock_urlopen_factory()):
+            request_email_verification("new@university.edu")
+
+        assert "verified_email" not in state
+        assert "verified_email_token" not in state
+        assert "verified_email_token_expires_at" not in state
+        assert state["pending_verification_email"] == "new@university.edu"
+
+    def test_request_verification_keeps_token_when_same_email(self, monkeypatch):
+        """Re-verifying the SAME email keeps the existing token until the new
+        one is confirmed (a token refresh, not an identity switch)."""
+        from clawjournal.workbench.daemon import request_email_verification
+
+        state = {
+            "verified_email": "same@university.edu",
+            "verified_email_token": "keep-token",
+            "verified_email_token_expires_at": int(time.time()) + 3600,
+        }
+        monkeypatch.setattr("clawjournal.workbench.daemon._HOSTED_SHARE_URL", "https://hosted.example.test/share")
+        monkeypatch.setattr("clawjournal.workbench.daemon._hosted_capabilities_cache", None)
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: dict(state))
+
+        def save_state(updated):
+            state.clear()
+            state.update(updated)
+
+        monkeypatch.setattr("clawjournal.workbench.daemon.save_config", save_state)
+
+        with patch("clawjournal.workbench.daemon.urllib.request.urlopen", side_effect=_mock_urlopen_factory()):
+            request_email_verification("Same@University.edu")
+
+        assert state["verified_email_token"] == "keep-token"
+        assert state["pending_verification_email"] == "same@university.edu"
+
 
 class TestShareAPI:
     """Tests for the hosted research submission flow."""
@@ -1787,6 +1929,193 @@ class TestShareAPI:
         status, data = _post(server, f"/api/shares/{share_id}/upload", self._consent_body())
         assert status == 429
         assert "Rate limited" in data["error"]
+
+    def test_share_upload_timeout_is_ambiguous_and_preserves_state(self, server, monkeypatch):
+        """A timeout after the bundle bytes were sent is ambiguous: the server
+        may have accepted it. Don't clear the token or mark the share shared,
+        and warn against a duplicate-causing blind retry."""
+        WorkbenchHandler._last_share_time = 0.0
+        share_id = self._create_and_export_share(server)
+        saved = {}
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: _share_config())
+        monkeypatch.setattr("clawjournal.workbench.daemon.save_config", lambda updated: saved.update(updated))
+
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(upload_error=TimeoutError("timed out")),
+        ):
+            status, data = _post(server, f"/api/shares/{share_id}/upload", self._consent_body())
+
+        assert status == 504, data
+        assert data.get("ambiguous") is True
+        assert "duplicate" in data["error"].lower()
+        # Token not cleared (single-use; the submission may actually have landed).
+        assert saved == {}
+        conn = open_index()
+        row = conn.execute(
+            "SELECT status, hosted_receipt_id FROM shares WHERE share_id = ?",
+            (share_id,),
+        ).fetchone()
+        conn.close()
+        assert row["status"] != "shared"
+        assert row["hosted_receipt_id"] is None
+
+    def test_share_upload_connection_refused_is_safe_retry(self, server, monkeypatch):
+        """A pre-send connection failure never reached the server, so it stays a
+        plain 502 'try again' without the ambiguous-duplicate warning."""
+        WorkbenchHandler._last_share_time = 0.0
+        share_id = self._create_and_export_share(server)
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: _share_config())
+
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(upload_error=urllib.error.URLError("connection refused")),
+        ):
+            status, data = _post(server, f"/api/shares/{share_id}/upload", self._consent_body())
+
+        assert status == 502, data
+        assert not data.get("ambiguous")
+        assert "try again" in data["error"].lower()
+
+    def test_share_upload_urlerror_wrapping_timeout_is_ambiguous(self, server, monkeypatch):
+        """A URLError whose reason is a timeout (a timeout raised while writing
+        the request body) is treated like a bare TimeoutError: ambiguous 504,
+        not a safe-retry 502 — exercises the wrapped-timeout branch."""
+        WorkbenchHandler._last_share_time = 0.0
+        share_id = self._create_and_export_share(server)
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: _share_config())
+
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(upload_error=urllib.error.URLError(TimeoutError("timed out"))),
+        ):
+            status, data = _post(server, f"/api/shares/{share_id}/upload", self._consent_body())
+
+        assert status == 504, data
+        assert data.get("ambiguous") is True
+        assert "duplicate" in data["error"].lower()
+
+    def test_failed_submit_still_starts_cooldown(self, server, monkeypatch):
+        """A failed submit marks in-flight, so an immediate retry is rate-limited
+        — previously the cooldown only advanced on success, leaving a retry-loop
+        / concurrent-submit window open."""
+        WorkbenchHandler._last_share_time = 0.0
+        share_id = self._create_and_export_share(server)
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: _share_config())
+
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(upload_error=TimeoutError("timed out")),
+        ):
+            status, _ = _post(server, f"/api/shares/{share_id}/upload", self._consent_body())
+        assert status == 504
+
+        status, data = _post(server, f"/api/shares/{share_id}/upload", self._consent_body())
+        assert status == 429
+        assert "Rate limited" in data["error"]
+
+    def test_missing_consent_does_not_consume_cooldown(self, server, monkeypatch):
+        """A malformed upload (missing consent fields) is rejected 400 BEFORE the
+        rate-limit gate, so it must not start the cooldown — a corrected submit
+        immediately afterwards proceeds rather than getting a 429."""
+        WorkbenchHandler._last_share_time = 0.0
+        share_id = self._create_and_export_share(server)
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: _share_config())
+
+        status, data = _post(server, f"/api/shares/{share_id}/upload", {})
+        assert status == 400
+        assert "missing" in data
+
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(),
+        ):
+            status, data = _post(server, f"/api/shares/{share_id}/upload", self._consent_body())
+        assert status == 200, data
+        assert data["ok"] is True
+
+    def _verify_email_mock_with_dev_code(self, dev_code):
+        """A urlopen mock that returns ``dev_code`` from /api/verify-email."""
+        base = _mock_urlopen_factory()
+
+        def mock_urlopen(req, **kwargs):
+            url = req.full_url if hasattr(req, "full_url") else str(req)
+            if "/api/verify-email" in url and "/confirm" not in url:
+                resp = MagicMock()
+                resp.read.return_value = json.dumps({
+                    "verification_id": "verify-123",
+                    "expires_at": "2026-01-01T00:00:00+00:00",
+                    "dev_code": dev_code,
+                }).encode()
+                resp.__enter__ = lambda s: s
+                resp.__exit__ = MagicMock(return_value=False)
+                return resp
+            return base(req, **kwargs)
+
+        return mock_urlopen
+
+    def test_verify_email_suppresses_dev_code_on_prod_url(self, server, monkeypatch):
+        """dev_code must never reach the browser against a production hosted URL,
+        even if the server returns it."""
+        # The class autouse fixture points _HOSTED_SHARE_URL at a prod-like https URL.
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {})
+        monkeypatch.setattr("clawjournal.workbench.daemon.save_config", lambda updated: None)
+
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=self._verify_email_mock_with_dev_code("000000"),
+        ):
+            status, data = _post(server, "/api/share/verify-email", {"email": "test@university.edu"})
+
+        assert status == 200
+        assert "dev_code" not in data
+
+    def test_verify_email_surfaces_dev_code_on_local_url(self, server, monkeypatch):
+        """On a localhost (dev) hosted URL, dev_code is surfaced for convenience."""
+        monkeypatch.setattr("clawjournal.workbench.daemon._HOSTED_SHARE_URL", "http://localhost:8799/share")
+        monkeypatch.setattr("clawjournal.workbench.daemon._hosted_capabilities_cache", None)
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {})
+        monkeypatch.setattr("clawjournal.workbench.daemon.save_config", lambda updated: None)
+
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=self._verify_email_mock_with_dev_code("424242"),
+        ):
+            status, data = _post(server, "/api/share/verify-email", {"email": "test@university.edu"})
+
+        assert status == 200
+        assert data.get("dev_code") == "424242"
+
+    def test_quick_share_blocks_held_session(self, server, monkeypatch):
+        """quick-share leads straight to submit, so it must fail fast (409) when
+        a selected session is on hold instead of packaging an unsubmittable
+        bundle."""
+        from clawjournal.workbench.index import open_index, set_hold_state, upsert_sessions
+
+        WorkbenchHandler._last_share_time = 0.0
+        conn = open_index()
+        try:
+            upsert_sessions(conn, [{
+                "session_id": "qs-held",
+                "project": "test-project",
+                "source": "claude",
+                "model": "claude-sonnet-4",
+                "messages": [{"role": "user", "content": "held content", "tool_uses": []}],
+                "stats": {
+                    "user_messages": 1, "assistant_messages": 0,
+                    "tool_uses": 0, "input_tokens": 100, "output_tokens": 0,
+                },
+            }])
+            set_hold_state(conn, "qs-held", "pending_review", changed_by="user", reason="test")
+        finally:
+            conn.close()
+
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {})
+        status, data = _post(server, "/api/quick-share", {"session_ids": ["qs-held"]})
+
+        assert status == 409, data
+        assert data["blockers"][0]["session_id"] == "qs-held"
+        assert data["blockers"][0]["hold_state"] == "pending_review"
 
     def test_share_duplicate_prevention(self, server, monkeypatch):
         """Already-submitted bundle → 409; force surfaces a clearer message."""
@@ -2563,6 +2892,95 @@ class TestShareAPI:
         assert data["redaction_summary"]["pii_review"]["ai_enabled"] is True
         assert data["redaction_summary"]["pii_review"]["finding_count"] == 1
         assert calls == 1
+
+    def test_seal_rebuilds_when_redaction_settings_change(self, server, monkeypatch):
+        """Editing the redaction settings (custom strings / allowlist / etc.)
+        must invalidate the finalized-export cache so a later seal/submit/
+        download never ships content redacted under the stale settings."""
+        conn = open_index()
+        upsert_sessions(conn, [{
+            "session_id": "seal-settings-change",
+            "project": "test-project",
+            "source": "claude",
+            "model": "claude-sonnet-4",
+            "messages": [
+                {"role": "user", "content": "Codename SHIPWRECK and Alice Example", "tool_uses": []},
+            ],
+            "stats": {
+                "user_messages": 1, "assistant_messages": 0,
+                "tool_uses": 0, "input_tokens": 100, "output_tokens": 0,
+            },
+        }])
+        conn.close()
+
+        calls = 0
+
+        def fake_review(session, **kw):
+            nonlocal calls
+            calls += 1
+            return ([{
+                "session_id": session["session_id"],
+                "message_index": 0,
+                "field": "content",
+                "entity_text": "Alice Example",
+                "entity_type": "person_name",
+                "confidence": 0.95,
+                "reason": "test name",
+                "replacement": "[REDACTED_NAME]",
+                "source": "test",
+            }], "full")
+
+        monkeypatch.setattr("clawjournal.redaction.pii.review_session_pii_hybrid", fake_review)
+
+        cfg: dict = {}
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: dict(cfg))
+
+        status, data = _post(server, "/api/shares", {
+            "session_ids": ["seal-settings-change"],
+            "note": "settings change",
+        })
+        assert status == 201
+        share_id = data["share_id"]
+
+        # First seal: no custom redaction strings configured.
+        status, data = _post(server, f"/api/shares/{share_id}/seal", {"ai_pii": True})
+        assert status == 200
+        assert calls == 1
+
+        # Re-seal with identical settings reuses the cache (no rebuild).
+        status, data = _post(server, f"/api/shares/{share_id}/seal", {"ai_pii": True})
+        assert status == 200
+        assert calls == 1
+
+        # Prove the cached export is genuinely stale once the setting changes:
+        # before adding the custom string, the downloaded zip still contains the
+        # raw 'SHIPWRECK' (it isn't a redaction target yet), and the download
+        # reuses the cache (no rebuild). This makes the rebuild assertion below
+        # a real content change, not just a call-count artifact.
+        status, _ct, before = _get_raw(server, f"/api/shares/{share_id}/download")
+        assert status == 200
+        with zipfile.ZipFile(BytesIO(before)) as archive:
+            before_content = archive.read("sessions.jsonl").decode("utf-8")
+        assert "SHIPWRECK" in before_content
+        assert calls == 1
+
+        # Add a custom redaction string → settings fingerprint changes.
+        cfg["redact_strings"] = ["SHIPWRECK"]
+
+        status, data = _post(server, f"/api/shares/{share_id}/seal", {"ai_pii": True})
+        assert status == 200
+        # Cache invalidated by the settings change → the export was rebuilt.
+        assert calls == 2
+
+        # The newly added custom string is now redacted in the downloaded zip.
+        status, content_type, body = _get_raw(server, f"/api/shares/{share_id}/download")
+        assert status == 200
+        with zipfile.ZipFile(BytesIO(body)) as archive:
+            sessions_content = archive.read("sessions.jsonl").decode("utf-8")
+        assert "SHIPWRECK" not in sessions_content
+        assert "[REDACTED_NAME]" in sessions_content
+        # The download reused the freshly rebuilt artifact (no extra AI pass).
+        assert calls == 2
 
     def test_seal_with_no_override_uses_config_default(self, server, monkeypatch):
         """When the request omits ai_pii, the persisted config default

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -25,6 +25,7 @@ from clawjournal.workbench.index import (
     query_unscored_sessions,
     remove_policy,
     search_fts,
+    set_hold_state,
     update_session,
     upsert_sessions,
 )
@@ -811,6 +812,53 @@ class TestShares:
 
         assert [s["session_id"] for s in stats["sessions"]] == ["failure", "legacy"]
         assert stats["recommended_session_ids"] == ["failure"]
+
+    def test_share_ready_excludes_held_sessions(self, index_conn):
+        """The queue must offer only shareable sessions: explicit holds
+        (pending_review, active embargo) are dropped, but an auto-expired
+        embargo passes through (treated as released)."""
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        upsert_sessions(index_conn, [
+            _make_session(
+                sid,
+                start_time=now.isoformat(),
+                end_time=(now + timedelta(minutes=10)).isoformat(),
+            )
+            for sid in ("ok", "held", "emb-active", "emb-expired")
+        ])
+        for sid in ("ok", "held", "emb-active", "emb-expired"):
+            update_session(
+                index_conn, sid,
+                status="approved", ai_quality_score=5, ai_failure_value_score=5,
+            )
+        set_hold_state(index_conn, "held", "pending_review", changed_by="user", reason="test")
+        set_hold_state(
+            index_conn, "emb-active", "embargoed", changed_by="user", reason="test",
+            embargo_until=(now + timedelta(days=30)).isoformat(),
+        )
+        # An expired embargo can't be set via set_hold_state (it requires a
+        # future date), so write it directly to exercise the expiry path.
+        index_conn.execute(
+            "UPDATE sessions SET hold_state = 'embargoed', embargo_until = ? "
+            "WHERE session_id = ?",
+            ((now - timedelta(days=1)).isoformat(), "emb-expired"),
+        )
+        index_conn.commit()
+
+        stats = get_share_ready_stats(index_conn)
+        ids = {s["session_id"] for s in stats["sessions"]}
+        assert "held" not in ids          # explicit pending_review hold
+        assert "emb-active" not in ids     # active embargo
+        assert "ok" in ids                 # default auto_redacted is shareable
+        assert "emb-expired" in ids        # expired embargo treated as released
+        assert "held" not in stats["recommended_session_ids"]
+        assert "emb-active" not in stats["recommended_session_ids"]
+        # The internal hold-state columns must not leak into the response shape.
+        assert all(
+            "hold_state" not in s and "embargo_until" not in s
+            for s in stats["sessions"]
+        )
 
     def test_share_ready_fills_default_queue_with_lower_failure_value_scores(self, index_conn):
         from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
## Summary

Review-driven correctness, privacy, friction, and robustness fixes across the PhD-student share workflow (queue → redact → package → submit), each with tests. Originated from a multi-pass review of the share/submission flow plus a contract check against the deployed hosted broker.

## Correctness & privacy
- **Stale finalized-export reuse**: invalidate the package cache when redaction settings (allowlist / custom strings / usernames / excluded projects / blocked domains) change, not just `ai_pii` — a re-submit can no longer ship a bundle redacted under stale settings.
- **Concurrent / double-submit**: mark the upload handler in-flight atomically inside the rate lock; validate consent fields *before* the lock so a malformed request doesn't consume the 10s cooldown.
- **Ambiguous submit timeout**: distinguish a post-upload timeout (504, "may have landed — don't blindly retry") from a safe-to-retry connection failure (502). Reinforced by the broker's server-side `(bundle_hash, email_hash)` dedup.
- **Stale verified-email token**: cleared when verifying a different email, so a submit can't upload under the previous identity.
- **dev_code gating**: daemon + CLI only surface `dev_code` for local/dev hosted URLs.

## Friction & resilience
- **Share queue** filters out non-shareable (`pending_review` / active-embargo) sessions using the same release-gate predicate as submit, so students don't pick sessions that fail at submit time.
- **Quick-share** gates on hold-state *before* creating the share row (no orphaned draft on rejection).
- **Email verification** falls back to default academic-domain suffixes when the hosted capabilities doc is briefly unreachable, instead of 502-blocking.

## Frontend (Share step machine)
- Route Submit → Done when hosted submission is unavailable on reload/deep-link.
- Route Submit → Queue when there is no packaged bundle.

## Docs
- Setup skill documents the `config --source` / `config --confirm-projects` prerequisites required before sharing.

## Hosted contract
Verified the share-tab uploader against the deployed `clawjournal-share` API (paths, request/response shapes, bundle validation, error semantics) — **no client changes required**; the admin/participant-ledger work is admin-side only.

## Test plan
- `pytest` — full suite green (**1893 passed**), including 17 new tests covering cache invalidation (incl. a 5-field fingerprint unit test + a stale-content proof), the concurrency/timeout branches, the queue filter, quick-share gating, email-verify resilience, and dev_code gating.
- Frontend: `tsc -b` + `vite build` + `eslint` clean (no React unit-test harness in this repo; guards verified by type-check / lint / build / reading).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
