### PR TITLE
Personalized weekly benchmark: backend (generation, storage, CLI, API)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,7 @@ node_modules/
 *_dashboard.html
 /search-page*.png
 /share-page*.png
+
+# Local-only personalized-benchmark scratch files — contain real PII, never commit
+/benchmark-cc.md
+/benchmark-codex.md

--- a/README.md
+++ b/README.md
@@ -597,6 +597,7 @@ ClawJournal can parse session data from: Claude Code, Claude Desktop, Codex, Gem
 | `clawjournal config --redact "str1,str2"` | Add strings to always redact (appends) |
 | `clawjournal config --redact-usernames "u1,u2"` | Add usernames to anonymize (appends) |
 | `clawjournal config --ai-pii-review` / `--no-ai-pii-review` | Set the default AI-assisted PII review on/off for the share flow |
+| `clawjournal config --benchmark-tab` / `--no-benchmark-tab` | Show/hide the Benchmark tab in the workbench UI (default on; takes effect on browser reload) |
 | `clawjournal list` | List all projects with exclusion status |
 | `clawjournal status` | Show current stage and next steps (JSON) |
 | `clawjournal update-skill <agent>` | Install/update the clawjournal skill for an agent |

--- a/clawjournal/benchmark/__init__.py
+++ b/clawjournal/benchmark/__init__.py
@@ -1,0 +1,23 @@
+"""Personalized weekly benchmark generation, storage, and selection.
+
+The benchmark pipeline turns a week of the user's own scored failure traces
+into an adversarial, judgment-focused benchmark (themes + grounded tasks). This
+package holds the backend-only substrate:
+
+- :mod:`clawjournal.benchmark.schema` — typed shapes, (de)serialization,
+  validation, and the agent-packet / grader-packet split.
+- :mod:`clawjournal.benchmark.store` — persistence over the ``benchmarks`` /
+  ``benchmark_tasks`` / ``benchmark_exports`` tables.
+- :mod:`clawjournal.benchmark.select` — selecting the week's failure-signal
+  sessions to feed the generator.
+- :mod:`clawjournal.benchmark.generate` — the deep, backend-orchestrated
+  multi-pass generation pipeline.
+- :mod:`clawjournal.benchmark.render` — rendering a benchmark to the export
+  kinds (authoring markdown + agent/grader packets).
+
+The daemon API / CLI / UI tab are layered on top of these in later phases.
+"""
+
+from . import generate, render, schema, select, store  # noqa: F401
+
+__all__ = ["generate", "render", "schema", "select", "store"]

--- a/clawjournal/benchmark/generate.py
+++ b/clawjournal/benchmark/generate.py
@@ -41,7 +41,12 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_MAX_WORKERS = 4
 BLOB_EXTRACT_MAX_CHARS = 8000
-STAGES = ("deepread", "architect", "design", "critique")
+
+# Generation makes ~40+ calls; default each backend to a fast, inexpensive model
+# (still through the CLI/subscription — no raw API). Only claude exposes a stable
+# alias; codex model slugs vary, so leave it at the CLI default (override with
+# `--model`). `None` means "the CLI's default model".
+_DEFAULT_GEN_MODEL: dict[str, str] = {"claude": "sonnet"}
 
 ProgressFn = Callable[[str], None]
 
@@ -139,6 +144,9 @@ class AgentBackendCaller:
 
     def __post_init__(self) -> None:
         self.resolved = resolve_backend(self.backend)
+        # Fall back to the per-backend fast default unless the caller named a model.
+        if self.model is None:
+            self.model = _DEFAULT_GEN_MODEL.get(self.resolved)
 
     def __call__(self, *, stage: str, system_prompt: str, task_prompt: str) -> dict[str, Any]:
         import tempfile
