### PR TITLE
release: 0.1.16

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "clawjournal",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "ClawJournal — review, curate, and share your coding agent conversation traces. 100% local. Scans sessions from Claude Code, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline. Auto-redacts secrets and PII. Browser workbench for triage and export.",
   "owner": {
     "name": "rayward-external",
@@ -11,7 +11,7 @@
     {
       "name": "clawjournal",
       "description": "ClawJournal agent skills: /clawjournal-setup (install + scan + launch workbench), /clawjournal (review, triage, and share traces), and /clawjournal-score (AI-assisted quality scoring).",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "author": {
         "name": "rayward-external",
         "url": "https://github.com/rayward-external"

--- a/clawjournal/__init__.py
+++ b/clawjournal/__init__.py
@@ -1,3 +1,3 @@
 """ClawJournal — Export and manage coding agent conversation data."""
 
-__version__ = "0.1.15"
+__version__ = "0.1.16"

--- a/plugins/clawjournal/.claude-plugin/plugin.json
+++ b/plugins/clawjournal/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clawjournal",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Review, curate, and share coding agent conversation traces. Bundles skills for setup, triage, and AI-assisted scoring.",
   "author": {
     "name": "kaiaiagent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawjournal"
-version = "0.1.15"
+version = "0.1.16"
 description = "Review, score, and curate your coding agent conversation traces locally"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Version bump only: `0.1.15 → 0.1.16` in `clawjournal/__init__.py` and `pyproject.toml`, to publish the current `main` to PyPI. The PyPI `0.1.15` artifact predates PRs #48–#53, so the source needs a new version number to ship.

## What 0.1.16 ships (since the 0.1.15 PyPI build)

- **#52** — share upload flow fixes: `manifest.json` metadata redaction leak, `clawjournal status` dispatch (`UnboundLocalError`), Share queue fallback, and a rewritten, decision-first Package & Share README.
- **#53** — in-product share-flow guidance: explain *why* the Share queue is empty, surface a closed-submissions banner on the Done step, and warn in `install.sh`/`install.ps1` when the built workbench is stale.
- **#48–#51** — hosted submit flow, opt-in AI PII review, automatic failure-corpus scoring, hardened share/submission workflow.

## Validation

- Smoke CI rebuilds the frontend and verifies the wheel contains `web/frontend/dist/index.html`.
- No code change beyond the two version strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)