### PR TITLE
[codex] Fix share upload flow docs and export redaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Review and curate your coding agent conversation traces — 100% locally. ClawJo
 
 ## Install or refresh in one step (no coding required)
 
-If you have an AI coding assistant — **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Hermes**, **Gemini CLI**, or similar — you can install or refresh ClawJournal without writing any code or running any commands yourself. Use the same prompt for a first-time install, or before a submission window if you installed days or weeks ago.
+If you have an AI coding assistant — **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Hermes**, **Gemini CLI**, or similar — you can install or refresh ClawJournal without writing any code or running any commands yourself. Use the same prompt for a first-time install, **or to refresh an existing install before you package or submit a bundle** (an out-of-date copy is the most common cause of submission errors).
 
 **1.** Open your AI assistant.
 
@@ -20,6 +20,8 @@ If you have an AI coding assistant — **Claude Code**, **Codex**, **Cursor**, *
 - **A separate password prompt on Mac.** macOS may ask for *your computer password* (the one you use to log in) when installing certain tools. This is your operating system asking, not the AI. Type your password and hit Enter — installing software almost always requires this.
 - **Silent waiting periods.** Some downloads and compiles take 30–90 seconds with no visible progress. **The AI isn't frozen — it's working.** Wait for it to come back. Total install time is usually 2–10 minutes depending on your network and what's already installed.
 - **A success message at the end:** `[ok] ClawJournal 0.1.15 installed.` (the version number may differ). On a refresh, the AI should also confirm that `clawjournal status` works and that `clawjournal bundle-export --help` shows the `--zip` option.
+
+> **Already installed? Refresh before submitting.** Re-paste the same prompt any time before you package or upload a bundle — it updates ClawJournal and rebuilds the browser workbench. Refresh first if you see **`unrecognized arguments: --zip`** or the Share tab says **"Your queue is empty"**; both mean your copy is out of date.
 
 ### Open the workbench
 
@@ -326,70 +328,89 @@ The browser workbench also keeps share-ready traces warm: on app load it offers 
 
 ### 6. Package & Share
 
-Package the conversations you approved into a redacted ZIP on your computer. Uploading anywhere is a separate, opt-in step — by default the ZIP just sits on your disk.
+Packaging is **100% local** — it writes a redacted ZIP to your own computer. Uploading is a **separate, opt-in step**. By default the ZIP just sits on your disk.
 
 **Just say to your AI:** *"Package my approved ClawJournal sessions and export them to a file on my computer."*
 
