### PR TITLE
Re-score sessions graded mid-flight by the background scanner

### DIFF
--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -93,6 +93,10 @@ logger = logging.getLogger(__name__)
 DEFAULT_PORT = 8384
 SCAN_INTERVAL = 60  # seconds
 AUTO_SCORE_BATCH_SIZE = 20
+# Don't auto-score a session until it has been quiet this long. Prevents
+# grading a still-running trace mid-flight (which then never gets corrected),
+# and keeps the re-score-on-growth path from churning on an active session.
+SCORE_SETTLE_SECONDS = 180
 SCORING_DISPLAY_NAMES = {
     "claude": "Claude Code",
     "codex": "Codex",
@@ -361,11 +365,18 @@ class Scanner:
                 # age cap (`since` is None for the background path). The
                 # `limit` bounds cost; callers that want a rolling window
                 # (CLI `--window`) pass `since` explicitly.
+                #
+                # `include_stale_scored` also re-selects sessions that were
+                # graded mid-flight and then grew (end_time advanced past
+                # ai_scored_at); `settle_seconds` defers sessions that are still
+                # active so we don't grade them prematurely in the first place.
                 sessions = query_unscored_sessions(
                     conn,
                     limit=limit,
                     source=FAILURE_VALUE_SOURCE_SCOPE,
                     since=since,
+                    include_stale_scored=True,
+                    settle_seconds=SCORE_SETTLE_SECONDS,
                 )
                 if not sessions:
                     return 0

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -2446,25 +2446,84 @@ def effective_hold_state(
     return "released" if parsed <= current else state
 
 
+# Seconds ``end_time`` must advance past ``ai_scored_at`` before an
+# already-scored session counts as "grew after it was scored" and is
+# re-selected. Small margin avoids re-scoring on a near-simultaneous
+# score/finish.
+RESCORE_GROWTH_MARGIN_SECONDS = 60
+
+_UNSCORED_RETURN_KEYS = (
+    "session_id", "display_title", "task_type", "outcome_badge", "project", "source",
+)
+
+
+def _parse_score_ts(ts: Any) -> datetime | None:
+    """Parse an ISO-8601 timestamp (accepting a trailing ``Z``) to aware UTC."""
+    if not isinstance(ts, str) or not ts.strip():
+        return None
+    try:
+        parsed = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed
+
+
 def query_unscored_sessions(
     conn: sqlite3.Connection,
     *,
     limit: int = 50,
     source: str | list[str] | tuple[str, ...] | None = None,
     since: str | None = None,
+    include_stale_scored: bool = False,
+    settle_seconds: int = 0,
+    growth_margin_seconds: int = RESCORE_GROWTH_MARGIN_SECONDS,
+    now: datetime | None = None,
 ) -> list[dict[str, Any]]:
-    """Return sessions missing either legacy quality or failure-value score.
+    """Return sessions that need (re)scoring.
 
-    Returns a list of dicts with session_id, display_title, task_type,
+    By default, returns sessions missing either legacy quality or failure-value
+    score — a list of dicts with session_id, display_title, task_type,
     outcome_badge, project, and source. Segmented parent sessions
-    (``review_status='segmented'``) are skipped — their scorable content
-    lives in the per-segment child rows, not the parent umbrella.
+    (``review_status='segmented'``) are skipped — their scorable content lives
+    in the per-segment child rows, not the parent umbrella.
+
+    Two opt-in behaviors support the background scanner, which would otherwise
+    grade a session once (often mid-flight) and never revisit it:
+
+    - ``include_stale_scored``: also return *already-scored* sessions whose
+      ``end_time`` advanced more than ``growth_margin_seconds`` past
+      ``ai_scored_at`` — i.e. they kept going after they were graded. Re-scoring
+      reads the current blob, so the stale early grade is corrected; once a
+      session is scored after it finishes, ``ai_scored_at >= end_time`` and it
+      drops out of this selection.
+    - ``settle_seconds``: skip sessions whose last activity (``end_time``) is
+      within ``settle_seconds`` of ``now`` — they are likely still in-flight, so
+      scoring now would just produce another premature grade (and, on the
+      re-score path, churn every scan cycle).
+
+    With both opt-ins off (the default) the behavior and return shape are
+    unchanged from the original contract.
     """
+    extended = include_stale_scored or settle_seconds > 0
     params: list[Any] = []
+    score_missing = "(ai_quality_score IS NULL OR ai_failure_value_score IS NULL)"
+    if include_stale_scored:
+        # Coarse pre-filter; the precise margin check happens in Python because
+        # ``end_time`` (``…Z``) and ``ai_scored_at`` (``…+00:00``) use different
+        # UTC spellings. Lexicographic ``>`` is safe as a *pre*-filter since a
+        # truly grown session differs in the minute/second portion.
+        where = (
+            f"({score_missing} OR (ai_scored_at IS NOT NULL "
+            "AND end_time IS NOT NULL AND end_time > ai_scored_at))"
+        )
+    else:
+        where = score_missing
     sql = (
-        "SELECT session_id, display_title, task_type, outcome_badge, project, source "
-        "FROM sessions WHERE (ai_quality_score IS NULL OR ai_failure_value_score IS NULL) "
-        "AND review_status != 'segmented'"
+        "SELECT session_id, display_title, task_type, outcome_badge, project, source, "
+        "end_time, ai_scored_at, ai_quality_score, ai_failure_value_score "
+        f"FROM sessions WHERE {where} AND review_status != 'segmented'"
     )
     if since is not None:
         sql += " AND start_time >= ?"
@@ -2479,10 +2538,38 @@ def query_unscored_sessions(
             sql += " AND source = ?"
             params.append(source)
     sql += " ORDER BY start_time DESC LIMIT ?"
-    params.append(limit)
+    # Over-fetch when we will refine in Python so we can still return `limit`
+    # rows after dropping non-stale / unsettled candidates.
+    params.append(max(limit * 5, 200) if extended else limit)
 
     rows = conn.execute(sql, params).fetchall()
-    return [dict(row) for row in rows]
+    if not extended:
+        return [{k: row[k] for k in _UNSCORED_RETURN_KEYS} for row in rows]
+
+    clock = now or datetime.now(timezone.utc)
+    out: list[dict[str, Any]] = []
+    for row in rows:
+        never_scored = row["ai_quality_score"] is None or row["ai_failure_value_score"] is None
+        end_dt = _parse_score_ts(row["end_time"])
+        scored_dt = _parse_score_ts(row["ai_scored_at"])
+        grew = (
+            include_stale_scored
+            and scored_dt is not None
+            and end_dt is not None
+            and (end_dt - scored_dt).total_seconds() > growth_margin_seconds
+        )
+        if not (never_scored or grew):
+            continue
+        if (
+            settle_seconds
+            and end_dt is not None
+            and (clock - end_dt).total_seconds() < settle_seconds
+        ):
+            continue
+        out.append({k: row[k] for k in _UNSCORED_RETURN_KEYS})
+        if len(out) >= limit:
+            break
+    return out
 
 
 def query_sessions_for_rescore(

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -551,8 +551,10 @@ class TestScanner:
             "project": "test-project",
             "source": "claude",
             "model": "claude-sonnet-4",
-            "start_time": now.isoformat(),
-            "end_time": (now + timedelta(minutes=10)).isoformat(),
+            # Settled session (last activity well before the settle window),
+            # so the auto-scorer grades it rather than deferring it as in-flight.
+            "start_time": (now - timedelta(minutes=20)).isoformat(),
+            "end_time": (now - timedelta(minutes=10)).isoformat(),
             "messages": [
                 {"role": "user", "content": "Fix it", "tool_uses": []},
                 {"role": "assistant", "content": "Done", "tool_uses": []},

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -460,6 +460,79 @@ class TestQueryUnscoredSessions:
         assert "plain-unscored" in ids
         assert "parent-segmented" not in ids
 
+    def test_rescore_on_growth_reselects_stale_scored(self, index_conn):
+        """Regression for the S16 bug: a session scored mid-flight (its
+        ``end_time`` advanced past ``ai_scored_at``) must be re-selected when
+        ``include_stale_scored=True`` so the stale early grade is corrected —
+        but stay hidden by default."""
+        from datetime import datetime, timezone
+        upsert_sessions(index_conn, [
+            _make_session(
+                "grew",
+                start_time="2026-05-24T00:00:00+00:00",
+                end_time="2026-05-24T00:18:00+00:00",
+            ),
+        ])
+        # Graded 16 minutes before the session's final activity.
+        update_session(
+            index_conn, "grew",
+            ai_quality_score=2,
+            ai_failure_value_score=2,
+            ai_scored_at="2026-05-24T00:02:00+00:00",
+        )
+        now = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        # Default contract: already-scored, so not returned.
+        assert query_unscored_sessions(index_conn, source=["claude"], now=now) == []
+        # Opt-in: returned for re-scoring.
+        ids = [r["session_id"] for r in query_unscored_sessions(
+            index_conn, source=["claude"], include_stale_scored=True, now=now)]
+        assert ids == ["grew"]
+
+    def test_rescore_skips_session_scored_after_it_finished(self, index_conn):
+        """A session graded *after* its last activity is not stale and must not
+        be re-selected (no churn on correctly-scored rows)."""
+        from datetime import datetime, timezone
+        upsert_sessions(index_conn, [
+            _make_session(
+                "done",
+                start_time="2026-05-24T00:00:00+00:00",
+                end_time="2026-05-24T00:18:00+00:00",
+            ),
+        ])
+        update_session(
+            index_conn, "done",
+            ai_quality_score=5, ai_failure_value_score=4,
+            ai_scored_at="2026-05-24T00:20:00+00:00",  # after end_time
+        )
+        now = datetime(2026, 5, 25, tzinfo=timezone.utc)
+        assert query_unscored_sessions(
+            index_conn, source=["claude"], include_stale_scored=True, now=now) == []
+
+    def test_settle_seconds_defers_in_flight_session(self, index_conn):
+        """An unscored session whose last activity is within the settle window
+        is deferred (likely still running) so it isn't graded prematurely."""
+        from datetime import datetime, timezone, timedelta
+        now = datetime(2026, 5, 25, 12, 0, 0, tzinfo=timezone.utc)
+        upsert_sessions(index_conn, [
+            _make_session(
+                "active",
+                start_time=(now - timedelta(minutes=2)).isoformat(),
+                end_time=(now - timedelta(seconds=30)).isoformat(),  # 30s ago
+            ),
+            _make_session(
+                "settled",
+                start_time=(now - timedelta(minutes=20)).isoformat(),
+                end_time=(now - timedelta(minutes=10)).isoformat(),  # 10m ago
+            ),
+        ])
+        ids = [r["session_id"] for r in query_unscored_sessions(
+            index_conn, source=["claude"], settle_seconds=180, now=now)]
+        assert ids == ["settled"]
+        # With no settle window, both are immediately scorable.
+        ids_all = {r["session_id"] for r in query_unscored_sessions(
+            index_conn, source=["claude"], now=now)}
+        assert ids_all == {"active", "settled"}
+
 
 class TestQuerySessionsForRescore:
     def test_returns_sessions_regardless_of_existing_score(self, index_conn):


### PR DESCRIPTION
## Problem

The background scanner can score a session **~2 minutes after it starts** — the daemon indexes and scores on its first scan pass, when the trace contains only its opening orientation steps. `query_unscored_sessions` only ever returns rows with a `NULL` score, so once that premature grade lands the session is **never re-scored**, even after it grows to its full length and its outcome changes.

Observed in a real index: **6 of 48 scored sessions (12.5%)** were graded before they finished (`end_time` up to **355 min** past `ai_scored_at`). One PR-review session is stored as `quality=2, outcome=partial, recovery=["unrecovered"]`, reason *"eleven steps of context gathering … no substantive review work"* — but it went on to fix a bug across 4 surfaces, pass 1770 tests, and merge the PR (`0f4c033`). The stored grade is the inverse of reality.

## Fix

- **Re-score on growth** — `query_unscored_sessions(include_stale_scored=True)` also returns already-scored sessions whose `end_time` advanced past `ai_scored_at` by a margin. Re-scoring reads the current blob, so the judge now sees the finished session; after a post-completion score `ai_scored_at >= end_time` and the row stops being selected (converges).
- **Settle guard** — `settle_seconds` (wired from the daemon as `SCORE_SETTLE_SECONDS = 180`) skips sessions whose last activity is within the window, so a still-running trace isn't graded prematurely and the re-score path doesn't churn each scan cycle.

Both parameters **default to inert** — the existing contract and the CLI `score` callers are unchanged; only the daemon's auto-score path opts in.

## Testing

- New unit tests: stale-scored row re-selected with the opt-in (and hidden without); a session scored after it finished is not re-selected; `settle_seconds` defers an in-flight session.
- Full suite: **1898 passed**.
- Read-only check against a real index: the new selection re-picks exactly the 6 stale rows and leaves correctly-scored sessions untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
