### PR TITLE
fix(share): unblock clean shares (TruffleHog) + download-filename, submit-button & routing fixes

### DIFF
--- a/clawjournal/findings.py
+++ b/clawjournal/findings.py
@@ -523,23 +523,32 @@ def _resolve_field_text(blob: dict[str, Any], finding: Finding) -> str | None:
 
     # tool_uses[<idx>].<input|output> or tool_uses[<idx>].<input|output>.<key>
     match = re.match(r"tool_uses\[(\d+)\]\.(\w+)(?:\.(.+))?$", field)
-    if not match:
-        return None
-    tool_idx = int(match.group(1))
-    branch = match.group(2)
-    nested_key = match.group(3)
-    tool_uses = msg.get("tool_uses")
-    if not isinstance(tool_uses, list) or tool_idx >= len(tool_uses):
-        return None
-    tool = tool_uses[tool_idx]
-    if not isinstance(tool, dict):
-        return None
-    value = tool.get(branch)
-    if nested_key:
-        if isinstance(value, dict) and isinstance(value.get(nested_key), str):
-            return value[nested_key]
-        return None
-    return value if isinstance(value, str) else None
+    if match:
+        tool_idx = int(match.group(1))
+        branch = match.group(2)
+        nested_key = match.group(3)
+        tool_uses = msg.get("tool_uses")
+        if not isinstance(tool_uses, list) or tool_idx >= len(tool_uses):
+            return None
+        tool = tool_uses[tool_idx]
+        if not isinstance(tool, dict):
+            return None
+        value = tool.get(branch)
+        if nested_key:
+            if isinstance(value, dict) and isinstance(value.get(nested_key), str):
+                return value[nested_key]
+            return None
+        return value if isinstance(value, str) else None
+
+    # Widened message model (author / invocations[...] / snippets[...] /
+    # extra.*). The labels come from iter_widened_text_locations; resolve by
+    # re-walking and matching the label rather than re-parsing the path.
+    from .parsing.widened import iter_widened_text_locations  # noqa: PLC0415 — lazy
+
+    for text, label in iter_widened_text_locations(msg):
+        if label == field:
+            return text
+    return None
 
 
 def derive_preview(

--- a/clawjournal/redaction/normalize.py
+++ b/clawjournal/redaction/normalize.py
@@ -1,0 +1,49 @@
+"""Text normalization for the share/export path.
+
+Terminal output captured in agent sessions carries ANSI/VT escape sequences
+(colors, cursor moves, OSC window-title, DCS/PM/APC payloads) and stray
+control bytes. These are rendering artifacts, not content: they bloat shared
+traces and trip TruffleHog's broad detectors as false positives — e.g. the
+generic Azure detector matched a base64-decoded ``\x1b[0m`` run and helped
+block an otherwise-clean share. Stripping them on the export path keeps shared
+bundles clean.
+"""
+
+import re
+
+# ANSI / VT escape sequences (ECMA-48), covering both the 7-bit (ESC-prefixed)
+# and 8-bit (C1) introducer forms. Sequences with payloads (CSI/OSC/DCS/…) are
+# matched whole; the payload character classes are negated (bounded) to avoid
+# catastrophic backtracking. The OSC/DCS terminators are REQUIRED: an
+# unterminated sequence (e.g. a truncated capture) must not greedily consume
+# the rest of the string and drop legitimate trailing text — the stray ESC
+# introducer is left to the control scrub instead. Order matters: payload-
+# bearing forms are tried before the single-byte Fe escape.
+_ANSI_ESCAPE_RE = re.compile(
+    r"(?:"
+    r"(?:\x1b\[|\x9b)[0-?]*[ -/]*[@-~]"                      # CSI (7- and 8-bit)
+    r"|(?:\x1b\]|\x9d)[^\x07\x1b\x9c]*(?:\x07|\x1b\\|\x9c)"  # OSC ... BEL/ST (required)
+    r"|(?:\x1b[PX^_]|[\x90\x98\x9e\x9f])[^\x1b\x9c]*(?:\x1b\\|\x9c)"  # DCS/SOS/PM/APC ... ST (required)
+    r"|\x1b[@-Z\\^_]"                                        # other single-byte Fe escapes
+    r")"
+)
+
+# Stray control characters left over after escape stripping: C0 (excluding tab
+# 0x09, newline 0x0a, carriage return 0x0d), DEL (0x7f), and C1 (0x80-0x9f).
+# Operating on a decoded ``str`` (code points, not bytes), so stripping C1
+# does not corrupt multibyte UTF-8 — those characters are higher code points.
+_CONTROL_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f-\x9f]")
+
+
+def strip_terminal_control_sequences(text: str) -> str:
+    """Remove ANSI/VT escape sequences and stray control characters from text.
+
+    Tab, newline, and carriage return are preserved, as is all printable and
+    multibyte-UTF-8 content. Non-string input is returned unchanged so callers
+    can apply this defensively to mixed values.
+    """
+    if not isinstance(text, str) or not text or not _CONTROL_RE.search(text):
+        return text
+    text = _ANSI_ESCAPE_RE.sub("", text)
+    text = _CONTROL_RE.sub("", text)
+    return text

--- a/clawjournal/redaction/trufflehog.py
+++ b/clawjournal/redaction/trufflehog.py
@@ -73,30 +73,6 @@ def _scrubbed_subprocess_env() -> dict[str, str]:
 #   returns ``unverified`` for those, so they are never real leaks.
 EXCLUDED_DETECTORS: tuple[str, ...] = ("refiner",)
 
