### PR TITLE
fix(redaction): stop TruffleHog gate blocking on generic-Azure false positives

### DIFF
--- a/clawjournal/redaction/trufflehog.py
+++ b/clawjournal/redaction/trufflehog.py
@@ -73,6 +73,21 @@ def _scrubbed_subprocess_env() -> dict[str, str]:
 #   returns ``unverified`` for those, so they are never real leaks.
 EXCLUDED_DETECTORS: tuple[str, ...] = ("refiner",)
 
+# Detectors whose UNVERIFIED findings are dropped as structural false
+# positives, while their verified/unknown findings still block. This is
+# narrower than EXCLUDED_DETECTORS (which disables a detector entirely,
+# reserved for detectors that never catch real leaks): the detector stays
+# active, so a real, live secret it confirms still blocks the share.
+#
+# - ``Azure`` is TruffleHog's legacy generic Azure detector (type 3). Its
+#   broad pattern, fed through the PLAIN and BASE64 decoders, matches ordinary
+#   agent-session terminal content — ``127.0.0.1:5432`` connection lines, file
+#   paths like ``scripts/foo.sh``, ANSI color codes (``\x1b[0m``) — and
+#   Azure-API verification returns unverified for all of them. The specific
+#   Azure detectors (AzureStorage, AzureSAS, AzureBatch, …) stay active and
+#   still catch real Azure keys by type.
+NOISY_UNVERIFIED_DETECTORS: frozenset[str] = frozenset({"Azure"})
+
 INSTALL_HINT = (
     "TruffleHog is required to export shares but was not found on PATH.\n"
     "Install it with:\n"
@@ -416,6 +431,14 @@ def scan_file(path: Path) -> TruffleHogReport:
             continue
         finding = _parse_finding(parsed)
         if finding is None:
+            continue
+        # Drop structural false positives from broad detectors before they can
+        # block the gate (see NOISY_UNVERIFIED_DETECTORS). Only unverified
+        # findings are dropped; verified/unknown ones still block.
+        if (
+            finding.status == "unverified"
+            and finding.detector in NOISY_UNVERIFIED_DETECTORS
+        ):
             continue
         key = (finding.detector, finding.status, finding.line, finding.raw_sha256)
         if key in seen_keys:

--- a/tests/redaction/test_trufflehog.py
+++ b/tests/redaction/test_trufflehog.py
@@ -208,6 +208,90 @@ class TestScanFile:
         assert other["Raw"] not in payload
         assert "GitHub" in summary["top_detectors"]
 
+    def test_unverified_generic_azure_false_positives_are_suppressed(self, tmp_path, monkeypatch):
+        """The legacy generic Azure detector fires on ordinary agent-session
+        terminal content (localhost connection strings, file paths, ANSI color
+        codes) and Azure-API verification returns unverified for all of them.
+        Those must not block the share."""
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+
+        false_positives = [
+            {
+                "DetectorName": "Azure",
+                "Verified": False,
+                "Raw": "127.0.0.1:51678->127.0.0.1:5432:",
+                "SourceMetadata": {"Data": {"Filesystem": {"line": 3}}},
+            },
+            {
+                "DetectorName": "Azure",
+                "Verified": False,
+                "Raw": "scripts/seed-routing-rules.sh\n??",
+                "SourceMetadata": {"Data": {"Filesystem": {"line": 3}}},
+            },
+            {
+                "DetectorName": "Azure",
+                "Verified": False,
+                "Raw": "[90mnull[0m[0m\n",
+                "SourceMetadata": {"Data": {"Filesystem": {"line": 5}}},
+            },
+        ]
+        stdout = "\n".join(json.dumps(x) for x in false_positives) + "\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 183, stdout=stdout, stderr=""),
+        )
+        report = trufflehog.scan_file(target)
+        assert report.findings == []
+        assert report.unverified == 0
+        assert report.blocking is False
+
+    def test_verified_generic_azure_still_blocks(self, tmp_path, monkeypatch):
+        """Suppression is surgical: a *verified* generic-Azure finding is a
+        real, live credential and must still block."""
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+        finding = {
+            "DetectorName": "Azure",
+            "Verified": True,
+            "Raw": "a-real-confirmed-azure-secret-0001",
+            "SourceMetadata": {"Data": {"Filesystem": {"line": 4}}},
+        }
+        stdout = json.dumps(finding) + "\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 183, stdout=stdout, stderr=""),
+        )
+        report = trufflehog.scan_file(target)
+        assert report.verified == 1
+        assert report.blocking is True
+
+    def test_specific_azure_detector_unverified_still_blocks(self, tmp_path, monkeypatch):
+        """Only the generic ``Azure`` detector is treated as noisy. Specific
+        Azure detectors (AzureStorage, …) still block even when unverified."""
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+        finding = {
+            "DetectorName": "AzureStorage",
+            "Verified": False,
+            "Raw": "DefaultEndpointsProtocol=https;AccountName=x;AccountKey=y==",
+            "SourceMetadata": {"Data": {"Filesystem": {"line": 6}}},
+        }
+        stdout = json.dumps(finding) + "\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 183, stdout=stdout, stderr=""),
+        )
+        report = trufflehog.scan_file(target)
+        assert report.unverified == 1
+        assert report.blocking is True
+
     def test_unexpected_exit_code_blocks_with_error_report(self, tmp_path, monkeypatch):
         self._enable_real_scan(monkeypatch)
         target = tmp_path / "sessions.jsonl"


### PR DESCRIPTION
## Summary

The mandatory TruffleHog gate blocks **every** share export that contains terminal output, because TruffleHog's **legacy generic `Azure` detector (type 3)** fires on ordinary agent-session content and always comes back `unverified`. A user hit:

```
TruffleHog blocked the share: 3 finding(s) (verified=0, unverified=3, unknown=0).
Examples: L3 unverified Azure 127.***432:, L3 unverified Azure scri***\n??, L5 unverified Azure \u00***0m\n
```

Reproduced against the real blocked bundle — the three "Azure" matches were:
- `127.0.0.1:51678->127.0.0.1:5432:` (PLAIN) — a localhost Postgres connection line
- `scripts/seed-routing-rules.sh\n??` (PLAIN) — a file path
- `[90mnull[0m[0m\n` (BASE64) — ANSI color codes

All three are structural noise, never real secrets — and since the gate blocks on *any* finding, traces with terminal output (i.e. almost all of them) can't be shared.

## Fix

Suppress **only the `unverified`** findings from the generic `Azure` detector in `scan_file`'s parse loop (new `NOISY_UNVERIFIED_DETECTORS`), keeping its `verified`/`unknown` findings and **every specific Azure detector** (`AzureStorage`, `AzureSAS`, …) fully active.

This is deliberately narrower than the existing `EXCLUDED_DETECTORS` (which disables a detector entirely, and per its own docstring is reserved for detectors that "never catch real leaks", e.g. `refiner`). Azure *can* catch real secrets and `secrets.py` has no Azure fallback, so a blanket exclusion would let **verified** Azure secrets through. Verified `AzureStorage` connection strings are still caught alongside this change.

## Tests

- `test_unverified_generic_azure_false_positives_are_suppressed` (RED→GREEN, reproduces the exact `127.***432:` finding)
- `test_verified_generic_azure_still_blocks` — suppression is surgical
- `test_specific_azure_detector_unverified_still_blocks` — only the generic detector is treated as noisy

Full suite green (1826). The user's real blocked bundle now scans `blocking=False, findings=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