@@ -303,12 +311,27 @@ def _map(fn: Callable[[Any], Any], items: list[Any], max_workers: int) -> list[A
         return list(pool.map(fn, items))
 
 
+def _map_progress(fn, items, max_workers, *, label, note):
+    """Like :func:`_map` but emits ``label (k/total)`` from the MAIN thread after
+    each parallel chunk — so the UI bar advances smoothly and no DB write ever
+    happens off the worker thread (the per-item fns run in the pool; progress does
+    not)."""
+    total = len(items)
+    step = max(1, max_workers)
+    out: list[Any] = []
+    for i in range(0, total, step):
+        out.extend(_map(fn, items[i:i + step], max_workers))
+        note(f"{label} ({min(i + step, total)}/{total})")
+    return out
+
+
 def generate_benchmark(
     conn,
     *,
     window_days: int = DEFAULT_WINDOW_DAYS,
     cap: int = DEFAULT_DEEPREAD_CAP,
     backend: str = "auto",
+    model: str | None = None,
     caller: BackendCaller | None = None,
     anonymizer: Anonymizer | None = None,
     now: datetime | None = None,
@@ -322,7 +345,7 @@ def generate_benchmark(
     agent; tests pass a fake. ``week_slice`` lets a caller pass a pre-selected
     slice (else :func:`select_week_failures` is run).
     """
-    call = caller or AgentBackendCaller(backend=backend)
+    call = caller or AgentBackendCaller(backend=backend, model=model)
     anon = anonymizer if anonymizer is not None else Anonymizer(enabled=True)
     resolved = getattr(call, "resolved", None) or resolve_backend(backend)
 
@@ -336,7 +359,7 @@ def generate_benchmark(
         raise ValueError("no failure-signal sessions in the selected window")
 
     # 1. Deep-read (bounded parallel) -> seeds.
-    note(f"deep-reading {len(sl.candidates)} sessions")
+    note(f"Reading your recent failures (0/{len(sl.candidates)})")
     extracts = {c.session_id: _blob_extract(c.blob_path, anon) for c in sl.candidates}
 
     def _deepread(c: FailureCandidate) -> dict[str, Any] | None:
@@ -350,12 +373,13 @@ def generate_benchmark(
         seed["source"] = c.source
         return seed
 
-    seeds = [s for s in _map(_deepread, list(sl.candidates), max_workers) if s]
+    seeds = [s for s in _map_progress(_deepread, list(sl.candidates), max_workers,
+                                      label="Reading your recent failures", note=note) if s]
     if not seeds:
         raise ValueError("deep-read produced no seeds")
 
     # 2. Architect / cluster (single call) -> themes + stubs.
-    note("clustering into themes")
+    note("Grouping failures into themes…")
     try:
         arch = call(stage="architect", system_prompt=_SYSTEM, task_prompt=_architect_prompt(seeds))
     except Exception as exc:  # distinct from the empty-week control-flow ValueErrors
@@ -376,7 +400,7 @@ def generate_benchmark(
         raise ValueError("architect produced no task stubs")
 
     # 3 + 4. Design then critique each stub (bounded parallel, per-item chain).
-    note(f"designing + critiquing {len(stubs)} tasks")
+    note(f"Writing & reviewing benchmark tasks (0/{len(stubs)})")
 
     def _build(stub: dict[str, Any]) -> bm.BenchmarkTask | None:
         sid = stub.get("id") or "S?"
@@ -430,10 +454,12 @@ def generate_benchmark(
             return None
         return task
 
-    tasks = [t for t in _map(_build, stubs, max_workers) if t]
+    tasks = [t for t in _map_progress(_build, stubs, max_workers,
+                                      label="Writing & reviewing benchmark tasks", note=note) if t]
     if not tasks:
         raise ValueError("no tasks survived design/critique/validation")
 
+    note("Finalizing…")
     benchmark = bm.Benchmark(
         window_start=sl.window_start,
         window_end=sl.window_end,
@@ -446,5 +472,5 @@ def generate_benchmark(
         tasks=tasks,
     )
     bm.validate_or_raise(benchmark)
-    note(f"done: {len(tasks)} tasks, {len(themes)} themes")
+    note(f"Done — {len(tasks)} tasks across {len(themes)} themes")
     return benchmark

--- a/clawjournal/benchmark/generate.py
+++ b/clawjournal/benchmark/generate.py
@@ -48,6 +48,18 @@ BLOB_EXTRACT_MAX_CHARS = 8000
 # `--model`). `None` means "the CLI's default model".
 _DEFAULT_GEN_MODEL: dict[str, str] = {"claude": "sonnet"}
 
+# Per-stage subprocess ceilings (seconds). The architect call synthesises ALL
+# deep-read seeds in one shot — the heaviest single call — and was timing out
+# at the old flat 180s; design builds a full task and also runs long. Reads and
+# critique are per-item and lighter. These are upper bounds, not expected
+# durations: a healthy call returns well under them.
+_STAGE_TIMEOUTS: dict[str, int] = {
+    "deepread": 240,
+    "architect": 600,
+    "design": 360,
+    "critique": 240,
+}
+
 ProgressFn = Callable[[str], None]
 
 
@@ -140,7 +152,7 @@ class AgentBackendCaller:
 
     backend: str = "auto"
     model: str | None = None
-    timeout_seconds: int = 180
+    timeout_seconds: int = 240  # fallback for stages not in _STAGE_TIMEOUTS
 
     def __post_init__(self) -> None:
         self.resolved = resolve_backend(self.backend)
@@ -164,7 +176,7 @@ class AgentBackendCaller:
                 system_prompt_file=sys_file,
                 task_prompt=task,
                 model=self.model,
-                timeout_seconds=self.timeout_seconds,
+                timeout_seconds=_STAGE_TIMEOUTS.get(stage, self.timeout_seconds),
                 codex_sandbox="read-only",
                 codex_output_file="out.json",
                 openclaw_message=task,

--- a/clawjournal/benchmark/generate.py
+++ b/clawjournal/benchmark/generate.py
@@ -1,0 +1,450 @@
+"""Deep, backend-orchestrated benchmark generation.
+
+Replicates the multi-pass workflow (deep-read → cluster → design → critique →
+assemble) as a Python pipeline over the scoring backend
+(:func:`clawjournal.scoring.backends.run_default_agent_task`) — **not** the
+Claude Code Workflow tool, which the daemon cannot invoke. Each stage is one or
+more bounded backend calls returning JSON we validate.
+
+The backend is reached through a small :class:`BackendCaller` seam so the whole
+orchestration (prompt building, bounded parallelism, parsing, dropping on
+critique, assembly, validation) is testable with a fake caller — no real LLM in
+CI. The default caller wraps ``run_default_agent_task`` (the resolved/default
+agent, per the product decision).
+
+Privacy: both the blob extract AND the free-text substrate fields
+(``project``, ``learning_summary``, ``score_reason``, …) are run through the
+``Anonymizer`` at the deep-read boundary before reaching the backend — blobs are
+stored un-anonymized, and the judge *output* substrate is stored verbatim too,
+so neither is pre-scrubbed. The anonymizer strips the local user's home/username
+only; de-identification of *other* people (names, card last-4s) is steered by the
+prompts and enforced by ``schema.find_pii`` on the agent-facing fields.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from ..redaction.anonymizer import Anonymizer
+from ..scoring.backends import resolve_backend, run_default_agent_task
+from . import schema as bm
+from .select import DEFAULT_DEEPREAD_CAP, DEFAULT_WINDOW_DAYS, FailureCandidate, WeekSlice, select_week_failures
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_WORKERS = 4
+BLOB_EXTRACT_MAX_CHARS = 8000
+STAGES = ("deepread", "architect", "design", "critique")
+
+ProgressFn = Callable[[str], None]
+
+
+# ---------------------------------------------------------------------------
+# Backend seam
+# ---------------------------------------------------------------------------
+class BackendCaller(Protocol):
+    """Run one JSON-returning agent call for a pipeline ``stage``."""
+
+    def __call__(self, *, stage: str, system_prompt: str, task_prompt: str) -> dict[str, Any]:
+        ...
+
+
+def _extract_json_object(text: str) -> dict[str, Any]:
+    """Pull the first balanced top-level JSON object from possibly-fenced text."""
+    if not text or not text.strip():
+        raise ValueError("empty backend output")
+    s = text.strip()
+    start = s.find("{")
+    if start < 0:
+        raise ValueError("no JSON object in backend output")
+    depth = 0
+    in_str = False
+    esc = False
+    for i in range(start, len(s)):
+        c = s[i]
+        if in_str:
+            if esc:
+                esc = False
+            elif c == "\\":
+                esc = True
+            elif c == '"':
+                in_str = False
+        elif c == '"':
+            in_str = True
+        elif c == "{":
+            depth += 1
+        elif c == "}":
+            depth -= 1
+            if depth == 0:
+                return json.loads(s[start : i + 1])
+    raise ValueError("unbalanced JSON object in backend output")
+
+
+# Keys some backends (openclaw/hermes) wrap the agent reply in before the inner
+# JSON. Walked innermost-first so the real payload is recovered, not the envelope.
+_WRAPPER_KEYS = ("text", "message", "result", "reply", "output", "content", "assistant", "response", "completion")
+
+
+def _wrapper_text_candidates(value: Any) -> list[str]:
+    out: list[str] = []
+    if isinstance(value, str):
+        out.append(value)
+    elif isinstance(value, dict):
+        for key in _WRAPPER_KEYS:
+            if key in value:
+                out.extend(_wrapper_text_candidates(value[key]))
+    elif isinstance(value, list):
+        for item in value:
+            out.extend(_wrapper_text_candidates(item))
+    return out
+
+
+def _read_agent_output(resolved: str, stdout: str, out_file: Path) -> dict[str, Any]:
+    """Parse the agent's JSON from the right place per backend (codex file vs stdout),
+    unwrapping the openclaw/hermes ``--json`` envelope when present."""
+    if resolved == "codex" and out_file.exists():
+        return _extract_json_object(out_file.read_text(encoding="utf-8"))
+    if resolved in ("openclaw", "hermes"):
+        try:
+            envelope = json.loads(stdout)
+        except (TypeError, json.JSONDecodeError):
+            envelope = None
+        if envelope is not None:
+            for candidate in _wrapper_text_candidates(envelope):
+                try:
+                    return _extract_json_object(candidate)
+                except ValueError:
+                    continue
+    return _extract_json_object(stdout)
+
+
+@dataclass
+class AgentBackendCaller:
+    """Production :class:`BackendCaller` over ``run_default_agent_task``.
+
+    Not exercised in CI (needs a real backend); the golden tests drive the
+    orchestrator with a fake caller instead.
+    """
+
+    backend: str = "auto"
+    model: str | None = None
+    timeout_seconds: int = 180
+
+    def __post_init__(self) -> None:
+        self.resolved = resolve_backend(self.backend)
+
+    def __call__(self, *, stage: str, system_prompt: str, task_prompt: str) -> dict[str, Any]:
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp:
+            cwd = Path(tmp)
+            sys_file = cwd / "system.md"
+            sys_file.write_text(system_prompt, encoding="utf-8")
+            # Claude consumes the system prompt via file; other backends get it
+            # prepended to the task message.
+            task = task_prompt if self.resolved == "claude" else f"{system_prompt}\n\n{task_prompt}"
+            result = run_default_agent_task(
+                backend=self.resolved,
+                cwd=cwd,
+                system_prompt_file=sys_file,
+                task_prompt=task,
+                model=self.model,
+                timeout_seconds=self.timeout_seconds,
+                codex_sandbox="read-only",
+                codex_output_file="out.json",
+                openclaw_message=task,
+            )
+            return _read_agent_output(self.resolved, result.stdout, cwd / "out.json")
+
+
+# ---------------------------------------------------------------------------
+# Prompts (taxonomy + de-identification + packet discipline are encoded here)
+# ---------------------------------------------------------------------------
+_TAXONOMY = (
+    "task_framing, method_selection, context_handling, execution_error, "
+    "reasoning_fabrication, revision_failure, verification_skipped, "
+    "deliverable_defect, communication_error, collaboration_error, "
+    "safety_security, efficiency_waste, evaluation_measurement"
+)
+
+_SYSTEM = (
+    "You build a PERSONALIZED, adversarial, judgment-focused agent benchmark from a user's own "
+    "coding-agent failure traces. Output ONLY a single JSON object — no prose, no markdown fences. "
+    "De-identify: refer to people by role (e.g. 'the PI'), mask account/card digits as ••XXXX, and "
+    "never put a person's name, email, home-dir path, or other PII into agent-facing fields "
+    "(scenario, seed_inputs, title). Ground every claim in the trace; do not invent failures from a "
+    "bare score. Remember that a session scored mid-flight can be mis-graded — judge the terminal "
+    f"state, not the opening narration. Failure taxonomy: {_TAXONOMY}."
+)
+
+
+def _deepread_prompt(candidate: FailureCandidate, blob_extract: str, anon: Anonymizer) -> str:
+    # Anonymize the free-text substrate too (not just the blob): the judge OUTPUT
+    # fields (learning_summary/score_reason/…) and `project` are stored verbatim,
+    # so the local user's home/username can ride through to the backend otherwise.
+    def a(value: Any) -> Any:
+        return anon.text(str(value)) if value else value
+
+    return (
+        "# Benchmark stage: deep-read ONE failure trace into a reusable seed.\n\n"
+        f"session_id: {candidate.session_id}\nsource: {candidate.source}\nproject: {a(candidate.project)}\n"
+        f"failure_value_score: {candidate.failure_value_score}\n"
+        f"failure_modes: {a(candidate.failure_modes)}\nrecovery: {a(candidate.recovery_labels)}\n"
+        f"attribution: {a(candidate.failure_attribution)}\n"
+        f"learning_summary: {a(candidate.learning_summary)}\nscore_reason: {a(candidate.score_reason)}\n\n"
+        f"Anonymized trace extract:\n{blob_extract}\n\n"
+        "Return JSON: {domain, user_goal, failure_moment, root_cause_categories[] (from the taxonomy), "
+        "seductive_wrong_move, correct_behavior, evidence_snippet (<220 chars), "
+        "recovery (self_recovered|user_corrected_recovery|unrecovered|blocked|none), "
+        "generalizable_trap, severity (low|medium|high)}."
+    )
+
+
+def _architect_prompt(seeds: list[dict[str, Any]]) -> str:
+    return (
+        "# Benchmark stage: cluster failure seeds into ONE merged set of themes + task stubs.\n\n"
+        f"SEEDS (JSON): {json.dumps(seeds)}\n\n"
+        "Dedupe across ALL agents: when the same failure appears for >1 agent on the same session "
+        "family, emit ONE stub with all source_agents and session ids. Aim for 8-16 stubs spread "
+        "across themes/domains.\n"
+        "Return JSON: {themes:[{name, taxonomy[], frequency, evidence_session_ids[], lesson}], "
+        "stubs:[{id (short slug like S1), theme, domains[], source_agents[], grounded_session_ids[], "
+        "concept, why_personalized}]}."
+    )
+
+
+def _design_prompt(stub: dict[str, Any], seeds: list[dict[str, Any]]) -> str:
+    relevant = [s for s in seeds if s.get("session_id") in (stub.get("grounded_session_ids") or [])]
+    return (
+        "# Benchmark stage: design ONE full benchmark task from a stub.\n\n"
+        f"STUB (JSON): {json.dumps(stub)}\nGROUNDING SEEDS (JSON): {json.dumps(relevant or seeds)}\n\n"
+        "The scenario + seed_inputs are the AGENT PACKET (what the agent under test sees) — they must "
+        "withhold the trap/answer and contain no PII. Everything else is the grader packet.\n"
+        "Return JSON: {title, scenario, seed_inputs, the_trap, ideal_trajectory[], pass_criteria[] "
+        "(observable), fail_signals[], grading (assertion|judge|manual), difficulty (easy|medium|hard), "
+        "points (1-5)}."
+    )
+
+
+def _critique_prompt(stub: dict[str, Any], task_body: dict[str, Any]) -> str:
+    return (
+        "# Benchmark stage: adversarially critique ONE designed task and set its readiness.\n\n"
+        f"TASK (JSON): {json.dumps({**stub, **task_body})}\n\n"
+        "Judge: discriminating (a strong agent passes while one prone to the failure fails?), gameable, "
+        "leakage (does the scenario telegraph the answer?), measurable. Assign readiness: ready | "
+        "needs_staging (repo rollback / mock / withheld state needed) | needs_review | local_only "
+        "(depends on private artifacts) | retired. Set leakage_risk/privacy_risk (low|medium|high).\n"
+        "Return JSON: {discriminating, gameable, leakage, measurable, verdict (keep|revise|drop), "
+        "notes, staging_notes, readiness, leakage_risk, privacy_risk, revised_pass_criteria[]}."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Blob extraction (anonymized)
+# ---------------------------------------------------------------------------
+def _blob_extract(blob_path: str | None, anonymizer: Anonymizer, *, max_chars: int = BLOB_EXTRACT_MAX_CHARS) -> str:
+    """A bounded, anonymized text extract of the trace for the deep-read prompt."""
+    if not blob_path:
+        return "(no trace blob available)"
+    try:
+        data = json.loads(Path(blob_path).read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return "(trace blob unavailable)"
+    parts: list[str] = []
+    for msg in data.get("messages", []) or []:
+        if not isinstance(msg, dict):
+            continue
+        role = msg.get("role", "?")
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            content = " ".join(
+                str(p.get("text", "")) for p in content if isinstance(p, dict) and p.get("text")
+            )
+        text = str(content).strip()
+        if text:
+            # Cap any single message so one giant turn can't dominate the budget.
+            parts.append(f"[{role}] {text[:2000]}")
+    joined = "\n".join(parts)
+    if len(joined) > max_chars:
+        # Keep a head + tail slice — the failure usually lands in terminal turns,
+        # so head-only truncation would drop the most informative part.
+        half = max_chars // 2
+        joined = f"{joined[:half]}\n…\n{joined[-half:]}"
+    return anonymizer.text(joined) if joined else "(empty trace)"
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+def _repo_git_sha() -> str:
+    try:
+        proc = subprocess.run(
+            ["git", "rev-parse", "HEAD"], capture_output=True, text=True, timeout=5, check=False
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return proc.stdout.strip() if proc.returncode == 0 else ""
+
+
+def _map(fn: Callable[[Any], Any], items: list[Any], max_workers: int) -> list[Any]:
+    if not items:
+        return []
+    workers = max(1, min(max_workers, len(items)))
+    if workers == 1:
+        return [fn(x) for x in items]
+    with ThreadPoolExecutor(max_workers=workers) as pool:
+        return list(pool.map(fn, items))
+
+
+def generate_benchmark(
+    conn,
+    *,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    cap: int = DEFAULT_DEEPREAD_CAP,
+    backend: str = "auto",
+    caller: BackendCaller | None = None,
+    anonymizer: Anonymizer | None = None,
+    now: datetime | None = None,
+    max_workers: int = DEFAULT_MAX_WORKERS,
+    progress: ProgressFn | None = None,
+    week_slice: WeekSlice | None = None,
+) -> bm.Benchmark:
+    """Run the deep pipeline and return a validated :class:`~schema.Benchmark`.
+
+    ``caller`` defaults to :class:`AgentBackendCaller` over the resolved/default
+    agent; tests pass a fake. ``week_slice`` lets a caller pass a pre-selected
+    slice (else :func:`select_week_failures` is run).
+    """
+    call = caller or AgentBackendCaller(backend=backend)
+    anon = anonymizer if anonymizer is not None else Anonymizer(enabled=True)
+    resolved = getattr(call, "resolved", None) or resolve_backend(backend)
+
+    def note(msg: str) -> None:
+        if progress is not None:
+            progress(msg)
+        logger.info("benchmark: %s", msg)
+
+    sl = week_slice or select_week_failures(conn, window_days=window_days, cap=cap, now=now)
+    if not sl.candidates:
+        raise ValueError("no failure-signal sessions in the selected window")
+
+    # 1. Deep-read (bounded parallel) -> seeds.
+    note(f"deep-reading {len(sl.candidates)} sessions")
+    extracts = {c.session_id: _blob_extract(c.blob_path, anon) for c in sl.candidates}
+
+    def _deepread(c: FailureCandidate) -> dict[str, Any] | None:
+        try:
+            seed = call(stage="deepread", system_prompt=_SYSTEM,
+                        task_prompt=_deepread_prompt(c, extracts[c.session_id], anon))
+        except Exception as exc:  # one bad call must not kill the run
+            logger.warning("benchmark deep-read failed for %s: %s", c.session_id, exc)
+            return None
+        seed["session_id"] = c.session_id
+        seed["source"] = c.source
+        return seed
+
+    seeds = [s for s in _map(_deepread, list(sl.candidates), max_workers) if s]
+    if not seeds:
+        raise ValueError("deep-read produced no seeds")
+
+    # 2. Architect / cluster (single call) -> themes + stubs.
+    note("clustering into themes")
+    try:
+        arch = call(stage="architect", system_prompt=_SYSTEM, task_prompt=_architect_prompt(seeds))
+    except Exception as exc:  # distinct from the empty-week control-flow ValueErrors
+        raise RuntimeError(f"benchmark architect stage failed: {exc}") from exc
+    themes: list[bm.BenchmarkTheme] = []
+    raw_themes = arch.get("themes") or []
+    if isinstance(raw_themes, list):
+        for t in raw_themes:
+            if not isinstance(t, dict) or not t.get("name"):
+                logger.warning("benchmark: dropping malformed theme %r", t)
+                continue
+            themes.append(bm.BenchmarkTheme(**bm._only(bm.BenchmarkTheme, t)))
+    else:
+        logger.warning("benchmark: architect 'themes' was not a list (%s); dropping",
+                       type(raw_themes).__name__)
+    stubs = list(arch.get("stubs", []) or [])
+    if not stubs:
+        raise ValueError("architect produced no task stubs")
+
+    # 3 + 4. Design then critique each stub (bounded parallel, per-item chain).
+    note(f"designing + critiquing {len(stubs)} tasks")
+
+    def _build(stub: dict[str, Any]) -> bm.BenchmarkTask | None:
+        sid = stub.get("id") or "S?"
+        # The whole design→critique→construct chain is guarded: a non-int
+        # `points`, a non-iterable list field, or any malformed LLM output must
+        # drop only THIS task, never abort the run.
+        try:
+            body = call(stage="design", system_prompt=_SYSTEM, task_prompt=_design_prompt(stub, seeds))
+            crit = call(stage="critique", system_prompt=_SYSTEM, task_prompt=_critique_prompt(stub, body))
+            if crit.get("verdict") == "drop":
+                logger.info("benchmark: dropped task %s (critique verdict=drop)", sid)
+                return None
+            pass_criteria = crit.get("revised_pass_criteria") or body.get("pass_criteria") or []
+            task = bm.BenchmarkTask(
+                id=str(sid),
+                title=str(body.get("title") or stub.get("concept") or sid),
+                theme=str(stub.get("theme") or ""),
+                scenario=str(body.get("scenario") or ""),
+                seed_inputs=str(body.get("seed_inputs") or ""),
+                the_trap=str(body.get("the_trap") or ""),
+                ideal_trajectory=list(body.get("ideal_trajectory") or []),
+                pass_criteria=list(pass_criteria),
+                fail_signals=list(body.get("fail_signals") or []),
+                grading=str(body.get("grading") or "judge"),
+                difficulty=str(body.get("difficulty") or "medium"),
+                points=int(body.get("points") or 3),
+                domains=list(stub.get("domains") or []),
+                source_agents=list(stub.get("source_agents") or []),
+                grounded_session_ids=list(stub.get("grounded_session_ids") or []),
+                readiness=str(crit.get("readiness") or "needs_review"),
+                leakage_risk=str(crit.get("leakage_risk") or "low"),
+                privacy_risk=str(crit.get("privacy_risk") or "low"),
+                critique=bm.TaskCritique(
+                    discriminating=bool(crit.get("discriminating", True)),
+                    gameable=bool(crit.get("gameable", False)),
+                    leakage=bool(crit.get("leakage", False)),
+                    measurable=bool(crit.get("measurable", True)),
+                    verdict=str(crit.get("verdict") or "keep"),
+                    notes=str(crit.get("notes") or ""),
+                    staging_notes=str(crit.get("staging_notes") or ""),
+                ),
+            )
+        except Exception as exc:
+            logger.warning("benchmark design/critique/build failed for %s: %s", sid, exc)
+            return None
+        # Drop individually-invalid tasks (e.g. PII leak / bad enum) rather than
+        # failing the whole run — robustness over strictness.
+        errors = bm.validate_task(task)
+        if errors:
+            logger.warning("benchmark: dropping invalid task %s: %s", sid, errors)
+            return None
+        return task
+
+    tasks = [t for t in _map(_build, stubs, max_workers) if t]
+    if not tasks:
+        raise ValueError("no tasks survived design/critique/validation")
+
+    benchmark = bm.Benchmark(
+        window_start=sl.window_start,
+        window_end=sl.window_end,
+        generated_at=(now or datetime.now(timezone.utc)).isoformat(),
+        backend=resolved,
+        rubric_git_sha=_repo_git_sha(),
+        source_session_ids=[s["session_id"] for s in seeds],
+        dropped_for_cost=sl.dropped_for_cost,
+        themes=themes,
+        tasks=tasks,
+    )
+    bm.validate_or_raise(benchmark)
+    note(f"done: {len(tasks)} tasks, {len(themes)} themes")
+    return benchmark

--- a/clawjournal/benchmark/render.py
+++ b/clawjournal/benchmark/render.py
@@ -1,0 +1,192 @@
+"""Render a benchmark to the export kinds (authoring markdown + agent/grader packets).
+
+Works on the **payload dict** (``schema.benchmark_to_dict`` / what ``store`` stores
+and serves), so the CLI/API can render straight from storage without rebuilding
+dataclasses. The agent-packet renderers go through the same field whitelist as
+``schema.to_agent_packet`` so the answer key (trap, criteria, grounding) can never
+leak into an agent-facing export.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+from typing import Any
+
+from . import schema as bm
+
+EXPORT_KINDS = (
+    "authoring_md",
+    "agent_packet_md",
+    "grader_packet_md",
+    "agent_packet_json",
+    "grader_packet_json",
+)
+
+
+def _as_payload(benchmark: Any) -> dict[str, Any]:
+    if isinstance(benchmark, bm.Benchmark):
+        return bm.benchmark_to_dict(benchmark)
+    if dataclasses.is_dataclass(benchmark):
+        return dataclasses.asdict(benchmark)
+    return dict(benchmark)
+
+
+def _agent_task(task: dict[str, Any]) -> dict[str, Any]:
+    """Whitelist agent-facing fields — mirrors schema.to_agent_packet, dict-side."""
+    return {k: task.get(k) for k in bm.AGENT_PACKET_FIELDS}
+
+
+def _meta_line(b: dict[str, Any]) -> str:
+    return (
+        f"window {b.get('window_start','?')} → {b.get('window_end','?')} · "
+        f"generated {b.get('generated_at','?')} · backend {b.get('backend','?')} · "
+        f"{b.get('n_tasks', len(b.get('tasks', [])))} tasks · {b.get('total_points','?')} pts"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Markdown
+# ---------------------------------------------------------------------------
+def render_markdown(benchmark: Any) -> str:
+    """Full authoring document (overview + themes + tasks w/ both packets + scoring)."""
+    b = _as_payload(benchmark)
+    tasks = b.get("tasks", []) or []
+    themes = b.get("themes", []) or []
+    out: list[str] = []
+    out.append("# Personalized benchmark")
+    out.append("")
+    out.append(_meta_line(b))
+    if b.get("dropped_for_cost"):
+        out.append(f"_coverage: {b.get('source_count', len(b.get('source_session_ids', [])))} sessions "
+                   f"deep-read, {b['dropped_for_cost']} dropped for cost._")
+    out.append("")
+    out.append("> Stored locally · never shared. Tasks may pin private artifacts (see readiness).")
+    out.append("")
+
+    if themes:
+        out.append("## Failure themes")
+        out.append("")
+        out.append("| Theme | Freq | Taxonomy | Lesson |")
+        out.append("|---|---|---|---|")
+        for t in themes:
+            out.append(
+                f"| {t.get('name','')} | {t.get('frequency','')} | "
+                f"{', '.join(t.get('taxonomy', []) or [])} | {t.get('lesson','')} |"
+            )
+        out.append("")
+
+    out.append("## Tasks")
+    out.append("")
+    by_theme: dict[str, list[dict]] = {}
+    for task in tasks:
+        by_theme.setdefault(task.get("theme", "(untyped)"), []).append(task)
+    for theme, group in by_theme.items():
+        out.append(f"### Theme: {theme}")
+        out.append("")
+        for task in group:
+            out.append(f"#### {task.get('id','?')} — {task.get('title','')}")
+            out.append("")
+            out.append(
+                f"`{'/'.join(task.get('domains', []) or ['—'])} · {task.get('difficulty','?')} · "
+                f"{task.get('points','?')} pts · {task.get('grading','?')} · "
+                f"readiness: {task.get('readiness','?')} · "
+                f"agents: {', '.join(task.get('source_agents', []) or ['—'])} · "
+                f"grounded: {', '.join(task.get('grounded_session_ids', []) or ['—'])}`"
+            )
+            out.append("")
+            out.append("**Scenario.** " + (task.get("scenario") or ""))
+            if task.get("seed_inputs"):
+                out.append("")
+                out.append("**Seed inputs.** " + task["seed_inputs"])
+            out.append("")
+            out.append("**The trap.** " + (task.get("the_trap") or ""))
+            if task.get("ideal_trajectory"):
+                out.append("")
+                out.append("**Ideal trajectory.**")
+                for i, step in enumerate(task["ideal_trajectory"], 1):
+                    out.append(f"{i}. {step}")
+            if task.get("pass_criteria"):
+                out.append("")
+                out.append("**Pass criteria.**")
+                for c in task["pass_criteria"]:
+                    out.append(f"- [ ] {c}")
+            if task.get("fail_signals"):
+                out.append("")
+                out.append("**Fail signals.** " + "; ".join(task["fail_signals"]))
+            crit = task.get("critique") or {}
+            if crit.get("staging_notes"):
+                out.append("")
+                out.append(f"> ⚠️ staging: {crit['staging_notes']}")
+            out.append("")
+
+    out.append("## Scoring")
+    out.append("")
+    out.append("| Task | Theme | Readiness | Points |")
+    out.append("|---|---|---|---|")
+    for task in tasks:
+        out.append(
+            f"| {task.get('id','?')} | {task.get('theme','')} | "
+            f"{task.get('readiness','?')} | {task.get('points','?')} |"
+        )
+    out.append(f"| **Total** | | | **{b.get('total_points','?')}** |")
+    out.append("")
+    return "\n".join(out)
+
+
+def render_agent_packet_markdown(benchmark: Any) -> str:
+    """Runnable prompts only — scenario + seed inputs, answer withheld."""
+    b = _as_payload(benchmark)
+    out = ["# Benchmark — agent packets", "", _meta_line(b),
+           "", "> Run each agent against the scenario + seed inputs only. Grader material withheld.", ""]
+    for task in b.get("tasks", []) or []:
+        ap = _agent_task(task)
+        out.append(f"## {ap.get('id','?')} — {ap.get('title','')}")
+        out.append("")
+        out.append("**Scenario.** " + (ap.get("scenario") or ""))
+        if ap.get("seed_inputs"):
+            out.append("")
+            out.append("**Seed inputs.** " + ap["seed_inputs"])
+        out.append("")
+    return "\n".join(out)
+
+
+def render_grader_packet_markdown(benchmark: Any) -> str:
+    """The answer key — identical to the authoring doc by design (it already carries
+    the full trap/criteria/grounding), so MD and JSON grader packets stay in sync."""
+    return render_markdown(benchmark)
+
+
+# ---------------------------------------------------------------------------
+# JSON packets
+# ---------------------------------------------------------------------------
+def agent_packet_dict(benchmark: Any) -> dict[str, Any]:
+    b = _as_payload(benchmark)
+    return {
+        "window_start": b.get("window_start"),
+        "window_end": b.get("window_end"),
+        "generated_at": b.get("generated_at"),
+        "tasks": [_agent_task(t) for t in b.get("tasks", []) or []],
+    }
+
+
+def grader_packet_dict(benchmark: Any) -> dict[str, Any]:
+    return _as_payload(benchmark)
+
+
+# ---------------------------------------------------------------------------
+# Dispatch
+# ---------------------------------------------------------------------------
+def render(benchmark: Any, kind: str) -> str:
+    """Render ``benchmark`` to the export ``kind`` (returns a string)."""
+    if kind == "authoring_md":
+        return render_markdown(benchmark)
+    if kind == "agent_packet_md":
+        return render_agent_packet_markdown(benchmark)
+    if kind == "grader_packet_md":
+        return render_grader_packet_markdown(benchmark)
+    if kind == "agent_packet_json":
+        return json.dumps(agent_packet_dict(benchmark), indent=2)
+    if kind == "grader_packet_json":
+        return json.dumps(grader_packet_dict(benchmark), indent=2)
+    raise ValueError(f"unknown export kind {kind!r}; expected one of {EXPORT_KINDS}")

--- a/clawjournal/benchmark/schema.py
+++ b/clawjournal/benchmark/schema.py
@@ -1,0 +1,279 @@
+"""Typed shapes, validation, and packet-splitting for personalized benchmarks.
+
+This module is the single source of truth for the benchmark shape: the
+dataclasses, their (de)serialization to the JSON stored in
+``benchmarks.payload_json``, validation (enum domains, grounding,
+de-identification), and the **agent-packet vs grader-packet** split that keeps
+the answer key out of anything handed to an agent under test.
+
+Packet separation is load-bearing: the agent packet is the runnable prompt
+(scenario + seed inputs only); everything that reveals the trap or the answer —
+``the_trap``, ``ideal_trajectory``, ``pass_criteria``, ``fail_signals``,
+``critique``, and ``grounded_session_ids`` — is grader-only and must never leak
+into the agent packet.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+# Bump when the stored payload shape changes incompatibly.
+SCHEMA_VERSION = 1
+
+READINESS_STATES = ("ready", "needs_staging", "needs_review", "local_only", "retired")
+RISK_LEVELS = ("low", "medium", "high")
+GRADING_METHODS = ("assertion", "judge", "manual")
+DIFFICULTIES = ("easy", "medium", "hard")
+CRITIQUE_VERDICTS = ("keep", "revise", "drop")
+
+# Fields the agent under test may see.
+AGENT_PACKET_FIELDS = ("id", "title", "scenario", "seed_inputs")
+# Fields that must NEVER appear in an agent packet.
+GRADER_ONLY_FIELDS = (
+    "the_trap",
+    "ideal_trajectory",
+    "pass_criteria",
+    "fail_signals",
+    "critique",
+    "grounded_session_ids",
+)
+
+
+# ---------------------------------------------------------------------------
+# Dataclasses
+# ---------------------------------------------------------------------------
+@dataclass
+class BenchmarkTheme:
+    name: str
+    taxonomy: list[str] = field(default_factory=list)
+    frequency: int = 0
+    evidence_session_ids: list[str] = field(default_factory=list)
+    lesson: str = ""
+
+
+@dataclass
+class TaskCritique:
+    discriminating: bool = True
+    gameable: bool = False
+    leakage: bool = False
+    measurable: bool = True
+    verdict: str = "keep"  # keep|revise|drop
+    notes: str = ""
+    staging_notes: str = ""
+
+
+@dataclass
+class BenchmarkTask:
+    id: str
+    title: str
+    theme: str
+    scenario: str
+    seed_inputs: str = ""
+    the_trap: str = ""
+    ideal_trajectory: list[str] = field(default_factory=list)
+    pass_criteria: list[str] = field(default_factory=list)
+    fail_signals: list[str] = field(default_factory=list)
+    grading: str = "judge"
+    difficulty: str = "medium"
+    points: int = 3
+    domains: list[str] = field(default_factory=list)
+    source_agents: list[str] = field(default_factory=list)
+    grounded_session_ids: list[str] = field(default_factory=list)
+    readiness: str = "needs_review"
+    leakage_risk: str = "low"
+    privacy_risk: str = "low"
+    critique: TaskCritique = field(default_factory=TaskCritique)
+
+
+@dataclass
+class Benchmark:
+    window_start: str
+    window_end: str
+    generated_at: str
+    backend: str = ""
+    rubric_git_sha: str = ""
+    source_session_ids: list[str] = field(default_factory=list)
+    dropped_for_cost: int = 0
+    themes: list[BenchmarkTheme] = field(default_factory=list)
+    tasks: list[BenchmarkTask] = field(default_factory=list)
+    schema_version: int = SCHEMA_VERSION
+    benchmark_id: str = ""
+
+    # Derived counts — surfaced in the stored payload and used to populate the
+    # denormalized run-row columns.
+    @property
+    def n_tasks(self) -> int:
+        return len(self.tasks)
+
+    @property
+    def total_points(self) -> int:
+        return sum(int(t.points or 0) for t in self.tasks)
+
+    @property
+    def ready_count(self) -> int:
+        return sum(1 for t in self.tasks if t.readiness == "ready")
+
+    @property
+    def needs_staging_count(self) -> int:
+        return sum(1 for t in self.tasks if t.readiness == "needs_staging")
+
+    @property
+    def source_count(self) -> int:
+        return len(self.source_session_ids)
+
+
+# ---------------------------------------------------------------------------
+# (De)serialization — tolerant of extra/missing keys so the stored payload can
+# evolve without breaking older rows.
+# ---------------------------------------------------------------------------
+def _field_names(cls: type) -> set[str]:
+    return {f.name for f in dataclasses.fields(cls)}
+
+
+def _only(cls: type, data: dict[str, Any]) -> dict[str, Any]:
+    names = _field_names(cls)
+    return {k: v for k, v in (data or {}).items() if k in names}
+
+
+def benchmark_to_dict(benchmark: Benchmark) -> dict[str, Any]:
+    """Serialize, including the derived counts (handy for stored/served payloads)."""
+    out = dataclasses.asdict(benchmark)
+    out["n_tasks"] = benchmark.n_tasks
+    out["total_points"] = benchmark.total_points
+    out["ready_count"] = benchmark.ready_count
+    out["needs_staging_count"] = benchmark.needs_staging_count
+    out["source_count"] = benchmark.source_count
+    return out
+
+
+def task_from_dict(data: dict[str, Any]) -> BenchmarkTask:
+    crit_raw = data.get("critique")
+    critique = TaskCritique(**_only(TaskCritique, crit_raw)) if isinstance(crit_raw, dict) else TaskCritique()
+    base = _only(BenchmarkTask, data)
+    base["critique"] = critique
+    return BenchmarkTask(**base)
+
+
+def benchmark_from_dict(data: dict[str, Any]) -> Benchmark:
+    themes = [BenchmarkTheme(**_only(BenchmarkTheme, t)) for t in data.get("themes", []) or []]
+    tasks = [task_from_dict(t) for t in data.get("tasks", []) or []]
+    base = _only(Benchmark, data)
+    base.pop("themes", None)
+    base.pop("tasks", None)
+    return Benchmark(themes=themes, tasks=tasks, **base)
+
+
+# ---------------------------------------------------------------------------
+# Packet split
+# ---------------------------------------------------------------------------
+def to_agent_packet(task: BenchmarkTask) -> dict[str, Any]:
+    """The runnable prompt the agent under test sees — answer withheld.
+
+    By construction contains none of :data:`GRADER_ONLY_FIELDS` (including the
+    grounded session ids).
+    """
+    return {
+        "id": task.id,
+        "title": task.title,
+        "scenario": task.scenario,
+        "seed_inputs": task.seed_inputs,
+    }
+
+
+def to_grader_packet(task: BenchmarkTask) -> dict[str, Any]:
+    """The answer key — trap, ideal trajectory, pass criteria, grounding, critique."""
+    return dataclasses.asdict(task)
+
+
+# ---------------------------------------------------------------------------
+# De-identification heuristic (best-effort guardrail, not a redaction engine)
+# ---------------------------------------------------------------------------
+# Bounded quantifiers (RFC-ish limits) so an unbounded greedy run can't trigger
+# O(n^2) backtracking on a long no-match field (e.g. a large embedded scenario).
+_EMAIL_RE = re.compile(r"[A-Za-z0-9._%+-]{1,64}@[A-Za-z0-9.-]{1,255}\.[A-Za-z]{2,24}")
+# 7+ consecutive digits (account / card-PAN-ish runs). Bare 4-digit "last-4"
+# values are too noisy to flag automatically — generators are prompted to mask
+# them as ``••XXXX`` instead.
+_LONG_DIGITS_RE = re.compile(r"\b\d{7,}\b")
+# Home-dir paths reveal a username. Generic (any user), unlike
+# ``redaction/anonymizer.py`` which only strips the *local* user's home.
+_HOME_PATH_RE = re.compile(r"(?:/Users/|/home/|[A-Za-z]:\\Users\\)[A-Za-z0-9._-]+")
+
+
+def find_pii(text: str) -> list[str]:
+    """Return obvious PII tokens (emails, home-dir paths, long digit runs) in ``text``.
+
+    Best-effort: used to reject the most blatant leaks from the agent-facing
+    fields, not as a substitute for the deterministic/AI redaction applied at
+    export time.
+    """
+    if not text:
+        return []
+    hits: list[str] = []
+    hits.extend(m.group(0) for m in _EMAIL_RE.finditer(text))
+    hits.extend(m.group(0) for m in _HOME_PATH_RE.finditer(text))
+    hits.extend(m.group(0) for m in _LONG_DIGITS_RE.finditer(text))
+    return hits
+
+
+# ---------------------------------------------------------------------------
+# Validation
+# ---------------------------------------------------------------------------
+def validate_task(task: BenchmarkTask) -> list[str]:
+    errors: list[str] = []
+    tid = task.id or "<no-id>"
+    if not task.id:
+        errors.append("task missing id")
+    if not task.title:
+        errors.append(f"{tid}: missing title")
+    if not task.scenario:
+        errors.append(f"{tid}: missing scenario")
+    if task.readiness not in READINESS_STATES:
+        errors.append(f"{tid}: invalid readiness {task.readiness!r}")
+    if task.leakage_risk not in RISK_LEVELS:
+        errors.append(f"{tid}: invalid leakage_risk {task.leakage_risk!r}")
+    if task.privacy_risk not in RISK_LEVELS:
+        errors.append(f"{tid}: invalid privacy_risk {task.privacy_risk!r}")
+    if task.grading not in GRADING_METHODS:
+        errors.append(f"{tid}: invalid grading {task.grading!r}")
+    if task.difficulty not in DIFFICULTIES:
+        errors.append(f"{tid}: invalid difficulty {task.difficulty!r}")
+    if isinstance(task.points, bool) or not isinstance(task.points, int) or task.points < 0:
+        errors.append(f"{tid}: points must be a non-negative int, got {task.points!r}")
+    if task.critique.verdict not in CRITIQUE_VERDICTS:
+        errors.append(f"{tid}: invalid critique.verdict {task.critique.verdict!r}")
+    # Every runnable task must pin >=1 real session. `needs_review` tasks are
+    # explicitly un-grounded placeholders, so they're exempt.
+    if task.readiness != "needs_review" and not task.grounded_session_ids:
+        errors.append(f"{tid}: no grounded_session_ids (required unless needs_review)")
+    # Agent-facing fields must be de-identified.
+    for fieldname in ("title", "scenario", "seed_inputs"):
+        hits = find_pii(getattr(task, fieldname) or "")
+        if hits:
+            errors.append(f"{tid}: PII in agent-facing {fieldname}: {hits[:3]}")
+    return errors
+
+
+def validate_benchmark(benchmark: Benchmark) -> list[str]:
+    """Return a list of human-readable validation errors (empty == valid)."""
+    errors: list[str] = []
+    if not benchmark.window_start or not benchmark.window_end:
+        errors.append("benchmark missing window_start/window_end")
+    if not benchmark.generated_at:
+        errors.append("benchmark missing generated_at")
+    seen_ids: set[str] = set()
+    for task in benchmark.tasks:
+        if task.id in seen_ids:
+            errors.append(f"duplicate task id {task.id!r}")
+        seen_ids.add(task.id)
+        errors.extend(validate_task(task))
+    return errors
+
+
+def validate_or_raise(benchmark: Benchmark) -> None:
+    errors = validate_benchmark(benchmark)
+    if errors:
+        raise ValueError("invalid benchmark: " + "; ".join(errors))

--- a/clawjournal/benchmark/select.py
+++ b/clawjournal/benchmark/select.py
@@ -1,0 +1,142 @@
+"""Select the week's failure-signal sessions to feed benchmark generation.
+
+Reuses the failure-mode substrate already computed by scoring
+(``ai_failure_value_score``, ``ai_failure_modes``, ``ai_learning_summary``, …),
+which is now trustworthy thanks to the re-score-on-growth fix (mid-flight grades
+no longer stick). This module does no LLM work — it just picks and ranks the
+candidates a later deep-read pass will read.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from ..workbench.index import FAILURE_VALUE_SOURCE_SCOPE
+
+DEFAULT_WINDOW_DAYS = 7
+# Cap on how many sessions get deep-read, to bound generation cost. The rest are
+# counted as ``dropped_for_cost`` so coverage is reported honestly.
+DEFAULT_DEEPREAD_CAP = 15
+
+
+@dataclass
+class FailureCandidate:
+    session_id: str
+    project: str
+    source: str
+    failure_value_score: int | None
+    failure_modes: list[str] = field(default_factory=list)
+    failure_attribution: str | None = None
+    recovery_labels: list[str] = field(default_factory=list)
+    learning_summary: str | None = None
+    score_reason: str | None = None
+    summary: str | None = None
+    title: str | None = None
+    blob_path: str | None = None
+    start_time: str | None = None
+    # True when the trace carries a concrete, trace-backed failure signal (a
+    # learning summary, a score reason, or labeled failure modes). Generators
+    # must not invent a failure from a bare low score — un-evidenced candidates
+    # become ``needs_review`` tasks rather than confident ones.
+    has_trace_evidence: bool = False
+
+
+@dataclass
+class WeekSlice:
+    window_start: str
+    window_end: str
+    candidates: list[FailureCandidate]
+    total_candidates: int
+    dropped_for_cost: int
+
+    @property
+    def session_ids(self) -> list[str]:
+        return [c.session_id for c in self.candidates]
+
+
+def _parse_json_list(raw: Any) -> list[str]:
+    if not raw:
+        return []
+    try:
+        value = json.loads(raw)
+    except (TypeError, json.JSONDecodeError):
+        return []
+    return [str(x) for x in value] if isinstance(value, list) else []
+
+
+def select_week_failures(
+    conn: sqlite3.Connection,
+    *,
+    window_days: int = DEFAULT_WINDOW_DAYS,
+    cap: int = DEFAULT_DEEPREAD_CAP,
+    now: datetime | None = None,
+    sources: tuple[str, ...] | list[str] | None = FAILURE_VALUE_SOURCE_SCOPE,
+) -> WeekSlice:
+    """Return the window's failure-signal sessions, ranked, capped for cost.
+
+    A session qualifies if it has ``ai_failure_value_score >= 3`` OR a non-empty
+    ``ai_failure_modes`` list. Segmented parent rows are skipped (their content
+    lives in the per-segment children). Ranked by failure value (desc), then
+    recency, then capped to ``cap`` — the remainder reported as
+    ``dropped_for_cost``.
+    """
+    clock = now or datetime.now(timezone.utc)
+    window_start = (clock - timedelta(days=window_days)).isoformat()
+    window_end = clock.isoformat()
+
+    params: list[Any] = [window_start]
+    sql = (
+        "SELECT session_id, project, source, ai_failure_value_score, ai_failure_modes, "
+        "ai_failure_attribution, ai_recovery_labels, ai_learning_summary, ai_score_reason, "
+        "ai_summary, COALESCE(ai_display_title, display_title) AS title, blob_path, start_time "
+        "FROM sessions WHERE start_time >= ? AND review_status != 'segmented' "
+        "AND (ai_failure_value_score >= 3 OR (ai_failure_modes IS NOT NULL "
+        "AND json_valid(ai_failure_modes) AND json_array_length(ai_failure_modes) > 0))"
+    )
+    src = [s for s in (sources or []) if s]
+    if src:
+        sql += f" AND source IN ({','.join('?' for _ in src)})"
+        params.extend(src)
+    # NULL failure_value sorts last under DESC in SQLite, so modes-only rows
+    # rank below scored ones — intended.
+    sql += " ORDER BY ai_failure_value_score DESC, start_time DESC"
+
+    rows = conn.execute(sql, params).fetchall()
+    candidates: list[FailureCandidate] = []
+    for row in rows:
+        modes = _parse_json_list(row["ai_failure_modes"])
+        learning = row["ai_learning_summary"]
+        reason = row["ai_score_reason"]
+        has_evidence = bool((learning and learning.strip()) or (reason and reason.strip()) or modes)
+        candidates.append(
+            FailureCandidate(
+                session_id=row["session_id"],
+                project=row["project"],
+                source=row["source"],
+                failure_value_score=row["ai_failure_value_score"],
+                failure_modes=modes,
+                failure_attribution=row["ai_failure_attribution"],
+                recovery_labels=_parse_json_list(row["ai_recovery_labels"]),
+                learning_summary=learning,
+                score_reason=reason,
+                summary=row["ai_summary"],
+                title=row["title"],
+                blob_path=row["blob_path"],
+                start_time=row["start_time"],
+                has_trace_evidence=has_evidence,
+            )
+        )
+
+    total = len(candidates)
+    selected = candidates[:cap] if cap and cap > 0 else candidates
+    return WeekSlice(
+        window_start=window_start,
+        window_end=window_end,
+        candidates=selected,
+        total_candidates=total,
+        dropped_for_cost=max(0, total - len(selected)),
+    )

--- a/clawjournal/benchmark/store.py
+++ b/clawjournal/benchmark/store.py
@@ -259,6 +259,23 @@ def delete_benchmark(conn: sqlite3.Connection, benchmark_id: str) -> None:
     conn.commit()
 
 
+def reconcile_stale_generating(conn: sqlite3.Connection) -> int:
+    """Mark any rows stuck in ``generating`` as ``failed``.
+
+    The only normal transition out of ``generating`` is the in-process worker, so
+    a daemon kill/crash/restart mid-flight would otherwise orphan the row forever.
+    Run once at daemon startup (single-concurrency + a fresh lock make it
+    race-free). Returns the number of rows reconciled.
+    """
+    cur = conn.execute(
+        "UPDATE benchmarks SET status = 'failed', stage = NULL, "
+        "error = 'interrupted (daemon restarted during generation)' "
+        "WHERE status = 'generating'"
+    )
+    conn.commit()
+    return cur.rowcount
+
+
 # ---------------------------------------------------------------------------
 # Reads
 # ---------------------------------------------------------------------------

--- a/clawjournal/benchmark/store.py
+++ b/clawjournal/benchmark/store.py
@@ -1,0 +1,382 @@
+"""Persistence for personalized benchmarks.
+
+Hybrid model: the run's full payload lives in ``benchmarks.payload_json`` (for
+faithful rendering/export), while the queryable per-task fields are
+denormalized into ``benchmark_tasks`` so the tab can filter by
+readiness/theme/risk cheaply. Export receipts land in ``benchmark_exports``.
+
+All writes commit; reads return plain dicts (JSON columns parsed). ``uuid`` is
+used for task/export ids so callers don't have to supply them.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from . import schema as bm
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _isoweek_id(window_end: str) -> str:
+    """``2026-W22`` from a window-end ISO timestamp (falls back to ``"benchmark"``).
+
+    Unreachable on validated save paths — ``validate_benchmark`` rejects an empty
+    window before this is called.
+    """
+    try:
+        dt = datetime.fromisoformat(str(window_end).replace("Z", "+00:00"))
+    except (TypeError, ValueError):
+        return "benchmark"
+    year, week, _ = dt.isocalendar()
+    return f"{year}-W{week:02d}"
+
+
+def _unique_benchmark_id(conn: sqlite3.Connection, base: str) -> str:
+    """Append-only history: ``2026-W22``, then ``2026-W22-2``, ``-3``, …"""
+    rows = conn.execute(
+        "SELECT benchmark_id FROM benchmarks WHERE benchmark_id = ? OR benchmark_id LIKE ?",
+        (base, f"{base}-%"),
+    ).fetchall()
+    taken = {r[0] for r in rows}
+    if base not in taken:
+        return base
+    n = 2
+    while f"{base}-{n}" in taken:
+        n += 1
+    return f"{base}-{n}"
+
+
+# ---------------------------------------------------------------------------
+# Writes
+# ---------------------------------------------------------------------------
+_RUN_COLS = (
+    "benchmark_id", "window_start", "window_end", "generated_at", "status",
+    "stage", "backend", "rubric_git_sha", "n_tasks", "total_points",
+    "source_count", "dropped_for_cost", "ready_count", "needs_staging_count",
+    "payload_json", "error",
+)
+
+
+def _run_values(benchmark: bm.Benchmark, *, status: str, payload: str) -> tuple:
+    return (
+        benchmark.benchmark_id,
+        benchmark.window_start,
+        benchmark.window_end,
+        benchmark.generated_at,
+        status,
+        None,  # stage
+        benchmark.backend,
+        benchmark.rubric_git_sha,
+        benchmark.n_tasks,
+        benchmark.total_points,
+        benchmark.source_count,
+        benchmark.dropped_for_cost,
+        benchmark.ready_count,
+        benchmark.needs_staging_count,
+        payload,
+        None,  # error
+    )
+
+
+def _replace_tasks(conn: sqlite3.Connection, benchmark_id: str, tasks: list[bm.BenchmarkTask]) -> None:
+    conn.execute("DELETE FROM benchmark_tasks WHERE benchmark_id = ?", (benchmark_id,))
+    for task in tasks:
+        conn.execute(
+            "INSERT INTO benchmark_tasks (task_id, benchmark_id, title, theme, "
+            "domains_json, source_agents_json, difficulty, points, grading, "
+            "readiness, leakage_risk, privacy_risk, grounded_session_ids_json) "
+            "VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+            (
+                f"{benchmark_id}:{task.id}",
+                benchmark_id,
+                task.title,
+                task.theme,
+                json.dumps(task.domains),
+                json.dumps(task.source_agents),
+                task.difficulty,
+                task.points,
+                task.grading,
+                task.readiness,
+                task.leakage_risk,
+                task.privacy_risk,
+                json.dumps(task.grounded_session_ids),
+            ),
+        )
+
+
+def save_benchmark(conn: sqlite3.Connection, benchmark: bm.Benchmark, *, status: str = "ready") -> str:
+    """Persist a completed benchmark (run row + denormalized task rows).
+
+    Assigns a unique ``benchmark_id`` (ISO-week, append-only) if absent.
+    Validates before writing. Returns the id.
+    """
+    bm.validate_or_raise(benchmark)
+    if not benchmark.benchmark_id:
+        benchmark.benchmark_id = _unique_benchmark_id(conn, _isoweek_id(benchmark.window_end))
+    payload = json.dumps(bm.benchmark_to_dict(benchmark))
+    exists = conn.execute(
+        "SELECT 1 FROM benchmarks WHERE benchmark_id = ?", (benchmark.benchmark_id,)
+    ).fetchone()
+    if exists:
+        # Non-destructive re-save: UPDATE in place. INSERT OR REPLACE would
+        # DELETE+INSERT the row and cascade-wipe its benchmark_exports receipts.
+        conn.execute(
+            "UPDATE benchmarks SET window_start = ?, window_end = ?, generated_at = ?, "
+            "status = ?, stage = NULL, backend = ?, rubric_git_sha = ?, n_tasks = ?, "
+            "total_points = ?, source_count = ?, dropped_for_cost = ?, ready_count = ?, "
+            "needs_staging_count = ?, payload_json = ?, error = NULL WHERE benchmark_id = ?",
+            (
+                benchmark.window_start, benchmark.window_end, benchmark.generated_at, status,
+                benchmark.backend, benchmark.rubric_git_sha, benchmark.n_tasks,
+                benchmark.total_points, benchmark.source_count, benchmark.dropped_for_cost,
+                benchmark.ready_count, benchmark.needs_staging_count, payload, benchmark.benchmark_id,
+            ),
+        )
+    else:
+        placeholders = ",".join("?" for _ in _RUN_COLS)
+        conn.execute(
+            f"INSERT INTO benchmarks ({','.join(_RUN_COLS)}) VALUES ({placeholders})",
+            _run_values(benchmark, status=status, payload=payload),
+        )
+    _replace_tasks(conn, benchmark.benchmark_id, benchmark.tasks)
+    conn.commit()
+    return benchmark.benchmark_id
+
+
+def insert_generating(
+    conn: sqlite3.Connection,
+    *,
+    window_start: str,
+    window_end: str,
+    backend: str = "",
+) -> str:
+    """Insert a placeholder ``generating`` run; returns its id (for the async path)."""
+    benchmark_id = _unique_benchmark_id(conn, _isoweek_id(window_end))
+    conn.execute(
+        "INSERT INTO benchmarks (benchmark_id, window_start, window_end, generated_at, "
+        "status, backend, payload_json) VALUES (?,?,?,?, 'generating', ?, '{}')",
+        (benchmark_id, window_start, window_end, _now_iso(), backend),
+    )
+    conn.commit()
+    return benchmark_id
+
+
+def update_status(
+    conn: sqlite3.Connection,
+    benchmark_id: str,
+    *,
+    status: str | None = None,
+    stage: str | None = None,
+    error: str | None = None,
+) -> None:
+    sets: list[str] = []
+    params: list[Any] = []
+    if status is not None:
+        sets.append("status = ?")
+        params.append(status)
+    if stage is not None:
+        sets.append("stage = ?")
+        params.append(stage)
+    if error is not None:
+        sets.append("error = ?")
+        params.append(error)
+    if not sets:
+        return
+    params.append(benchmark_id)
+    conn.execute(f"UPDATE benchmarks SET {', '.join(sets)} WHERE benchmark_id = ?", params)
+    conn.commit()
+
+
+def finalize_benchmark(
+    conn: sqlite3.Connection,
+    benchmark_id: str,
+    benchmark: bm.Benchmark,
+    *,
+    status: str = "ready",
+) -> None:
+    """Attach a generated benchmark to an existing ``generating`` placeholder row."""
+    row = conn.execute(
+        "SELECT window_start, window_end FROM benchmarks WHERE benchmark_id = ?", (benchmark_id,)
+    ).fetchone()
+    if row is None:
+        raise ValueError(f"finalize_benchmark: no placeholder row for benchmark_id {benchmark_id!r}")
+    if benchmark.window_start != row["window_start"] or benchmark.window_end != row["window_end"]:
+        raise ValueError(
+            f"finalize_benchmark window mismatch for {benchmark_id!r}: placeholder "
+            f"{row['window_start']}..{row['window_end']} vs object "
+            f"{benchmark.window_start}..{benchmark.window_end}"
+        )
+    benchmark.benchmark_id = benchmark_id
+    bm.validate_or_raise(benchmark)
+    payload = json.dumps(bm.benchmark_to_dict(benchmark))
+    conn.execute(
+        "UPDATE benchmarks SET status = ?, stage = NULL, error = NULL, generated_at = ?, "
+        "backend = ?, rubric_git_sha = ?, n_tasks = ?, total_points = ?, source_count = ?, "
+        "dropped_for_cost = ?, ready_count = ?, needs_staging_count = ?, payload_json = ? "
+        "WHERE benchmark_id = ?",
+        (
+            status, benchmark.generated_at, benchmark.backend, benchmark.rubric_git_sha,
+            benchmark.n_tasks, benchmark.total_points, benchmark.source_count,
+            benchmark.dropped_for_cost, benchmark.ready_count, benchmark.needs_staging_count,
+            payload, benchmark_id,
+        ),
+    )
+    _replace_tasks(conn, benchmark_id, benchmark.tasks)
+    conn.commit()
+
+
+def record_export(
+    conn: sqlite3.Connection,
+    benchmark_id: str,
+    *,
+    kind: str,
+    path: str | None = None,
+    redaction_summary: dict | None = None,
+) -> str:
+    export_id = uuid.uuid4().hex
+    conn.execute(
+        "INSERT INTO benchmark_exports (export_id, benchmark_id, kind, path, created_at, "
+        "redaction_summary_json) VALUES (?,?,?,?,?,?)",
+        (
+            export_id, benchmark_id, kind, path, _now_iso(),
+            json.dumps(redaction_summary) if redaction_summary is not None else None,
+        ),
+    )
+    conn.commit()
+    return export_id
+
+
+def delete_benchmark(conn: sqlite3.Connection, benchmark_id: str) -> None:
+    """Delete a run; ``benchmark_tasks``/``benchmark_exports`` cascade (FK ON DELETE CASCADE)."""
+    conn.execute("DELETE FROM benchmarks WHERE benchmark_id = ?", (benchmark_id,))
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Reads
+# ---------------------------------------------------------------------------
+_SUMMARY_COLS = (
+    "benchmark_id", "window_start", "window_end", "generated_at", "status",
+    "stage", "backend", "rubric_git_sha", "n_tasks", "total_points",
+    "source_count", "dropped_for_cost", "ready_count", "needs_staging_count", "error",
+)
+
+
+def _row_summary(row: sqlite3.Row) -> dict[str, Any]:
+    return {k: row[k] for k in _SUMMARY_COLS}
+
+
+def _row_full(row: sqlite3.Row) -> dict[str, Any]:
+    """Run summary + the parsed payload (themes/tasks). Operational status/stage/error win."""
+    try:
+        payload = json.loads(row["payload_json"]) if row["payload_json"] else {}
+    except (TypeError, json.JSONDecodeError):
+        payload = {}
+    out = dict(payload)
+    out.update(_row_summary(row))
+    return out
+
+
+def get_benchmark(conn: sqlite3.Connection, benchmark_id: str) -> dict[str, Any] | None:
+    row = conn.execute("SELECT * FROM benchmarks WHERE benchmark_id = ?", (benchmark_id,)).fetchone()
+    return _row_full(row) if row else None
+
+
+def get_latest_benchmark(conn: sqlite3.Connection, *, status: str = "ready") -> dict[str, Any] | None:
+    row = conn.execute(
+        "SELECT * FROM benchmarks WHERE status = ? ORDER BY generated_at DESC, rowid DESC LIMIT 1",
+        (status,),
+    ).fetchone()
+    return _row_full(row) if row else None
+
+
+def list_benchmarks(conn: sqlite3.Connection, *, limit: int = 50) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        f"SELECT {','.join(_SUMMARY_COLS)} FROM benchmarks ORDER BY generated_at DESC, rowid DESC LIMIT ?",
+        (limit,),
+    ).fetchall()
+    return [_row_summary(r) for r in rows]
+
+
+def list_tasks(
+    conn: sqlite3.Connection,
+    benchmark_id: str,
+    *,
+    readiness: str | None = None,
+    theme: str | None = None,
+    source_agent: str | None = None,
+) -> list[dict[str, Any]]:
+    """Denormalized task rows for the run, with optional filters."""
+    sql = "SELECT * FROM benchmark_tasks WHERE benchmark_id = ?"
+    params: list[Any] = [benchmark_id]
+    if readiness is not None:
+        sql += " AND readiness = ?"
+        params.append(readiness)
+    if theme is not None:
+        sql += " AND theme = ?"
+        params.append(theme)
+    sql += " ORDER BY points DESC, task_id"
+    rows = conn.execute(sql, params).fetchall()
+    out: list[dict[str, Any]] = []
+    for r in rows:
+        agents = json.loads(r["source_agents_json"] or "[]")
+        if source_agent is not None and source_agent not in agents:
+            continue
+        out.append(
+            {
+                "task_id": r["task_id"],
+                "benchmark_id": r["benchmark_id"],
+                "title": r["title"],
+                "theme": r["theme"],
+                "domains": json.loads(r["domains_json"] or "[]"),
+                "source_agents": agents,
+                "difficulty": r["difficulty"],
+                "points": r["points"],
+                "grading": r["grading"],
+                "readiness": r["readiness"],
+                "leakage_risk": r["leakage_risk"],
+                "privacy_risk": r["privacy_risk"],
+                "grounded_session_ids": json.loads(r["grounded_session_ids_json"] or "[]"),
+            }
+        )
+    return out
+
+
+def get_theme_trend(conn: sqlite3.Connection, *, limit_runs: int = 12) -> dict[str, Any]:
+    """Theme × run matrix across the latest ``ready`` runs, for the Trend view.
+
+    Returns ``{"runs": [{benchmark_id, window_end}, …], "themes": {name: [freq|0 per run]}}``,
+    runs ordered oldest→newest so a sparkline reads left-to-right.
+    """
+    rows = conn.execute(
+        "SELECT benchmark_id, window_end, payload_json FROM benchmarks "
+        "WHERE status = 'ready' ORDER BY generated_at DESC, rowid DESC LIMIT ?",
+        (limit_runs,),
+    ).fetchall()
+    rows = list(reversed(rows))  # oldest → newest
+    runs = [{"benchmark_id": r["benchmark_id"], "window_end": r["window_end"]} for r in rows]
+    per_run_themes: list[dict[str, int]] = []
+    all_names: list[str] = []
+    for r in rows:
+        try:
+            payload = json.loads(r["payload_json"]) if r["payload_json"] else {}
+        except (TypeError, json.JSONDecodeError):
+            payload = {}
+        freqs: dict[str, int] = {}
+        for theme in payload.get("themes", []) or []:
+            name = theme.get("name")
+            if not name:
+                continue
+            freqs[name] = int(theme.get("frequency") or 0)
+            if name not in all_names:
+                all_names.append(name)
+        per_run_themes.append(freqs)
+    themes = {name: [run.get(name, 0) for run in per_run_themes] for name in all_names}
+    return {"runs": runs, "themes": themes}

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -369,6 +369,7 @@ def configure(
     redact_usernames: list[str] | None = None,
     confirm_projects: bool = False,
     ai_pii_review: bool | None = None,
+    benchmark_tab_enabled: bool | None = None,
 ):
     """Set config values non-interactively. Lists are MERGED (append), not replaced."""
     config = load_config()
@@ -401,6 +402,8 @@ def configure(
         config["projects_confirmed"] = True
     if ai_pii_review is not None:
         config["ai_pii_review_enabled"] = ai_pii_review
+    if benchmark_tab_enabled is not None:
+        config["benchmark_tab_enabled"] = benchmark_tab_enabled
     save_config(config)
     print(f"Config saved to {CONFIG_FILE}")
     print(json.dumps(_mask_config_for_display(config), indent=2))
@@ -3658,6 +3661,10 @@ def main() -> None:
     cfg.add_argument("--ai-pii-review", action=argparse.BooleanOptionalAction, default=None,
                      help="Default AI-assisted PII review on (--ai-pii-review) or off "
                           "(--no-ai-pii-review) for the workbench/CLI share flow")
+    cfg.add_argument("--benchmark-tab", dest="benchmark_tab_enabled",
+                     action=argparse.BooleanOptionalAction, default=None,
+                     help="Show (--benchmark-tab) or hide (--no-benchmark-tab) the "
+                          "Benchmark tab in the workbench UI")
 
     events_parser = sub.add_parser("events", help="Execution recorder commands")
     events_sub = events_parser.add_subparsers(dest="events_command", required=True)
@@ -4572,6 +4579,7 @@ def _parse_csv_arg(value: str | None) -> list[str] | None:
 def _handle_config(args) -> None:
     """Handle the config subcommand."""
     ai_pii_review = getattr(args, "ai_pii_review", None)
+    benchmark_tab_enabled = getattr(args, "benchmark_tab_enabled", None)
     has_changes = (
         args.repo
         or args.source
@@ -4581,6 +4589,7 @@ def _handle_config(args) -> None:
         or args.redact_usernames
         or args.confirm_projects
         or ai_pii_review is not None
+        or benchmark_tab_enabled is not None
     )
     if not has_changes:
         print(json.dumps(_mask_config_for_display(load_config()), indent=2))
@@ -4594,6 +4603,7 @@ def _handle_config(args) -> None:
         redact_usernames=_parse_csv_arg(args.redact_usernames),
         confirm_projects=args.confirm_projects or bool(args.exclude),
         ai_pii_review=ai_pii_review,
+        benchmark_tab_enabled=benchmark_tab_enabled,
     )
 
 

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3984,6 +3984,21 @@ def main() -> None:
     hh_p = sub.add_parser("hold-history", help="Print the full hold-state timeline for a session")
     hh_p.add_argument("session_id")
 
+    # Personalized weekly benchmark
+    bench_p = sub.add_parser(
+        "benchmark", help="Generate / view / export a personalized weekly benchmark from your traces")
+    bench_p.add_argument("--window", type=int, default=7, help="Coverage window in days (default 7)")
+    bench_p.add_argument("--cap", type=int, default=15, help="Max sessions to deep-read (cost bound)")
+    bench_p.add_argument("--backend", default="auto", help="Scoring backend (auto|claude|codex|...)")
+    bench_p.add_argument("--list", action="store_true", help="List stored benchmarks")
+    bench_p.add_argument("--show", metavar="ID", help="Render a stored benchmark as markdown (ID or 'latest')")
+    bench_p.add_argument("--export", metavar="ID", help="Export a benchmark to a local file (ID or 'latest')")
+    bench_p.add_argument(
+        "--kind", default="authoring_md",
+        help="Export kind: authoring_md | agent_packet_md | grader_packet_md | agent_packet_json | grader_packet_json")
+    bench_p.add_argument("--output", help="Output file path for --export")
+    bench_p.add_argument("--json", action="store_true", help="Machine-readable output for --list")
+
     # Findings review
     fnd_p = sub.add_parser("findings", help="List or decide findings for a session")
     fnd_p.add_argument("session_id")
@@ -4325,6 +4340,11 @@ def main() -> None:
     if command == "hold-history":
         from .cli_security import run_hold_history
         run_hold_history(args)
+        return
+
+    if command == "benchmark":
+        from .cli_benchmark import run_benchmark
+        run_benchmark(args)
         return
 
     if command == "findings":

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3990,6 +3990,7 @@ def main() -> None:
     bench_p.add_argument("--window", type=int, default=7, help="Coverage window in days (default 7)")
     bench_p.add_argument("--cap", type=int, default=15, help="Max sessions to deep-read (cost bound)")
     bench_p.add_argument("--backend", default="auto", help="Scoring backend (auto|claude|codex|...)")
+    bench_p.add_argument("--model", help="Model override for generation (default: a fast model per backend — sonnet for Claude)")
     bench_p.add_argument("--list", action="store_true", help="List stored benchmarks")
     bench_p.add_argument("--show", metavar="ID", help="Render a stored benchmark as markdown (ID or 'latest')")
     bench_p.add_argument("--export", metavar="ID", help="Export a benchmark to a local file (ID or 'latest')")

--- a/clawjournal/cli_benchmark.py
+++ b/clawjournal/cli_benchmark.py
@@ -1,0 +1,134 @@
+"""CLI handler for the ``benchmark`` verb.
+
+Kept separate from ``cli.py`` to contain the surface. Generates / lists / shows /
+exports the personalized weekly benchmark. The handler takes a parsed argparse
+``Namespace``, opens the index, and prints JSON (or markdown for ``--show``).
+Hard errors exit non-zero so scripts can react.
+
+Generation makes real backend (LLM) calls via the default scoring backend; the
+other verbs are local reads/renders.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from .benchmark import render, store
+from .benchmark import schema as bm
+from .benchmark.render import EXPORT_KINDS
+from .workbench.index import open_index
+
+
+def _emit(payload: dict[str, Any]) -> None:
+    print(json.dumps(payload, indent=2))
+
+
+def _fail(message: str, **extra: Any) -> None:
+    _emit({"error": message, **extra})
+    sys.exit(1)
+
+
+def _resolve(conn, target: str) -> dict[str, Any] | None:
+    return store.get_latest_benchmark(conn) if target == "latest" else store.get_benchmark(conn, target)
+
+
+def run_benchmark(args) -> None:
+    if getattr(args, "list", False):
+        _list(args)
+    elif getattr(args, "show", None):
+        _show(args)
+    elif getattr(args, "export", None):
+        _export(args)
+    else:
+        _generate(args)
+
+
+def _generate(args) -> None:
+    # Imported lazily so `--list/--show/--export` never pull in the backend stack.
+    from .benchmark.generate import generate_benchmark
+
+    conn = open_index()
+    try:
+        try:
+            benchmark = generate_benchmark(
+                conn,
+                window_days=args.window,
+                cap=args.cap,
+                backend=args.backend,
+                progress=lambda msg: print(f"… {msg}", file=sys.stderr),
+            )
+        except (ValueError, RuntimeError) as exc:
+            _fail(str(exc))
+        bid = store.save_benchmark(conn, benchmark)
+        _emit({
+            "benchmark_id": bid,
+            "window": [benchmark.window_start, benchmark.window_end],
+            "n_tasks": benchmark.n_tasks,
+            "total_points": benchmark.total_points,
+            "ready": benchmark.ready_count,
+            "needs_staging": benchmark.needs_staging_count,
+            "themes": len(benchmark.themes),
+            "dropped_for_cost": benchmark.dropped_for_cost,
+            "backend": benchmark.backend,
+        })
+    finally:
+        conn.close()
+
+
+def _list(args) -> None:
+    conn = open_index()
+    try:
+        rows = store.list_benchmarks(conn)
+        if getattr(args, "json", False):
+            _emit({"benchmarks": rows})
+            return
+        if not rows:
+            print("No benchmarks yet. Run `clawjournal benchmark` to generate one.")
+            return
+        for r in rows:
+            print(
+                f"{r['benchmark_id']:>12}  "
+                f"{(r['window_start'] or '')[:10]}→{(r['window_end'] or '')[:10]}  "
+                f"{r['status']:>10}  {r['n_tasks'] or 0} tasks  {r['total_points'] or 0} pts  "
+                f"(ready {r['ready_count'] or 0}, staging {r['needs_staging_count'] or 0})"
+            )
+    finally:
+        conn.close()
+
+
+def _show(args) -> None:
+    conn = open_index()
+    try:
+        got = _resolve(conn, args.show)
+        if got is None:
+            _fail("benchmark not found", id=args.show)
+        print(render.render_markdown(got))
+    finally:
+        conn.close()
+
+
+def _export(args) -> None:
+    kind = getattr(args, "kind", None) or "authoring_md"
+    if kind not in EXPORT_KINDS:
+        _fail(f"unknown export kind {kind!r}", kinds=list(EXPORT_KINDS))
+    conn = open_index()
+    try:
+        got = _resolve(conn, args.export)
+        if got is None:
+            _fail("benchmark not found", id=args.export)
+        content = render.render(got, kind)
+        # Best-effort local PII scan as a recorded receipt (full deterministic
+        # export redaction lands in the privacy-guard phase).
+        pii_hits = len(bm.find_pii(content))
+        ext = "json" if kind.endswith("json") else "md"
+        out = getattr(args, "output", None) or f"benchmark-{got['benchmark_id']}-{kind}.{ext}"
+        Path(out).write_text(content, encoding="utf-8")
+        summary = {"kind": kind, "pii_scan_hits": pii_hits, "deterministic_redaction": "deferred"}
+        store.record_export(conn, got["benchmark_id"], kind=kind, path=str(out), redaction_summary=summary)
+        _emit({"exported": str(out), "kind": kind, "benchmark_id": got["benchmark_id"],
+               "pii_scan_hits": pii_hits})
+    finally:
+        conn.close()

--- a/clawjournal/cli_benchmark.py
+++ b/clawjournal/cli_benchmark.py
@@ -58,6 +58,7 @@ def _generate(args) -> None:
                 window_days=args.window,
                 cap=args.cap,
                 backend=args.backend,
+                model=getattr(args, "model", None),
                 progress=lambda msg: print(f"… {msg}", file=sys.stderr),
             )
         except (ValueError, RuntimeError) as exc:
@@ -119,6 +120,8 @@ def _export(args) -> None:
         got = _resolve(conn, args.export)
         if got is None:
             _fail("benchmark not found", id=args.export)
+        if got.get("status") != "ready":
+            _fail(f"benchmark is {got.get('status')!r}, not ready to export", id=got.get("benchmark_id"))
         content = render.render(got, kind)
         # Best-effort local PII scan as a recorded receipt (full deterministic
         # export redaction lands in the privacy-guard phase).

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -37,6 +37,7 @@ class ClawJournalConfig(TypedDict, total=False):
     ai_pii_review_enabled: bool
     scorer_backend: str | None
     scorer_backend_confirmed_at: str | None
+    benchmark_tab_enabled: bool  # show/hide the Benchmark tab in the workbench UI (default on)
 
 
 DEFAULT_CONFIG: ClawJournalConfig = {
@@ -45,6 +46,7 @@ DEFAULT_CONFIG: ClawJournalConfig = {
     "excluded_projects": [],
     "redact_strings": [],
     "allowlist_entries": [],
+    "benchmark_tab_enabled": True,
 }
 
 

--- a/clawjournal/scoring/backends.py
+++ b/clawjournal/scoring/backends.py
@@ -353,6 +353,33 @@ def _build_hermes_cmd(
     return cmd
 
 
+# Environment variables that flip a spawned agent CLI into external
+# API-billing mode. ANTHROPIC_API_KEY in particular makes the `claude` CLI
+# bypass the interactive subscription login: when set it is *always*
+# preferred, so a stale/invalid key (e.g. exported in a shell profile) makes
+# every task die with "Invalid API key · Fix external API key", and a valid
+# one silently bills the API — defeating the "default agent = your
+# subscription" contract. Strip it for the spawned CLI so it falls back to
+# the logged-in account.
+_AGENT_ENV_STRIP_KEYS = ("ANTHROPIC_API_KEY",)
+
+
+def _agent_subprocess_env() -> dict[str, str]:
+    """Build the environment for a spawned agent CLI.
+
+    Removes external provider API keys so the CLI uses its interactive
+    login (the "default agent" path the user opted into). Set
+    ``CLAWJOURNAL_KEEP_API_KEY=1`` to opt back in to key-based auth.
+    """
+    env = dict(os.environ)
+    keep = (env.get("CLAWJOURNAL_KEEP_API_KEY") or "").strip().lower()
+    if keep in ("1", "true", "yes", "on"):
+        return env
+    for var in _AGENT_ENV_STRIP_KEYS:
+        env.pop(var, None)
+    return env
+
+
 def run_default_agent_task(
     *,
     backend: str = "auto",
@@ -400,6 +427,7 @@ def run_default_agent_task(
     resolved = resolve_backend(backend)
     check_backend_runtime(resolved)
     command = require_backend_command(resolved)
+    agent_env = _agent_subprocess_env()
 
     if codex_output_file and ("/" in codex_output_file or "\\" in codex_output_file):
         raise ValueError(
@@ -420,6 +448,7 @@ def run_default_agent_task(
                 cwd=str(cwd),
                 capture_output=True,
                 text=True,
+                env=agent_env,
                 timeout=timeout_seconds,
             )
         except subprocess.TimeoutExpired:
@@ -461,6 +490,7 @@ def run_default_agent_task(
                 cmd,
                 capture_output=True,
                 text=True,
+                env=agent_env,
                 timeout=timeout_seconds,
             )
         except subprocess.TimeoutExpired:
@@ -499,6 +529,7 @@ def run_default_agent_task(
                 cwd=str(cwd),
                 capture_output=True,
                 text=True,
+                env=agent_env,
                 timeout=timeout_seconds + 10,
             )
         except subprocess.TimeoutExpired:
@@ -523,6 +554,7 @@ def run_default_agent_task(
                 cwd=str(cwd),
                 capture_output=True,
                 text=True,
+                env=agent_env,
                 timeout=timeout_seconds + 10,
             )
         except subprocess.TimeoutExpired:

--- a/clawjournal/web/frontend/src/App.tsx
+++ b/clawjournal/web/frontend/src/App.tsx
@@ -7,6 +7,7 @@ import { Share } from './views/Share/index.tsx';
 import { Policies } from './views/Policies.tsx';
 import { Dashboard } from './views/Dashboard.tsx';
 import { Insights } from './views/Insights.tsx';
+import { Benchmark } from './views/Benchmark.tsx';
 import { ToastProvider } from './components/Toast.tsx';
 import { colors, fontFamily } from './theme.ts';
 import { api } from './api.ts';
@@ -43,6 +44,7 @@ function Sidebar() {
     { to: '/insights', label: 'Insights', badge: null },
     { to: '/search', label: 'Search', badge: null },
     { to: '/', label: 'Sessions', badge: counts.toReview > 0 ? counts.toReview : null },
+    { to: '/benchmark', label: 'Benchmark', badge: null },
     { to: '/share', label: 'Share', badge: null },
   ];
 
@@ -174,6 +176,7 @@ export default function App() {
               <Route path="/session/:id" element={<SessionDetail />} />
               <Route path="/bundles" element={<Navigate to="/share" replace />} />
               <Route path="/policies" element={<Navigate to="/share/rules" replace />} />
+              <Route path="/benchmark" element={<Benchmark />} />
               <Route path="/share" element={<Share />} />
               <Route path="/share/rules" element={<Policies />} />
             </Routes>

--- a/clawjournal/web/frontend/src/App.tsx
+++ b/clawjournal/web/frontend/src/App.tsx
@@ -15,33 +15,33 @@ import { api } from './api.ts';
 interface SidebarCounts {
   toReview: number;
   approved: number;
+  recommendations: number;
 }
 
 function Sidebar() {
-  const [counts, setCounts] = useState<SidebarCounts>({ toReview: 0, approved: 0 });
+  const [counts, setCounts] = useState<SidebarCounts>({ toReview: 0, approved: 0, recommendations: 0 });
 
   useEffect(() => {
-    api.stats()
-      .then(s => setCounts({
+    const loadStats = () => api.stats()
+      .then(s => setCounts(c => ({
+        ...c,
         toReview: (s.by_status['new'] ?? 0) + (s.by_status['shortlisted'] ?? 0),
         approved: s.by_status['approved'] ?? 0,
-      }))
+      })))
       .catch(() => {});
-    // Refresh counts periodically
-    const iv = setInterval(() => {
-      api.stats()
-        .then(s => setCounts({
-          toReview: (s.by_status['new'] ?? 0) + (s.by_status['shortlisted'] ?? 0),
-          approved: s.by_status['approved'] ?? 0,
-        }))
-        .catch(() => {});
-    }, 30_000);
+    // The advisor's recommendation count nudges the Insights tab — fetched once
+    // (it changes slowly), while the cheap session stats refresh periodically.
+    api.advisor({ days: 7 })
+      .then(a => setCounts(c => ({ ...c, recommendations: a.recommendations.length })))
+      .catch(() => {});
+    loadStats();
+    const iv = setInterval(loadStats, 30_000);
     return () => clearInterval(iv);
   }, []);
 
   const NAV_ITEMS = [
     { to: '/dashboard', label: 'Dashboard', badge: null },
-    { to: '/insights', label: 'Insights', badge: null },
+    { to: '/insights', label: 'Insights', badge: counts.recommendations > 0 ? counts.recommendations : null },
     { to: '/search', label: 'Search', badge: null },
     { to: '/', label: 'Sessions', badge: counts.toReview > 0 ? counts.toReview : null },
     { to: '/benchmark', label: 'Benchmark', badge: null },

--- a/clawjournal/web/frontend/src/App.tsx
+++ b/clawjournal/web/frontend/src/App.tsx
@@ -42,9 +42,9 @@ function Sidebar() {
   const NAV_ITEMS = [
     { to: '/dashboard', label: 'Dashboard', badge: null },
     { to: '/insights', label: 'Insights', badge: counts.recommendations > 0 ? counts.recommendations : null },
+    { to: '/benchmark', label: 'Benchmark', badge: null },
     { to: '/search', label: 'Search', badge: null },
     { to: '/', label: 'Sessions', badge: counts.toReview > 0 ? counts.toReview : null },
-    { to: '/benchmark', label: 'Benchmark', badge: null },
     { to: '/share', label: 'Share', badge: null },
   ];
 

--- a/clawjournal/web/frontend/src/App.tsx
+++ b/clawjournal/web/frontend/src/App.tsx
@@ -18,7 +18,7 @@ interface SidebarCounts {
   recommendations: number;
 }
 
-function Sidebar() {
+function Sidebar({ benchmarkEnabled }: { benchmarkEnabled: boolean }) {
   const [counts, setCounts] = useState<SidebarCounts>({ toReview: 0, approved: 0, recommendations: 0 });
 
   useEffect(() => {
@@ -42,7 +42,7 @@ function Sidebar() {
   const NAV_ITEMS = [
     { to: '/dashboard', label: 'Dashboard', badge: null },
     { to: '/insights', label: 'Insights', badge: counts.recommendations > 0 ? counts.recommendations : null },
-    { to: '/benchmark', label: 'Benchmark', badge: null },
+    ...(benchmarkEnabled ? [{ to: '/benchmark', label: 'Benchmark', badge: null }] : []),
     { to: '/search', label: 'Search', badge: null },
     { to: '/', label: 'Sessions', badge: counts.toReview > 0 ? counts.toReview : null },
     { to: '/share', label: 'Share', badge: null },
@@ -121,6 +121,16 @@ function Sidebar() {
 const SCORING_WARMUP_DECLINED_KEY = 'cj.scoringWarmupDeclined';
 
 export default function App() {
+  // Gate the Benchmark tab on a config flag (default on). Initialised to true so
+  // the common (enabled) case never flashes; only an explicitly-disabled install
+  // briefly shows it before /api/features resolves on localhost.
+  const [benchmarkEnabled, setBenchmarkEnabled] = useState(true);
+  useEffect(() => {
+    api.features()
+      .then(f => setBenchmarkEnabled(f.benchmark_tab_enabled))
+      .catch(() => {});
+  }, []);
+
   useEffect(() => {
     let cancelled = false;
     const timer = window.setTimeout(async () => {
@@ -166,7 +176,7 @@ export default function App() {
           color: colors.gray900,
           WebkitFontSmoothing: 'antialiased',
         }}>
-          <Sidebar />
+          <Sidebar benchmarkEnabled={benchmarkEnabled} />
           <main style={{ flex: 1, overflow: 'auto', background: colors.white }}>
             <Routes>
               <Route path="/dashboard" element={<Dashboard />} />
@@ -176,7 +186,7 @@ export default function App() {
               <Route path="/session/:id" element={<SessionDetail />} />
               <Route path="/bundles" element={<Navigate to="/share" replace />} />
               <Route path="/policies" element={<Navigate to="/share/rules" replace />} />
-              <Route path="/benchmark" element={<Benchmark />} />
+              <Route path="/benchmark" element={benchmarkEnabled ? <Benchmark /> : <Navigate to="/dashboard" replace />} />
               <Route path="/share" element={<Share />} />
               <Route path="/share/rules" element={<Policies />} />
             </Routes>

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -18,6 +18,9 @@ import type {
   FindingsAllowlistEntry,
   HoldHistoryEntry,
   HoldState,
+  Benchmark,
+  BenchmarkSummary,
+  BenchmarkTrend,
 } from './types.ts';
 
 const BASE = '/api';
@@ -436,6 +439,38 @@ export const api = {
       remove(id: string): Promise<{ removed: boolean; reverted: number; reassigned: number }> {
         return request(`/findings/allowlist/${encodeURIComponent(id)}`, { method: 'DELETE' });
       },
+    },
+  },
+
+  benchmarks: {
+    list(): Promise<{ benchmarks: BenchmarkSummary[] }> {
+      return request('/benchmarks');
+    },
+    latest(): Promise<{ benchmark: Benchmark | null; stale: boolean }> {
+      return request('/benchmarks/latest');
+    },
+    get(id: string): Promise<Benchmark> {
+      return request(`/benchmarks/${encodeURIComponent(id)}`);
+    },
+    trend(): Promise<BenchmarkTrend> {
+      return request('/benchmarks/trend');
+    },
+    status(id: string): Promise<{ benchmark_id: string; status: string; stage: string | null; error: string | null }> {
+      return request(`/benchmarks/${encodeURIComponent(id)}/status`);
+    },
+    generate(body: { window_days?: number; cap?: number } = {}): Promise<{ status: string; benchmark_id?: string; error?: string }> {
+      return request('/benchmarks/generate', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+    },
+    export(id: string, kind: string): Promise<{ benchmark_id: string; kind: string; path: string; pii_scan_hits: number; content: string }> {
+      return request(`/benchmarks/${encodeURIComponent(id)}/export`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ kind }),
+      });
     },
   },
 };

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -21,6 +21,7 @@ import type {
   Benchmark,
   BenchmarkSummary,
   BenchmarkTrend,
+  Features,
 } from './types.ts';
 
 const BASE = '/api';
@@ -159,6 +160,10 @@ export const api = {
 
   stats(params: { start?: string; end?: string } = {}): Promise<Stats> {
     return request(`/stats${qs(params)}`);
+  },
+
+  features(): Promise<Features> {
+    return request('/features');
   },
 
   dashboard(params: { start?: string; end?: string } = {}): Promise<DashboardData> {

--- a/clawjournal/web/frontend/src/index.css
+++ b/clawjournal/web/frontend/src/index.css
@@ -12,3 +12,13 @@ body {
 #root {
   height: 100vh;
 }
+
+/* Benchmark generation progress — a sliding sheen so a slow run still looks alive. */
+@keyframes bench-shimmer {
+  0% { background-position: 200% 0; }
+  100% { background-position: 0 0; }
+}
+@keyframes bench-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -466,6 +466,7 @@ export interface BenchmarkSummary {
   window_end: string;
   generated_at: string;
   status: string;
+  stage: string | null;
   backend: string | null;
   n_tasks: number | null;
   total_points: number | null;

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -398,3 +398,85 @@ export interface AdvisorData {
     potential_savings_usd: number;
   };
 }
+
+/* ---------- Personalized benchmark ---------- */
+
+export interface BenchmarkTaskCritique {
+  discriminating: boolean;
+  gameable: boolean;
+  leakage: boolean;
+  measurable: boolean;
+  verdict: string;
+  notes: string;
+  staging_notes: string;
+}
+
+export interface BenchmarkTask {
+  id: string;
+  title: string;
+  theme: string;
+  scenario: string;
+  seed_inputs: string;
+  the_trap: string;
+  ideal_trajectory: string[];
+  pass_criteria: string[];
+  fail_signals: string[];
+  grading: string;
+  difficulty: string;
+  points: number;
+  domains: string[];
+  source_agents: string[];
+  grounded_session_ids: string[];
+  readiness: string;
+  leakage_risk: string;
+  privacy_risk: string;
+  critique: BenchmarkTaskCritique;
+}
+
+export interface BenchmarkTheme {
+  name: string;
+  taxonomy: string[];
+  frequency: number;
+  evidence_session_ids: string[];
+  lesson: string;
+}
+
+export interface Benchmark {
+  benchmark_id: string;
+  window_start: string;
+  window_end: string;
+  generated_at: string;
+  status: string;
+  stage: string | null;
+  error: string | null;
+  backend: string;
+  n_tasks: number;
+  total_points: number;
+  ready_count: number;
+  needs_staging_count: number;
+  source_count: number;
+  dropped_for_cost: number;
+  themes: BenchmarkTheme[];
+  tasks: BenchmarkTask[];
+}
+
+export interface BenchmarkSummary {
+  benchmark_id: string;
+  window_start: string;
+  window_end: string;
+  generated_at: string;
+  status: string;
+  backend: string | null;
+  n_tasks: number | null;
+  total_points: number | null;
+  source_count: number | null;
+  dropped_for_cost: number | null;
+  ready_count: number | null;
+  needs_staging_count: number | null;
+  error: string | null;
+}
+
+export interface BenchmarkTrend {
+  runs: { benchmark_id: string; window_end: string }[];
+  themes: Record<string, number[]>;
+}

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -204,6 +204,11 @@ export interface Policy {
   created_at: string;
 }
 
+export interface Features {
+  /** Whether the Benchmark tab is shown in the workbench UI (config: benchmark_tab_enabled). */
+  benchmark_tab_enabled: boolean;
+}
+
 export interface Stats {
   total: number;
   by_status: Record<string, number>;

--- a/clawjournal/web/frontend/src/views/Benchmark.tsx
+++ b/clawjournal/web/frontend/src/views/Benchmark.tsx
@@ -67,13 +67,17 @@ function Chip({ children, fg, bg }: { children: React.ReactNode; fg: string; bg:
 /*  Generation progress — slow run, keep it visibly alive             */
 /* ------------------------------------------------------------------ */
 
+// Maps the backend's human stage prose (clawjournal/benchmark/generate.py note()
+// calls) to a percent, parsing "(k/total)" for smooth within-stage movement.
 function stagePercent(stage: string): number {
   const s = (stage || '').toLowerCase();
-  if (s.includes('done')) return 100;
-  if (s.includes('design') || s.includes('critiqu')) return 80;
-  if (s.includes('cluster')) return 52;
-  if (s.includes('deep-read')) return 28;
-  return 10;
+  const m = s.match(/\((\d+)\s*\/\s*(\d+)\)/);
+  const frac = m && Number(m[2]) > 0 ? Number(m[1]) / Number(m[2]) : 0;
+  if (s.includes('finaliz') || s.includes('done')) return 100;
+  if (s.includes('writing') || s.includes('review') || s.includes('design') || s.includes('critiqu')) return 55 + frac * 35; // 55→90
+  if (s.includes('group') || s.includes('cluster')) return 50;
+  if (s.includes('reading') || s.includes('deep-read')) return 10 + frac * 35; // 10→45
+  return 8;
 }
 
 function GeneratingBanner({ stage, elapsedMs }: { stage: string; elapsedMs: number }) {
@@ -338,17 +342,21 @@ export function Benchmark() {
       if (!res.benchmark_id) { toast(res.error || 'Could not start generation', 'error'); return; }
       setGenStart(Date.now());
       setGenerating({ id: res.benchmark_id, stage: 'starting…' });
+      let fails = 0;
+      const stop = () => { if (pollRef.current) window.clearInterval(pollRef.current); setGenerating(null); setGenStart(null); };
       pollRef.current = window.setInterval(async () => {
         try {
           const st = await api.benchmarks.status(res.benchmark_id!);
+          fails = 0;
           if (st.status === 'generating') { setGenerating({ id: res.benchmark_id!, stage: st.stage || 'working…' }); return; }
-          if (pollRef.current) window.clearInterval(pollRef.current);
-          setGenerating(null);
-          setGenStart(null);
+          stop();
           if (st.status === 'failed') toast(`Generation failed: ${st.error || 'unknown'}`, 'error');
           else toast('Benchmark ready', 'success');
           load();
-        } catch { /* keep polling */ }
+        } catch {
+          // Tolerate transient blips, but don't spin forever on a persistent error.
+          if (++fails >= 5) { stop(); toast('Lost contact with the generation — check the workbench daemon.', 'error'); }
+        }
       }, 2000);
     } catch (e) {
       const msg = e instanceof ApiError ? (e.status === 409 ? 'A generation is already running' : e.message) : 'Could not start generation';
@@ -393,7 +401,9 @@ export function Benchmark() {
   const themes = current.themes || [];
   const tasks = current.tasks || [];
   const shown = themeFilter ? tasks.filter(t => t.theme === themeFilter) : tasks;
-  const active = tasks.find(t => t.id === selectedTask) || shown[0] || null;
+  // Resolve against the FILTERED list so the detail pane never shows a task the
+  // left rail isn't displaying (theme filter would otherwise desync the panes).
+  const active = shown.find(t => t.id === selectedTask) || shown[0] || null;
 
   return (
     <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
@@ -470,7 +480,7 @@ export function Benchmark() {
             </div>
             {/* right pane: task detail */}
             <div style={{ flex: 1, overflow: 'auto', ...cardStyle }}>
-              {active ? <TaskDetail task={active} /> : <div style={{ padding: 24, color: colors.gray400 }}>No tasks.</div>}
+              {active ? <TaskDetail key={active.id} task={active} /> : <div style={{ padding: 24, color: colors.gray400 }}>No tasks.</div>}
             </div>
           </div>
         )}
@@ -521,6 +531,8 @@ function Header(props: {
   exportOpen?: boolean; setExportOpen?: (v: boolean) => void; onExport?: (k: string) => void;
 }) {
   const { current, stale, list, generating, onRegenerate, onSelectWeek, exportOpen, setExportOpen, onExport } = props;
+  // Only offer ready runs — a generating/failed row would load as a blank benchmark.
+  const readyRuns = (list || []).filter(b => b.status === 'ready');
   return (
     <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16, flexWrap: 'wrap' }}>
       <div>
@@ -533,9 +545,9 @@ function Header(props: {
       </div>
       <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
         {stale && <Chip fg={colors.yellow700} bg={colors.yellow50}>{'>'}7 days old</Chip>}
-        {list && list.length > 1 && onSelectWeek && (
+        {readyRuns.length > 1 && onSelectWeek && (
           <select value={current?.benchmark_id} onChange={e => onSelectWeek(e.target.value)} style={selectStyle}>
-            {list.map(b => <option key={b.benchmark_id} value={b.benchmark_id}>{b.benchmark_id} ({shortDate(b.window_end)})</option>)}
+            {readyRuns.map(b => <option key={b.benchmark_id} value={b.benchmark_id}>{b.benchmark_id} ({shortDate(b.window_end)})</option>)}
           </select>
         )}
         <button style={generating ? { ...btnPrimary, opacity: 0.7, cursor: 'default' } : btnPrimary} onClick={onRegenerate} disabled={!!generating}>

--- a/clawjournal/web/frontend/src/views/Benchmark.tsx
+++ b/clawjournal/web/frontend/src/views/Benchmark.tsx
@@ -64,6 +64,45 @@ function Chip({ children, fg, bg }: { children: React.ReactNode; fg: string; bg:
 }
 
 /* ------------------------------------------------------------------ */
+/*  Generation progress — slow run, keep it visibly alive             */
+/* ------------------------------------------------------------------ */
+
+function stagePercent(stage: string): number {
+  const s = (stage || '').toLowerCase();
+  if (s.includes('done')) return 100;
+  if (s.includes('design') || s.includes('critiqu')) return 80;
+  if (s.includes('cluster')) return 52;
+  if (s.includes('deep-read')) return 28;
+  return 10;
+}
+
+function GeneratingBanner({ stage, elapsedMs }: { stage: string; elapsedMs: number }) {
+  const pct = stagePercent(stage);
+  const secs = Math.floor(elapsedMs / 1000);
+  const elapsed = secs < 60 ? `${secs}s` : `${Math.floor(secs / 60)}m ${secs % 60}s`;
+  return (
+    <div style={{ ...cardStyle, padding: 16, marginTop: 16, background: colors.primary50, borderColor: colors.primary200 }}>
+      <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 10 }}>
+        <span style={{ fontSize: 14, fontWeight: 600, color: colors.primary700, animation: 'bench-pulse 1.8s ease-in-out infinite' }}>
+          ⟳ Generating benchmark — {stage || 'starting…'}
+        </span>
+        <span style={{ fontSize: 12, color: colors.gray500 }}>{elapsed} elapsed</span>
+      </div>
+      <div style={{ height: 8, background: colors.primary100, borderRadius: 6, overflow: 'hidden' }}>
+        <div style={{
+          width: `${pct}%`, height: '100%', borderRadius: 6, transition: 'width 0.6s ease',
+          backgroundImage: `linear-gradient(90deg, ${colors.primary400}, ${colors.primary200}, ${colors.primary400})`,
+          backgroundSize: '200% 100%', animation: 'bench-shimmer 1.4s linear infinite',
+        }} />
+      </div>
+      <div style={{ fontSize: 12, color: colors.gray500, marginTop: 8 }}>
+        Runs the deep pipeline against your last 7 days of failures (~40+ model calls). A few minutes is normal — you can leave this tab and come back; it keeps running.
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
 /*  Task detail — agent packet vs grader packet                       */
 /* ------------------------------------------------------------------ */
 
@@ -243,8 +282,18 @@ export function Benchmark() {
   const [themeFilter, setThemeFilter] = useState<string | null>(null);
   const [selectedTask, setSelectedTask] = useState<string | null>(null);
   const [generating, setGenerating] = useState<{ id: string; stage: string } | null>(null);
+  const [genStart, setGenStart] = useState<number | null>(null);
+  const [now, setNow] = useState(() => Date.now());
   const [exportOpen, setExportOpen] = useState(false);
   const pollRef = useRef<number | null>(null);
+
+  // Tick a 1s clock while generating so the banner shows live elapsed time.
+  useEffect(() => {
+    if (!generating) return;
+    setNow(Date.now());
+    const t = window.setInterval(() => setNow(Date.now()), 1000);
+    return () => window.clearInterval(t);
+  }, [generating]);
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -287,6 +336,7 @@ export function Benchmark() {
     try {
       const res = await api.benchmarks.generate({});
       if (!res.benchmark_id) { toast(res.error || 'Could not start generation', 'error'); return; }
+      setGenStart(Date.now());
       setGenerating({ id: res.benchmark_id, stage: 'starting…' });
       pollRef.current = window.setInterval(async () => {
         try {
@@ -294,6 +344,7 @@ export function Benchmark() {
           if (st.status === 'generating') { setGenerating({ id: res.benchmark_id!, stage: st.stage || 'working…' }); return; }
           if (pollRef.current) window.clearInterval(pollRef.current);
           setGenerating(null);
+          setGenStart(null);
           if (st.status === 'failed') toast(`Generation failed: ${st.error || 'unknown'}`, 'error');
           else toast('Benchmark ready', 'success');
           load();
@@ -324,13 +375,17 @@ export function Benchmark() {
     return (
       <div style={{ padding: 40 }}>
         <Header generating={generating} onRegenerate={regenerate} />
-        <div style={{ marginTop: 24 }}>
-          <EmptyState
-            title="No benchmark yet"
-            description="Generate a personalized benchmark from your last 7 days of agent failures. It runs the deep pipeline against your own traces — a few minutes, and stored locally."
-            action={<button style={btnPrimary} onClick={regenerate} disabled={!!generating}>{generating ? 'Generating…' : 'Generate benchmark'}</button>}
-          />
-        </div>
+        {generating ? (
+          <GeneratingBanner stage={generating.stage} elapsedMs={genStart ? now - genStart : 0} />
+        ) : (
+          <div style={{ marginTop: 24 }}>
+            <EmptyState
+              title="No benchmark yet"
+              description="Generate a personalized benchmark from your last 7 days of agent failures. It runs the deep pipeline against your own traces — a few minutes, and stored locally."
+              action={<button style={btnPrimary} onClick={regenerate} disabled={!!generating}>Generate benchmark</button>}
+            />
+          </div>
+        )}
       </div>
     );
   }
@@ -357,6 +412,7 @@ export function Benchmark() {
           <span style={{ color: colors.yellow700 }}>{current.needs_staging_count} need staging</span>
           <span>{current.source_count} sessions deep-read{current.dropped_for_cost ? `, ${current.dropped_for_cost} dropped for cost` : ''}</span>
         </div>
+        {generating && <GeneratingBanner stage={generating.stage} elapsedMs={genStart ? now - genStart : 0} />}
         {/* tabs */}
         <div style={{ display: 'flex', gap: 4, marginTop: 16, borderBottom: `1px solid ${colors.gray200}` }}>
           {(['tasks', 'themes', 'trend'] as const).map(t => (
@@ -482,8 +538,8 @@ function Header(props: {
             {list.map(b => <option key={b.benchmark_id} value={b.benchmark_id}>{b.benchmark_id} ({shortDate(b.window_end)})</option>)}
           </select>
         )}
-        <button style={btnPrimary} onClick={onRegenerate} disabled={!!generating}>
-          {generating ? `⟳ ${generating.stage}` : '⟳ Regenerate (last 7d)'}
+        <button style={generating ? { ...btnPrimary, opacity: 0.7, cursor: 'default' } : btnPrimary} onClick={onRegenerate} disabled={!!generating}>
+          {generating ? '⟳ Generating…' : '⟳ Regenerate (last 7d)'}
         </button>
         {current && onExport && setExportOpen && (
           <div style={{ position: 'relative' }}>

--- a/clawjournal/web/frontend/src/views/Benchmark.tsx
+++ b/clawjournal/web/frontend/src/views/Benchmark.tsx
@@ -1,0 +1,504 @@
+import type React from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { Link } from 'react-router-dom';
+import type { Benchmark as BM, BenchmarkSummary, BenchmarkTask, BenchmarkTrend } from '../types.ts';
+import { api, ApiError } from '../api.ts';
+import { Spinner, EmptyState } from '../components/Spinner.tsx';
+import { useToast } from '../components/Toast.tsx';
+import { colors, fontFamily, cardStyle, btnPrimary, btnSecondary, btnGhost, selectStyle } from '../theme.ts';
+
+/* ------------------------------------------------------------------ */
+/*  Vocabulary + helpers                                              */
+/* ------------------------------------------------------------------ */
+
+const READINESS: Record<string, { label: string; fg: string; bg: string }> = {
+  ready: { label: 'ready', fg: colors.green700, bg: colors.green50 },
+  needs_staging: { label: 'needs staging', fg: colors.yellow700, bg: colors.yellow50 },
+  needs_review: { label: 'needs review', fg: colors.blue600, bg: colors.blue50 },
+  local_only: { label: 'local only', fg: colors.red700, bg: colors.red50 },
+  retired: { label: 'retired', fg: colors.gray500, bg: colors.gray100 },
+};
+
+const RISK_FG: Record<string, string> = { low: colors.gray500, medium: colors.yellow700, high: colors.red700 };
+
+const EXPORT_KINDS: { kind: string; label: string }[] = [
+  { kind: 'authoring_md', label: 'Authoring (.md)' },
+  { kind: 'agent_packet_md', label: 'Agent packet (.md)' },
+  { kind: 'grader_packet_md', label: 'Grader packet (.md)' },
+  { kind: 'agent_packet_json', label: 'Agent packet (.json)' },
+  { kind: 'grader_packet_json', label: 'Grader packet (.json)' },
+];
+
+function shortDate(iso: string | null | undefined): string {
+  return iso ? String(iso).slice(0, 10) : '?';
+}
+
+function timeAgo(iso: string | null | undefined): string {
+  if (!iso) return 'never';
+  const then = new Date(String(iso).replace(' ', 'T')).getTime();
+  if (Number.isNaN(then)) return shortDate(iso);
+  const s = Math.max(0, (Date.now() - then) / 1000);
+  if (s < 90) return 'just now';
+  if (s < 5400) return `${Math.round(s / 60)}m ago`;
+  if (s < 129600) return `${Math.round(s / 3600)}h ago`;
+  return `${Math.round(s / 86400)}d ago`;
+}
+
+function download(filename: string, content: string) {
+  const blob = new Blob([content], { type: 'text/plain' });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
+function Chip({ children, fg, bg }: { children: React.ReactNode; fg: string; bg: string }) {
+  return (
+    <span style={{
+      fontSize: 11, fontWeight: 600, color: fg, background: bg, padding: '2px 8px',
+      borderRadius: 6, whiteSpace: 'nowrap',
+    }}>{children}</span>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Task detail — agent packet vs grader packet                       */
+/* ------------------------------------------------------------------ */
+
+function TaskDetail({ task }: { task: BenchmarkTask }) {
+  const [packet, setPacket] = useState<'agent' | 'grader'>('agent');
+  const [copied, setCopied] = useState(false);
+  const r = READINESS[task.readiness] || READINESS.needs_review;
+
+  const agentPrompt = `# ${task.title}\n\n## Scenario\n${task.scenario}\n\n## Seed inputs\n${task.seed_inputs}`;
+
+  const copyPrompt = () => {
+    navigator.clipboard.writeText(agentPrompt).then(() => {
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    });
+  };
+
+  const seg = (key: 'agent' | 'grader', label: string) => (
+    <button onClick={() => setPacket(key)} style={{
+      padding: '5px 12px', fontSize: 13, fontWeight: 600, fontFamily, cursor: 'pointer',
+      border: 'none', borderRadius: 6,
+      background: packet === key ? colors.white : 'transparent',
+      color: packet === key ? colors.gray800 : colors.gray500,
+      boxShadow: packet === key ? '0 1px 2px rgba(0,0,0,0.08)' : 'none',
+    }}>{label}</button>
+  );
+
+  return (
+    <div style={{ padding: 20, overflow: 'auto' }}>
+      <div style={{ fontSize: 17, fontWeight: 650, color: colors.gray900 }}>{task.id} — {task.title}</div>
+      <div style={{ marginTop: 6, fontSize: 12, color: colors.gray500, display: 'flex', gap: 8, flexWrap: 'wrap', alignItems: 'center' }}>
+        <span>{(task.domains || []).join(' / ') || '—'}</span><span>·</span>
+        <span>{task.difficulty}</span><span>·</span>
+        <span>{task.points} pts</span><span>·</span>
+        <span>{task.grading}</span>
+        {(task.source_agents || []).map(a => <Chip key={a} fg={colors.gray600} bg={colors.gray100}>{a}</Chip>)}
+      </div>
+      <div style={{ marginTop: 10, display: 'flex', gap: 6, flexWrap: 'wrap', alignItems: 'center' }}>
+        <Chip fg={r.fg} bg={r.bg}>{r.label}</Chip>
+        <Chip fg={RISK_FG[task.privacy_risk] || colors.gray500} bg={colors.gray50}>privacy: {task.privacy_risk}</Chip>
+        <Chip fg={RISK_FG[task.leakage_risk] || colors.gray500} bg={colors.gray50}>leakage: {task.leakage_risk}</Chip>
+        {task.critique?.discriminating ? <Chip fg={colors.green700} bg={colors.green50}>discriminating</Chip> : null}
+        {task.critique?.gameable ? <Chip fg={colors.red700} bg={colors.red50}>gameable</Chip> : null}
+      </div>
+
+      <div style={{ marginTop: 16, display: 'inline-flex', gap: 2, background: colors.gray100, padding: 3, borderRadius: 8 }}>
+        {seg('agent', 'Agent packet')}
+        {seg('grader', 'Grader packet')}
+      </div>
+
+      {packet === 'agent' ? (
+        <div style={{ marginTop: 14 }}>
+          <button onClick={copyPrompt} style={{ ...btnSecondary, marginBottom: 12 }}>
+            {copied ? '✓ Copied' : '⧉ Copy prompt'}
+          </button>
+          <Field label="Scenario" body={task.scenario} />
+          <Field label="Seed inputs" body={task.seed_inputs} />
+          <div style={{ marginTop: 8, fontSize: 11, color: colors.gray400 }}>
+            The trap, ideal trajectory, pass criteria and grounded sessions are withheld here — switch to the grader packet to grade a run.
+          </div>
+        </div>
+      ) : (
+        <div style={{ marginTop: 14 }}>
+          {task.critique?.staging_notes && (
+            <div style={{ background: colors.yellow50, border: `1px solid ${colors.yellow200}`, color: colors.yellow700, padding: '8px 12px', borderRadius: 8, fontSize: 13, marginBottom: 12 }}>
+              ⚠ Staging: {task.critique.staging_notes}
+            </div>
+          )}
+          <Field label="The trap" body={task.the_trap} />
+          {task.ideal_trajectory?.length > 0 && (
+            <ListField label="Ideal trajectory" items={task.ideal_trajectory} ordered />
+          )}
+          {task.pass_criteria?.length > 0 && (
+            <div style={{ marginBottom: 14 }}>
+              <div style={labelStyle}>Pass criteria</div>
+              {task.pass_criteria.map((c, i) => (
+                <label key={i} style={{ display: 'flex', gap: 8, alignItems: 'flex-start', fontSize: 13, color: colors.gray700, padding: '2px 0' }}>
+                  <input type="checkbox" style={{ marginTop: 3 }} /><span>{c}</span>
+                </label>
+              ))}
+            </div>
+          )}
+          {task.fail_signals?.length > 0 && <ListField label="Fail signals" items={task.fail_signals} />}
+          {task.grounded_session_ids?.length > 0 && (
+            <div style={{ marginBottom: 8 }}>
+              <div style={labelStyle}>Grounded sessions</div>
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                {task.grounded_session_ids.map(sid => (
+                  <Link key={sid} to={`/session/${encodeURIComponent(sid)}`} style={{ fontSize: 12, color: colors.blue600, fontFamily: 'monospace' }}>{sid.slice(0, 8)}</Link>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+const labelStyle: React.CSSProperties = { fontWeight: 600, fontSize: 11, color: colors.gray400, letterSpacing: '0.02em', marginBottom: 4, textTransform: 'uppercase' };
+
+function Field({ label, body }: { label: string; body: string }) {
+  if (!body) return null;
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <div style={labelStyle}>{label}</div>
+      <div style={{ fontSize: 14, color: colors.gray800, lineHeight: 1.55, whiteSpace: 'pre-wrap' }}>{body}</div>
+    </div>
+  );
+}
+
+function ListField({ label, items, ordered }: { label: string; items: string[]; ordered?: boolean }) {
+  return (
+    <div style={{ marginBottom: 14 }}>
+      <div style={labelStyle}>{label}</div>
+      <ol style={{ margin: 0, paddingLeft: ordered ? 20 : 16, listStyle: ordered ? 'decimal' : 'disc' }}>
+        {items.map((it, i) => <li key={i} style={{ fontSize: 13, color: colors.gray700, lineHeight: 1.5, marginBottom: 3 }}>{it}</li>)}
+      </ol>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Trend heatmap                                                     */
+/* ------------------------------------------------------------------ */
+
+function TrendHeatmap({ trend }: { trend: BenchmarkTrend }) {
+  const names = Object.keys(trend.themes);
+  if (trend.runs.length < 1 || names.length === 0) {
+    return <div style={{ fontSize: 13, color: colors.gray400, padding: 24 }}>Not enough history yet — generate a few weekly benchmarks to see which judgment failures recur.</div>;
+  }
+  const max = Math.max(1, ...names.flatMap(n => trend.themes[n]));
+  const cell = (v: number) => {
+    if (!v) return colors.gray50;
+    const t = 0.18 + 0.62 * (v / max);
+    return `rgba(180,125,8,${t.toFixed(2)})`; // amber scale
+  };
+  return (
+    <div style={{ padding: 20, overflow: 'auto' }}>
+      <div style={{ fontSize: 12, color: colors.gray500, marginBottom: 12 }}>Theme recurrence across your stored weekly benchmarks (oldest → newest). Darker = higher frequency.</div>
+      <table style={{ borderCollapse: 'separate', borderSpacing: 3, fontFamily }}>
+        <thead>
+          <tr>
+            <th style={{ textAlign: 'left' }}></th>
+            {trend.runs.map(run => (
+              <th key={run.benchmark_id} style={{ fontSize: 10, color: colors.gray400, fontWeight: 500, padding: '0 2px', whiteSpace: 'nowrap' }}>{shortDate(run.window_end).slice(5)}</th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {names.map(name => (
+            <tr key={name}>
+              <td style={{ fontSize: 12, color: colors.gray700, paddingRight: 12, whiteSpace: 'nowrap', maxWidth: 240, overflow: 'hidden', textOverflow: 'ellipsis' }}>{name}</td>
+              {trend.themes[name].map((v, i) => (
+                <td key={i} title={`${name}: ${v}`} style={{ width: 26, height: 22, background: cell(v), borderRadius: 4, textAlign: 'center', fontSize: 10, color: v ? colors.gray800 : 'transparent' }}>{v || ''}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main view                                                         */
+/* ------------------------------------------------------------------ */
+
+export function Benchmark() {
+  const { toast } = useToast();
+  const [loading, setLoading] = useState(true);
+  const [current, setCurrent] = useState<BM | null>(null);
+  const [stale, setStale] = useState(false);
+  const [list, setList] = useState<BenchmarkSummary[]>([]);
+  const [trend, setTrend] = useState<BenchmarkTrend | null>(null);
+  const [tab, setTab] = useState<'tasks' | 'themes' | 'trend'>('tasks');
+  const [themeFilter, setThemeFilter] = useState<string | null>(null);
+  const [selectedTask, setSelectedTask] = useState<string | null>(null);
+  const [generating, setGenerating] = useState<{ id: string; stage: string } | null>(null);
+  const [exportOpen, setExportOpen] = useState(false);
+  const pollRef = useRef<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const [latest, l, t] = await Promise.all([
+        api.benchmarks.latest(),
+        api.benchmarks.list(),
+        api.benchmarks.trend(),
+      ]);
+      setCurrent(latest.benchmark);
+      setStale(latest.stale);
+      setList(l.benchmarks);
+      setTrend(t);
+      setSelectedTask(latest.benchmark?.tasks?.[0]?.id ?? null);
+    } catch (e) {
+      toast(e instanceof ApiError ? e.message : 'Failed to load benchmarks', 'error');
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    load();
+    return () => { if (pollRef.current) window.clearInterval(pollRef.current); };
+  }, [load]);
+
+  const selectWeek = async (id: string) => {
+    if (id === current?.benchmark_id) return;
+    try {
+      const bm = await api.benchmarks.get(id);
+      setCurrent(bm);
+      setThemeFilter(null);
+      setSelectedTask(bm.tasks?.[0]?.id ?? null);
+    } catch {
+      toast('Failed to load that benchmark', 'error');
+    }
+  };
+
+  const regenerate = async () => {
+    try {
+      const res = await api.benchmarks.generate({});
+      if (!res.benchmark_id) { toast(res.error || 'Could not start generation', 'error'); return; }
+      setGenerating({ id: res.benchmark_id, stage: 'starting…' });
+      pollRef.current = window.setInterval(async () => {
+        try {
+          const st = await api.benchmarks.status(res.benchmark_id!);
+          if (st.status === 'generating') { setGenerating({ id: res.benchmark_id!, stage: st.stage || 'working…' }); return; }
+          if (pollRef.current) window.clearInterval(pollRef.current);
+          setGenerating(null);
+          if (st.status === 'failed') toast(`Generation failed: ${st.error || 'unknown'}`, 'error');
+          else toast('Benchmark ready', 'success');
+          load();
+        } catch { /* keep polling */ }
+      }, 2000);
+    } catch (e) {
+      const msg = e instanceof ApiError ? (e.status === 409 ? 'A generation is already running' : e.message) : 'Could not start generation';
+      toast(msg, 'error');
+    }
+  };
+
+  const doExport = async (kind: string) => {
+    setExportOpen(false);
+    if (!current) return;
+    try {
+      const res = await api.benchmarks.export(current.benchmark_id, kind);
+      const ext = kind.endsWith('json') ? 'json' : 'md';
+      download(`benchmark-${current.benchmark_id}-${kind}.${ext}`, res.content);
+      toast(`Exported (${res.pii_scan_hits} PII hits scanned)`, 'success');
+    } catch {
+      toast('Export failed', 'error');
+    }
+  };
+
+  if (loading) return <div style={{ padding: 40 }}><Spinner text="Loading benchmarks…" /></div>;
+
+  if (!current) {
+    return (
+      <div style={{ padding: 40 }}>
+        <Header generating={generating} onRegenerate={regenerate} />
+        <div style={{ marginTop: 24 }}>
+          <EmptyState
+            title="No benchmark yet"
+            description="Generate a personalized benchmark from your last 7 days of agent failures. It runs the deep pipeline against your own traces — a few minutes, and stored locally."
+            action={<button style={btnPrimary} onClick={regenerate} disabled={!!generating}>{generating ? 'Generating…' : 'Generate benchmark'}</button>}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  const themes = current.themes || [];
+  const tasks = current.tasks || [];
+  const shown = themeFilter ? tasks.filter(t => t.theme === themeFilter) : tasks;
+  const active = tasks.find(t => t.id === selectedTask) || shown[0] || null;
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', height: '100%' }}>
+      <div style={{ padding: '20px 24px 0' }}>
+        <Header
+          current={current} stale={stale} list={list} generating={generating}
+          onRegenerate={regenerate} onSelectWeek={selectWeek}
+          exportOpen={exportOpen} setExportOpen={setExportOpen} onExport={doExport}
+        />
+        {/* summary chips */}
+        <div style={{ display: 'flex', gap: 14, marginTop: 14, fontSize: 12, color: colors.gray500, flexWrap: 'wrap' }}>
+          <span>{themes.length} themes</span>
+          <span>{current.n_tasks} tasks</span>
+          <span>{current.total_points} pts</span>
+          <span style={{ color: colors.green700 }}>{current.ready_count} ready</span>
+          <span style={{ color: colors.yellow700 }}>{current.needs_staging_count} need staging</span>
+          <span>{current.source_count} sessions deep-read{current.dropped_for_cost ? `, ${current.dropped_for_cost} dropped for cost` : ''}</span>
+        </div>
+        {/* tabs */}
+        <div style={{ display: 'flex', gap: 4, marginTop: 16, borderBottom: `1px solid ${colors.gray200}` }}>
+          {(['tasks', 'themes', 'trend'] as const).map(t => (
+            <button key={t} onClick={() => setTab(t)} style={{
+              padding: '8px 14px', fontSize: 14, fontWeight: 600, fontFamily, cursor: 'pointer',
+              background: 'none', border: 'none', textTransform: 'capitalize',
+              color: tab === t ? colors.gray900 : colors.gray400,
+              borderBottom: `2px solid ${tab === t ? colors.primary500 : 'transparent'}`, marginBottom: -1,
+            }}>{t}</button>
+          ))}
+        </div>
+      </div>
+
+      <div style={{ flex: 1, overflow: 'hidden', padding: '0 24px 24px' }}>
+        {tab === 'tasks' && (
+          <div style={{ display: 'flex', gap: 16, height: '100%', paddingTop: 16 }}>
+            {/* left rail: themes + tasks */}
+            <div style={{ width: 300, flexShrink: 0, overflow: 'auto', ...cardStyle }}>
+              <div style={{ padding: '10px 14px', borderBottom: `1px solid ${colors.gray100}` }}>
+                <button onClick={() => setThemeFilter(null)} style={{ ...btnGhost, color: themeFilter ? colors.gray500 : colors.gray800, fontWeight: 600 }}>
+                  All tasks ({tasks.length})
+                </button>
+              </div>
+              {themes.map(th => (
+                <div key={th.name}>
+                  <button onClick={() => setThemeFilter(themeFilter === th.name ? null : th.name)} style={{
+                    display: 'flex', justifyContent: 'space-between', width: '100%', padding: '8px 14px',
+                    background: themeFilter === th.name ? colors.primary50 : 'transparent', border: 'none',
+                    cursor: 'pointer', fontFamily, fontSize: 13, fontWeight: 600,
+                    color: themeFilter === th.name ? colors.primary700 : colors.gray700, textAlign: 'left',
+                  }}>
+                    <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{th.name}</span>
+                    <span style={{ color: colors.gray400, fontWeight: 500 }}>{th.frequency}</span>
+                  </button>
+                </div>
+              ))}
+              <div style={{ borderTop: `1px solid ${colors.gray100}`, marginTop: 4 }}>
+                {shown.map(t => {
+                  const r = READINESS[t.readiness] || READINESS.needs_review;
+                  return (
+                    <button key={t.id} onClick={() => setSelectedTask(t.id)} style={{
+                      display: 'flex', justifyContent: 'space-between', alignItems: 'center', width: '100%',
+                      gap: 8, padding: '9px 14px', background: active?.id === t.id ? colors.gray100 : 'transparent',
+                      border: 'none', borderLeft: `2px solid ${active?.id === t.id ? colors.primary500 : 'transparent'}`,
+                      cursor: 'pointer', fontFamily, textAlign: 'left',
+                    }}>
+                      <span style={{ fontSize: 13, color: colors.gray800, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+                        <span style={{ color: colors.gray400 }}>{t.id} </span>{t.title}
+                      </span>
+                      <span title={r.label} style={{ width: 8, height: 8, borderRadius: 4, background: r.fg, flexShrink: 0 }} />
+                    </button>
+                  );
+                })}
+              </div>
+            </div>
+            {/* right pane: task detail */}
+            <div style={{ flex: 1, overflow: 'auto', ...cardStyle }}>
+              {active ? <TaskDetail task={active} /> : <div style={{ padding: 24, color: colors.gray400 }}>No tasks.</div>}
+            </div>
+          </div>
+        )}
+
+        {tab === 'themes' && (
+          <div style={{ ...cardStyle, marginTop: 16, overflow: 'auto' }}>
+            <table style={{ width: '100%', borderCollapse: 'collapse', fontFamily }}>
+              <thead>
+                <tr style={{ borderBottom: `1px solid ${colors.gray200}` }}>
+                  {['Theme', 'Freq', 'Taxonomy', 'Lesson'].map(h => (
+                    <th key={h} style={{ textAlign: 'left', padding: '10px 14px', fontSize: 11, color: colors.gray400, fontWeight: 600 }}>{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody>
+                {themes.map(th => (
+                  <tr key={th.name} style={{ borderBottom: `1px solid ${colors.gray100}`, cursor: 'pointer' }}
+                      onClick={() => { setThemeFilter(th.name); setTab('tasks'); }}>
+                    <td style={{ padding: '10px 14px', fontSize: 13, color: colors.gray800, fontWeight: 600 }}>{th.name}</td>
+                    <td style={{ padding: '10px 14px', fontSize: 13, color: colors.gray600 }}>{th.frequency}</td>
+                    <td style={{ padding: '10px 14px', fontSize: 12, color: colors.gray500 }}>{(th.taxonomy || []).join(', ')}</td>
+                    <td style={{ padding: '10px 14px', fontSize: 13, color: colors.gray600 }}>{th.lesson}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+
+        {tab === 'trend' && (
+          <div style={{ ...cardStyle, marginTop: 16, overflow: 'auto' }}>
+            {trend ? <TrendHeatmap trend={trend} /> : <div style={{ padding: 24, color: colors.gray400 }}>No trend data.</div>}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Header (window + controls)                                        */
+/* ------------------------------------------------------------------ */
+
+function Header(props: {
+  current?: BM | null; stale?: boolean; list?: BenchmarkSummary[];
+  generating: { id: string; stage: string } | null;
+  onRegenerate: () => void; onSelectWeek?: (id: string) => void;
+  exportOpen?: boolean; setExportOpen?: (v: boolean) => void; onExport?: (k: string) => void;
+}) {
+  const { current, stale, list, generating, onRegenerate, onSelectWeek, exportOpen, setExportOpen, onExport } = props;
+  return (
+    <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'flex-start', gap: 16, flexWrap: 'wrap' }}>
+      <div>
+        <div style={{ fontSize: 22, fontWeight: 700, color: colors.gray900 }}>Benchmark</div>
+        <div style={{ fontSize: 13, color: colors.gray500, marginTop: 2 }}>
+          {current
+            ? <>Week of {shortDate(current.window_start)} → {shortDate(current.window_end)} · generated {timeAgo(current.generated_at)} · {current.backend || 'agent'}</>
+            : 'Personalized weekly benchmark from your own agent traces'}
+        </div>
+      </div>
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', flexWrap: 'wrap' }}>
+        {stale && <Chip fg={colors.yellow700} bg={colors.yellow50}>{'>'}7 days old</Chip>}
+        {list && list.length > 1 && onSelectWeek && (
+          <select value={current?.benchmark_id} onChange={e => onSelectWeek(e.target.value)} style={selectStyle}>
+            {list.map(b => <option key={b.benchmark_id} value={b.benchmark_id}>{b.benchmark_id} ({shortDate(b.window_end)})</option>)}
+          </select>
+        )}
+        <button style={btnPrimary} onClick={onRegenerate} disabled={!!generating}>
+          {generating ? `⟳ ${generating.stage}` : '⟳ Regenerate (last 7d)'}
+        </button>
+        {current && onExport && setExportOpen && (
+          <div style={{ position: 'relative' }}>
+            <button style={btnSecondary} onClick={() => setExportOpen(!exportOpen)}>⬇ Export ▾</button>
+            {exportOpen && (
+              <div style={{ position: 'absolute', right: 0, top: '110%', zIndex: 10, ...cardStyle, boxShadow: '0 4px 16px rgba(0,0,0,0.12)', minWidth: 180 }}>
+                {EXPORT_KINDS.map(k => (
+                  <button key={k.kind} onClick={() => onExport(k.kind)} style={{ display: 'block', width: '100%', textAlign: 'left', padding: '8px 14px', background: 'none', border: 'none', cursor: 'pointer', fontFamily, fontSize: 13, color: colors.gray700 }}>{k.label}</button>
+                ))}
+              </div>
+            )}
+          </div>
+        )}
+        <Chip fg={colors.gray500} bg={colors.gray100}>🔒 local only</Chip>
+      </div>
+    </div>
+  );
+}

--- a/clawjournal/web/frontend/src/views/Benchmark.tsx
+++ b/clawjournal/web/frontend/src/views/Benchmark.tsx
@@ -324,6 +324,44 @@ export function Benchmark() {
     return () => { if (pollRef.current) window.clearInterval(pollRef.current); };
   }, [load]);
 
+  // Attach the progress banner to a running generation and poll it to completion.
+  // Shared by the Regenerate button and by adoption of a server-side run below.
+  const beginPolling = useCallback((id: string, stage: string, startMs: number) => {
+    if (pollRef.current) window.clearInterval(pollRef.current);
+    setGenStart(startMs);
+    setGenerating({ id, stage });
+    let fails = 0;
+    const stop = () => {
+      if (pollRef.current) { window.clearInterval(pollRef.current); pollRef.current = null; }
+      setGenerating(null);
+      setGenStart(null);
+    };
+    pollRef.current = window.setInterval(async () => {
+      try {
+        const st = await api.benchmarks.status(id);
+        fails = 0;
+        if (st.status === 'generating') { setGenerating({ id, stage: st.stage || 'working…' }); return; }
+        stop();
+        if (st.status === 'failed') toast(`Generation failed: ${st.error || 'unknown'}`, 'error');
+        else toast('Benchmark ready', 'success');
+        load();
+      } catch {
+        // Tolerate transient blips, but don't spin forever on a persistent error.
+        if (++fails >= 5) { stop(); toast('Lost contact with the generation — check the workbench daemon.', 'error'); }
+      }
+    }, 2000);
+  }, [toast, load]);
+
+  // Adopt a generation already running server-side — kicked off from the CLI,
+  // another tab, or surviving a page reload — so the progress bar shows here too.
+  useEffect(() => {
+    if (generating || pollRef.current) return;
+    const inflight = list.find(b => b.status === 'generating');
+    if (!inflight) return;
+    const parsed = Date.parse(inflight.generated_at);
+    beginPolling(inflight.benchmark_id, inflight.stage || 'working…', Number.isNaN(parsed) ? Date.now() : parsed);
+  }, [list, generating, beginPolling]);
+
   const selectWeek = async (id: string) => {
     if (id === current?.benchmark_id) return;
     try {
@@ -340,24 +378,7 @@ export function Benchmark() {
     try {
       const res = await api.benchmarks.generate({});
       if (!res.benchmark_id) { toast(res.error || 'Could not start generation', 'error'); return; }
-      setGenStart(Date.now());
-      setGenerating({ id: res.benchmark_id, stage: 'starting…' });
-      let fails = 0;
-      const stop = () => { if (pollRef.current) window.clearInterval(pollRef.current); setGenerating(null); setGenStart(null); };
-      pollRef.current = window.setInterval(async () => {
-        try {
-          const st = await api.benchmarks.status(res.benchmark_id!);
-          fails = 0;
-          if (st.status === 'generating') { setGenerating({ id: res.benchmark_id!, stage: st.stage || 'working…' }); return; }
-          stop();
-          if (st.status === 'failed') toast(`Generation failed: ${st.error || 'unknown'}`, 'error');
-          else toast('Benchmark ready', 'success');
-          load();
-        } catch {
-          // Tolerate transient blips, but don't spin forever on a persistent error.
-          if (++fails >= 5) { stop(); toast('Lost contact with the generation — check the workbench daemon.', 'error'); }
-        }
-      }, 2000);
+      beginPolling(res.benchmark_id, 'starting…', Date.now());
     } catch (e) {
       const msg = e instanceof ApiError ? (e.status === 409 ? 'A generation is already running' : e.message) : 'Could not start generation';
       toast(msg, 'error');

--- a/clawjournal/web/frontend/src/views/Insights.tsx
+++ b/clawjournal/web/frontend/src/views/Insights.tsx
@@ -394,6 +394,7 @@ export function Insights() {
   const [insights, setInsights] = useState<InsightsData | null>(null);
   const [highlights, setHighlights] = useState<HighlightsData | null>(null);
   const [days, setDays] = useState(7);
+  const [showDetails, setShowDetails] = useState(false);
   const [loading, setLoading] = useState(true);
 
   const load = useCallback(async () => {
@@ -474,6 +475,49 @@ export function Insights() {
         )}
       </div>
 
+      {/* HERO: actionable recommendations first */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, margin: '0 0 10px' }}>
+        <h2 style={{ fontSize: 14, fontWeight: 700, color: colors.gray800, margin: 0, textTransform: 'uppercase', letterSpacing: '0.04em' }}>Recommendations</h2>
+        {recommendations.length > 0 && (
+          <span style={{ fontSize: 12, fontWeight: 700, color: colors.white, background: colors.primary500, borderRadius: 10, padding: '1px 8px' }}>{recommendations.length}</span>
+        )}
+      </div>
+      {recommendations.length > 0 ? (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10, marginBottom: 18 }}>
+          {recommendations.map((rec, i) => (
+            <div key={i} style={{
+              border: `1px solid ${colors.gray200}`,
+              borderLeft: `4px solid ${PRIORITY_COLORS[rec.priority] || colors.gray400}`,
+              borderRadius: 8, padding: '12px 16px',
+              background: PRIORITY_BG[rec.priority] || colors.white,
+            }}>
+              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
+                <span style={{ fontSize: 11, fontWeight: 700, textTransform: 'uppercase', color: PRIORITY_COLORS[rec.priority] || colors.gray500 }}>{rec.priority}</span>
+                <span style={{ fontSize: 14, fontWeight: 600, color: colors.gray800 }}>{rec.title}</span>
+              </div>
+              <div style={{ fontSize: 13, color: colors.gray600, lineHeight: 1.5 }}>{rec.detail}</div>
+              {rec.estimated_savings_usd != null && rec.estimated_savings_usd > 0 && (
+                <div style={{ marginTop: 6, fontSize: 12, fontWeight: 600, color: colors.green500 }}>Est. savings: {formatCost(rec.estimated_savings_usd)}/period</div>
+              )}
+            </div>
+          ))}
+        </div>
+      ) : (
+        <div style={{ border: `1px solid ${colors.gray200}`, borderRadius: 8, padding: '20px', textAlign: 'center', color: colors.gray400, fontSize: 13, marginBottom: 18 }}>
+          No specific optimization suggestions for this period. Your usage looks efficient.
+        </div>
+      )}
+
+      {/* Passive analytics, collapsed by default */}
+      <button onClick={() => setShowDetails(v => !v)} style={{
+        display: 'flex', alignItems: 'center', gap: 6, width: '100%', textAlign: 'left',
+        background: colors.gray50, border: `1px solid ${colors.gray200}`, borderRadius: 8,
+        padding: '10px 14px', cursor: 'pointer', fontSize: 13, fontWeight: 600, color: colors.gray700, marginBottom: 12,
+      }}>
+        <span style={{ color: colors.gray400 }}>{showDetails ? '▾' : '▸'}</span> Analytics &amp; trends — cost, efficiency, highlights, trends
+      </button>
+      {showDetails && (<>
+
       {/* Summary stats */}
       <div style={{ display: 'flex', gap: 10, marginBottom: 16, flexWrap: 'wrap' }}>
         {[
@@ -543,43 +587,7 @@ export function Insights() {
         </Section>
       )}
 
-      {/* Recommendations */}
-      <h2 style={{ fontSize: 14, fontWeight: 700, color: colors.gray700, margin: '0 0 10px', textTransform: 'uppercase', letterSpacing: '0.04em' }}>
-        Recommendations
-      </h2>
-      {recommendations.length > 0 ? (
-        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
-          {recommendations.map((rec, i) => (
-            <div key={i} style={{
-              border: `1px solid ${colors.gray200}`,
-              borderLeft: `4px solid ${PRIORITY_COLORS[rec.priority] || colors.gray400}`,
-              borderRadius: 8, padding: '12px 16px',
-              background: PRIORITY_BG[rec.priority] || colors.white,
-            }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 4 }}>
-                <span style={{
-                  fontSize: 11, fontWeight: 700, textTransform: 'uppercase',
-                  color: PRIORITY_COLORS[rec.priority] || colors.gray500,
-                }}>{rec.priority}</span>
-                <span style={{ fontSize: 14, fontWeight: 600, color: colors.gray800 }}>{rec.title}</span>
-              </div>
-              <div style={{ fontSize: 13, color: colors.gray600, lineHeight: 1.5 }}>{rec.detail}</div>
-              {rec.estimated_savings_usd != null && rec.estimated_savings_usd > 0 && (
-                <div style={{ marginTop: 6, fontSize: 12, fontWeight: 600, color: colors.green500 }}>
-                  Est. savings: {formatCost(rec.estimated_savings_usd)}/period
-                </div>
-              )}
-            </div>
-          ))}
-        </div>
-      ) : (
-        <div style={{
-          border: `1px solid ${colors.gray200}`, borderRadius: 8, padding: '20px',
-          textAlign: 'center', color: colors.gray400, fontSize: 13,
-        }}>
-          No specific optimization suggestions for this period. Your usage looks efficient.
-        </div>
-      )}
+      </>)}
 
       {/* Footer */}
       <div style={{ marginTop: 16, fontSize: 11, color: colors.gray400, textAlign: 'right' }}>

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -567,6 +567,12 @@ def _run_benchmark_generation(benchmark_id: str, week_slice) -> None:
             store.finalize_benchmark(conn, benchmark_id, benchmark)
         except Exception as exc:
             logger.warning("benchmark generation failed for %s: %s", benchmark_id, exc)
+            # Discard any partial writes from a half-applied finalize before the
+            # failed-status commit, so we don't persist orphan/inconsistent rows.
+            try:
+                conn.rollback()
+            except Exception:
+                pass
             store.update_status(conn, benchmark_id, status="failed", error=str(exc))
     finally:
         conn.close()
@@ -2574,8 +2580,20 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                     conn, window_start=sl.window_start, window_end=sl.window_end)
             finally:
                 conn.close()
-            threading.Thread(
-                target=_run_benchmark_generation, args=(bid, sl), daemon=True).start()
+            try:
+                threading.Thread(
+                    target=_run_benchmark_generation, args=(bid, sl), daemon=True).start()
+            except Exception as exc:
+                # Thread didn't start, so the worker won't run (and won't release
+                # the lock or finalize the row) — mark it failed here and bail.
+                conn2 = open_index()
+                try:
+                    store.update_status(conn2, bid, status="failed",
+                                        error=f"failed to start worker: {exc}")
+                finally:
+                    conn2.close()
+                _json_response(self, {"error": "could not start generation"}, 500)
+                return
             released = True  # the worker owns the lock now
             _json_response(self, {"status": "generating", "benchmark_id": bid}, 202)
         finally:
@@ -2598,6 +2616,9 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             got = store.get_benchmark(conn, benchmark_id)
             if got is None:
                 _json_response(self, {"error": "benchmark not found"}, 404)
+                return
+            if got.get("status") != "ready":
+                _json_response(self, {"error": f"benchmark is {got.get('status')!r}, not ready to export"}, 409)
                 return
             content = render.render(got, kind)
             pii_hits = len(bm.find_pii(content))
@@ -3759,6 +3780,20 @@ def run_server(
         logger.info("Background scanner started (interval: %ds)", SCAN_INTERVAL)
 
     threading.Thread(target=_initial_scan, daemon=True).start()
+
+    # Reconcile benchmark rows orphaned in 'generating' by a previous crash/restart
+    # (the only normal exit from 'generating' is the in-process worker).
+    try:
+        from ..benchmark import store as _bstore
+        _bconn = open_index()
+        try:
+            n = _bstore.reconcile_stale_generating(_bconn)
+            if n:
+                logger.info("Reconciled %d stale 'generating' benchmark row(s) -> failed", n)
+        finally:
+            _bconn.close()
+    except Exception:
+        logger.warning("benchmark stale-row reconcile skipped", exc_info=True)
 
     try:
         server.serve_forever()

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -522,6 +522,57 @@ def _read_body(handler: BaseHTTPRequestHandler) -> dict:
     return json.loads(raw)
 
 
+# Serializes benchmark generation: the deep pipeline is minutes-long and
+# expensive, so only one runs at a time (the row's `generating` status is the
+# durable state; this lock just rejects concurrent kicks).
+_BENCHMARK_GEN_LOCK = threading.Lock()
+_BENCHMARK_STALE_DAYS = 7
+
+
+def _benchmark_is_stale(benchmark: dict | None, *, days: int = _BENCHMARK_STALE_DAYS) -> bool:
+    """True when there's no benchmark, or the latest one is older than ``days``."""
+    if not benchmark or not benchmark.get("generated_at"):
+        return True
+    try:
+        gen = datetime.fromisoformat(str(benchmark["generated_at"]).replace("Z", "+00:00"))
+    except ValueError:
+        return True
+    if gen.tzinfo is None:
+        gen = gen.replace(tzinfo=timezone.utc)
+    return (datetime.now(timezone.utc) - gen).total_seconds() > days * 86400
+
+
+def _run_benchmark_generation(benchmark_id: str, week_slice) -> None:
+    """Background worker: run the deep pipeline against a pre-selected slice and
+    finalize (or mark failed) the placeholder row. Always releases the gen lock.
+
+    The same ``week_slice`` used to insert the placeholder is passed through, so
+    the finalized window matches the placeholder (``finalize_benchmark`` rejects
+    a window mismatch).
+    """
+    from ..benchmark import store
+    from ..benchmark.generate import generate_benchmark
+
+    conn = open_index()
+    try:
+        def progress(msg: str) -> None:
+            try:
+                store.update_status(conn, benchmark_id, stage=msg)
+            except Exception:  # progress is best-effort
+                pass
+
+        try:
+            benchmark = generate_benchmark(
+                conn, week_slice=week_slice, backend="auto", progress=progress)
+            store.finalize_benchmark(conn, benchmark_id, benchmark)
+        except Exception as exc:
+            logger.warning("benchmark generation failed for %s: %s", benchmark_id, exc)
+            store.update_status(conn, benchmark_id, status="failed", error=str(exc))
+    finally:
+        conn.close()
+        _BENCHMARK_GEN_LOCK.release()
+
+
 def _parse_json_fields(rows: list[dict]) -> None:
     """Parse JSON string fields in session rows into Python objects.
 
@@ -1987,6 +2038,16 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             self._handle_list_allowlist()
         elif path == "/api/findings/allowlist":
             self._handle_list_findings_allowlist()
+        elif path == "/api/benchmarks":
+            self._handle_benchmarks_list()
+        elif path == "/api/benchmarks/latest":
+            self._handle_benchmark_latest()
+        elif path == "/api/benchmarks/trend":
+            self._handle_benchmark_trend()
+        elif path.startswith("/api/benchmarks/") and path.endswith("/status"):
+            self._handle_benchmark_status(path[len("/api/benchmarks/"):-len("/status")])
+        elif path.startswith("/api/benchmarks/"):
+            self._handle_benchmark_get(path[len("/api/benchmarks/"):])
         elif path.startswith("/timeline/"):
             if self._handle_session_timeline(path):
                 return
@@ -2054,6 +2115,10 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         elif path == "/api/scan":
             force = parse_qs(parsed.query).get("force", [""])[0] in ("1", "true")
             self._handle_trigger_scan(force=force)
+        elif path == "/api/benchmarks/generate":
+            self._handle_benchmark_generate()
+        elif path.startswith("/api/benchmarks/") and path.endswith("/export"):
+            self._handle_benchmark_export(path[len("/api/benchmarks/"):-len("/export")])
         else:
             _json_response(self, {"error": "Not found"}, 404)
 
@@ -2423,6 +2488,130 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                 "task_type": result.task_type,
                 "outcome": result.outcome_label,
                 "summary": result.summary,
+            })
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Personalized benchmark API
+    # ------------------------------------------------------------------
+    def _handle_benchmarks_list(self) -> None:
+        from ..benchmark import store
+        conn = open_index()
+        try:
+            _json_response(self, {"benchmarks": store.list_benchmarks(conn)})
+        finally:
+            conn.close()
+
+    def _handle_benchmark_latest(self) -> None:
+        from ..benchmark import store
+        conn = open_index()
+        try:
+            latest = store.get_latest_benchmark(conn)
+            _json_response(self, {"benchmark": latest, "stale": _benchmark_is_stale(latest)})
+        finally:
+            conn.close()
+
+    def _handle_benchmark_trend(self) -> None:
+        from ..benchmark import store
+        conn = open_index()
+        try:
+            _json_response(self, store.get_theme_trend(conn))
+        finally:
+            conn.close()
+
+    def _handle_benchmark_get(self, benchmark_id: str) -> None:
+        from ..benchmark import store
+        conn = open_index()
+        try:
+            got = store.get_benchmark(conn, benchmark_id)
+            if got is None:
+                _json_response(self, {"error": "benchmark not found"}, 404)
+                return
+            _json_response(self, got)
+        finally:
+            conn.close()
+
+    def _handle_benchmark_status(self, benchmark_id: str) -> None:
+        from ..benchmark import store
+        conn = open_index()
+        try:
+            got = store.get_benchmark(conn, benchmark_id)
+            if got is None:
+                _json_response(self, {"error": "benchmark not found"}, 404)
+                return
+            _json_response(self, {
+                "benchmark_id": benchmark_id,
+                "status": got.get("status"),
+                "stage": got.get("stage"),
+                "error": got.get("error"),
+            })
+        finally:
+            conn.close()
+
+    def _handle_benchmark_generate(self) -> None:
+        from ..benchmark import store
+        from ..benchmark.select import select_week_failures
+
+        body = _read_body(self) or {}
+        window = int(body.get("window_days", 7))
+        cap = int(body.get("cap", 15))
+
+        if not _BENCHMARK_GEN_LOCK.acquire(blocking=False):
+            _json_response(self, {"status": "busy",
+                                  "error": "a benchmark generation is already running"}, 409)
+            return
+        released = False
+        try:
+            conn = open_index()
+            try:
+                sl = select_week_failures(conn, window_days=window, cap=cap)
+                if not sl.candidates:
+                    _json_response(
+                        self, {"error": "no failure-signal sessions in the selected window"}, 400)
+                    return
+                bid = store.insert_generating(
+                    conn, window_start=sl.window_start, window_end=sl.window_end)
+            finally:
+                conn.close()
+            threading.Thread(
+                target=_run_benchmark_generation, args=(bid, sl), daemon=True).start()
+            released = True  # the worker owns the lock now
+            _json_response(self, {"status": "generating", "benchmark_id": bid}, 202)
+        finally:
+            if not released:
+                _BENCHMARK_GEN_LOCK.release()
+
+    def _handle_benchmark_export(self, benchmark_id: str) -> None:
+        from ..benchmark import render, store
+        from ..benchmark import schema as bm
+        from ..benchmark.render import EXPORT_KINDS
+
+        body = _read_body(self) or {}
+        kind = body.get("kind", "authoring_md")
+        if kind not in EXPORT_KINDS:
+            _json_response(self, {"error": f"unknown export kind {kind!r}",
+                                  "kinds": list(EXPORT_KINDS)}, 400)
+            return
+        conn = open_index()
+        try:
+            got = store.get_benchmark(conn, benchmark_id)
+            if got is None:
+                _json_response(self, {"error": "benchmark not found"}, 404)
+                return
+            content = render.render(got, kind)
+            pii_hits = len(bm.find_pii(content))
+            ext = "json" if kind.endswith("json") else "md"
+            out_dir = CONFIG_DIR / "benchmark_exports"
+            out_dir.mkdir(parents=True, exist_ok=True)
+            out_path = out_dir / f"{benchmark_id}-{kind}.{ext}"
+            out_path.write_text(content, encoding="utf-8")
+            summary = {"kind": kind, "pii_scan_hits": pii_hits, "deterministic_redaction": "deferred"}
+            store.record_export(
+                conn, benchmark_id, kind=kind, path=str(out_path), redaction_summary=summary)
+            _json_response(self, {
+                "benchmark_id": benchmark_id, "kind": kind, "path": str(out_path),
+                "pii_scan_hits": pii_hits, "content": content,
             })
         finally:
             conn.close()

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -2044,6 +2044,8 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             self._handle_list_allowlist()
         elif path == "/api/findings/allowlist":
             self._handle_list_findings_allowlist()
+        elif path == "/api/features":
+            self._handle_features()
         elif path == "/api/benchmarks":
             self._handle_benchmarks_list()
         elif path == "/api/benchmarks/latest":
@@ -2822,6 +2824,15 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             })
         finally:
             conn.close()
+
+    def _handle_features(self) -> None:
+        """Return UI feature flags read fresh from config (no DB, no restart needed
+        to pick up a toggle — the browser just reloads)."""
+        from ..config import load_config
+        config = load_config()
+        _json_response(self, {
+            "benchmark_tab_enabled": bool(config.get("benchmark_tab_enabled", True)),
+        })
 
     def _handle_list_allowlist(self) -> None:
         """Return current allowlist entries from config."""

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -207,6 +207,61 @@ CREATE TABLE IF NOT EXISTS session_hold_history (
     reason         TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_hold_history_session ON session_hold_history(session_id, changed_at);
+
+-- Personalized weekly benchmark tables. Net-new tables ship in SCHEMA_SQL as
+-- idempotent CREATE TABLE IF NOT EXISTS (benchmarks before its FK referents);
+-- open_index() runs executescript(SCHEMA_SQL) on every open, so existing DBs
+-- gain them on next open. No user_version bump or _migrate_* is needed — those
+-- are reserved for ALTER/rename/backfill on existing tables. Add a
+-- BENCHMARK_SCHEMA_VERSION sentinel + _migrate_ only if a future column
+-- ALTER/backfill is required.
+CREATE TABLE IF NOT EXISTS benchmarks (
+    benchmark_id        TEXT PRIMARY KEY,
+    window_start        TEXT NOT NULL,
+    window_end          TEXT NOT NULL,
+    generated_at        TEXT NOT NULL,
+    status              TEXT NOT NULL DEFAULT 'ready',
+    stage               TEXT,
+    backend             TEXT,
+    rubric_git_sha      TEXT,
+    n_tasks             INTEGER,
+    total_points        INTEGER,
+    source_count        INTEGER,
+    dropped_for_cost    INTEGER,
+    ready_count         INTEGER,
+    needs_staging_count INTEGER,
+    payload_json        TEXT NOT NULL,
+    error               TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_benchmarks_generated ON benchmarks(generated_at DESC);
+
+CREATE TABLE IF NOT EXISTS benchmark_tasks (
+    task_id                   TEXT PRIMARY KEY,
+    benchmark_id              TEXT NOT NULL REFERENCES benchmarks(benchmark_id) ON DELETE CASCADE,
+    title                     TEXT,
+    theme                     TEXT,
+    domains_json              TEXT,
+    source_agents_json        TEXT,
+    difficulty                TEXT,
+    points                    INTEGER,
+    grading                   TEXT,
+    readiness                 TEXT,
+    leakage_risk              TEXT,
+    privacy_risk              TEXT,
+    grounded_session_ids_json TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_benchmark_tasks_run ON benchmark_tasks(benchmark_id);
+CREATE INDEX IF NOT EXISTS idx_benchmark_tasks_readiness ON benchmark_tasks(benchmark_id, readiness);
+
+CREATE TABLE IF NOT EXISTS benchmark_exports (
+    export_id              TEXT PRIMARY KEY,
+    benchmark_id           TEXT NOT NULL REFERENCES benchmarks(benchmark_id) ON DELETE CASCADE,
+    kind                   TEXT NOT NULL,
+    path                   TEXT,
+    created_at             TEXT NOT NULL,
+    redaction_summary_json TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_benchmark_exports_run ON benchmark_exports(benchmark_id);
 """
 
 FTS_SCHEMA_SQL = """

--- a/tests/benchmark/conftest.py
+++ b/tests/benchmark/conftest.py
@@ -1,0 +1,15 @@
+"""Shared fixtures for benchmark module tests."""
+
+import pytest
+
+from clawjournal.workbench.index import open_index
+
+
+@pytest.fixture
+def index_conn(tmp_path, monkeypatch):
+    """Open an index DB (with the benchmark tables) in a temp directory."""
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+    monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+    conn = open_index()
+    yield conn
+    conn.close()

--- a/tests/benchmark/test_api.py
+++ b/tests/benchmark/test_api.py
@@ -1,0 +1,223 @@
+"""Integration tests for the benchmark daemon API (GET endpoints, export, async generate)."""
+
+import json
+import time
+from datetime import datetime, timedelta, timezone
+from http.client import HTTPConnection
+from pathlib import Path
+from threading import Thread
+
+import pytest
+
+from clawjournal.benchmark import schema as bm
+from clawjournal.benchmark import store
+from clawjournal.benchmark.select import WeekSlice
+from clawjournal.workbench import daemon as dmod
+from clawjournal.workbench.daemon import (
+    WorkbenchHandler,
+    _benchmark_is_stale,
+    _run_benchmark_generation,
+)
+from clawjournal.workbench.index import open_index
+
+
+@pytest.fixture
+def api(tmp_path, monkeypatch):
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+    monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+    monkeypatch.setattr("clawjournal.workbench.daemon.CONFIG_DIR", tmp_path)
+    open_index().close()  # bootstrap DB + api_token
+    from http.server import ThreadingHTTPServer
+    srv = ThreadingHTTPServer(("127.0.0.1", 0), WorkbenchHandler)
+    port = srv.server_address[1]
+    Thread(target=srv.serve_forever, daemon=True).start()
+    yield port
+    srv.shutdown()
+
+
+def _auth():
+    from clawjournal.paths import API_TOKEN_FILENAME
+    from clawjournal.workbench.index import INDEX_DB
+    token = (Path(str(INDEX_DB)).parent / API_TOKEN_FILENAME).read_text().strip()
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _get(port, path):
+    c = HTTPConnection("127.0.0.1", port, timeout=5)
+    c.request("GET", path, headers=_auth())
+    r = c.getresponse()
+    return r.status, json.loads(r.read().decode())
+
+
+def _post(port, path, data=None):
+    c = HTTPConnection("127.0.0.1", port, timeout=10)
+    c.request("POST", path, body=json.dumps(data or {}).encode(),
+              headers={"Content-Type": "application/json", **_auth()})
+    r = c.getresponse()
+    return r.status, json.loads(r.read().decode())
+
+
+def _canned(window_end="2026-05-31T00:00:00+00:00"):
+    task = bm.BenchmarkTask(
+        id="S1", title="Confirm readiness", theme="Th",
+        scenario="In the repo, confirm X is ready.", the_trap="SECRET-TRAP",
+        pass_criteria=["c"], grading="judge", difficulty="hard", points=5,
+        grounded_session_ids=["sess-a"], readiness="ready", source_agents=["claude"])
+    return bm.Benchmark(
+        window_start="2026-05-24T00:00:00+00:00", window_end=window_end, generated_at=window_end,
+        backend="claude", source_session_ids=["sess-a"],
+        themes=[bm.BenchmarkTheme(name="Th", frequency=2)], tasks=[task])
+
+
+def _save(benchmark=None):
+    conn = open_index()
+    try:
+        return store.save_benchmark(conn, benchmark or _canned())
+    finally:
+        conn.close()
+
+
+class TestGetEndpoints:
+    def test_list_get_status(self, api):
+        bid = _save()
+        s, data = _get(api, "/api/benchmarks")
+        assert s == 200 and [b["benchmark_id"] for b in data["benchmarks"]] == [bid]
+        s, data = _get(api, f"/api/benchmarks/{bid}")
+        assert s == 200 and data["n_tasks"] == 1 and len(data["tasks"]) == 1
+        s, data = _get(api, f"/api/benchmarks/{bid}/status")
+        assert s == 200 and data["status"] == "ready" and data["stage"] is None
+
+    def test_latest_stale_flags(self, api):
+        _save(_canned(window_end="2000-01-01T00:00:00+00:00"))
+        _, data = _get(api, "/api/benchmarks/latest")
+        assert data["stale"] is True
+        recent = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+        _save(_canned(window_end=recent))
+        _, data = _get(api, "/api/benchmarks/latest")
+        assert data["benchmark"]["window_end"] == recent and data["stale"] is False
+
+    def test_trend(self, api):
+        _save()
+        s, data = _get(api, "/api/benchmarks/trend")
+        assert s == 200 and data["themes"]["Th"] == [2]
+
+    def test_not_found(self, api):
+        assert _get(api, "/api/benchmarks/nope")[0] == 404
+        assert _get(api, "/api/benchmarks/nope/status")[0] == 404
+
+
+class TestExport:
+    def test_agent_packet_withholds_trap_and_records_receipt(self, api):
+        bid = _save()
+        s, data = _post(api, f"/api/benchmarks/{bid}/export", {"kind": "agent_packet_md"})
+        assert s == 200
+        assert "In the repo" in data["content"] and "SECRET-TRAP" not in data["content"]
+        assert data["pii_scan_hits"] == 0 and data["path"].endswith("agent_packet_md.md")
+        assert Path(data["path"]).read_text() == data["content"]
+        conn = open_index()
+        try:
+            n = conn.execute("SELECT COUNT(*) FROM benchmark_exports WHERE benchmark_id=?",
+                             (bid,)).fetchone()[0]
+        finally:
+            conn.close()
+        assert n == 1
+
+    def test_unknown_kind_400(self, api):
+        bid = _save()
+        assert _post(api, f"/api/benchmarks/{bid}/export", {"kind": "pdf"})[0] == 400
+
+    def test_export_not_found_404(self, api):
+        assert _post(api, "/api/benchmarks/nope/export", {"kind": "authoring_md"})[0] == 404
+
+
+class TestGenerate:
+    def _seed_failure(self):
+        conn = open_index()
+        now = datetime.now(timezone.utc).isoformat()
+        conn.execute(
+            "INSERT INTO sessions (session_id, project, source, indexed_at, start_time, "
+            "review_status, ai_failure_value_score, ai_failure_modes, ai_learning_summary) "
+            "VALUES (?,?,?,?,?, 'new', 5, '[\"x\"]', 'lesson')",
+            ("s1", "p", "codex", now, now))
+        conn.commit()
+        conn.close()
+
+    def test_async_generate_then_poll_ready(self, api, monkeypatch):
+        self._seed_failure()
+
+        def fake(conn, *, week_slice=None, **kw):
+            b = _canned()
+            b.window_start, b.window_end = week_slice.window_start, week_slice.window_end
+            b.generated_at = week_slice.window_end
+            return b
+        monkeypatch.setattr("clawjournal.benchmark.generate.generate_benchmark", fake)
+
+        s, data = _post(api, "/api/benchmarks/generate", {})
+        assert s == 202 and data["status"] == "generating"
+        bid = data["benchmark_id"]
+        for _ in range(60):
+            st = _get(api, f"/api/benchmarks/{bid}/status")[1]
+            if st["status"] != "generating":
+                break
+            time.sleep(0.05)
+        assert st["status"] == "ready"
+        assert _get(api, f"/api/benchmarks/{bid}")[1]["n_tasks"] == 1
+
+    def test_no_candidates_400(self, api):
+        assert _post(api, "/api/benchmarks/generate", {})[0] == 400
+
+    def test_busy_returns_409(self, api):
+        dmod._BENCHMARK_GEN_LOCK.acquire()
+        try:
+            assert _post(api, "/api/benchmarks/generate", {})[0] == 409
+        finally:
+            dmod._BENCHMARK_GEN_LOCK.release()
+
+
+class TestWorkerUnit:
+    def test_is_stale(self):
+        assert _benchmark_is_stale(None) is True
+        assert _benchmark_is_stale({"generated_at": "2000-01-01T00:00:00+00:00"}) is True
+        recent = (datetime.now(timezone.utc) - timedelta(hours=1)).isoformat()
+        assert _benchmark_is_stale({"generated_at": recent}) is False
+
+    def _slice(self):
+        return WeekSlice(window_start="2026-05-24T00:00:00+00:00",
+                         window_end="2026-05-31T00:00:00+00:00",
+                         candidates=[], total_candidates=0, dropped_for_cost=0)
+
+    def test_worker_finalizes(self, api, monkeypatch):
+        sl = self._slice()
+        conn = open_index()
+        bid = store.insert_generating(conn, window_start=sl.window_start, window_end=sl.window_end)
+        conn.close()
+
+        def fake(conn, *, week_slice=None, **kw):
+            b = _canned()
+            b.window_start, b.window_end = week_slice.window_start, week_slice.window_end
+            b.generated_at = week_slice.window_end
+            return b
+        monkeypatch.setattr("clawjournal.benchmark.generate.generate_benchmark", fake)
+
+        dmod._BENCHMARK_GEN_LOCK.acquire()  # the worker releases it (mirrors prod)
+        _run_benchmark_generation(bid, sl)
+        conn = open_index()
+        got = store.get_benchmark(conn, bid)
+        conn.close()
+        assert got["status"] == "ready" and got["n_tasks"] == 1
+        assert not dmod._BENCHMARK_GEN_LOCK.locked()
+
+    def test_worker_marks_failed(self, api, monkeypatch):
+        sl = self._slice()
+        conn = open_index()
+        bid = store.insert_generating(conn, window_start=sl.window_start, window_end=sl.window_end)
+        conn.close()
+        monkeypatch.setattr("clawjournal.benchmark.generate.generate_benchmark",
+                            lambda conn, **kw: (_ for _ in ()).throw(RuntimeError("kaboom")))
+        dmod._BENCHMARK_GEN_LOCK.acquire()
+        _run_benchmark_generation(bid, sl)
+        conn = open_index()
+        got = store.get_benchmark(conn, bid)
+        conn.close()
+        assert got["status"] == "failed" and "kaboom" in got["error"]
+        assert not dmod._BENCHMARK_GEN_LOCK.locked()

--- a/tests/benchmark/test_api.py
+++ b/tests/benchmark/test_api.py
@@ -129,6 +129,13 @@ class TestExport:
     def test_export_not_found_404(self, api):
         assert _post(api, "/api/benchmarks/nope/export", {"kind": "authoring_md"})[0] == 404
 
+    def test_export_non_ready_409(self, api):
+        conn = open_index()
+        bid = store.insert_generating(conn, window_start="2026-05-24T00:00:00+00:00",
+                                      window_end="2026-05-31T00:00:00+00:00")
+        conn.close()
+        assert _post(api, f"/api/benchmarks/{bid}/export", {"kind": "authoring_md"})[0] == 409
+
 
 class TestGenerate:
     def _seed_failure(self):

--- a/tests/benchmark/test_api.py
+++ b/tests/benchmark/test_api.py
@@ -228,3 +228,19 @@ class TestWorkerUnit:
         conn.close()
         assert got["status"] == "failed" and "kaboom" in got["error"]
         assert not dmod._BENCHMARK_GEN_LOCK.locked()
+
+
+class TestFeatures:
+    def test_default_enabled_when_key_missing(self, api, monkeypatch):
+        # Older configs lack the key → the gate defaults ON.
+        monkeypatch.setattr("clawjournal.config.load_config", lambda: {})
+        status, body = _get(api, "/api/features")
+        assert status == 200
+        assert body == {"benchmark_tab_enabled": True}
+
+    def test_respects_disabled_flag(self, api, monkeypatch):
+        monkeypatch.setattr("clawjournal.config.load_config",
+                            lambda: {"benchmark_tab_enabled": False})
+        status, body = _get(api, "/api/features")
+        assert status == 200
+        assert body == {"benchmark_tab_enabled": False}

--- a/tests/benchmark/test_cli_benchmark.py
+++ b/tests/benchmark/test_cli_benchmark.py
@@ -111,6 +111,12 @@ class TestExport:
         with pytest.raises(SystemExit):
             cli_benchmark.run_benchmark(_args(export="nope"))
 
+    def test_non_ready_exits(self, index_conn):
+        store.insert_generating(index_conn, window_start="2026-05-24T00:00:00+00:00",
+                                window_end="2026-05-31T00:00:00+00:00")
+        with pytest.raises(SystemExit):
+            cli_benchmark.run_benchmark(_args(export="2026-W22"))
+
 
 class TestArgparseWiring:
     def test_main_routes_benchmark_list(self, index_conn, monkeypatch, capsys):

--- a/tests/benchmark/test_cli_benchmark.py
+++ b/tests/benchmark/test_cli_benchmark.py
@@ -1,0 +1,120 @@
+"""Tests for the `clawjournal benchmark` CLI verb (generate/list/show/export)."""
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from clawjournal import cli_benchmark
+from clawjournal.benchmark import schema as bm
+from clawjournal.benchmark import store
+
+
+def _args(**over):
+    base = dict(window=7, cap=15, backend="auto", list=False, show=None,
+                export=None, kind="authoring_md", output=None, json=False)
+    base.update(over)
+    return SimpleNamespace(**base)
+
+
+def _canned(window_end="2026-05-31T00:00:00+00:00"):
+    task = bm.BenchmarkTask(
+        id="S1", title="Confirm readiness", theme="Tests-as-proof",
+        scenario="In the Django repo, confirm the importer is ready.", seed_inputs="repo @ commit",
+        the_trap="SECRET-TRAP: cite the green suite", pass_criteria=["answers NO"],
+        grading="judge", difficulty="hard", points=5, domains=["clawjournal-dev"],
+        source_agents=["claude"], grounded_session_ids=["sess-a"], readiness="ready")
+    return bm.Benchmark(
+        window_start="2026-05-24T00:00:00+00:00", window_end=window_end, generated_at=window_end,
+        backend="claude", source_session_ids=["sess-a"],
+        themes=[bm.BenchmarkTheme(name="Tests-as-proof", frequency=1)], tasks=[task])
+
+
+class TestGenerate:
+    def test_stores_and_prints_summary(self, index_conn, monkeypatch, capsys):
+        monkeypatch.setattr("clawjournal.benchmark.generate.generate_benchmark",
+                            lambda conn, **kw: _canned())
+        cli_benchmark.run_benchmark(_args())
+        out = json.loads(capsys.readouterr().out)
+        assert out["n_tasks"] == 1 and out["total_points"] == 5 and out["ready"] == 1
+        assert store.get_benchmark(index_conn, out["benchmark_id"])["status"] == "ready"
+
+    def test_passes_window_cap_backend(self, index_conn, monkeypatch):
+        seen = {}
+        def fake(conn, **kw):
+            seen.update(kw)
+            return _canned()
+        monkeypatch.setattr("clawjournal.benchmark.generate.generate_benchmark", fake)
+        cli_benchmark.run_benchmark(_args(window=14, cap=8, backend="codex"))
+        assert seen["window_days"] == 14 and seen["cap"] == 8 and seen["backend"] == "codex"
+
+    def test_failure_exits_nonzero(self, index_conn, monkeypatch):
+        def boom(conn, **kw):
+            raise ValueError("no failure-signal sessions in the selected window")
+        monkeypatch.setattr("clawjournal.benchmark.generate.generate_benchmark", boom)
+        with pytest.raises(SystemExit):
+            cli_benchmark.run_benchmark(_args())
+
+
+class TestList:
+    def test_human(self, index_conn, capsys):
+        store.save_benchmark(index_conn, _canned())
+        cli_benchmark.run_benchmark(_args(list=True))
+        out = capsys.readouterr().out
+        assert "2026-W22" in out and "tasks" in out
+
+    def test_json(self, index_conn, capsys):
+        store.save_benchmark(index_conn, _canned())
+        cli_benchmark.run_benchmark(_args(list=True, json=True))
+        assert len(json.loads(capsys.readouterr().out)["benchmarks"]) == 1
+
+    def test_empty(self, index_conn, capsys):
+        cli_benchmark.run_benchmark(_args(list=True))
+        assert "No benchmarks yet" in capsys.readouterr().out
+
+
+class TestShow:
+    def test_latest(self, index_conn, capsys):
+        store.save_benchmark(index_conn, _canned())
+        cli_benchmark.run_benchmark(_args(show="latest"))
+        out = capsys.readouterr().out
+        assert "# Personalized benchmark" in out and "#### S1" in out
+
+    def test_not_found(self, index_conn):
+        with pytest.raises(SystemExit):
+            cli_benchmark.run_benchmark(_args(show="nope"))
+
+
+class TestExport:
+    def test_agent_packet_withholds_trap_and_records_receipt(self, index_conn, tmp_path, capsys):
+        store.save_benchmark(index_conn, _canned())
+        out = tmp_path / "ap.md"
+        cli_benchmark.run_benchmark(_args(export="latest", kind="agent_packet_md", output=str(out)))
+        content = out.read_text()
+        assert "In the Django repo" in content and "SECRET-TRAP" not in content
+        res = json.loads(capsys.readouterr().out)
+        assert res["kind"] == "agent_packet_md" and res["pii_scan_hits"] == 0
+        assert index_conn.execute("SELECT COUNT(*) FROM benchmark_exports").fetchone()[0] == 1
+
+    def test_authoring_default_kind(self, index_conn, tmp_path, capsys):
+        store.save_benchmark(index_conn, _canned())
+        out = tmp_path / "auth.md"
+        cli_benchmark.run_benchmark(_args(export="latest", output=str(out)))
+        assert "## Tasks" in out.read_text()
+
+    def test_unknown_kind_exits(self, index_conn):
+        store.save_benchmark(index_conn, _canned())
+        with pytest.raises(SystemExit):
+            cli_benchmark.run_benchmark(_args(export="latest", kind="pdf"))
+
+    def test_not_found_exits(self, index_conn):
+        with pytest.raises(SystemExit):
+            cli_benchmark.run_benchmark(_args(export="nope"))
+
+
+class TestArgparseWiring:
+    def test_main_routes_benchmark_list(self, index_conn, monkeypatch, capsys):
+        from clawjournal import cli
+        monkeypatch.setattr("sys.argv", ["clawjournal", "benchmark", "--list"])
+        cli.main()
+        assert "No benchmarks yet" in capsys.readouterr().out

--- a/tests/benchmark/test_frontend_contract.py
+++ b/tests/benchmark/test_frontend_contract.py
@@ -1,0 +1,54 @@
+"""Cross-language guard tests.
+
+The React frontend has no JS test runner (only the wheel smoke check), and a few
+backend↔frontend behaviors are coupled by fragile string conventions. These read
+the .tsx source and pin those contracts from Python so a rename can't silently
+break them.
+"""
+
+import re
+from pathlib import Path
+
+from clawjournal.benchmark import schema as bm
+from clawjournal.benchmark.render import EXPORT_KINDS
+
+_REPO = Path(__file__).resolve().parents[2]
+BENCHMARK_TSX = _REPO / "clawjournal" / "web" / "frontend" / "src" / "views" / "Benchmark.tsx"
+
+
+def _tsx() -> str:
+    return BENCHMARK_TSX.read_text(encoding="utf-8")
+
+
+def test_export_kinds_match_backend():
+    """The UI Export menu must offer exactly the kinds render.render accepts (S9)."""
+    m = re.search(r"const EXPORT_KINDS.*?=\s*\[(.*?)\];", _tsx(), re.S)
+    assert m, "EXPORT_KINDS array not found in Benchmark.tsx"
+    fe_kinds = set(re.findall(r"kind:\s*'([a-z_]+)'", m.group(1)))
+    assert fe_kinds == set(EXPORT_KINDS), f"frontend {fe_kinds} != backend {set(EXPORT_KINDS)}"
+
+
+def test_agent_prompt_template_has_no_grader_fields():
+    """The 'Copy prompt' template must reference only agent-packet fields (S10)."""
+    m = re.search(r"const agentPrompt = `(.*?)`;", _tsx(), re.S)
+    assert m, "agentPrompt template not found in Benchmark.tsx"
+    template = m.group(1)
+    for field in bm.GRADER_ONLY_FIELDS:
+        assert field not in template, f"agent prompt template references grader field {field!r}"
+
+
+def test_progress_prose_maps_to_stage_percent():
+    """The backend's progress prose must contain the keywords the UI stagePercent
+    matches, else a rename silently drops the progress bar to the fallback (S8)."""
+    keywords = ["reading", "group", "writing", "finaliz", "done"]
+    # frontend side: stagePercent recognises each keyword
+    sp = _tsx().split("function stagePercent", 1)[1].split("\n}", 1)[0].lower()
+    for kw in keywords:
+        assert kw in sp, f"stagePercent lost keyword {kw!r}"
+    # backend side: note() literals + the _map_progress label= literals cover them
+    gen_src = (_REPO / "clawjournal" / "benchmark" / "generate.py").read_text(encoding="utf-8")
+    strings = (re.findall(r'note\(\s*f?["\']([^"\']+)["\']', gen_src)
+               + re.findall(r'label="([^"]+)"', gen_src))
+    joined = " ".join(strings).lower()
+    for kw in keywords:
+        assert kw in joined, f"no backend progress string contains stage keyword {kw!r}"

--- a/tests/benchmark/test_generate.py
+++ b/tests/benchmark/test_generate.py
@@ -307,6 +307,40 @@ class TestDefaultModel:
         assert AgentBackendCaller(backend="auto", model="opus").model == "opus"
 
 
+class TestStageTimeouts:
+    """The heavy synthesis stages (architect/design) get a longer subprocess
+    ceiling than per-item reads; unknown stages fall back to the default."""
+
+    def _timeout_for(self, monkeypatch, stage):
+        monkeypatch.setattr("clawjournal.benchmark.generate.resolve_backend", lambda b: "claude")
+        captured = {}
+
+        def fake_run(**kw):
+            captured.update(kw)
+
+            class _R:
+                stdout = '{"ok": true}'
+                stderr = ''
+                returncode = 0
+            return _R()
+
+        monkeypatch.setattr("clawjournal.benchmark.generate.run_default_agent_task", fake_run)
+        AgentBackendCaller(backend="auto")(stage=stage, system_prompt="sys", task_prompt="task")
+        return captured["timeout_seconds"]
+
+    def test_architect_gets_the_longest_ceiling(self, monkeypatch):
+        assert self._timeout_for(monkeypatch, "architect") == 600
+
+    def test_design_ceiling(self, monkeypatch):
+        assert self._timeout_for(monkeypatch, "design") == 360
+
+    def test_deepread_ceiling(self, monkeypatch):
+        assert self._timeout_for(monkeypatch, "deepread") == 240
+
+    def test_unknown_stage_uses_default(self, monkeypatch):
+        assert self._timeout_for(monkeypatch, "mystery") == 240
+
+
 class TestProgressMessages:
     def test_incremental_human_messages(self, index_conn):
         for sid in ("s1", "s2", "s3"):

--- a/tests/benchmark/test_generate.py
+++ b/tests/benchmark/test_generate.py
@@ -1,0 +1,292 @@
+"""Tests for the benchmark generator: JSON extraction + a golden pipeline run with a fake backend."""
+
+import json
+import re
+from datetime import datetime, timezone
+
+import pytest
+
+from clawjournal.benchmark import schema as bm
+from clawjournal.benchmark.generate import (
+    _blob_extract,
+    _extract_json_object,
+    _read_agent_output,
+    generate_benchmark,
+)
+from clawjournal.redaction.anonymizer import Anonymizer
+
+NOW = datetime(2026, 5, 31, 12, 0, 0, tzinfo=timezone.utc)
+NO_ANON = Anonymizer(enabled=False)
+
+
+# ---------------------------------------------------------------------------
+# JSON extraction
+# ---------------------------------------------------------------------------
+class TestExtractJson:
+    def test_plain_object(self):
+        assert _extract_json_object('{"a": 1}') == {"a": 1}
+
+    def test_fenced(self):
+        assert _extract_json_object('```json\n{"a": 1}\n```') == {"a": 1}
+
+    def test_prose_wrapped_and_nested(self):
+        assert _extract_json_object('Here you go: {"a": {"b": 2}} — done') == {"a": {"b": 2}}
+
+    def test_braces_inside_strings_dont_confuse_the_scanner(self):
+        assert _extract_json_object('{"s": "a}b{c", "n": 1}') == {"s": "a}b{c", "n": 1}
+
+    @pytest.mark.parametrize("bad", ["", "   ", "no json here", "{unbalanced"])
+    def test_invalid_raises(self, bad):
+        with pytest.raises(ValueError):
+            _extract_json_object(bad)
+
+
+# ---------------------------------------------------------------------------
+# Fake backend + fixtures
+# ---------------------------------------------------------------------------
+def _ins(conn, sid, *, fvs=5, modes='["wrong_assumption"]', source="codex",
+         start_time="2026-05-28T00:00:00+00:00", learning="a concrete lesson"):
+    conn.execute(
+        "INSERT INTO sessions (session_id, project, source, indexed_at, start_time, "
+        "review_status, ai_failure_value_score, ai_failure_modes, ai_learning_summary) "
+        "VALUES (?,?,?,?,?, 'new', ?, ?, ?)",
+        (sid, "proj", source, start_time, start_time, fvs, modes, learning),
+    )
+    conn.commit()
+
+
+def _after(text, marker):
+    i = text.index(marker) + len(marker)
+    return text[i:text.index("\n", i)].strip()
+
+
+def _stub_id(prompt):
+    m = re.search(r'"id":\s*"([^"]+)"', prompt)
+    return m.group(1) if m else None
+
+
+def _seed():
+    return {
+        "domain": "clawjournal-dev", "user_goal": "g", "failure_moment": "m",
+        "root_cause_categories": ["verification_skipped"], "seductive_wrong_move": "w",
+        "correct_behavior": "c", "evidence_snippet": "e", "recovery": "self_recovered",
+        "generalizable_trap": "t", "severity": "medium",
+    }
+
+
+def _design(scenario="Confirm the importer against the real tracker."):
+    return {
+        "title": "Confirm readiness", "scenario": scenario, "seed_inputs": "repo @ commit",
+        "the_trap": "cite the green suite as proof", "ideal_trajectory": ["read real data"],
+        "pass_criteria": ["answers NO"], "fail_signals": ["says ready"],
+        "grading": "judge", "difficulty": "hard", "points": 5,
+    }
+
+
+THEMES = [
+    {"name": "Tests-as-proof", "taxonomy": ["verification_skipped"], "frequency": 2,
+     "evidence_session_ids": ["s1"], "lesson": "validate the invariant"},
+    {"name": "Auth-wall", "taxonomy": ["collaboration_error"], "frequency": 1,
+     "evidence_session_ids": ["s2"], "lesson": "hand over a complete path"},
+]
+STUBS = [
+    {"id": "S1", "theme": "Tests-as-proof", "domains": ["clawjournal-dev"],
+     "source_agents": ["codex", "claude"], "grounded_session_ids": ["s1"],
+     "concept": "tests pass != done", "why_personalized": "recurs"},
+    {"id": "S2", "theme": "Auth-wall", "domains": ["pr-review"], "source_agents": ["codex"],
+     "grounded_session_ids": ["s2"], "concept": "auth wall handoff", "why_personalized": "recurs"},
+    {"id": "S3", "theme": "Tests-as-proof", "domains": ["clawjournal-dev"], "source_agents": ["codex"],
+     "grounded_session_ids": ["s3"], "concept": "pii leak task", "why_personalized": "recurs"},
+]
+DESIGN = {"S1": _design(), "S2": _design(), "S3": _design(scenario="email ops@rayward.ai to begin")}
+CRITIQUE = {
+    "S1": {"discriminating": True, "gameable": False, "leakage": False, "measurable": True,
+           "verdict": "keep", "notes": "", "staging_notes": "revert the importer",
+           "readiness": "needs_staging", "leakage_risk": "low", "privacy_risk": "high"},
+    "S2": {"verdict": "drop", "readiness": "retired", "leakage_risk": "low", "privacy_risk": "low"},
+    "S3": {"verdict": "keep", "readiness": "ready", "leakage_risk": "low", "privacy_risk": "low"},
+}
+
+
+class FakeCaller:
+    resolved = "claude"
+
+    def __init__(self, *, themes=THEMES, stubs=STUBS, design=DESIGN, critique=CRITIQUE,
+                 raise_sessions=(), raise_architect=False):
+        self.themes, self.stubs, self.design, self.critique = themes, stubs, design, critique
+        self.raise_sessions = set(raise_sessions)
+        self.raise_architect = raise_architect
+        self.stages: list[str] = []
+
+    def __call__(self, *, stage, system_prompt, task_prompt):
+        self.stages.append(stage)
+        if stage == "deepread":
+            sid = _after(task_prompt, "session_id: ")
+            if sid in self.raise_sessions:
+                raise RuntimeError("deepread boom")
+            return _seed()
+        if stage == "architect":
+            if self.raise_architect:
+                raise RuntimeError("architect boom")
+            return {"themes": self.themes, "stubs": self.stubs}
+        if stage == "design":
+            return self.design[_stub_id(task_prompt)]
+        if stage == "critique":
+            return self.critique[_stub_id(task_prompt)]
+        raise AssertionError(f"unexpected stage {stage}")
+
+
+class TestGoldenPipeline:
+    def test_full_run(self, index_conn):
+        for sid in ("s1", "s2", "s3"):
+            _ins(index_conn, sid)
+        caller = FakeCaller()
+        b = generate_benchmark(index_conn, caller=caller, anonymizer=NO_ANON, now=NOW, max_workers=2)
+
+        assert b.backend == "claude"
+        assert len(b.themes) == 2
+        # S2 dropped (verdict=drop); S3 dropped (email PII in agent-facing scenario) → only S1
+        assert [t.id for t in b.tasks] == ["S1"]
+        t = b.tasks[0]
+        assert t.readiness == "needs_staging"
+        assert t.privacy_risk == "high"
+        assert t.source_agents == ["codex", "claude"]
+        assert t.critique.staging_notes == "revert the importer"
+        assert t.points == 5
+        assert set(b.source_session_ids) == {"s1", "s2", "s3"}
+        assert b.window_start == "2026-05-24T12:00:00+00:00"
+        assert "architect" in caller.stages and caller.stages.count("deepread") == 3
+        bm.validate_or_raise(b)  # the assembled benchmark is valid
+
+    def test_revised_pass_criteria_override(self, index_conn):
+        _ins(index_conn, "s1")
+        crit = {"S1": {**CRITIQUE["S1"], "revised_pass_criteria": ["tightened criterion"]}}
+        caller = FakeCaller(stubs=[STUBS[0]], design={"S1": _design()}, critique=crit)
+        b = generate_benchmark(index_conn, caller=caller, anonymizer=NO_ANON, now=NOW)
+        assert b.tasks[0].pass_criteria == ["tightened criterion"]
+
+
+class TestRobustness:
+    def test_deepread_error_skips_session(self, index_conn):
+        _ins(index_conn, "s1")
+        _ins(index_conn, "s2")
+        caller = FakeCaller(stubs=[STUBS[0]], design={"S1": _design()}, critique={"S1": CRITIQUE["S1"]},
+                            raise_sessions={"s2"})
+        b = generate_benchmark(index_conn, caller=caller, anonymizer=NO_ANON, now=NOW)
+        assert set(b.source_session_ids) == {"s1"}  # s2's deep-read raised → skipped
+
+    def test_no_candidates_raises(self, index_conn):
+        with pytest.raises(ValueError, match="no failure-signal"):
+            generate_benchmark(index_conn, caller=FakeCaller(), anonymizer=NO_ANON, now=NOW)
+
+    def test_all_tasks_dropped_raises(self, index_conn):
+        _ins(index_conn, "s1")
+        caller = FakeCaller(stubs=[STUBS[1]], design={"S2": _design()}, critique={"S2": CRITIQUE["S2"]})
+        with pytest.raises(ValueError, match="no tasks survived"):
+            generate_benchmark(index_conn, caller=caller, anonymizer=NO_ANON, now=NOW)
+
+
+class TestThemeAndArchitectRobustness:
+    def test_malformed_theme_dropped_run_survives(self, index_conn):
+        _ins(index_conn, "s1")
+        caller = FakeCaller(themes=[{"taxonomy": ["x"]}, {"name": "Good", "frequency": 1}],
+                            stubs=[STUBS[0]], design={"S1": _design()}, critique={"S1": CRITIQUE["S1"]})
+        b = generate_benchmark(index_conn, caller=caller, anonymizer=NO_ANON, now=NOW)
+        assert [t.name for t in b.themes] == ["Good"]   # nameless theme dropped
+        assert [t.id for t in b.tasks] == ["S1"]         # run survived
+
+    def test_non_list_themes_yields_empty(self, index_conn):
+        _ins(index_conn, "s1")
+        caller = FakeCaller(themes="oops", stubs=[STUBS[0]],
+                            design={"S1": _design()}, critique={"S1": CRITIQUE["S1"]})
+        b = generate_benchmark(index_conn, caller=caller, anonymizer=NO_ANON, now=NOW)
+        assert b.themes == []
+
+    def test_architect_error_raises_runtime(self, index_conn):
+        _ins(index_conn, "s1")
+        with pytest.raises(RuntimeError, match="architect stage failed"):
+            generate_benchmark(index_conn, caller=FakeCaller(raise_architect=True),
+                               anonymizer=NO_ANON, now=NOW)
+
+    def test_zero_stubs_raises(self, index_conn):
+        _ins(index_conn, "s1")
+        with pytest.raises(ValueError, match="no task stubs"):
+            generate_benchmark(index_conn, caller=FakeCaller(stubs=[]), anonymizer=NO_ANON, now=NOW)
+
+    def test_zero_themes_ok(self, index_conn):
+        _ins(index_conn, "s1")
+        caller = FakeCaller(themes=[], stubs=[STUBS[0]],
+                            design={"S1": _design()}, critique={"S1": CRITIQUE["S1"]})
+        b = generate_benchmark(index_conn, caller=caller, anonymizer=NO_ANON, now=NOW)
+        assert b.themes == [] and [t.id for t in b.tasks] == ["S1"]
+
+
+class TestBadTaskBody:
+    @pytest.mark.parametrize("bad", ["five", "3.5", [3]])
+    def test_bad_field_drops_only_that_task(self, index_conn, bad):
+        # a non-int points (or non-iterable list field) must drop just that task
+        _ins(index_conn, "s1")
+        caller = FakeCaller(
+            stubs=[STUBS[0], STUBS[1]],
+            design={"S1": {**_design(), "points": bad}, "S2": _design()},
+            critique={"S1": CRITIQUE["S1"], "S2": dict(CRITIQUE["S1"])})
+        b = generate_benchmark(index_conn, caller=caller, anonymizer=NO_ANON, now=NOW)
+        assert [t.id for t in b.tasks] == ["S2"]  # S1 dropped, run survived
+
+    def test_non_iterable_trajectory_drops_task(self, index_conn):
+        _ins(index_conn, "s1")
+        caller = FakeCaller(
+            stubs=[STUBS[0], STUBS[1]],
+            design={"S1": {**_design(), "ideal_trajectory": 5}, "S2": _design()},
+            critique={"S1": CRITIQUE["S1"], "S2": dict(CRITIQUE["S1"])})
+        b = generate_benchmark(index_conn, caller=caller, anonymizer=NO_ANON, now=NOW)
+        assert [t.id for t in b.tasks] == ["S2"]
+
+
+class TestReadAgentOutput:
+    def test_claude_stdout(self, tmp_path):
+        assert _read_agent_output("claude", '{"a": 1}', tmp_path / "none.json") == {"a": 1}
+
+    def test_codex_output_file(self, tmp_path):
+        f = tmp_path / "out.json"
+        f.write_text('{"b": 2}')
+        assert _read_agent_output("codex", "ignored stdout", f) == {"b": 2}
+
+    def test_openclaw_envelope_unwrapped(self, tmp_path):
+        env = json.dumps({"reply": {"content": [{"text": '{"domain": "x"}'}]}})
+        assert _read_agent_output("openclaw", env, tmp_path / "none.json") == {"domain": "x"}
+
+    def test_openclaw_bare_json_falls_back(self, tmp_path):
+        assert _read_agent_output("openclaw", '{"domain": "y"}', tmp_path / "none.json") == {"domain": "y"}
+
+
+class TestBlobExtract:
+    def test_missing_blob_path(self):
+        assert _blob_extract(None, NO_ANON) == "(no trace blob available)"
+
+    def test_unreadable_blob(self, tmp_path):
+        assert _blob_extract(str(tmp_path / "nope.json"), NO_ANON) == "(trace blob unavailable)"
+
+    def test_invalid_json(self, tmp_path):
+        p = tmp_path / "b.json"
+        p.write_text("{not json")
+        assert _blob_extract(str(p), NO_ANON) == "(trace blob unavailable)"
+
+    def test_anonymizes_usernames_and_flattens_list_content(self, tmp_path):
+        p = tmp_path / "b.json"
+        p.write_text(json.dumps({"messages": [
+            {"role": "user", "content": "work in /Users/acmeuser/proj as acmeuser"},
+            {"role": "assistant", "content": [{"text": "part1"}, {"text": "part2"}]},
+        ]}))
+        out = _blob_extract(str(p), Anonymizer(extra_usernames=["acmeuser"], enabled=True))
+        assert "acmeuser" not in out          # username stripped (incl. inside the path)
+        assert "part1 part2" in out           # list content flattened
+        assert "[user]" in out and "[assistant]" in out
+
+    def test_head_tail_truncation_keeps_terminal_turns(self, tmp_path):
+        p = tmp_path / "b.json"
+        msgs = [{"role": "user", "content": f"MSG{i:04d}-" + ("x" * 80)} for i in range(80)]
+        p.write_text(json.dumps({"messages": msgs}))
+        out = _blob_extract(str(p), NO_ANON, max_chars=1000)
+        assert "MSG0000" in out and "MSG0079" in out and "…" in out
+        assert len(out) <= 1010

--- a/tests/benchmark/test_generate.py
+++ b/tests/benchmark/test_generate.py
@@ -8,6 +8,7 @@ import pytest
 
 from clawjournal.benchmark import schema as bm
 from clawjournal.benchmark.generate import (
+    AgentBackendCaller,
     _blob_extract,
     _extract_json_object,
     _read_agent_output,
@@ -290,3 +291,31 @@ class TestBlobExtract:
         out = _blob_extract(str(p), NO_ANON, max_chars=1000)
         assert "MSG0000" in out and "MSG0079" in out and "…" in out
         assert len(out) <= 1010
+
+
+class TestDefaultModel:
+    def test_claude_defaults_to_sonnet(self, monkeypatch):
+        monkeypatch.setattr("clawjournal.benchmark.generate.resolve_backend", lambda b: "claude")
+        assert AgentBackendCaller(backend="auto").model == "sonnet"
+
+    def test_codex_keeps_cli_default(self, monkeypatch):
+        monkeypatch.setattr("clawjournal.benchmark.generate.resolve_backend", lambda b: "codex")
+        assert AgentBackendCaller(backend="auto").model is None
+
+    def test_explicit_model_overrides_default(self, monkeypatch):
+        monkeypatch.setattr("clawjournal.benchmark.generate.resolve_backend", lambda b: "claude")
+        assert AgentBackendCaller(backend="auto", model="opus").model == "opus"
+
+
+class TestProgressMessages:
+    def test_incremental_human_messages(self, index_conn):
+        for sid in ("s1", "s2", "s3"):
+            _ins(index_conn, sid)
+        msgs: list[str] = []
+        generate_benchmark(index_conn, caller=FakeCaller(), anonymizer=NO_ANON, now=NOW,
+                           max_workers=2, progress=msgs.append)
+        blob = " | ".join(msgs)
+        assert "Reading your recent failures (" in blob   # incremental count
+        assert "Grouping failures into themes" in blob
+        assert "Writing & reviewing benchmark tasks (" in blob
+        assert "Finalizing" in blob and "Done —" in blob

--- a/tests/benchmark/test_privacy.py
+++ b/tests/benchmark/test_privacy.py
@@ -1,0 +1,91 @@
+"""Privacy guards: agent packets never leak the answer key, and benchmarks never
+enter the share/export path."""
+
+import json
+from pathlib import Path
+
+from clawjournal.benchmark import render
+from clawjournal.benchmark import schema as bm
+from clawjournal.benchmark import store
+
+# Sentinels planted in every grader-only field; none may surface in an agent packet.
+GRADER_SENTINELS = [
+    "TRAP_SENTINEL", "IDEAL_SENTINEL", "CRITERIA_SENTINEL", "FAIL_SENTINEL",
+    "NOTES_SENTINEL", "STAGING_SENTINEL",
+]
+SESSION_SENTINEL = "SESSIONID_SENTINEL"
+
+
+def _sentinel_benchmark():
+    task = bm.BenchmarkTask(
+        id="S1", title="agent-safe title", theme="Th",
+        scenario="agent-safe scenario text", seed_inputs="agent-safe seed inputs",
+        the_trap="TRAP_SENTINEL", ideal_trajectory=["IDEAL_SENTINEL"],
+        pass_criteria=["CRITERIA_SENTINEL"], fail_signals=["FAIL_SENTINEL"],
+        grounded_session_ids=[SESSION_SENTINEL], readiness="ready", points=3,
+        critique=bm.TaskCritique(notes="NOTES_SENTINEL", staging_notes="STAGING_SENTINEL"))
+    return bm.Benchmark(
+        window_start="2026-05-24T00:00:00+00:00", window_end="2026-05-31T00:00:00+00:00",
+        generated_at="2026-05-31T00:00:00+00:00", themes=[bm.BenchmarkTheme(name="Th")],
+        tasks=[task])
+
+
+class TestPacketLeakage:
+    def test_schema_agent_packet_has_no_grader_content(self):
+        blob = json.dumps(bm.to_agent_packet(_sentinel_benchmark().tasks[0]))
+        for s in GRADER_SENTINELS + [SESSION_SENTINEL]:
+            assert s not in blob
+        assert "agent-safe scenario text" in blob
+
+    def test_render_agent_packet_md_has_no_grader_content(self):
+        md = render.render_agent_packet_markdown(_sentinel_benchmark())
+        for s in GRADER_SENTINELS + [SESSION_SENTINEL]:
+            assert s not in md
+        assert "agent-safe scenario text" in md
+
+    def test_render_agent_packet_json_has_no_grader_content(self):
+        blob = json.dumps(render.agent_packet_dict(_sentinel_benchmark()))
+        for s in GRADER_SENTINELS + [SESSION_SENTINEL]:
+            assert s not in blob
+
+    def test_grader_packet_does_carry_the_answer_key(self):
+        # the grader packet is the answer key — it MUST contain the sentinels
+        blob = json.dumps(render.grader_packet_dict(_sentinel_benchmark()))
+        for s in GRADER_SENTINELS + [SESSION_SENTINEL]:
+            assert s in blob
+
+
+class TestDenormalizedStorage:
+    def test_benchmark_tasks_table_stores_no_grader_prose(self, index_conn):
+        store.save_benchmark(index_conn, _sentinel_benchmark())
+        row = index_conn.execute("SELECT * FROM benchmark_tasks").fetchone()
+        blob = json.dumps({k: row[k] for k in row.keys()})
+        # grader prose (trap/ideal/criteria/fail/notes/staging) lives only in payload_json
+        for s in GRADER_SENTINELS:
+            assert s not in blob
+        # grounded_session_ids IS stored here by design (filtering), so it is present
+        assert SESSION_SENTINEL in blob
+
+
+class TestShareExportExclusion:
+    # Benchmarks are a separate table family and must NEVER be wired into the
+    # session share/export bundle. Pin it so a future change can't quietly do so.
+    SHARE_EXPORT_MODULES = [
+        "clawjournal/export/markdown.py",
+        "clawjournal/export/training_data.py",
+    ]
+    BENCHMARK_TABLES = ("benchmarks", "benchmark_tasks", "benchmark_exports")
+
+    def test_export_modules_never_reference_benchmark_tables(self):
+        for mod in self.SHARE_EXPORT_MODULES:
+            src = Path(mod).read_text()
+            for tbl in self.BENCHMARK_TABLES:
+                assert tbl not in src, (
+                    f"{mod} references benchmark table {tbl!r} — benchmarks must never "
+                    "enter the session share/export path")
+
+    def test_export_modules_do_not_import_the_benchmark_package(self):
+        for mod in self.SHARE_EXPORT_MODULES:
+            src = Path(mod).read_text()
+            assert "benchmark" not in src.lower(), (
+                f"{mod} mentions 'benchmark' — the share/export path must stay benchmark-free")

--- a/tests/benchmark/test_render.py
+++ b/tests/benchmark/test_render.py
@@ -1,0 +1,103 @@
+"""Tests for benchmark rendering: markdown sections, export kinds, packet-leakage guarantee."""
+
+import json
+
+import pytest
+
+from clawjournal.benchmark import render, schema as bm
+
+
+def _benchmark():
+    task = bm.BenchmarkTask(
+        id="S1", title="Confirm readiness", theme="Tests-as-proof",
+        scenario="In the Django repo, confirm the importer is ready.",
+        seed_inputs="repo @ <commit>; the real Roster workbook present",
+        the_trap="SECRET-TRAP: cite the green 3/3 suite as proof",
+        ideal_trajectory=["Load the real workbook", "Catch the consent defect"],
+        pass_criteria=["Answers NO", "Names the consent defect"],
+        fail_signals=["Says ready citing tests"],
+        grading="judge", difficulty="hard", points=5,
+        domains=["django-stemops"], source_agents=["codex", "claude"],
+        grounded_session_ids=["010fae78"], readiness="needs_staging",
+        privacy_risk="high",
+        critique=bm.TaskCritique(verdict="keep", staging_notes="revert the importer"),
+    )
+    return bm.Benchmark(
+        window_start="2026-05-24T00:00:00+00:00", window_end="2026-05-31T00:00:00+00:00",
+        generated_at="2026-05-31T01:00:00+00:00", backend="claude",
+        source_session_ids=["010fae78"], dropped_for_cost=3,
+        themes=[bm.BenchmarkTheme(name="Tests-as-proof", frequency=2,
+                                  taxonomy=["verification_skipped"], lesson="Validate the invariant.")],
+        tasks=[task],
+    )
+
+
+class TestAuthoringMarkdown:
+    def test_has_overview_themes_tasks_scoring(self):
+        md = render.render_markdown(_benchmark())
+        assert "# Personalized benchmark" in md
+        assert "backend claude" in md
+        assert "## Failure themes" in md and "Tests-as-proof" in md
+        assert "#### S1 — Confirm readiness" in md
+        assert "readiness: needs_staging" in md
+        assert "- [ ] Answers NO" in md  # pass criteria as checkboxes
+        assert "**Total** | | | **5**" in md
+        assert "⚠️ staging: revert the importer" in md
+
+    def test_accepts_payload_dict_too(self):
+        payload = bm.benchmark_to_dict(_benchmark())
+        assert render.render_markdown(payload) == render.render_markdown(_benchmark())
+
+
+class TestPacketLeakage:
+    def test_agent_packet_md_withholds_answer_key(self):
+        md = render.render_agent_packet_markdown(_benchmark())
+        assert "In the Django repo" in md          # scenario present
+        assert "SECRET-TRAP" not in md              # trap withheld
+        assert "Answers NO" not in md               # pass criteria withheld
+        assert "010fae78" not in md                 # grounded session id withheld
+        assert "revert the importer" not in md      # staging notes withheld
+
+    def test_agent_packet_json_only_whitelisted_fields(self):
+        d = render.agent_packet_dict(_benchmark())
+        assert set(d["tasks"][0]) == set(bm.AGENT_PACKET_FIELDS)
+        blob = json.dumps(d)
+        assert "SECRET-TRAP" not in blob and "010fae78" not in blob
+
+    def test_grader_packet_has_answer_key(self):
+        d = render.grader_packet_dict(_benchmark())
+        assert d["tasks"][0]["the_trap"].startswith("SECRET-TRAP")
+        assert d["tasks"][0]["grounded_session_ids"] == ["010fae78"]
+
+
+class TestDispatch:
+    @pytest.mark.parametrize("kind", render.EXPORT_KINDS)
+    def test_every_kind_renders_a_string(self, kind):
+        out = render.render(_benchmark(), kind)
+        assert isinstance(out, str) and out.strip()
+
+    def test_json_kinds_parse(self):
+        assert json.loads(render.render(_benchmark(), "agent_packet_json"))["tasks"]
+        assert json.loads(render.render(_benchmark(), "grader_packet_json"))["tasks"][0]["the_trap"]
+
+    def test_unknown_kind_raises(self):
+        with pytest.raises(ValueError, match="unknown export kind"):
+            render.render(_benchmark(), "pdf")
+
+
+class TestEmptyAndFallback:
+    def test_empty_benchmark_renders_every_kind(self):
+        b = bm.Benchmark(window_start="2026-05-24", window_end="2026-05-31",
+                         generated_at="2026-05-31", backend="claude")
+        for kind in render.EXPORT_KINDS:
+            assert isinstance(render.render(b, kind), str)
+        md = render.render_markdown(b)
+        assert "## Failure themes" not in md          # no themes section when empty
+        assert "**Total** | | | **0**" in md
+        assert render.agent_packet_dict(b)["tasks"] == []
+
+    def test_meta_line_fallback_for_raw_dict(self):
+        # a raw dict lacking the derived counts falls back to len(tasks) / '?'
+        md = render.render_markdown({"tasks": [{"id": "X", "title": "t", "theme": "T"}]})
+        assert "1 tasks" in md
+        assert "? pts" in md

--- a/tests/benchmark/test_schema.py
+++ b/tests/benchmark/test_schema.py
@@ -1,0 +1,175 @@
+"""Tests for benchmark schema: round-trip, validation, packet split, PII guard."""
+
+import json
+
+import pytest
+
+from clawjournal.benchmark import schema as bm
+
+
+def _task(task_id="T1", **over):
+    base = dict(
+        id=task_id,
+        title="Confirm the importer against the real tracker",
+        theme="Tests-as-proof",
+        scenario="In the Django repo, the user asks whether the importer is ready.",
+        seed_inputs="repo @ <commit>; the real Roster workbook present",
+        the_trap="Cite the green 3/3 suite as proof without exercising real data.",
+        ideal_trajectory=["Load the real workbook", "Catch the consent defect"],
+        pass_criteria=["Answers NO", "Names the consent defect"],
+        fail_signals=["Says ready citing tests"],
+        grading="judge",
+        difficulty="hard",
+        points=5,
+        domains=["django-stemops"],
+        source_agents=["claude", "codex"],
+        grounded_session_ids=["010fae78"],
+        readiness="needs_staging",
+        leakage_risk="low",
+        privacy_risk="high",
+        critique=bm.TaskCritique(discriminating=True, verdict="keep", staging_notes="revert importer"),
+    )
+    base.update(over)
+    return bm.BenchmarkTask(**base)
+
+
+def _benchmark(**over):
+    base = dict(
+        window_start="2026-05-24T00:00:00+00:00",
+        window_end="2026-05-31T00:00:00+00:00",
+        generated_at="2026-05-31T01:00:00+00:00",
+        backend="claude",
+        rubric_git_sha="abc123",
+        source_session_ids=["010fae78", "019e62f9"],
+        dropped_for_cost=3,
+        themes=[bm.BenchmarkTheme(name="Tests-as-proof", frequency=3, taxonomy=["verification_skipped"],
+                                  evidence_session_ids=["010fae78"], lesson="Validate the invariant.")],
+        tasks=[_task()],
+    )
+    base.update(over)
+    return bm.Benchmark(**base)
+
+
+class TestRoundTrip:
+    def test_to_from_dict_is_stable(self):
+        original = _benchmark()
+        restored = bm.benchmark_from_dict(bm.benchmark_to_dict(original))
+        assert restored.window_start == original.window_start
+        assert restored.backend == "claude"
+        assert len(restored.tasks) == 1
+        assert restored.tasks[0].id == "T1"
+        assert restored.tasks[0].critique.verdict == "keep"
+        assert restored.tasks[0].source_agents == ["claude", "codex"]
+        assert restored.themes[0].name == "Tests-as-proof"
+
+    def test_to_dict_includes_derived_counts(self):
+        d = bm.benchmark_to_dict(_benchmark(tasks=[_task("A", points=5), _task("B", points=3,
+                                                    readiness="ready", grounded_session_ids=["x"])]))
+        assert d["n_tasks"] == 2
+        assert d["total_points"] == 8
+        assert d["ready_count"] == 1
+        assert d["needs_staging_count"] == 1
+        assert d["source_count"] == 2
+
+    def test_from_dict_tolerates_extra_and_missing_keys(self):
+        d = bm.benchmark_to_dict(_benchmark())
+        d["unknown_future_field"] = "ignored"
+        d["tasks"][0]["another_unknown"] = 42
+        restored = bm.benchmark_from_dict(d)  # must not raise
+        assert restored.tasks[0].id == "T1"
+
+
+class TestPacketSplit:
+    def test_agent_packet_has_no_grader_fields(self):
+        packet = bm.to_agent_packet(_task())
+        assert set(packet) == set(bm.AGENT_PACKET_FIELDS)
+        for forbidden in bm.GRADER_ONLY_FIELDS:
+            assert forbidden not in packet
+
+    def test_agent_packet_text_does_not_leak_the_trap(self):
+        task = _task()
+        blob = json.dumps(bm.to_agent_packet(task))
+        assert task.the_trap not in blob
+        assert "010fae78" not in blob  # grounded session id is grader-only
+        assert task.pass_criteria[0] not in blob
+
+    def test_grader_packet_has_the_answer_key(self):
+        packet = bm.to_grader_packet(_task())
+        assert packet["the_trap"]
+        assert packet["pass_criteria"]
+        assert packet["grounded_session_ids"] == ["010fae78"]
+
+
+class TestValidation:
+    def test_valid_benchmark_has_no_errors(self):
+        assert bm.validate_benchmark(_benchmark()) == []
+
+    @pytest.mark.parametrize("field,bad", [
+        ("readiness", "almost_ready"),
+        ("leakage_risk", "extreme"),
+        ("privacy_risk", "nope"),
+        ("grading", "vibes"),
+        ("difficulty", "impossible"),
+    ])
+    def test_invalid_enums_are_rejected(self, field, bad):
+        errors = bm.validate_benchmark(_benchmark(tasks=[_task(**{field: bad})]))
+        assert any(field.split("_")[0] in e or field in e for e in errors)
+
+    def test_missing_grounding_is_rejected_unless_needs_review(self):
+        bad = bm.validate_benchmark(_benchmark(tasks=[_task(readiness="ready", grounded_session_ids=[])]))
+        assert any("grounded_session_ids" in e for e in bad)
+        ok = bm.validate_benchmark(_benchmark(tasks=[_task(readiness="needs_review", grounded_session_ids=[])]))
+        assert ok == []
+
+    def test_negative_points_rejected(self):
+        assert any("points" in e for e in bm.validate_benchmark(_benchmark(tasks=[_task(points=-1)])))
+
+    @pytest.mark.parametrize("bad", [True, False, 3.0, None])
+    def test_non_int_points_rejected(self, bad):
+        # bool is an int subclass — must be rejected explicitly, as must float/None
+        assert any("points" in e for e in bm.validate_benchmark(_benchmark(tasks=[_task(points=bad)])))
+
+    def test_duplicate_task_ids_rejected(self):
+        errors = bm.validate_benchmark(_benchmark(tasks=[_task("D"), _task("D")]))
+        assert any("duplicate" in e for e in errors)
+
+    def test_validate_or_raise(self):
+        with pytest.raises(ValueError):
+            bm.validate_or_raise(_benchmark(tasks=[_task(readiness="bogus")]))
+
+
+class TestPIIGuard:
+    def test_email_in_agent_field_is_flagged(self):
+        errors = bm.validate_benchmark(_benchmark(tasks=[
+            _task(scenario="email the operator at ops@rayward.ai for access")]))
+        assert any("PII" in e and "scenario" in e for e in errors)
+
+    def test_long_digit_run_flagged(self):
+        assert bm.find_pii("account 4111111111111111 is locked")
+        assert not bm.find_pii("masked card ••XXXX is fine")  # masked placeholder OK
+
+    def test_bare_last4_is_not_flagged(self):
+        # bare 4-digit last-4 is too noisy to auto-flag; generators mask it instead
+        assert bm.find_pii("card ending 9972") == []
+
+    def test_home_paths_flagged(self):
+        assert bm.find_pii("/Users/alice/work/secret.py")
+        assert bm.find_pii("/home/bob/.ssh/id_rsa")
+        assert bm.find_pii(r"C:\Users\kaidu\Desktop")
+
+    def test_home_path_in_agent_field_rejected(self):
+        errors = bm.validate_benchmark(_benchmark(tasks=[
+            _task(scenario="open /Users/alice/work/secret.py and fix it")]))
+        assert any("PII" in e and "scenario" in e for e in errors)
+
+    def test_incidental_home_word_not_flagged(self):
+        # "/home" without a trailing "/username" must not trip the detector
+        assert bm.find_pii("check $HOME and the /home mount settings") == []
+
+    def test_grader_only_fields_not_scanned_for_pii(self):
+        # grader prose (the_trap, …) is intentionally NOT validated here — its
+        # de-identification is deferred to export redaction (spec §5). find_pii
+        # WOULD catch it; validate_task deliberately does not.
+        task = _task(the_trap="email ops@rayward.ai to reproduce")
+        assert bm.validate_benchmark(_benchmark(tasks=[task])) == []
+        assert bm.find_pii(task.the_trap)

--- a/tests/benchmark/test_select.py
+++ b/tests/benchmark/test_select.py
@@ -1,0 +1,80 @@
+"""Tests for weekly failure-session selection."""
+
+from datetime import datetime, timezone
+
+from clawjournal.benchmark.select import select_week_failures
+
+NOW = datetime(2026, 5, 31, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _ins(conn, sid, *, source="codex", start_time="2026-05-28T00:00:00+00:00",
+         review_status="new", fvs=None, modes=None, learning=None, reason=None):
+    conn.execute(
+        "INSERT INTO sessions (session_id, project, source, indexed_at, start_time, "
+        "review_status, ai_failure_value_score, ai_failure_modes, ai_learning_summary, "
+        "ai_score_reason) VALUES (?,?,?,?,?,?,?,?,?,?)",
+        (sid, "proj", source, "2026-05-28T00:00:00+00:00", start_time, review_status,
+         fvs, modes, learning, reason),
+    )
+    conn.commit()
+
+
+class TestSelection:
+    def test_includes_failure_signal_excludes_clean(self, index_conn):
+        _ins(index_conn, "high-fvs", fvs=5, learning="agent fabricated a config value")
+        _ins(index_conn, "modes-only", fvs=2, modes='["wrong_assumption"]')
+        _ins(index_conn, "clean", fvs=1, modes="[]")          # excluded: no signal
+        _ins(index_conn, "clean-null")                          # excluded: nothing
+        result = select_week_failures(index_conn, now=NOW)
+        assert set(result.session_ids) == {"high-fvs", "modes-only"}
+
+    def test_excludes_out_of_window(self, index_conn):
+        _ins(index_conn, "recent", fvs=4, start_time="2026-05-28T00:00:00+00:00")
+        _ins(index_conn, "old", fvs=4, start_time="2026-05-10T00:00:00+00:00")
+        result = select_week_failures(index_conn, now=NOW, window_days=7)
+        assert result.session_ids == ["recent"]
+        assert result.window_start == "2026-05-24T12:00:00+00:00"
+        assert result.window_end == "2026-05-31T12:00:00+00:00"
+
+    def test_excludes_segmented_parents(self, index_conn):
+        _ins(index_conn, "plain", fvs=4)
+        _ins(index_conn, "parent", fvs=4, review_status="segmented")
+        assert select_week_failures(index_conn, now=NOW).session_ids == ["plain"]
+
+    def test_source_scope_default_and_override(self, index_conn):
+        _ins(index_conn, "codex-row", source="codex", fvs=4)
+        _ins(index_conn, "gemini-row", source="gemini", fvs=4)
+        # default scope excludes gemini
+        assert select_week_failures(index_conn, now=NOW).session_ids == ["codex-row"]
+        # explicit None scope includes all sources
+        ids = set(select_week_failures(index_conn, now=NOW, sources=None).session_ids)
+        assert ids == {"codex-row", "gemini-row"}
+
+    def test_orders_by_failure_value_desc(self, index_conn):
+        _ins(index_conn, "low", fvs=3)
+        _ins(index_conn, "high", fvs=5)
+        _ins(index_conn, "mid", fvs=4)
+        assert select_week_failures(index_conn, now=NOW).session_ids == ["high", "mid", "low"]
+
+    def test_cap_and_dropped_for_cost(self, index_conn):
+        for i in range(5):
+            _ins(index_conn, f"s{i}", fvs=5)
+        result = select_week_failures(index_conn, now=NOW, cap=3)
+        assert len(result.candidates) == 3
+        assert result.total_candidates == 5
+        assert result.dropped_for_cost == 2
+
+    def test_whitespace_empty_modes_not_selected(self, index_conn):
+        # `NOT IN ('','[]')` would let '[ ]' / '[\n]' through; json_array_length won't
+        _ins(index_conn, "real", fvs=2, modes='["x"]')
+        _ins(index_conn, "ws-empty", fvs=2, modes='[ ]')
+        _ins(index_conn, "newline-empty", fvs=2, modes='[\n]')
+        assert select_week_failures(index_conn, now=NOW).session_ids == ["real"]
+
+    def test_has_trace_evidence_flag(self, index_conn):
+        _ins(index_conn, "evidenced", fvs=4, learning="concrete lesson here")
+        _ins(index_conn, "bare-score", fvs=4)  # score only, no modes/learning/reason
+        result = select_week_failures(index_conn, now=NOW)
+        by_id = {c.session_id: c for c in result.candidates}
+        assert by_id["evidenced"].has_trace_evidence is True
+        assert by_id["bare-score"].has_trace_evidence is False

--- a/tests/benchmark/test_store.py
+++ b/tests/benchmark/test_store.py
@@ -1,0 +1,237 @@
+"""Tests for benchmark persistence: save/get, history, denormalized filter, lifecycle, cascade."""
+
+import sqlite3
+
+import pytest
+
+from clawjournal.benchmark import schema as bm
+from clawjournal.benchmark import store
+
+
+def _task(task_id, **over):
+    base = dict(
+        id=task_id, title=f"Task {task_id}", theme="Tests-as-proof",
+        scenario="scenario text", seed_inputs="seed", the_trap="trap",
+        pass_criteria=["passes"], grading="judge", difficulty="hard", points=5,
+        domains=["clawjournal-dev"], source_agents=["claude"],
+        grounded_session_ids=["sess-a"], readiness="ready",
+    )
+    base.update(over)
+    return bm.BenchmarkTask(**base)
+
+
+def _benchmark(window_end="2026-05-31T00:00:00+00:00", tasks=None, **over):
+    base = dict(
+        window_start="2026-05-24T00:00:00+00:00",
+        window_end=window_end,
+        generated_at=window_end,
+        backend="claude",
+        source_session_ids=["sess-a", "sess-b"],
+        dropped_for_cost=2,
+        themes=[bm.BenchmarkTheme(name="Tests-as-proof", frequency=2)],
+        tasks=tasks if tasks is not None else [
+            _task("S1"),
+            _task("S2", readiness="needs_staging", theme="Auth-wall", points=3, source_agents=["codex"]),
+        ],
+    )
+    base.update(over)
+    return bm.Benchmark(**base)
+
+
+class TestSaveGet:
+    def test_save_assigns_isoweek_id_and_round_trips(self, index_conn):
+        bid = store.save_benchmark(index_conn, _benchmark())
+        assert bid.startswith("2026-W")
+        got = store.get_benchmark(index_conn, bid)
+        assert got is not None
+        assert got["status"] == "ready"
+        assert got["n_tasks"] == 2
+        assert got["total_points"] == 8
+        assert got["ready_count"] == 1
+        assert got["needs_staging_count"] == 1
+        assert len(got["tasks"]) == 2
+
+    def test_latest_returns_newest_ready(self, index_conn):
+        store.save_benchmark(index_conn, _benchmark(
+            window_end="2026-05-17T00:00:00+00:00"))
+        store.save_benchmark(index_conn, _benchmark(
+            window_end="2026-05-31T00:00:00+00:00"))
+        latest = store.get_latest_benchmark(index_conn)
+        assert latest["window_end"] == "2026-05-31T00:00:00+00:00"
+
+    def test_list_summaries_exclude_payload(self, index_conn):
+        store.save_benchmark(index_conn, _benchmark())
+        rows = store.list_benchmarks(index_conn)
+        assert len(rows) == 1
+        assert "payload_json" not in rows[0]
+        assert "tasks" not in rows[0]
+        assert rows[0]["n_tasks"] == 2
+
+
+class TestHistory:
+    def test_keep_every_generation_appends(self, index_conn):
+        a = store.save_benchmark(index_conn, _benchmark())
+        b = store.save_benchmark(index_conn, _benchmark())  # same window/week
+        c = store.save_benchmark(index_conn, _benchmark())
+        assert a != b != c
+        assert {a, b, c} == {"2026-W22", "2026-W22-2", "2026-W22-3"}
+        assert len(store.list_benchmarks(index_conn)) == 3
+
+
+class TestDenormalizedTasks:
+    def test_filter_by_readiness_and_theme_and_agent(self, index_conn):
+        bid = store.save_benchmark(index_conn, _benchmark())
+        assert {t["task_id"] for t in store.list_tasks(index_conn, bid)} == {
+            f"{bid}:S1", f"{bid}:S2"}
+        ready = store.list_tasks(index_conn, bid, readiness="ready")
+        assert [t["title"] for t in ready] == ["Task S1"]
+        auth = store.list_tasks(index_conn, bid, theme="Auth-wall")
+        assert [t["task_id"] for t in auth] == [f"{bid}:S2"]
+        codex = store.list_tasks(index_conn, bid, source_agent="codex")
+        assert [t["task_id"] for t in codex] == [f"{bid}:S2"]
+
+    def test_task_rows_decode_json_fields(self, index_conn):
+        bid = store.save_benchmark(index_conn, _benchmark())
+        t = store.list_tasks(index_conn, bid, readiness="ready")[0]
+        assert t["domains"] == ["clawjournal-dev"]
+        assert t["source_agents"] == ["claude"]
+        assert t["grounded_session_ids"] == ["sess-a"]
+
+
+class TestGeneratingLifecycle:
+    def test_insert_generating_then_finalize(self, index_conn):
+        bid = store.insert_generating(
+            index_conn, window_start="2026-05-24T00:00:00+00:00",
+            window_end="2026-05-31T00:00:00+00:00", backend="claude")
+        row = store.get_benchmark(index_conn, bid)
+        assert row["status"] == "generating"
+        store.update_status(index_conn, bid, stage="deep-reading 3/14")
+        assert store.get_benchmark(index_conn, bid)["stage"] == "deep-reading 3/14"
+        store.finalize_benchmark(index_conn, bid, _benchmark())
+        done = store.get_benchmark(index_conn, bid)
+        assert done["status"] == "ready"
+        assert done["stage"] is None
+        assert done["n_tasks"] == 2
+        assert len(store.list_tasks(index_conn, bid)) == 2
+
+    def test_failed_status(self, index_conn):
+        bid = store.insert_generating(
+            index_conn, window_start="2026-05-24T00:00:00+00:00",
+            window_end="2026-05-31T00:00:00+00:00")
+        store.update_status(index_conn, bid, status="failed", error="backend not found")
+        row = store.get_benchmark(index_conn, bid)
+        assert row["status"] == "failed"
+        assert row["error"] == "backend not found"
+        assert store.get_latest_benchmark(index_conn) is None  # only ready counts
+
+
+class TestExportsAndCascade:
+    def test_record_export(self, index_conn):
+        bid = store.save_benchmark(index_conn, _benchmark())
+        eid = store.record_export(index_conn, bid, kind="agent_packet_md", path="/tmp/x.md",
+                                  redaction_summary={"emails": 0})
+        row = index_conn.execute(
+            "SELECT * FROM benchmark_exports WHERE export_id = ?", (eid,)).fetchone()
+        assert row["kind"] == "agent_packet_md"
+        assert row["benchmark_id"] == bid
+
+    def test_delete_cascades_tasks_and_exports(self, index_conn):
+        bid = store.save_benchmark(index_conn, _benchmark())
+        store.record_export(index_conn, bid, kind="authoring_md")
+        store.delete_benchmark(index_conn, bid)
+        assert store.get_benchmark(index_conn, bid) is None
+        assert index_conn.execute(
+            "SELECT COUNT(*) FROM benchmark_tasks WHERE benchmark_id = ?", (bid,)).fetchone()[0] == 0
+        assert index_conn.execute(
+            "SELECT COUNT(*) FROM benchmark_exports WHERE benchmark_id = ?", (bid,)).fetchone()[0] == 0
+
+    def test_foreign_key_enforced_on_orphan_task(self, index_conn):
+        with pytest.raises(sqlite3.IntegrityError):
+            index_conn.execute(
+                "INSERT INTO benchmark_tasks (task_id, benchmark_id) VALUES ('x', 'no-such-run')")
+            index_conn.commit()
+
+
+class TestTieBreak:
+    def test_latest_and_trend_deterministic_on_tied_generated_at(self, index_conn):
+        # three same-week regenerations share generated_at; rowid breaks the tie
+        ids = [
+            store.save_benchmark(index_conn, _benchmark(
+                themes=[bm.BenchmarkTheme(name="Tests-as-proof", frequency=freq)]))
+            for freq in (1, 2, 3)
+        ]
+        assert store.get_latest_benchmark(index_conn)["benchmark_id"] == ids[-1]
+        assert store.get_theme_trend(index_conn)["themes"]["Tests-as-proof"] == [1, 2, 3]
+
+
+class TestSaveRobustness:
+    def test_resave_same_id_preserves_exports(self, index_conn):
+        b = _benchmark()
+        bid = store.save_benchmark(index_conn, b)  # populates b.benchmark_id
+        store.record_export(index_conn, bid, kind="authoring_md")
+        store.save_benchmark(index_conn, b)  # re-save same id must not cascade-wipe exports
+        n = index_conn.execute(
+            "SELECT COUNT(*) FROM benchmark_exports WHERE benchmark_id = ?", (bid,)).fetchone()[0]
+        assert n == 1
+
+    def test_finalize_unknown_id_raises_cleanly(self, index_conn):
+        with pytest.raises(ValueError, match="no placeholder"):
+            store.finalize_benchmark(index_conn, "2099-W99", _benchmark())
+        assert index_conn.execute("SELECT COUNT(*) FROM benchmarks").fetchone()[0] == 0
+        assert index_conn.execute("SELECT COUNT(*) FROM benchmark_tasks").fetchone()[0] == 0
+
+    def test_finalize_window_mismatch_raises(self, index_conn):
+        bid = store.insert_generating(
+            index_conn, window_start="2026-05-24T00:00:00+00:00",
+            window_end="2026-05-31T00:00:00+00:00")
+        with pytest.raises(ValueError, match="window mismatch"):
+            store.finalize_benchmark(index_conn, bid, _benchmark(window_end="2026-06-07T00:00:00+00:00"))
+
+
+class TestPayloadEdgeCases:
+    def test_malformed_payload_json_read_safely(self, index_conn):
+        index_conn.execute(
+            "INSERT INTO benchmarks (benchmark_id, window_start, window_end, generated_at, "
+            "status, payload_json) VALUES ('bad','2026-05-24','2026-05-31','2026-05-31','ready','{not json')")
+        index_conn.commit()
+        got = store.get_benchmark(index_conn, "bad")
+        assert got["status"] == "ready"
+        assert "tasks" not in got
+        trend = store.get_theme_trend(index_conn)
+        assert trend["themes"] == {}
+        assert [r["benchmark_id"] for r in trend["runs"]] == ["bad"]
+
+    def test_zero_task_benchmark(self, index_conn):
+        bid = store.save_benchmark(index_conn, _benchmark(tasks=[]))
+        got = store.get_benchmark(index_conn, bid)
+        assert got["n_tasks"] == 0 and got["total_points"] == 0
+        assert got["ready_count"] == 0 and got["needs_staging_count"] == 0
+        assert store.list_tasks(index_conn, bid) == []
+        assert store.get_latest_benchmark(index_conn)["benchmark_id"] == bid
+
+    def test_unicode_round_trips(self, index_conn):
+        u = "测试 émoji 🚀 á"
+        bid = store.save_benchmark(index_conn, _benchmark(tasks=[_task("U", title=u, theme=u, scenario=u)]))
+        assert store.get_benchmark(index_conn, bid)["tasks"][0]["title"] == u
+        assert store.list_tasks(index_conn, bid)[0]["title"] == u
+
+    def test_large_scenario_round_trips(self, index_conn):
+        big = "x" * 200_000
+        bid = store.save_benchmark(index_conn, _benchmark(tasks=[_task("L", scenario=big)]))
+        assert store.get_benchmark(index_conn, bid)["tasks"][0]["scenario"] == big
+
+
+class TestTrend:
+    def test_theme_trend_matrix_oldest_to_newest(self, index_conn):
+        store.save_benchmark(index_conn, _benchmark(
+            window_end="2026-05-17T00:00:00+00:00",
+            themes=[bm.BenchmarkTheme(name="Tests-as-proof", frequency=1)]))
+        store.save_benchmark(index_conn, _benchmark(
+            window_end="2026-05-31T00:00:00+00:00",
+            themes=[bm.BenchmarkTheme(name="Tests-as-proof", frequency=4),
+                    bm.BenchmarkTheme(name="Auth-wall", frequency=2)]))
+        trend = store.get_theme_trend(index_conn)
+        assert [r["window_end"] for r in trend["runs"]] == [
+            "2026-05-17T00:00:00+00:00", "2026-05-31T00:00:00+00:00"]
+        assert trend["themes"]["Tests-as-proof"] == [1, 4]
+        assert trend["themes"]["Auth-wall"] == [0, 2]  # absent in week 1

--- a/tests/benchmark/test_store.py
+++ b/tests/benchmark/test_store.py
@@ -152,6 +152,20 @@ class TestExportsAndCascade:
             index_conn.commit()
 
 
+class TestReconcile:
+    def test_reconcile_stale_generating(self, index_conn):
+        bid = store.insert_generating(
+            index_conn, window_start="2026-05-24T00:00:00+00:00",
+            window_end="2026-05-31T00:00:00+00:00")
+        # a ready run must be untouched
+        ready = store.save_benchmark(index_conn, _benchmark())
+        n = store.reconcile_stale_generating(index_conn)
+        assert n == 1
+        failed = store.get_benchmark(index_conn, bid)
+        assert failed["status"] == "failed" and "interrupted" in failed["error"]
+        assert store.get_benchmark(index_conn, ready)["status"] == "ready"
+
+
 class TestTieBreak:
     def test_latest_and_trend_deterministic_on_tied_generated_at(self, index_conn):
         # three same-week regenerations share generated_at; rowid breaks the tie

--- a/tests/scoring/test_backends.py
+++ b/tests/scoring/test_backends.py
@@ -11,6 +11,7 @@ from clawjournal.scoring.backends import (
     AgentResult,
     BACKEND_CHOICES,
     SUPPORTED_BACKENDS,
+    _agent_subprocess_env,
     _build_claude_cmd,
     _build_codex_cmd,
     _build_hermes_cmd,
@@ -317,6 +318,46 @@ def _stub_subprocess(monkeypatch, *, stdout="", stderr="", returncode=0):
 def _stub_which(monkeypatch):
     """Make shutil.which always succeed."""
     monkeypatch.setattr("clawjournal.scoring.backends.shutil.which", lambda cmd: f"/usr/bin/{cmd}")
+
+
+class TestAgentSubprocessEnv:
+    """The spawned agent CLI must not inherit an external ANTHROPIC_API_KEY,
+    so it falls back to the user's subscription login (the "default agent")."""
+
+    def test_strips_anthropic_api_key_by_default(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-invalid")
+        monkeypatch.delenv("CLAWJOURNAL_KEEP_API_KEY", raising=False)
+        env = _agent_subprocess_env()
+        assert "ANTHROPIC_API_KEY" not in env
+        # unrelated environment is preserved
+        assert "PATH" in env
+
+    def test_keep_api_key_opt_out(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-keepme")
+        for val in ("1", "true", "yes", "on"):
+            monkeypatch.setenv("CLAWJOURNAL_KEEP_API_KEY", val)
+            assert _agent_subprocess_env()["ANTHROPIC_API_KEY"] == "sk-ant-keepme"
+
+    def test_keep_api_key_falsey_still_strips(self, monkeypatch):
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-invalid")
+        monkeypatch.setenv("CLAWJOURNAL_KEEP_API_KEY", "0")
+        assert "ANTHROPIC_API_KEY" not in _agent_subprocess_env()
+
+    def test_claude_subprocess_receives_sanitized_env(self, monkeypatch, tmp_path):
+        """End-to-end: the claude subprocess gets env without the API key."""
+        _stub_which(monkeypatch)
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-invalid")
+        monkeypatch.delenv("CLAWJOURNAL_KEEP_API_KEY", raising=False)
+        captured = {}
+
+        def spy_run(cmd, **kw):
+            captured.update(kw)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("clawjournal.scoring.backends.subprocess.run", spy_run)
+        run_default_agent_task(backend="claude", cwd=tmp_path, task_prompt="hello")
+        assert "env" in captured
+        assert "ANTHROPIC_API_KEY" not in captured["env"]
 
 
 class TestRunDefaultAgentTaskClaude:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -346,6 +346,28 @@ class TestConfigure:
         configure(source="codex")
         assert "ai_pii_review_enabled" not in saved
 
+    def test_sets_benchmark_tab_flag(self, tmp_config, monkeypatch, capsys):
+        monkeypatch.setattr("clawjournal.cli.CONFIG_FILE", tmp_config)
+        monkeypatch.setattr("clawjournal.cli.load_config", lambda: {"repo": None})
+        saved = {}
+        monkeypatch.setattr("clawjournal.cli.save_config", lambda c: saved.update(c))
+
+        configure(benchmark_tab_enabled=False)
+        assert saved["benchmark_tab_enabled"] is False
+
+        configure(benchmark_tab_enabled=True)
+        assert saved["benchmark_tab_enabled"] is True
+
+    def test_benchmark_tab_unset_leaves_config_untouched(self, tmp_config, monkeypatch, capsys):
+        # Tri-state default (None): omitting the flag must not write the key.
+        monkeypatch.setattr("clawjournal.cli.CONFIG_FILE", tmp_config)
+        monkeypatch.setattr("clawjournal.cli.load_config", lambda: {"repo": None})
+        saved = {}
+        monkeypatch.setattr("clawjournal.cli.save_config", lambda c: saved.update(c))
+
+        configure(source="codex")
+        assert "benchmark_tab_enabled" not in saved
+
 
 # --- list_projects ---
 


### PR DESCRIPTION
## What

Adds the **backend** for a personalized weekly benchmark generated from the user's own scored failure traces — the recurring *judgment* failures (wrong scope, false-success-under-green-tests, blocker mishandling, over-building, stale verification, grader self-trust) turned into runnable, grounded, adversarial tasks. Local-first.

The workbench **UI tab is the only remaining piece and is tracked in #64** — deliberately not in this PR, since it touches the JS/build toolchain and the committed `dist/` assets.

## Layers (all backend, fully tested)

- **`clawjournal/benchmark/`** — `schema` (dataclasses + validation + the agent-packet / grader-packet split), `select` (the week's failure-signal sessions from the existing scoring substrate, ranked + cost-capped), `store` (hybrid: run payload JSON + denormalized `benchmark_tasks` for filtering + `benchmark_exports` receipts; `generating→ready/failed` lifecycle; theme-trend matrix; cascade delete), `generate` (the deep backend-orchestrated `deep-read → cluster → design → critique → assemble` pipeline over `run_default_agent_task`, with a mockable `BackendCaller` seam, bounded parallelism, per-item error isolation, and anonymization at the backend boundary), `render` (the 5 export kinds sharing the agent-packet whitelist).
- **Storage** — 3 tables in `SCHEMA_SQL` (idempotent `CREATE TABLE IF NOT EXISTS`; net-new additive tables, no `user_version` bump).
- **CLI** — `clawjournal benchmark` (generate (default) / `--list` / `--show <id|latest>` / `--export <id> --kind <...>`).
- **Daemon API** (loopback, bearer-gated) — `GET /api/benchmarks[/latest|/trend|/<id>|/<id>/status]`; `POST /api/benchmarks/generate` (async background worker serialized by a lock, polled via `/status`) and `/<id>/export`.

## Privacy

Benchmarks are local-only and **structurally separate from the session share/export path** (pinned by a guard test). Agent packets are sentinel-tested to never carry the trap / pass-criteria / grounding; trace extracts are anonymized before any backend call.

## Testing

**133 tests** under `tests/benchmark/`: schema round-trip, store lifecycle / cascade / FK, selection windowing/ranking/caps, a **golden generate pipeline driven by a fake backend** (no real LLM in CI), render packet-leakage, the CLI verbs, the **async API** (incl. lock discipline + window-mismatch handling), and the privacy guards. Full suite **2031 passed**.

Each layer was adversarially reviewed during development; those multi-pass reviews caught and fixed real bugs (an O(n²) backtracking regex, an unguarded-coercion crash that could abort a whole run, a substrate-not-anonymized leak) before this PR.

Tracks #64 for the UI tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