-If you installed ClawJournal days or weeks ago, or your local CLI/UI does not match this README, refresh before a submission window:
+Then follow the path below. **Rayward / STEM Data Program participants: use the workbench (Step B).**
+
+#### A. First, refresh if you installed a while ago
+
+Almost every submission problem is an out-of-date copy. **Refresh before you package or submit** if you installed more than a few days ago — or if you hit either of these exact messages:
+
+- `clawjournal bundle-export ...` says **`error: unrecognized arguments: --zip`**
+- The **Share** tab says **"Your queue is empty"** even though you approved sessions
+
+The easy way: re-paste the install prompt from the [top of this README](#install-or-refresh-in-one-step-no-coding-required) into your AI assistant — *"Install or refresh ClawJournal…"*. To do it by hand:
 
 ```bash
 cd ~/clawjournal
-./scripts/install.sh --with-frontend
+./scripts/install.sh --with-frontend     # rebuilds the CLI *and* the browser workbench
 ```
 
-You do not need to sync and rebuild every time you run `clawjournal serve`; the refresh is mainly for infrequent users before packaging/submission or when troubleshooting.
+> This rebuilds the browser workbench too (`--with-frontend`), which is what clears a stale "Your queue is empty" Share tab. You don't need to refresh every time you run `clawjournal serve` — just before a submission window.
 
-#### Option A: Workbench embedded upload (recommended)
+#### B. Submit through the workbench (recommended)
 
-Use this path when you are participating in Rayward research or the STEM Data Program:
+1. Run `clawjournal serve` and open the workbench in your browser.
+2. Click **Share**.
+3. Walk through the steps: **Queue → Redact → Review → Package**. Redaction always runs on your machine first.
+4. ClawJournal then sends you to **one** of two final steps **automatically** — you don't choose which:
 
-1. Run `clawjournal serve` and open the local workbench.
-2. Go to **Share**.
-3. Walk through **Queue → Redact → Review → Package**.
-4. On **Submit**, verify your email, review consent, and click **Submit to ClawJournal Research**.
-5. The workbench uploads the finalized ZIP directly from your local machine and stores the receipt locally. You do not need to download and re-upload the ZIP.
+   | You land on… | What it means | What to do |
+   |--------------|---------------|------------|
+   | **Submit** | Hosted submissions are open | Verify your academic email when prompted, review the consent terms, then click **Submit to ClawJournal Research**. The workbench uploads the finalized ZIP straight from your computer and saves a receipt locally — no manual download or re-upload. |
+   | **Done** | Hosted submissions are closed (or this build has no hosted integration) | Click **Download zip**, then upload that file at **[data.rayward.ai/share](https://data.rayward.ai/share)** once submissions reopen. |
 
-If the workbench shows **Done** instead of **Submit**, or you prefer manual upload, click **Download zip** and use the hosted upload page at `https://data.rayward.ai/share` when submissions are open.
+   Seeing **Done** instead of **Submit** is normal — it just means submissions aren't open right now. Nothing is broken.
 
-The Share page always redacts on your device first. The Redact step uses deterministic and policy rules; you can opt in to AI review to catch contextual personal info the automatic scan missed. When enabled, upload-time AI review runs a small parallel worker pool by default; set `CLAWJOURNAL_UPLOAD_PII_WORKERS=1` to serialize it or `CLAWJOURNAL_UPLOAD_PII_TIMEOUT_SECONDS=90` to allow longer AI review per trace.
+#### If the Share queue is empty (after refreshing)
 
-#### Option B: CLI package, manual browser upload
+The queue only lists sessions that are cleared to leave your machine. If it's still empty:
 
-Use this path if the local packaging UI is inconvenient but you can still upload the generated ZIP through a browser:
+- **Approve some sessions** — only *approved* sessions are eligible. Triage them in the **Sessions** tab ([Stage 4](#4-triage)).
+- **Release any holds** — sessions on hold (`pending_review`) or under an active embargo are excluded until you release them.
+- **Check your exclusions** — a project you excluded with `clawjournal config --exclude` won't show up.
+
+#### Alternative: package on the command line, upload in a browser
+
+Only if you prefer the terminal. This builds the **same** redacted ZIP, which you then upload yourself:
 
 ```bash
 clawjournal bundle-create --status approved
 clawjournal bundle-list
-clawjournal bundle-view <bundle_id>
-clawjournal bundle-export <bundle_id> --zip
+clawjournal bundle-view <bundle_id>          # inspect before exporting
+clawjournal bundle-export <bundle_id> --zip  # prints the export folder AND a zip_path
 ```
 
-The last command prints both the local export directory and `zip_path`. Upload that ZIP through the hosted browser page at `https://data.rayward.ai/share` when submissions are open.
+Upload the printed `zip_path` at **[data.rayward.ai/share](https://data.rayward.ai/share)** when submissions are open.
 
-There is no Rayward hosted CLI upload in the public local-first build. `clawjournal bundle-share` is only for explicitly configured self-hosted ingest servers.
+> ⚠️ **`clawjournal bundle-share` is NOT the Rayward path.** There is no Rayward hosted CLI upload in this local-first build — that's why `bundle-share` reports *"Hosted sharing is not configured."* It only uploads to a **self-hosted** ingest server you set up yourself via `CLAWJOURNAL_INGEST_URL`. STEM Data Program participants should ignore it.
 
-Uploads are gated: only conversations you approved and confirmed for sharing leave your machine. Sessions in `pending_review` or active `embargoed` are blocked.
+**What leaves your machine — and what's redacted.** Only sessions you approved and confirmed for sharing are ever uploaded; `pending_review` and active `embargoed` sessions are blocked. Redaction (your configured strings, file paths, usernames, secrets) is applied to **everything in the bundle** — the session traces *and* the `manifest.json` metadata (project, source, model, and IDs). If you saw a configured term in `manifest.json` before, refresh and re-export: that's fixed.
 
 <details>
 <summary><b>Show shell commands</b></summary>
 
 ```bash
-# Browser workbench path:
+# Recommended — browser workbench:
 clawjournal serve
-# open http://localhost:8384/share, package, then use the embedded Submit step
-# (Download zip + https://data.rayward.ai/share is the manual fallback)
+# open http://localhost:8384/share → Queue → Redact → Review → Package → Submit/Done
+# Submit uploads directly; Done offers "Download zip" to upload at https://data.rayward.ai/share
 
-# CLI packaging path:
+# Alternative — package via CLI, then upload the zip in a browser:
 clawjournal bundle-create --status approved          # bundle all approved sessions
 clawjournal bundle-list
 clawjournal bundle-view <bundle_id>                  # inspect before exporting
-clawjournal bundle-export <bundle_id> --zip          # write an uploadable zip plus export folder
-# upload the printed zip_path at https://data.rayward.ai/share if hosted submissions are open
+clawjournal bundle-export <bundle_id> --zip          # writes an export folder + an uploadable zip
+# upload the printed zip_path at https://data.rayward.ai/share when submissions are open
 
-# Advanced self-hosted ingest only; not Rayward hosted research upload:
+# Self-hosted ingest ONLY (not the Rayward path; requires CLAWJOURNAL_INGEST_URL):
 clawjournal share --preview --status approved        # dry-run
-clawjournal bundle-share <bundle_id>                 # requires CLAWJOURNAL_INGEST_URL
+clawjournal bundle-share <bundle_id>
 ```
+
+**Opt-in AI PII review** (workbench Redact step): on top of the always-on deterministic redaction, you can enable an extra AI pass to catch contextual personal info. It runs a small parallel worker pool by default — set `CLAWJOURNAL_UPLOAD_PII_WORKERS=1` to serialize it, or `CLAWJOURNAL_UPLOAD_PII_TIMEOUT_SECONDS=90` to allow longer review per trace.
 
 </details>
 
@@ -496,7 +517,7 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal config --scorer-backend codex` | Confirm the AI scoring backend used for background workbench scoring (`none` clears it) |
 | `clawjournal score --batch --source failure-corpus --auto-triage` | AI-score failure-value scope; auto-block low-value productivity-1 noise |
 | `clawjournal bundle-create --status approved` | Bundle approved sessions |
-| `clawjournal bundle-export <bundle_id> --zip` | Export a redacted ZIP to upload through the hosted browser page |
+| `clawjournal bundle-export <bundle_id> --zip` | Package approved sessions into a redacted ZIP on disk (then upload it in a browser) |
 
 ### Triage & review
 
@@ -650,6 +671,7 @@ Each line in the exported JSONL is one session:
 - **`scan` already redacts.** Secrets and PII findings are computed and stored as hashed references at scan time. For additional LLM-PII review, opt in on the workbench Share page. The legacy `--pii-review` / `--pii-apply` CLI path still works for sanitizing already-exported files.
 - **Hold-state gates uploads.** Sessions in `pending_review` or active `embargoed` cannot be shared; `auto_redacted` (default) and `released` can.
 - **If `bundle-export --zip` is not recognized, your shell is running an older ClawJournal.** Re-run the GitHub installer, then use `~/.clawjournal-venv/bin/clawjournal bundle-export <bundle_id> --zip` or put `~/.clawjournal-venv/bin` first on `PATH`. The PyPI fallback can lag behind the README.
+- **"Your queue is empty" in the Share tab?** Refresh first (`./scripts/install.sh --with-frontend` rebuilds the workbench). If it persists, the queue only lists *approved*, non-held, non-excluded sessions — approve some in the Sessions tab, release any holds/embargoes, and check `clawjournal config --exclude`.
 - **Large exports take time** — 500+ sessions may take 1–3 minutes.
 - **Virtual environment recommended** — modern Linux (and some macOS setups) block system-wide pip installs. Use a venv to avoid issues.
 

--- a/README.md
+++ b/README.md
@@ -326,36 +326,70 @@ The browser workbench also keeps share-ready traces warm: on app load it offers 
 
 ### 6. Package & Share
 
-Package the conversations you approved into a redacted file on your computer. Uploading anywhere is a separate, opt-in step — by default the file just sits on your disk.
+Package the conversations you approved into a redacted ZIP on your computer. Uploading anywhere is a separate, opt-in step — by default the ZIP just sits on your disk.
 
 **Just say to your AI:** *"Package my approved ClawJournal sessions and export them to a file on my computer."*
 
-The agent walks you through the Share page in the browser workbench: **Queue → Redact → Review → Package → Submit → Done**. The Redact step always uses deterministic and policy rules; you can opt in to AI review to catch contextual personal info the automatic scan missed. When enabled, upload-time AI review runs a small parallel worker pool by default; set `CLAWJOURNAL_UPLOAD_PII_WORKERS=1` to serialize it or `CLAWJOURNAL_UPLOAD_PII_TIMEOUT_SECONDS=90` to allow longer AI review per trace.
+If you installed ClawJournal days or weeks ago, or your local CLI/UI does not match this README, refresh before a submission window:
 
-To actually upload after packaging (optional), use the workbench **Submit** step. It verifies email, shows consent, sends the finalized zip to the hosted service, and stores the returned receipt locally. Self-hosters can override the destination with `CLAWJOURNAL_SHARE_URL`; setting `CLAWJOURNAL_SHARE_URL=` disables hosted submission and leaves download-only packaging.
+```bash
+cd ~/clawjournal
+./scripts/install.sh --with-frontend
+```
 
-> *(optional)* *"Submit this bundle to ClawJournal Research."*
+You do not need to sync and rebuild every time you run `clawjournal serve`; the refresh is mainly for infrequent users before packaging/submission or when troubleshooting.
 
-Uploads are gated: only conversations you approved and confirmed for sharing leave your machine.
+#### Option A: Workbench embedded upload (recommended)
+
+Use this path when you are participating in Rayward research or the STEM Data Program:
+
+1. Run `clawjournal serve` and open the local workbench.
+2. Go to **Share**.
+3. Walk through **Queue → Redact → Review → Package**.
+4. On **Submit**, verify your email, review consent, and click **Submit to ClawJournal Research**.
+5. The workbench uploads the finalized ZIP directly from your local machine and stores the receipt locally. You do not need to download and re-upload the ZIP.
+
+If the workbench shows **Done** instead of **Submit**, or you prefer manual upload, click **Download zip** and use the hosted upload page at `https://data.rayward.ai/share` when submissions are open.
+
+The Share page always redacts on your device first. The Redact step uses deterministic and policy rules; you can opt in to AI review to catch contextual personal info the automatic scan missed. When enabled, upload-time AI review runs a small parallel worker pool by default; set `CLAWJOURNAL_UPLOAD_PII_WORKERS=1` to serialize it or `CLAWJOURNAL_UPLOAD_PII_TIMEOUT_SECONDS=90` to allow longer AI review per trace.
+
+#### Option B: CLI package, manual browser upload
+
+Use this path if the local packaging UI is inconvenient but you can still upload the generated ZIP through a browser:
+
+```bash
+clawjournal bundle-create --status approved
+clawjournal bundle-list
+clawjournal bundle-view <bundle_id>
+clawjournal bundle-export <bundle_id> --zip
+```
+
+The last command prints both the local export directory and `zip_path`. Upload that ZIP through the hosted browser page at `https://data.rayward.ai/share` when submissions are open.
+
+There is no Rayward hosted CLI upload in the public local-first build. `clawjournal bundle-share` is only for explicitly configured self-hosted ingest servers.
+
+Uploads are gated: only conversations you approved and confirmed for sharing leave your machine. Sessions in `pending_review` or active `embargoed` are blocked.
 
 <details>
 <summary><b>Show shell commands</b></summary>
 
 ```bash
+# Browser workbench path:
+clawjournal serve
+# open http://localhost:8384/share, package, then use the embedded Submit step
+# (Download zip + https://data.rayward.ai/share is the manual fallback)
+
+# CLI packaging path:
 clawjournal bundle-create --status approved          # bundle all approved sessions
 clawjournal bundle-list
 clawjournal bundle-view <bundle_id>                  # inspect before exporting
 clawjournal bundle-export <bundle_id> --zip          # write an uploadable zip plus export folder
+# upload the printed zip_path at https://data.rayward.ai/share if hosted submissions are open
 
-# Optional hosted research submission:
-# use the workbench Share tab's Submit step
-
-# Advanced self-hosted ingest upload:
+# Advanced self-hosted ingest only; not Rayward hosted research upload:
 clawjournal share --preview --status approved        # dry-run
-clawjournal bundle-share <bundle_id>                 # self-hosted ingest upload
+clawjournal bundle-share <bundle_id>                 # requires CLAWJOURNAL_INGEST_URL
 ```
-
-Upload is gated on hold-state: only sessions in `auto_redacted` or `released` can leave the machine.
 
 </details>
 
@@ -462,7 +496,7 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal config --scorer-backend codex` | Confirm the AI scoring backend used for background workbench scoring (`none` clears it) |
 | `clawjournal score --batch --source failure-corpus --auto-triage` | AI-score failure-value scope; auto-block low-value productivity-1 noise |
 | `clawjournal bundle-create --status approved` | Bundle approved sessions |
-| `clawjournal bundle-export <bundle_id> --zip` | Export bundle to disk and write an uploadable zip |
+| `clawjournal bundle-export <bundle_id> --zip` | Export a redacted ZIP to upload through the hosted browser page |
 
 ### Triage & review
 
@@ -507,8 +541,8 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal bundle-create --status approved` | Create bundle from all approved sessions |
 | `clawjournal bundle-list` | List bundles |
 | `clawjournal bundle-view <bundle_id>` | View bundle details |
-| `clawjournal bundle-export <bundle_id> --zip` | Export bundle and write an uploadable zip |
-| `clawjournal bundle-share <bundle_id>` | Advanced self-hosted ingest upload |
+| `clawjournal bundle-export <bundle_id> --zip` | Export a redacted ZIP for manual browser upload at `https://data.rayward.ai/share` |
+| `clawjournal bundle-share <bundle_id>` | Advanced self-hosted ingest only; requires `CLAWJOURNAL_INGEST_URL` |
 
 ### Quick share
 
@@ -520,15 +554,15 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal card <id> --depth workflow` | Workflow-only card (safe for public channels) |
 | `clawjournal card <id> --depth full` | Full card with redacted content |
 
-### Advanced self-hosted ingest upload
+### Hosted upload helpers and self-hosted ingest
 
 | Command | Description |
 |---------|-------------|
-| `clawjournal verify-email you@university.edu` | Verify an academic email for hosted workbench submission |
+| `clawjournal verify-email you@university.edu` | Verify an academic email for the hosted browser submission flow |
 | `clawjournal share --preview --status approved` | Preview what would be packaged |
-| `clawjournal share --status approved` | Package locally and print the workbench Submit URL |
-| `clawjournal share --status approved --ai-pii-review` | Package with optional AI-assisted PII review |
-| `clawjournal bundle-share <bundle_id>` | Upload through an explicitly configured self-hosted ingest service |
+| `clawjournal share --status approved` | Package locally and print the workbench Share URL; hosted upload still happens in the browser |
+| `clawjournal share --status approved --ai-pii-review` | Package locally with optional AI-assisted PII review |
+| `clawjournal bundle-share <bundle_id>` | Upload through an explicitly configured self-hosted ingest service; not Rayward hosted upload |
 
 ### Configuration
 
@@ -615,6 +649,7 @@ Each line in the exported JSONL is one session:
 - **Source and project confirmation are required** — the CLI blocks export until both are set.
 - **`scan` already redacts.** Secrets and PII findings are computed and stored as hashed references at scan time. For additional LLM-PII review, opt in on the workbench Share page. The legacy `--pii-review` / `--pii-apply` CLI path still works for sanitizing already-exported files.
 - **Hold-state gates uploads.** Sessions in `pending_review` or active `embargoed` cannot be shared; `auto_redacted` (default) and `released` can.
+- **If `bundle-export --zip` is not recognized, your shell is running an older ClawJournal.** Re-run the GitHub installer, then use `~/.clawjournal-venv/bin/clawjournal bundle-export <bundle_id> --zip` or put `~/.clawjournal-venv/bin` first on `PATH`. The PyPI fallback can lag behind the README.
 - **Large exports take time** — 500+ sessions may take 1–3 minutes.
 - **Virtual environment recommended** — modern Linux (and some macOS setups) block system-wide pip installs. Use a venv to avoid issues.
 

--- a/README.md
+++ b/README.md
@@ -2,24 +2,24 @@
 
 Review and curate your coding agent conversation traces — 100% locally. ClawJournal scans session logs from Claude Code, Claude Desktop, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline, automatically anonymizes secrets and personal information, and gives you a browser workbench to review everything before it ever leaves your machine.
 
-## Install in one step (no coding required)
+## Install or refresh in one step (no coding required)
 
-If you have an AI coding assistant — **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Hermes**, **Gemini CLI**, or similar — you can install ClawJournal without writing any code or running any commands yourself.
+If you have an AI coding assistant — **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Hermes**, **Gemini CLI**, or similar — you can install or refresh ClawJournal without writing any code or running any commands yourself. Use the same prompt for a first-time install, or before a submission window if you installed days or weeks ago.
 
 **1.** Open your AI assistant.
 
 **2.** Paste this message:
 
-> *Install ClawJournal from https://github.com/rayward-external/clawjournal. Read its README and follow the install instructions for my operating system. Install any missing prerequisites. Verify it works at the end.*
+> *Install or refresh ClawJournal from https://github.com/rayward-external/clawjournal. Read its README and follow the instructions for my operating system. If ClawJournal is already installed, update it from the public GitHub repo and rebuild the browser workbench. Install any missing prerequisites. Verify it works at the end.*
 
-**3.** The AI does the rest. It'll figure out your operating system (Mac, Windows, Linux), install any background tools it needs (git, Python, Node.js), run the install script, and tell you when it's done.
+**3.** The AI does the rest. It'll figure out your operating system (Mac, Windows, Linux), install any background tools it needs (git, Python, Node.js), run the install script, rebuild the workbench when needed, and tell you when it's done.
 
 ### What to expect
 
 - **Permission prompts — lots of them.** Your AI will ask permission to run several commands. Expect 10–25 prompts before install finishes — more if your computer is fresh, fewer if it already has dev tools. **Click "Allow" each time.** This is normal. The tools the AI installs (git for fetching code, Python for running ClawJournal, Node.js for the browser workbench) are widely-used software your computer probably has parts of already.
 - **A separate password prompt on Mac.** macOS may ask for *your computer password* (the one you use to log in) when installing certain tools. This is your operating system asking, not the AI. Type your password and hit Enter — installing software almost always requires this.
 - **Silent waiting periods.** Some downloads and compiles take 30–90 seconds with no visible progress. **The AI isn't frozen — it's working.** Wait for it to come back. Total install time is usually 2–10 minutes depending on your network and what's already installed.
-- **A success message at the end:** `[ok] ClawJournal 0.1.15 installed.` (the version number may differ).
+- **A success message at the end:** `[ok] ClawJournal 0.1.15 installed.` (the version number may differ). On a refresh, the AI should also confirm that `clawjournal status` works and that `clawjournal bundle-export --help` shows the `--zip` option.
 
 ### Open the workbench
 
@@ -42,7 +42,7 @@ Your first scan may take a minute or two if you have lots of past sessions, and 
 <details>
 <summary><b>For AI agents reading this README directly</b> (humans following the 3 steps above can skip this)</summary>
 
-Detect the user's OS, follow the matching block in [Quickstart](#quickstart) below, install all missing prereqs (git, Python 3.10+, and Node.js — the install includes the browser workbench by default), then verify with `clawjournal status`. The install script handles Python detection, venv creation, and dependency install. You have everything you need; proceed.
+Detect the user's OS, follow the matching block in [Quickstart](#quickstart) below, install all missing prereqs (git, Python 3.10+, and Node.js — the install includes the browser workbench by default), then verify with `clawjournal status` and `clawjournal bundle-export --help`. If a checkout already exists, fetch/update it from `rayward-external/clawjournal` first and rerun the installer with `--with-frontend` so the built workbench assets match the current source. The install script handles Python detection, venv creation, dependency install, and frontend build. You have everything you need; proceed.
 
 </details>
 

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -4492,37 +4492,37 @@ def main() -> None:
         if args.json:
             print(json.dumps(result, indent=2))
         else:
-            status = result.get("status")
-            if status == "not-a-checkout":
+            selfupdate_status = result.get("status")
+            if selfupdate_status == "not-a-checkout":
                 print("clawjournal is not installed from an editable git checkout — nothing to update.")
-            elif status == "up-to-date":
+            elif selfupdate_status == "up-to-date":
                 print(f"Already up to date ({str(result.get('head', ''))[:7]}).")
-            elif status == "behind":
+            elif selfupdate_status == "behind":
                 print(
                     f"Update available: {str(result.get('head', ''))[:7]} -> "
                     f"{str(result.get('upstream', ''))[:7]}. Run `clawjournal selfupdate` to apply."
                 )
-            elif status == "updated":
+            elif selfupdate_status == "updated":
                 print(
                     f"Updated {str(result.get('head', ''))[:7]} -> "
                     f"{str(result.get('upstream', ''))[:7]}."
                 )
-            elif status == "dirty":
+            elif selfupdate_status == "dirty":
                 print("Skipped: the checkout has local changes. Commit/stash or pass --force.")
-            elif isinstance(status, str) and status.startswith("branch-"):
-                print(f"Skipped: not on the main branch ({status[len('branch-'):]}). Check out main first.")
-            elif status == "ahead":
+            elif isinstance(selfupdate_status, str) and selfupdate_status.startswith("branch-"):
+                print(f"Skipped: not on the main branch ({selfupdate_status[len('branch-'):]}). Check out main first.")
+            elif selfupdate_status == "ahead":
                 print("Skipped: local main has commits not present on origin/main. Update manually.")
-            elif status == "diverged":
+            elif selfupdate_status == "diverged":
                 print("Skipped: local main has diverged from origin/main. Update manually.")
-            elif status == "ancestry-failed":
+            elif selfupdate_status == "ancestry-failed":
                 print("Skipped: could not compare local main with origin/main.")
-            elif status == "fetch-failed":
+            elif selfupdate_status == "fetch-failed":
                 print(f"Fetch failed: {result.get('stderr', '')}".rstrip())
-            elif status == "update-failed":
+            elif selfupdate_status == "update-failed":
                 print(f"Update failed: {result.get('stderr', '')}".rstrip())
             else:
-                print(f"selfupdate status: {status}")
+                print(f"selfupdate status: {selfupdate_status}")
         return
 
     if command == "list":

--- a/clawjournal/web/frontend/src/views/Share/helpers.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.ts
@@ -110,8 +110,13 @@ export function formatShareDestination(url: string): string {
 
 export function queueFromStats(stats: ShareReadyStats): string[] {
   const validIds = new Set(stats.sessions.map((s) => s.session_id));
-  return (stats.recommended_session_ids || [])
+  const recommended = (stats.recommended_session_ids || [])
     .filter((id) => validIds.has(id))
+    .slice(0, DEFAULT_SHARE_QUEUE_SIZE);
+  if (recommended.length > 0) return recommended;
+  return stats.sessions
+    .map((s) => s.session_id)
+    .filter(Boolean)
     .slice(0, DEFAULT_SHARE_QUEUE_SIZE);
 }
 

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -608,10 +608,10 @@ def _is_edu_email(email: str) -> bool:
 def _missing_ingest_url_error() -> str:
     return (
         "CLI ingest upload is not configured in this build. "
-        "Use the workbench Download zip action or "
-        "`clawjournal bundle-export <bundle_id> --zip` to produce a local zip. "
-        "Hosted research submissions use the configured "
-        "workbench Submit step; self-hosters can set CLAWJOURNAL_INGEST_URL to "
+        "Use the workbench Share tab's Submit step when hosted submissions are "
+        "open, or use Download zip / "
+        "`clawjournal bundle-export <bundle_id> --zip` for manual browser upload. "
+        "Self-hosters can set CLAWJOURNAL_INGEST_URL to "
         "point at their own ingest backend."
     )
 

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -608,8 +608,9 @@ def _is_edu_email(email: str) -> bool:
 def _missing_ingest_url_error() -> str:
     return (
         "CLI ingest upload is not configured in this build. "
-        "Use the workbench Download zip action or `clawjournal bundle-export` "
-        "to produce a local zip. Hosted research submissions use the configured "
+        "Use the workbench Download zip action or "
+        "`clawjournal bundle-export <bundle_id> --zip` to produce a local zip. "
+        "Hosted research submissions use the configured "
         "workbench Submit step; self-hosters can set CLAWJOURNAL_INGEST_URL to "
         "point at their own ingest backend."
     )

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -3682,10 +3682,10 @@ def export_share_to_disk(
                     clean = {k: v for k, v in detail.items() if k in EXPORT_FIELDS}
                     f.write(json.dumps(clean, default=str) + "\n")
                     manifest["sessions"].append({
-                        "session_id": s["session_id"],
-                        "project": s.get("project"),
-                        "source": s.get("source"),
-                        "model": s.get("model"),
+                        "session_id": clean.get("session_id") or s["session_id"],
+                        "project": clean.get("project"),
+                        "source": clean.get("source"),
+                        "model": clean.get("model"),
                         # Aggregated counts per §Bundle manifest provenance —
                         # no hashes, plaintext, or offsets.
                         "redactions": build_session_redactions_summary(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -432,6 +432,13 @@ class TestListProjects:
         assert len(data) == 1
         assert data[0]["name"] == "codex:proj2"
 
+    def test_main_status_dispatch_is_not_shadowed(self, monkeypatch):
+        called = []
+        monkeypatch.setattr("clawjournal.cli.status", lambda: called.append(True))
+        monkeypatch.setattr("sys.argv", ["clawjournal", "status"])
+        main()
+        assert called == [True]
+
 
 class TestWorkflowGateMessages:
     @staticmethod
@@ -981,7 +988,7 @@ class TestBundleExport:
         sessions = [
             {
                 "session_id": "redact-test",
-                "project": "test-project",
+                "project": "MySecretName-project",
                 "source": "claude",
                 "model": "claude-sonnet-4",
                 "messages": [
@@ -1012,6 +1019,9 @@ class TestBundleExport:
         content = sessions_file.read_text()
         assert "MySecretName" not in content, "Custom redact_string was not redacted"
         assert "sk-ant-api03" not in content, "API key was not redacted"
+
+        manifest_content = (Path(output["export_path"]) / "manifest.json").read_text()
+        assert "MySecretName" not in manifest_content, "manifest metadata was not redacted"
 
     def test_export_applies_policy_rules(self, tmp_path, monkeypatch, capsys):
         """Bundle export applies workbench policy rules in addition to config."""

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -19,6 +19,7 @@ from clawjournal.workbench.daemon import (
     run_server,
     _SHARE_COOLDOWN_SECONDS,
     _apply_upload_pii_redactions,
+    _missing_ingest_url_error,
     trigger_scoring_warmup,
 )
 from clawjournal.workbench.index import open_index, upsert_sessions
@@ -817,6 +818,13 @@ class TestProjectsAPI:
 
 
 class TestShareDestinationAPI:
+    def test_missing_ingest_url_error_points_to_workbench_submit(self):
+        message = _missing_ingest_url_error()
+
+        assert "Share tab's Submit step" in message
+        assert "bundle-export <bundle_id> --zip" in message
+        assert "CLAWJOURNAL_INGEST_URL" in message
+
     def test_packaged_default_points_to_rayward_research(self):
         from clawjournal.workbench.daemon import _HOSTED_SHARE_URL_DEFAULT
 


### PR DESCRIPTION
## Summary

- Clarify the top-level install prompt so it covers both first-time install and later refresh/update before submission windows.
- Clarify the participant share workflow in the README: embedded workbench Submit is the recommended path, CLI export produces a ZIP for manual browser upload, and `bundle-share` is self-hosted ingest only.
- Fix `clawjournal status` dispatch by avoiding a local `status` variable that shadowed the command function.
- Make Share queue defaults fall back to eligible sessions when no scored recommendations exist.
- Build manifest session metadata from the redacted export object so configured redaction strings do not remain in `manifest.json`.
- Tighten missing-ingest messaging to point users to the workbench Submit step first, then ZIP/manual upload, and keep self-hosted ingest separate.

## Root Cause

The public docs and CLI/UI behavior had drifted around hosted submission and refresh workflows. Participants could infer that Rayward hosted CLI upload existed, or that the one-step prompt was only for first-time install, while the local-first build actually packages locally and uses the workbench hosted Submit flow or a manual browser ZIP upload. Separately, manifest metadata was assembled from pre-redaction share rows instead of the redacted session object.

## Validation

- `python -m pytest -q` passed: 1895 tests
- `npm run build` passed in `clawjournal/web/frontend`
- `git diff --check` passed
- Targeted follow-up passed: missing ingest guidance, manifest custom-redaction coverage, and `clawjournal status` dispatch
- GitHub Actions passed: smoke plus Python 3.10, 3.11, 3.12, and 3.13