### PR TITLE
ci: auto-publish to PyPI on tag (Trusted Publishing)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,97 @@
+name: Publish to PyPI
+
+# Cuts a PyPI release automatically when a vX.Y.Z tag is pushed.
+#
+# ONE-TIME SETUP (required before the first tag — uses Trusted Publishing,
+# so there is no API token to store):
+#   1. On https://pypi.org/manage/project/clawjournal/settings/publishing/
+#      add a GitHub trusted publisher with:
+#        Owner:        rayward-external
+#        Repository:   clawjournal
+#        Workflow:     publish.yml
+#        Environment:  pypi
+#   2. (Optional) In repo Settings → Environments, create an environment named
+#      `pypi` and add reviewers/branch rules if you want a manual approval gate.
+#
+# RELEASE FLOW after setup: bump the version (see test_repo_layout for the
+# files that must agree), merge, then `git tag vX.Y.Z && git push origin vX.Y.Z`.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - name: Install build tooling
+        run: python -m pip install --upgrade pip "setuptools>=77.0" wheel build twine
+
+      # Refuse to publish a tag whose version disagrees with the source, so a
+      # stray tag can never ship a mismatched (or already-released) version.
+      - name: Verify tag matches package version
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(python -c 'import tomllib, pathlib; print(tomllib.loads(pathlib.Path("pyproject.toml").read_text())["project"]["version"])')"
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Tag ${GITHUB_REF_NAME} ($tag) does not match pyproject version $pkg. Bump the version or fix the tag."
+            exit 1
+          fi
+          echo "Tag and package version agree: $pkg"
+
+      # The wheel ships the pre-built workbench assets, so build the frontend
+      # before packaging (mirrors the smoke job in test.yml).
+      - name: Build browser workbench
+        working-directory: clawjournal/web/frontend
+        run: |
+          npm ci
+          npm run build
+      - run: test -f clawjournal/web/frontend/dist/index.html
+
+      - name: Build sdist and wheel
+        run: python -m build
+
+      - name: Verify wheel ships the frontend assets
+        run: |
+          wheel_file=$(ls dist/clawjournal-*.whl)
+          python -m zipfile -l "$wheel_file" | grep -q 'web/frontend/dist/index.html' \
+            || { echo "::error::wheel missing frontend assets: $wheel_file"; exit 1; }
+
+      - name: Check artifact metadata
+        run: python -m twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+  publish:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/clawjournal
+    permissions:
+      id-token: write  # OIDC token for PyPI Trusted Publishing (no stored secret)
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Re-running a tag that is already on PyPI is a no-op instead of a
+          # hard failure; a genuine new release still requires a version bump.
+          skip-existing: true

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,55 @@
+# Releasing ClawJournal
+
+Releases publish to [PyPI](https://pypi.org/project/clawjournal/) automatically
+via `.github/workflows/publish.yml` when a `vX.Y.Z` tag is pushed. Publishing
+uses [PyPI Trusted Publishing](https://docs.pypi.org/trusted-publishers/) (OIDC),
+so there is **no API token to store or rotate**.
+
+## One-time setup (do this once, before the first tagged release)
+
+1. On the PyPI project's
+   [publishing settings](https://pypi.org/manage/project/clawjournal/settings/publishing/),
+   add a **GitHub** trusted publisher:
+   - **Owner:** `rayward-external`
+   - **Repository:** `clawjournal`
+   - **Workflow name:** `publish.yml`
+   - **Environment:** `pypi`
+2. *(Optional)* In **repo Settings → Environments**, create an environment named
+   `pypi`. Add required reviewers there if you want a manual approval gate before
+   each publish.
+
+Until step 1 is done, the `publish` job will fail with an OIDC/authentication
+error — that is expected, not a workflow bug.
+
+## Cutting a release
+
+1. **Bump the version** in lockstep across all four files
+   (`tests/test_repo_layout.py` enforces that they agree):
+   - `clawjournal/__init__.py` — `__version__`
+   - `pyproject.toml` — `[project].version`
+   - `.claude-plugin/marketplace.json` — top-level `version` **and** `plugins[0].version`
+   - `plugins/clawjournal/.claude-plugin/plugin.json` — `version`
+2. Open a `release: X.Y.Z` PR, let CI pass, and merge.
+3. Tag the merged commit and push the tag:
+   ```bash
+   git checkout main && git pull
+   git tag -a vX.Y.Z -m "ClawJournal X.Y.Z"
+   git push origin vX.Y.Z
+   ```
+4. The workflow builds the browser workbench, builds the sdist + wheel, verifies
+   the wheel ships `web/frontend/dist/index.html`, checks the tag matches the
+   package version, and publishes to PyPI.
+5. *(Optional)* Create a GitHub Release for the tag with notes:
+   ```bash
+   gh release create vX.Y.Z --title "vX.Y.Z — <summary>" --notes "..."
+   ```
+
+## Notes
+
+- The tag's commit must contain `publish.yml`, so always tag from `main` after
+  the version-bump PR is merged.
+- `skip-existing: true` means re-running a tag already on PyPI is a no-op; a
+  genuine new release still requires a version bump (a mismatched tag is rejected
+  by the version-check step).
+- No need to build or upload locally anymore — the manual `python -m build` +
+  `twine upload` flow is fully replaced by the tag trigger.


### PR DESCRIPTION
## Summary

Replaces the manual `python -m build` + `twine upload` release with an automated workflow. Pushing a `vX.Y.Z` tag now builds and publishes to PyPI by itself — fixing the root cause behind "PyPI lags GitHub" (the version simply never got bumped + published after merges).

`.github/workflows/publish.yml`:
- **Trigger:** push of a `v*` tag.
- **`build` job:** verifies the tag matches `pyproject` version → builds the browser workbench (`npm ci && npm run build`, mirroring the smoke job) → `python -m build` → verifies the wheel ships `web/frontend/dist/index.html` → `twine check` → uploads artifacts.
- **`publish` job:** least-privilege (`id-token: write` only), runs in the `pypi` environment, publishes via `pypa/gh-action-pypi-publish` using **OIDC Trusted Publishing — no stored API token**. `skip-existing: true` so re-running a released tag is a no-op.

`RELEASING.md` documents the one-time setup and the release flow.

## ⚠️ One-time setup required before this works

Trusted Publishing needs a publisher registered on PyPI (I can't do this — it's on pypi.org and needs the maintainer's login):

On https://pypi.org/manage/project/clawjournal/settings/publishing/ add a GitHub publisher:
- **Owner:** `rayward-external`  ·  **Repository:** `clawjournal`  ·  **Workflow:** `publish.yml`  ·  **Environment:** `pypi`

Until that's added, the `publish` job will fail with an OIDC auth error (expected). The `build` job works regardless. *(Alternative if you'd rather not use OIDC: swap the publish step for a `PYPI_API_TOKEN` repo secret — say the word and I'll adjust.)*

## Validation

- YAML parses; jobs/permissions/environment verified.
- Tag-vs-version guard tested locally: `v0.1.16` → match, `v0.1.17` → fail (correct).
- Frontend-build + wheel-asset verification mirror the existing green smoke job.
- This `v0.1.16` release was published manually; the next tag (`v0.1.17`) will exercise this workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)