### PR TITLE
Explain share-flow dead-ends at the source

### DIFF
--- a/clawjournal/web/frontend/src/views/Share/DoneStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/DoneStep.tsx
@@ -34,6 +34,10 @@ export function DoneStep(p: DoneStepProps) {
   const hostedShareUrl = p.shareDestination?.configured ? p.shareDestination.share_page_url : null;
   const hostedShareLabel = hostedShareUrl ? formatShareDestination(hostedShareUrl) : null;
   const submitted = !!p.receiptId;
+  // The flow routes here (instead of Submit) when hosted submissions are
+  // closed. Surface that explicitly so a participant doesn't think the
+  // missing Submit button means their workbench is broken.
+  const submissionsClosed = !!p.shareDestination?.configured && !p.shareDestination?.submissions_open;
   // `bundle.approxSize` is the whole zip's compressed size (from the seal
   // response); it doesn't belong on the sessions.jsonl row, which the user
   // would read as "this JSONL is that big". Keep the row generic — the zip
@@ -103,6 +107,17 @@ export function DoneStep(p: DoneStepProps) {
         <p style={{ color: colors.gray500, margin: '0 0 24px', fontSize: 14 }}>
           {submitted ? `Receipt ${p.receiptId}` : 'Download the finalized zip, then upload it through the hosted submission page.'}
         </p>
+
+        {!submitted && submissionsClosed && (
+          <div style={{
+            margin: '0 auto 22px', maxWidth: 520, padding: '12px 14px',
+            background: colors.yellow50, border: `1px solid ${colors.yellow200}`,
+            borderRadius: 8, fontSize: 13, color: colors.yellow700, textAlign: 'left' as const,
+          }}>
+            {p.shareDestination?.message
+              || 'Hosted research submissions are currently closed, so there is no Submit step right now — this is expected, not a problem. Download the zip below and upload it once submissions reopen.'}
+          </div>
+        )}
 
         {p.bundle && (
           <div style={{

--- a/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
@@ -47,6 +47,11 @@ export function QueueStep(p: QueueStepProps) {
   const [dragId, setDragId] = useState<string | null>(null);
 
   const allSessions = p.readyStats?.sessions || [];
+  // `total_approved` counts every approved session; `allSessions` only holds the
+  // ones actually eligible to share. When approved > 0 but eligible == 0, the
+  // sessions exist but are all held/embargoed/excluded/already-shared — say so
+  // instead of telling the user to "approve traces" they already approved.
+  const totalApproved = p.readyStats?.total_approved ?? 0;
   const totalTokens = p.queuedSessions.reduce((sum, s) => sum + sessionTotalTokens(s), 0);
   const uniqueProjects = [...new Set(p.queuedSessions.map(s => s.project).filter(Boolean))];
 
@@ -107,9 +112,18 @@ export function QueueStep(p: QueueStepProps) {
             <h3 style={{ color: colors.gray900, fontWeight: 500, margin: '0 0 6px', fontSize: 16 }}>
               No traces ready to share
             </h3>
-            <p style={{ margin: '0 auto 20px', maxWidth: '38ch', fontSize: 13 }}>
-              Approve traces in Sessions to build a bundle.
-            </p>
+            {totalApproved > 0 ? (
+              <p style={{ margin: '0 auto 20px', maxWidth: '46ch', fontSize: 13 }}>
+                You have {totalApproved} approved session{totalApproved === 1 ? '' : 's'}, but none are eligible to
+                share right now — they may be on hold, under an active embargo, in an excluded project, or already
+                shared. Release a hold or check your excluded projects (<code>clawjournal config --exclude</code>),
+                then come back.
+              </p>
+            ) : (
+              <p style={{ margin: '0 auto 20px', maxWidth: '38ch', fontSize: 13 }}>
+                Approve traces in Sessions to build a bundle.
+              </p>
+            )}
             <Link to="/" style={{ ...btnPrimary, textDecoration: 'none' }}>Go to Sessions</Link>
           </div>
         </>

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -142,11 +142,27 @@ Write-Host "Or add the venv to PATH for this session:"
 Write-Host "        `$env:Path = `"$VenvBin;`" + `$env:Path"
 
 # 6) Soft hints for optional runtime deps.
-$frontendBuilt = Test-Path (Join-Path $RepoDir 'clawjournal\web\frontend\dist\index.html')
+$DistHtml = Join-Path $RepoDir 'clawjournal\web\frontend\dist\index.html'
+$FeSrcDir = Join-Path $RepoDir 'clawjournal\web\frontend\src'
+$frontendBuilt = Test-Path $DistHtml
 if (-not $frontendBuilt) {
     Write-Host ""
     Write-Host "[i] Browser workbench not built. To enable 'clawjournal serve':"
     Write-Host "      .\scripts\install.ps1 -WithFrontend     (requires Node.js)"
+}
+elseif (Test-Path $FeSrcDir) {
+    # Source newer than the built assets — a sync without a rebuild leaves
+    # 'clawjournal serve' showing a stale workbench (e.g. an empty Share queue).
+    $distTime = (Get-Item $DistHtml).LastWriteTimeUtc
+    $newestSrc = Get-ChildItem -Path $FeSrcDir -Recurse -File -ErrorAction SilentlyContinue |
+        Sort-Object LastWriteTimeUtc -Descending | Select-Object -First 1
+    if ($newestSrc -and $newestSrc.LastWriteTimeUtc -gt $distTime) {
+        Write-Host ""
+        Write-Host "[i] The browser workbench build looks out of date (its source is newer"
+        Write-Host "    than the built assets). 'clawjournal serve' may show an old UI until"
+        Write-Host "    you rebuild:"
+        Write-Host "      .\scripts\install.ps1 -WithFrontend     (requires Node.js)"
+    }
 }
 
 if (-not (Get-Command trufflehog -ErrorAction SilentlyContinue)) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -141,10 +141,21 @@ Or add the venv to your PATH:
 EOF
 
 # 6) Soft hints for optional runtime deps.
-if [ ! -f "$REPO_DIR/clawjournal/web/frontend/dist/index.html" ]; then
+FE_DIST_HTML="$REPO_DIR/clawjournal/web/frontend/dist/index.html"
+FE_SRC_DIR="$REPO_DIR/clawjournal/web/frontend/src"
+if [ ! -f "$FE_DIST_HTML" ]; then
   cat <<EOF
 
 [i] Browser workbench not built. To enable 'clawjournal serve':
+    ./scripts/install.sh --with-frontend       (requires Node.js)
+EOF
+elif [ -d "$FE_SRC_DIR" ] && [ -n "$(find "$FE_SRC_DIR" -type f -newer "$FE_DIST_HTML" 2>/dev/null | head -n 1)" ]; then
+  # Source is newer than the built assets — a sync without a rebuild leaves
+  # 'clawjournal serve' showing a stale workbench (e.g. an empty Share queue).
+  cat <<EOF
+
+[i] The browser workbench build looks out of date (its source is newer than
+    the built assets). 'clawjournal serve' may show an old UI until you rebuild:
     ./scripts/install.sh --with-frontend       (requires Node.js)
 EOF
 fi


### PR DESCRIPTION
## Summary

Follow-up to #52. That PR fixed the share/submission flow and made the README clear; this one closes the loop in the **product itself** so a participant who hits a dead end is told *why* and *what to do* — without needing the README.

Three small, at-the-source guidance fixes:

- **`QueueStep`** — when you have approved sessions but none are eligible to share, the empty state no longer says "Approve traces in Sessions" (which you already did). It now explains the real cause using `readyStats.total_approved`: the sessions are on hold, under an active embargo, in an excluded project, or already shared — and points at releasing a hold / checking `clawjournal config --exclude`.
- **`DoneStep`** — when the flow routes to **Done** instead of **Submit** because hosted submissions are *closed*, it now shows an explicit banner (preferring the daemon's `message`) so the missing Submit button reads as "submissions aren't open right now," not "my workbench is broken."
- **`install.sh` / `install.ps1`** — warn when the built workbench is older than its source. This is the exact stale-build state behind the "Your queue is empty" report: a background sync updates the source, but `serve` keeps showing the old UI until a `--with-frontend` rebuild.

## Why

The reported STEM Data Program failures (#52) were mostly stale-build symptoms with no in-product signal. The README now explains them, but the UI and installer stayed silent. These changes surface the cause where the user actually is.

## Validation

- `npm run build` (`tsc -b && vite build`) passes — no type errors.
- `eslint` clean on both changed components.
- `bash -n scripts/install.sh` passes; stale-detection `find` verified both ways (empty right after a build, non-empty when a source file is newer than `dist/index.html`).
- No Python changed.

## Notes

- The browser `dist/` is gitignored and built at packaging time, so there are no built assets in this diff.
- Pure additive guidance — no behavior change to packaging, redaction, or the hold-state gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)