-# Detectors whose UNVERIFIED findings are dropped as structural false
-# positives, while their verified/unknown findings still block. This is
-# narrower than EXCLUDED_DETECTORS (which disables a detector entirely,
-# reserved for detectors that never catch real leaks): the detector stays
-# active, so a real, live secret it confirms still blocks the share.
-#
-# - ``Azure`` is TruffleHog's legacy generic Azure detector (type 3). Its
-#   broad pattern, fed through the PLAIN and BASE64 decoders, matches ordinary
-#   agent-session terminal content — ``127.0.0.1:5432`` connection lines, file
-#   paths like ``scripts/foo.sh``, ANSI color codes (``\x1b[0m``) — and
-#   Azure-API verification returns unverified for all of them. The specific
-#   Azure detectors (AzureStorage, AzureSAS, AzureBatch, …) stay active and
-#   still catch real Azure keys by type.
-NOISY_UNVERIFIED_DETECTORS: frozenset[str] = frozenset({"Azure"})
-
-
-def _is_suppressed_noise(detector: str, status: str) -> bool:
-    """True for a structural false positive to drop: an UNVERIFIED finding
-    from a broad detector in NOISY_UNVERIFIED_DETECTORS. Applied uniformly by
-    the gate (``scan_file``) and the redaction-engine path
-    (``_scan_text_for_raw_matches``) so they never disagree about what counts
-    as a secret — verified/unknown findings from those detectors still count."""
-    return status == "unverified" and detector in NOISY_UNVERIFIED_DETECTORS
-
 INSTALL_HINT = (
     "TruffleHog is required to export shares but was not found on PATH.\n"
     "Install it with:\n"
@@ -441,10 +417,6 @@ def scan_file(path: Path) -> TruffleHogReport:
         finding = _parse_finding(parsed)
         if finding is None:
             continue
-        # Drop structural false positives from broad detectors (see
-        # NOISY_UNVERIFIED_DETECTORS) before they can block the gate.
-        if _is_suppressed_noise(finding.detector, finding.status):
-            continue
         key = (finding.detector, finding.status, finding.line, finding.raw_sha256)
         if key in seen_keys:
             continue
@@ -590,10 +562,6 @@ def _scan_text_for_raw_matches(text: str) -> list[dict]:
         if not isinstance(detector, str) or not isinstance(raw, str) or not raw:
             continue
         status = _classify_trufflehog_status(parsed)
-        # Same suppression as the gate: a broad detector's unverified false
-        # positives must not be redacted as fake secrets either.
-        if _is_suppressed_noise(detector, status):
-            continue
         key = (detector, raw)
         if key in seen:
             continue

--- a/clawjournal/redaction/trufflehog.py
+++ b/clawjournal/redaction/trufflehog.py
@@ -73,6 +73,30 @@ def _scrubbed_subprocess_env() -> dict[str, str]:
 #   returns ``unverified`` for those, so they are never real leaks.
 EXCLUDED_DETECTORS: tuple[str, ...] = ("refiner",)
 
+# Detectors whose UNVERIFIED findings are dropped as structural false
+# positives, while their verified/unknown findings still block. This is
+# narrower than EXCLUDED_DETECTORS (which disables a detector entirely,
+# reserved for detectors that never catch real leaks): the detector stays
+# active, so a real, live secret it confirms still blocks the share.
+#
+# - ``Azure`` is TruffleHog's legacy generic Azure detector (type 3). Its
+#   broad pattern, fed through the PLAIN and BASE64 decoders, matches ordinary
+#   agent-session terminal content — ``127.0.0.1:5432`` connection lines, file
+#   paths like ``scripts/foo.sh``, ANSI color codes (``\x1b[0m``) — and
+#   Azure-API verification returns unverified for all of them. The specific
+#   Azure detectors (AzureStorage, AzureSAS, AzureBatch, …) stay active and
+#   still catch real Azure keys by type.
+NOISY_UNVERIFIED_DETECTORS: frozenset[str] = frozenset({"Azure"})
+
+
+def _is_suppressed_noise(detector: str, status: str) -> bool:
+    """True for a structural false positive to drop: an UNVERIFIED finding
+    from a broad detector in NOISY_UNVERIFIED_DETECTORS. Applied uniformly by
+    the gate (``scan_file``) and the redaction-engine path
+    (``_scan_text_for_raw_matches``) so they never disagree about what counts
+    as a secret — verified/unknown findings from those detectors still count."""
+    return status == "unverified" and detector in NOISY_UNVERIFIED_DETECTORS
+
 INSTALL_HINT = (
     "TruffleHog is required to export shares but was not found on PATH.\n"
     "Install it with:\n"
@@ -417,6 +441,10 @@ def scan_file(path: Path) -> TruffleHogReport:
         finding = _parse_finding(parsed)
         if finding is None:
             continue
+        # Drop structural false positives from broad detectors (see
+        # NOISY_UNVERIFIED_DETECTORS) before they can block the gate.
+        if _is_suppressed_noise(finding.detector, finding.status):
+            continue
         key = (finding.detector, finding.status, finding.line, finding.raw_sha256)
         if key in seen_keys:
             continue
@@ -562,6 +590,10 @@ def _scan_text_for_raw_matches(text: str) -> list[dict]:
         if not isinstance(detector, str) or not isinstance(raw, str) or not raw:
             continue
         status = _classify_trufflehog_status(parsed)
+        # Same suppression as the gate: a broad detector's unverified false
+        # positives must not be redacted as fake secrets either.
+        if _is_suppressed_noise(detector, status):
+            continue
         key = (detector, raw)
         if key in seen:
             continue
@@ -576,10 +608,18 @@ def placeholder_for_detector(detector: str) -> str:
     return f"[REDACTED_{normalized}]" if normalized else "[REDACTED_TRUFFLEHOG]"
 
 
-def _iter_session_text_fields(session: dict):
+def _iter_session_text_fields(session: dict, *, include_widened: bool = False):
     """Yield ``(text, field, msg_idx, tool_field)`` for every scannable
     string in ``session``. Mirrors ``secrets._iter_text_locations`` but
-    returns only what the findings-engine entry point needs."""
+    returns only what the findings-engine entry point needs.
+
+    ``include_widened`` adds the widened message fields (author / invocations
+    / snippets / extra). It is used for finding RELOCATION only — the scan
+    payload deliberately omits them, since the full-JSON serialization in
+    ``_serialize_session_for_scan`` already covers them and duplicating large
+    widened values would push big sessions past the engine's size cap."""
+    from ..parsing.widened import iter_widened_text_locations  # noqa: PLC0415 — lazy
+
     for field_name in ("display_title", "project", "git_branch"):
         val = session.get(field_name)
         if isinstance(val, str) and val:
@@ -608,6 +648,14 @@ def _iter_session_text_fields(session: dict):
                                 msg_idx,
                                 branch,
                             )
+        # Widened message model — mirror secrets._iter_text_locations so
+        # TruffleHog hits in author/invocations/snippets/extra also surface as
+        # reviewable findings (apply-time redaction already covers them via the
+        # blob re-scan in trufflehog_secret_map_from_blob). Relocation only:
+        # see the docstring on why the scan payload omits these.
+        if include_widened:
+            for widened_text, field_label in iter_widened_text_locations(msg):
+                yield widened_text, field_label, msg_idx, None
 
 
 def _serialize_session_for_scan(session: dict) -> str:
@@ -648,7 +696,9 @@ def scan_session_for_trufflehog_findings(
             continue
         detector = match["detector"]
         confidence = 1.0 if match["status"] == "verified" else 0.9
-        for text, field_name, msg_idx, tool_field in _iter_session_text_fields(session):
+        for text, field_name, msg_idx, tool_field in _iter_session_text_fields(
+            session, include_widened=True
+        ):
             start = 0
             while True:
                 idx = text.find(raw, start)

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -320,17 +320,31 @@ export const api = {
         throw new ApiError(res.status, body.error || `HTTP ${res.status}`, body);
       }
       const disposition = res.headers.get('Content-Disposition') || '';
-      const match = /filename="?([^";]+)"?/.exec(disposition);
-      const filename = match ? match[1] : `share-${id}.zip`;
+      // Prefer RFC 5987 `filename*=charset'lang'percent-encoded` when present,
+      // else plain `filename="..."`. Fall back to a name that still carries the
+      // .zip extension so the OS can open the saved file.
+      const extMatch = /filename\*=[^']*'[^']*'([^";]+)/i.exec(disposition);
+      const plainMatch = /filename="?([^";]+)"?/i.exec(disposition);
+      let filename = plainMatch ? plainMatch[1] : `clawjournal-share-${id}.zip`;
+      if (extMatch) {
+        // Malformed percent-encoding must not abort an otherwise valid
+        // download — fall back to the plain form / default instead of throwing.
+        try { filename = decodeURIComponent(extMatch[1]); } catch { /* keep fallback */ }
+      }
       const blob = await res.blob();
       const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
       a.href = url;
       a.download = filename;
+      a.rel = 'noopener';
       document.body.appendChild(a);
       a.click();
       a.remove();
-      URL.revokeObjectURL(url);
+      // Revoke on a later tick, not synchronously. Chromium processes a blob
+      // download asynchronously after click(); revoking the object URL right
+      // away drops the suggested filename (the browser then saves a bare UUID
+      // with no .zip extension) and can truncate large downloads.
+      setTimeout(() => URL.revokeObjectURL(url), 60_000);
     },
 
     upload(id: string, body: {

--- a/clawjournal/web/frontend/src/views/Share/DoneStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/DoneStep.tsx
@@ -15,6 +15,9 @@ export interface DoneStepProps {
   onNew: () => void;
   globalStyles: React.ReactNode;
   shareDestination: ShareDestination | null;
+  destinationLoading: boolean;
+  destinationFailed: boolean;
+  onRetryDestination: () => void;
 }
 
 export function DoneStep(p: DoneStepProps) {
@@ -155,7 +158,35 @@ export function DoneStep(p: DoneStepProps) {
           >
             <Icon name="download" size={15} /> Download zip
           </button>
-          {hostedShareUrl && !submitted && (
+          {!submitted && p.destinationLoading && (
+            <span style={{
+              display: 'inline-flex', alignItems: 'center', gap: 8,
+              padding: '11px 20px', background: colors.white, color: colors.gray400,
+              border: `1px solid ${colors.gray200}`, borderRadius: 8,
+              fontSize: 14, fontWeight: 600,
+            }}>
+              <span style={{
+                width: 13, height: 13, borderRadius: '50%',
+                border: `2px solid ${colors.gray200}`, borderTopColor: colors.gray400,
+                animation: 'clawSpin 0.7s linear infinite',
+              }} />
+              Checking submission options…
+            </span>
+          )}
+          {!submitted && !p.destinationLoading && p.destinationFailed && (
+            <button
+              onClick={p.onRetryDestination}
+              style={{
+                display: 'inline-flex', alignItems: 'center', gap: 8,
+                padding: '11px 20px', background: colors.white, color: colors.gray900,
+                border: `1px solid ${colors.gray300}`, borderRadius: 8,
+                fontSize: 14, fontWeight: 600, cursor: 'pointer',
+              }}
+            >
+              <Icon name="retry" size={14} /> Retry submission check
+            </button>
+          )}
+          {!submitted && !p.destinationLoading && !p.destinationFailed && hostedShareUrl && (
             <a
               href={hostedShareUrl}
               target="_blank"
@@ -177,6 +208,10 @@ export function DoneStep(p: DoneStepProps) {
               {p.hostedStatus ? `Status: ${p.hostedStatus}. ` : null}
               {p.supportContact ? `For deletion or withdrawal, contact ${p.supportContact} with the receipt ID.` : null}
             </>
+          ) : p.destinationLoading ? (
+            <>Checking whether hosted submission is available…</>
+          ) : p.destinationFailed ? (
+            <>Couldn&rsquo;t reach the submission service. Your redacted zip is saved locally — retry above to check for the Submit option.</>
           ) : hostedShareLabel ? (
             <>
               Upload this zip at <span style={{ fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace' }}>{hostedShareLabel}</span> to contribute to research.

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -112,23 +112,46 @@ export function Share() {
   const [candidates, setCandidates] = useState<Session[]>([]);
   const [scoringBackend, setScoringBackend] = useState<{ backend: string | null; display_name: string | null } | null>(null);
   const [shareDestination, setShareDestination] = useState<ShareDestination | null>(null);
+  // Distinguish "still loading / failed to reach" from "loaded, not configured".
+  // The hosted-destination probe is a remote network call, so collapsing all
+  // three into `shareDestination === null` made the Done page hide the Submit
+  // button on a transient failure (or a slow load right after a daemon
+  // restart), which looks identical to "no submit option for this install".
+  const [destinationLoading, setDestinationLoading] = useState(true);
+  const [destinationFailed, setDestinationFailed] = useState(false);
 
   // =================================================
   // Initial load
   // =================================================
 
+  const loadShareDestination = useCallback(() => {
+    setDestinationLoading(true);
+    setDestinationFailed(false);
+    api.shareDestination()
+      .then((destination) => {
+        setShareDestination(destination);
+        setSupportContact(destination?.support_contact || null);
+      })
+      .catch(() => {
+        setShareDestination(null);
+        setDestinationFailed(true);
+      })
+      .finally(() => setDestinationLoading(false));
+  }, []);
+
   useEffect(() => {
+    // The hosted-destination probe can be slow/flaky (remote round-trip); load
+    // it independently so it never blocks the page or its failure poisons the
+    // whole initial load.
+    loadShareDestination();
     Promise.all([
       api.shareReady({ includeUnapproved: true }),
       api.shares.list(),
       api.scoringBackend().catch(() => ({ backend: null, display_name: null })),
-      api.shareDestination().catch(() => null),
-    ]).then(([stats, shareList, backend, destination]) => {
+    ]).then(([stats, shareList, backend]) => {
       setReadyStats(stats);
       setShares(shareList);
       setScoringBackend(backend);
-      setShareDestination(destination);
-      setSupportContact(destination?.support_contact || null);
       if (!selectionInitialized && stats.sessions.length > 0) {
         // Server recommendation is an ordered, reviewable default package.
         // Trust it and only filter out ids the client can't resolve
@@ -725,25 +748,30 @@ export function Share() {
   // animation has finished. Runs even if the inline `setActiveStep('done')`
   // inside `runPackage` fell through a silent error path.
   useEffect(() => {
-    if (activeStep === 'package' && packagedShareId && packageProgress >= 100 && !packagingFailed) {
+    // Wait for the destination probe before deciding submit-vs-done. The probe
+    // loads independently of the page now, so a null `shareDestination` here may
+    // just mean "still loading" — routing to Done on that would strand a
+    // genuinely-submittable bundle, since this effect can't re-route once
+    // `activeStep` leaves 'package'.
+    if (activeStep === 'package' && packagedShareId && packageProgress >= 100 && !packagingFailed && !destinationLoading) {
       setCompletedKeys((prev) => new Set([...prev, 'package']));
       const canSubmit = !!shareDestination?.daemon_upload_supported && !!shareDestination?.submissions_open;
       setActiveStep(canSubmit ? 'submit' : 'done');
     }
-  }, [activeStep, packagedShareId, packageProgress, packagingFailed, shareDestination]);
+  }, [activeStep, packagedShareId, packageProgress, packagingFailed, shareDestination, destinationLoading]);
 
   // Reload/deep-link robustness: a page reload or bookmark can land directly on
   // Submit. If hosted submission isn't available (disabled, closed, or the
   // destination failed to load) and the share hasn't already been submitted,
   // fall back to the download-only Done view instead of stranding the user on a
-  // Submit step they can't complete. Gated on `loading` so we wait for the
-  // initial destination fetch (a still-null destination after load means
-  // not-submittable). Mirrors the package→done branch above.
+  // Submit step they can't complete. Gated on `destinationLoading` so we wait
+  // for the (now-independent) destination probe — a still-null destination only
+  // after it resolves means not-submittable. Mirrors the package→done branch.
   useEffect(() => {
-    if (activeStep !== 'submit' || receiptId || loading) return;
+    if (activeStep !== 'submit' || receiptId || loading || destinationLoading) return;
     const canSubmit = !!shareDestination?.daemon_upload_supported && !!shareDestination?.submissions_open;
     if (!canSubmit) setActiveStep('done');
-  }, [activeStep, shareDestination, receiptId, loading]);
+  }, [activeStep, shareDestination, receiptId, loading, destinationLoading]);
 
   // A Submit deep-link with no packaged share has nothing to act on; send the
   // user back to the start rather than rendering a dead-end Submit bound to a
@@ -941,6 +969,9 @@ export function Share() {
         onNew={() => { startFreshShare(); reload(); }}
         globalStyles={globalStyles}
         shareDestination={shareDestination}
+        destinationLoading={destinationLoading}
+        destinationFailed={destinationFailed}
+        onRetryDestination={loadShareDestination}
       />
     );
   }

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -1269,10 +1269,44 @@ def apply_share_redactions(
 ) -> tuple[dict[str, Any], int, list[dict[str, Any]]]:
     """Apply the full share/export redaction pipeline to a session."""
     from ..redaction.anonymizer import Anonymizer
+    from ..redaction.normalize import strip_terminal_control_sequences
     from ..redaction.secrets import apply_findings_to_blob
 
     total_redactions = 0
     redaction_log: list[dict[str, Any]] = []
+
+    # Normalize terminal control sequences (ANSI colors, cursor moves, stray
+    # control bytes) out of all text up front. They are rendering noise, not
+    # content: stripping them keeps shared bundles clean, lets downstream
+    # redaction patterns match cleanly, and stops TruffleHog's broad detectors
+    # from flagging them as false positives. This is normalization, not
+    # redaction, so it is not counted in total_redactions.
+    for field in ("display_title", "project", "git_branch"):
+        if session.get(field):
+            session[field] = _transform_nested_strings(
+                session[field], strip_terminal_control_sequences
+            )
+    for msg in session.get("messages", []):
+        for field in ("content", "thinking"):
+            if msg.get(field):
+                msg[field] = _transform_nested_strings(
+                    msg[field], strip_terminal_control_sequences
+                )
+        for tool_use in msg.get("tool_uses", []):
+            for tool_field in ("input", "output"):
+                if tool_use.get(tool_field):
+                    tool_use[tool_field] = _transform_nested_strings(
+                        tool_use[tool_field], strip_terminal_control_sequences
+                    )
+        # Widened message model (author / invocations / snippets / extra) —
+        # these ship in the export too, so normalize them with the same
+        # recursive walk the secrets stage uses (iter_widened_text_locations).
+        for widened_field in ("author", "invocations", "snippets", "extra"):
+            if msg.get(widened_field):
+                msg[widened_field] = _transform_nested_strings(
+                    msg[widened_field], strip_terminal_control_sequences
+                )
+    _apply_to_ai_text(session, lambda text, _label: strip_terminal_control_sequences(text))
 
     if custom_strings:
         custom_total = 0

--- a/tests/redaction/test_normalize.py
+++ b/tests/redaction/test_normalize.py
@@ -1,0 +1,58 @@
+"""Tests for terminal-control-sequence normalization on the share path."""
+
+from clawjournal.redaction.normalize import strip_terminal_control_sequences
+
+
+class TestStripTerminalControlSequences:
+    def test_strips_sgr_color_codes(self):
+        # The exact false-positive shape that tripped TruffleHog's Azure detector.
+        assert strip_terminal_control_sequences("\x1b[90mnull\x1b[0m\x1b[0m") == "null"
+
+    def test_keeps_plain_text_and_standard_whitespace(self):
+        text = "hello\tworld\nsecond line\r\nthird"
+        assert strip_terminal_control_sequences(text) == text
+
+    def test_strips_csi_cursor_and_erase_sequences(self):
+        assert strip_terminal_control_sequences("a\x1b[2K\x1b[1Gb") == "ab"
+
+    def test_strips_osc_title_sequence(self):
+        # OSC 0 ; <title> BEL — used to set the terminal title.
+        assert strip_terminal_control_sequences("x\x1b]0;my-title\x07y") == "xy"
+
+    def test_strips_stray_c0_controls_but_keeps_tab_newline_cr(self):
+        assert strip_terminal_control_sequences("a\x00\x07b\tc\nd\re") == "ab\tc\nd\re"
+
+    def test_preserves_non_ascii_utf8(self):
+        # Must not corrupt multibyte UTF-8 (C1 range bytes are part of those).
+        assert strip_terminal_control_sequences("café — 日本語") == "café — 日本語"
+
+    def test_empty_and_clean_strings_unchanged(self):
+        assert strip_terminal_control_sequences("") == ""
+        assert strip_terminal_control_sequences("nothing to strip") == "nothing to strip"
+
+    def test_strips_8bit_c1_csi(self):
+        # 8-bit CSI introducer (U+009B) instead of ESC[.
+        assert strip_terminal_control_sequences("a\x9b31mb") == "ab"
+
+    def test_strips_dcs_pm_apc_sos_payloads(self):
+        # ESC P/^/_/X ... ST — the whole payload must go, not just the introducer.
+        assert strip_terminal_control_sequences("a\x1bP1;2|payload\x1b\\b") == "ab"
+        assert strip_terminal_control_sequences("a\x1b^pm-data\x1b\\b") == "ab"
+        assert strip_terminal_control_sequences("a\x1b_apc-data\x1b\\b") == "ab"
+        assert strip_terminal_control_sequences("a\x1bXsos-data\x1b\\b") == "ab"
+
+    def test_strips_8bit_osc_and_dcs_with_st(self):
+        assert strip_terminal_control_sequences("a\x9d0;title\x9cb") == "ab"  # 8-bit OSC + ST
+        assert strip_terminal_control_sequences("a\x90dcs\x9cb") == "ab"      # 8-bit DCS + ST
+
+    def test_strips_stray_c1_controls(self):
+        # Lone C1 controls (NEL, ST) are not legitimate text content.
+        assert strip_terminal_control_sequences("a\x85\x9cb") == "ab"
+
+    def test_unterminated_osc_dcs_does_not_eat_trailing_text(self):
+        # A payload-bearing escape with no BEL/ST terminator must NOT consume
+        # the rest of the string — that would drop legitimate trailing content
+        # on truncated terminal captures.
+        assert strip_terminal_control_sequences("a\x1b]0;titleb") == "a]0;titleb"
+        out = strip_terminal_control_sequences("a\x1bPpayload no-st KEEPME")
+        assert "KEEPME" in out and "\x1b" not in out

--- a/tests/redaction/test_trufflehog.py
+++ b/tests/redaction/test_trufflehog.py
@@ -208,6 +208,90 @@ class TestScanFile:
         assert other["Raw"] not in payload
         assert "GitHub" in summary["top_detectors"]
 
+    def test_unverified_generic_azure_false_positives_are_suppressed(self, tmp_path, monkeypatch):
+        """The legacy generic Azure detector fires on ordinary agent-session
+        terminal content (localhost connection strings, file paths, ANSI color
+        codes) and Azure-API verification returns unverified for all of them.
+        Those must not block the share."""
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+
+        false_positives = [
+            {
+                "DetectorName": "Azure",
+                "Verified": False,
+                "Raw": "127.0.0.1:51678->127.0.0.1:5432:",
+                "SourceMetadata": {"Data": {"Filesystem": {"line": 3}}},
+            },
+            {
+                "DetectorName": "Azure",
+                "Verified": False,
+                "Raw": "scripts/seed-routing-rules.sh\n??",
+                "SourceMetadata": {"Data": {"Filesystem": {"line": 3}}},
+            },
+            {
+                "DetectorName": "Azure",
+                "Verified": False,
+                "Raw": "[90mnull[0m[0m\n",
+                "SourceMetadata": {"Data": {"Filesystem": {"line": 5}}},
+            },
+        ]
+        stdout = "\n".join(json.dumps(x) for x in false_positives) + "\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 183, stdout=stdout, stderr=""),
+        )
+        report = trufflehog.scan_file(target)
+        assert report.findings == []
+        assert report.unverified == 0
+        assert report.blocking is False
+
+    def test_verified_generic_azure_still_blocks(self, tmp_path, monkeypatch):
+        """Suppression is surgical: a *verified* generic-Azure finding is a
+        real, live credential and must still block."""
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+        finding = {
+            "DetectorName": "Azure",
+            "Verified": True,
+            "Raw": "a-real-confirmed-azure-secret-0001",
+            "SourceMetadata": {"Data": {"Filesystem": {"line": 4}}},
+        }
+        stdout = json.dumps(finding) + "\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 183, stdout=stdout, stderr=""),
+        )
+        report = trufflehog.scan_file(target)
+        assert report.verified == 1
+        assert report.blocking is True
+
+    def test_specific_azure_detector_unverified_still_blocks(self, tmp_path, monkeypatch):
+        """Only the generic ``Azure`` detector is treated as noisy. Specific
+        Azure detectors (AzureStorage, …) still block even when unverified."""
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+        finding = {
+            "DetectorName": "AzureStorage",
+            "Verified": False,
+            "Raw": "DefaultEndpointsProtocol=https;AccountName=x;AccountKey=y==",
+            "SourceMetadata": {"Data": {"Filesystem": {"line": 6}}},
+        }
+        stdout = json.dumps(finding) + "\n"
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 183, stdout=stdout, stderr=""),
+        )
+        report = trufflehog.scan_file(target)
+        assert report.unverified == 1
+        assert report.blocking is True
+
     def test_unexpected_exit_code_blocks_with_error_report(self, tmp_path, monkeypatch):
         self._enable_real_scan(monkeypatch)
         target = tmp_path / "sessions.jsonl"
@@ -342,6 +426,60 @@ class TestFindingsEngineEntryPoints:
                 for raw, detector in raws
             ],
         )
+
+    def test_scan_text_for_raw_matches_suppresses_unverified_noisy_detector(self, monkeypatch):
+        """The generic Azure detector's unverified false positives are dropped
+        in the redaction-engine path too (not just the gate), so they are never
+        redacted as fake secrets. Verified Azure and other detectors pass."""
+        monkeypatch.delenv(trufflehog.SKIP_ENV_VAR, raising=False)
+        monkeypatch.setattr(trufflehog, "is_available", lambda: True)
+        rows = [
+            {"DetectorName": "Azure", "Verified": False, "Raw": "127.0.0.1:5432"},
+            {"DetectorName": "Azure", "Verified": True, "Raw": "real-azure-secret-0001"},
+            {"DetectorName": "Slack", "Verified": False, "Raw": "xoxb-abc-def"},
+        ]
+        stdout = ("\n".join(json.dumps(r) for r in rows) + "\n").encode()
+        monkeypatch.setattr(
+            subprocess, "run",
+            lambda *a, **k: subprocess.CompletedProcess(a, 183, stdout=stdout, stderr=b""),
+        )
+        matches = trufflehog._scan_text_for_raw_matches("payload")
+        pairs = {(m["detector"], m["status"]) for m in matches}
+        assert ("Azure", "unverified") not in pairs   # suppressed
+        assert ("Azure", "verified") in pairs          # real Azure still found
+        assert ("Slack", "unverified") in pairs        # other detectors unaffected
+
+    def test_serialize_session_does_not_duplicate_widened_text(self):
+        """Widened leaves appear once (via the JSON dump), not twice — the
+        relocation walk must not bloat the scan payload toward the size cap."""
+        raw = "WIDENEDUNIQUEMARKERXYZ"
+        session = {"messages": [{"content": "c", "extra": {"k": raw}, "tool_uses": []}]}
+        payload = trufflehog._serialize_session_for_scan(session)
+        assert payload.count(raw) == 1
+
+    def test_findings_emitted_for_widened_message_fields(self, monkeypatch):
+        """A secret living only in the widened message model (author /
+        invocations / snippets / extra) must surface as a reviewable
+        RawFinding, not just get redacted silently at apply time."""
+        raw_secret = "synthetic_widened_secret_abcdef"
+        self._fake_matches(monkeypatch, [(raw_secret, "Stripe")])
+        session = {
+            "messages": [
+                {
+                    "content": "legacy text",
+                    "author": raw_secret,
+                    "invocations": [{"result": f"out {raw_secret}"}],
+                    "extra": {"raw": {"deep": raw_secret}},
+                    "tool_uses": [],
+                },
+            ],
+        }
+        out = trufflehog.scan_session_for_trufflehog_findings(session)
+        fields = {f.field for f in out}
+        assert "author" in fields
+        assert any(f.field.startswith("invocations[0]") for f in out)
+        assert any(f.field.startswith("extra") for f in out)
+        assert all(f.entity_text == raw_secret for f in out)
 
     def test_findings_emitted_per_occurrence(self, monkeypatch):
         from clawjournal.findings import RawFinding

--- a/tests/redaction/test_trufflehog.py
+++ b/tests/redaction/test_trufflehog.py
@@ -208,16 +208,17 @@ class TestScanFile:
         assert other["Raw"] not in payload
         assert "GitHub" in summary["top_detectors"]
 
-    def test_unverified_generic_azure_false_positives_are_suppressed(self, tmp_path, monkeypatch):
+    def test_unverified_generic_azure_findings_still_block(self, tmp_path, monkeypatch):
         """The legacy generic Azure detector fires on ordinary agent-session
         terminal content (localhost connection strings, file paths, ANSI color
-        codes) and Azure-API verification returns unverified for all of them.
-        Those must not block the share."""
+        codes) and Azure-API verification can return unverified. The export
+        gate remains fail-closed: TruffleHog findings still block unless the
+        detector is explicitly excluded."""
         self._enable_real_scan(monkeypatch)
         target = tmp_path / "sessions.jsonl"
         target.write_text("x\n")
 
-        false_positives = [
+        findings = [
             {
                 "DetectorName": "Azure",
                 "Verified": False,
@@ -237,20 +238,20 @@ class TestScanFile:
                 "SourceMetadata": {"Data": {"Filesystem": {"line": 5}}},
             },
         ]
-        stdout = "\n".join(json.dumps(x) for x in false_positives) + "\n"
+        stdout = "\n".join(json.dumps(x) for x in findings) + "\n"
         monkeypatch.setattr(
             subprocess,
             "run",
             lambda cmd, **kwargs: subprocess.CompletedProcess(cmd, 183, stdout=stdout, stderr=""),
         )
         report = trufflehog.scan_file(target)
-        assert report.findings == []
-        assert report.unverified == 0
-        assert report.blocking is False
+        assert len(report.findings) == 3
+        assert report.unverified == 3
+        assert report.blocking is True
 
     def test_verified_generic_azure_still_blocks(self, tmp_path, monkeypatch):
-        """Suppression is surgical: a *verified* generic-Azure finding is a
-        real, live credential and must still block."""
+        """A verified generic-Azure finding is a real, live credential and
+        must still block."""
         self._enable_real_scan(monkeypatch)
         target = tmp_path / "sessions.jsonl"
         target.write_text("x\n")
@@ -271,8 +272,8 @@ class TestScanFile:
         assert report.blocking is True
 
     def test_specific_azure_detector_unverified_still_blocks(self, tmp_path, monkeypatch):
-        """Only the generic ``Azure`` detector is treated as noisy. Specific
-        Azure detectors (AzureStorage, …) still block even when unverified."""
+        """Specific Azure detectors (AzureStorage, etc.) also block even when
+        unverified."""
         self._enable_real_scan(monkeypatch)
         target = tmp_path / "sessions.jsonl"
         target.write_text("x\n")
@@ -427,10 +428,9 @@ class TestFindingsEngineEntryPoints:
             ],
         )
 
-    def test_scan_text_for_raw_matches_suppresses_unverified_noisy_detector(self, monkeypatch):
-        """The generic Azure detector's unverified false positives are dropped
-        in the redaction-engine path too (not just the gate), so they are never
-        redacted as fake secrets. Verified Azure and other detectors pass."""
+    def test_scan_text_for_raw_matches_keeps_unverified_generic_azure(self, monkeypatch):
+        """The redaction-engine path preserves unverified generic Azure hits so
+        it stays consistent with the fail-closed gate."""
         monkeypatch.delenv(trufflehog.SKIP_ENV_VAR, raising=False)
         monkeypatch.setattr(trufflehog, "is_available", lambda: True)
         rows = [
@@ -445,9 +445,9 @@ class TestFindingsEngineEntryPoints:
         )
         matches = trufflehog._scan_text_for_raw_matches("payload")
         pairs = {(m["detector"], m["status"]) for m in matches}
-        assert ("Azure", "unverified") not in pairs   # suppressed
-        assert ("Azure", "verified") in pairs          # real Azure still found
-        assert ("Slack", "unverified") in pairs        # other detectors unaffected
+        assert ("Azure", "unverified") in pairs
+        assert ("Azure", "verified") in pairs
+        assert ("Slack", "unverified") in pairs
 
     def test_serialize_session_does_not_duplicate_widened_text(self):
         """Widened leaves appear once (via the JSON dump), not twice — the

--- a/tests/test_findings_substrate.py
+++ b/tests/test_findings_substrate.py
@@ -345,6 +345,25 @@ class TestDerivePreview:
         assert preview["before"].endswith("🔑 x")
         assert preview["after"].startswith("tail")
 
+    def test_resolves_widened_message_field(self, conn):
+        """A finding whose field is a widened-model label (e.g. ``author``)
+        must resolve to real preview context, not empty strings."""
+        finding = Finding(
+            finding_id="f1", session_id="s", engine="trufflehog", rule="r",
+            entity_type="r", entity_hash="h", entity_length=6,
+            field="author", message_index=0, tool_field=None,
+            offset=4, length=6, confidence=1.0,
+            status="open", decided_by=None, decision_source_id=None,
+            decided_at=None, decision_reason=None,
+            revision="v1:x", created_at="now",
+        )
+        # "pre SECRET post": SECRET at offset 4, length 6.
+        blob = {"messages": [{"role": "user", "content": "x", "author": "pre SECRET post"}]}
+        preview = derive_preview(blob, finding, context_chars=10)
+        assert preview["before"].endswith("pre ")
+        assert preview["after"].startswith(" post")
+        assert preview["match_placeholder"] == "[...]"
+
 
 class TestAllowlistRetroactive:
     def test_add_flips_existing_open_findings(self, conn):

--- a/tests/workbench/test_share_gates.py
+++ b/tests/workbench/test_share_gates.py
@@ -250,6 +250,43 @@ class TestExportManifestRedactions:
         assert n >= 1
         assert any(entry["type"] == "trufflehog_slack" for entry in log)
 
+    def test_apply_share_redactions_strips_terminal_control_sequences(self, conn):
+        """Terminal ANSI escape codes are stripped from shared content so they
+        don't bloat the bundle or trip TruffleHog's broad detectors."""
+        sess = _settled_session("sess-ansi", content="\x1b[90mnull\x1b[0m done")
+        sess["messages"][0]["thinking"] = "think \x1b[31mred\x1b[0m"
+        sess["messages"][0]["tool_uses"] = [
+            {"name": "bash", "input": "ls \x1b[1mx\x1b[0m", "output": "ok\x1b[0m\x07"}
+        ]
+        upsert_sessions(conn, [sess])
+        conn.commit()
+
+        redacted, _, _ = apply_share_redactions(conn, sess)
+        msg = redacted["messages"][0]
+        assert msg["content"] == "null done"
+        assert "\x1b" not in msg["thinking"]
+        assert "\x1b" not in msg["tool_uses"][0]["input"]
+        assert "\x1b" not in msg["tool_uses"][0]["output"]
+
+    def test_apply_share_redactions_strips_ansi_in_widened_message_fields(self, conn):
+        """ANSI must also be stripped from the widened message model
+        (author / invocations / snippets / extra), not just legacy fields."""
+        sess = _settled_session("sess-widened", content="hi")
+        msg = sess["messages"][0]
+        msg["author"] = "agent\x1b[0m"
+        msg["invocations"] = [{"name": "bash", "result": "out \x1b[31mred\x1b[0m"}]
+        msg["snippets"] = [{"code": "x = 1 \x1b[2K"}]
+        msg["extra"] = {"raw": {"line": "deep \x1b[90mgray\x1b[0m"}}
+        upsert_sessions(conn, [sess])
+        conn.commit()
+
+        redacted, _, _ = apply_share_redactions(conn, sess)
+        m = redacted["messages"][0]
+        assert "\x1b" not in m["author"]
+        assert "\x1b" not in m["invocations"][0]["result"]
+        assert "\x1b" not in m["snippets"][0]["code"]
+        assert "\x1b" not in m["extra"]["raw"]["line"]
+
     def test_apply_share_redactions_raises_on_missing_session_id(self, conn):
         """Deterministic engines route through the findings table,
         keyed by session_id. A session stripped of its ID would


### PR DESCRIPTION
## Summary

Several issues blocked or confused the share/export path. The branch now includes the original share-flow fixes plus a forward fix that keeps the TruffleHog export gate fail-closed.

## 1. TruffleHog gate — reduce clean-share terminal noise without broad detector suppression
`redaction/trufflehog.py`, `redaction/normalize.py`, `findings.py`, `workbench/index.py`

The mandatory post-redaction gate still blocks on **any** TruffleHog finding, including unverified generic `Azure` findings. Earlier in this branch we considered dropping all `Azure` + `unverified` findings, but that was too broad for the export privacy boundary.

- Strip terminal/ANSI control sequences before scanning (`strip_terminal_control_sequences`) so rendering artifacts do not bloat bundles or create avoidable detector noise.
- Walk the **widened** message fields (author/invocations/snippets/extra) so the gate, the engine, and finding preview see the same payload.
- Keep generic Azure findings fail-closed: verified, unknown, and unverified TruffleHog hits all remain visible/blocking unless a detector is explicitly excluded.

## 2. Download zip → bare-UUID filename
`web/frontend/src/api.ts`

"Download zip" saved the bundle as a bare UUID with no `.zip` extension (bytes were correct; only the suggested filename was lost). Cause: `URL.revokeObjectURL(url)` ran synchronously right after `a.click()`, and Chromium reads the blob asynchronously, dropping the filename.

- Defer the revoke (60s), add `rel="noopener"`, parse RFC 5987 `filename*` (the general `charset'lang'value` form) **safely** (try/catch), and fall back to a `.zip`-bearing name.

## 3. Submit button flicker + premature Done routing
`web/frontend/src/views/Share/DoneStep.tsx`, `index.tsx`

The "Submit to ClawJournal Research" button toggled present/absent for the **same URL** because `shareDestination` (loaded by an async, network-dependent probe) collapsed loading / failed / not-configured into `null`.

- Track `destinationLoading` / `destinationFailed`, load the probe independently, and render a spinner / Retry / button accordingly.
- Because the probe is now independent, the package→done and submit-deeplink routing effects could decide submit-vs-done before it resolved and route to Done irreversibly. Both are gated on `!destinationLoading`.

## Review & verification

Verified the PR head merged cleanly into latest `origin/main` (`accab5d`). On that merge result:

- `PYTHONPATH=. /tmp/clawjournal-pr59-review-venv/bin/python -m pytest -q`: **1931 passed**.
- `npm ci && npm run build`: passes.
- `git diff --cached --check`: passes.

Also ran targeted TruffleHog/normalization/share-gate tests on the PR branch after the forward fix.