### PR TITLE
[codex] Add first-run Sessions guide

### DIFF
--- a/clawjournal/web/frontend/src/components/GettingStartedGuide.tsx
+++ b/clawjournal/web/frontend/src/components/GettingStartedGuide.tsx
@@ -17,7 +17,7 @@ export function GettingStartedGuide({ stats, onDismiss }: GettingStartedGuidePro
   ];
 
   return (
-    <div style={{
+    <div role="note" aria-label="Getting started" style={{
       display: 'flex',
       flexWrap: 'wrap',
       gap: 14,
@@ -37,7 +37,7 @@ export function GettingStartedGuide({ stats, onDismiss }: GettingStartedGuidePro
         </div>
       </div>
 
-      <div style={{
+      <div role="list" style={{
         display: 'grid',
         gridTemplateColumns: 'repeat(auto-fit, minmax(132px, 1fr))',
         gap: 6,
@@ -47,6 +47,7 @@ export function GettingStartedGuide({ stats, onDismiss }: GettingStartedGuidePro
         {steps.map((step, idx) => (
           <div
             key={step.label}
+            role="listitem"
             style={{
               display: 'flex',
               gap: 7,
@@ -58,7 +59,7 @@ export function GettingStartedGuide({ stats, onDismiss }: GettingStartedGuidePro
               background: colors.white,
             }}
           >
-            <span style={{
+            <span aria-hidden="true" style={{
               width: 20,
               height: 20,
               borderRadius: '50%',
@@ -103,8 +104,8 @@ export function GettingStartedGuide({ stats, onDismiss }: GettingStartedGuidePro
         <button
           type="button"
           onClick={onDismiss}
-          aria-label="Dismiss"
-          title="Dismiss"
+          aria-label="Dismiss getting-started guide"
+          title="Dismiss getting-started guide"
           style={{
             width: 28,
             height: 28,
@@ -119,7 +120,7 @@ export function GettingStartedGuide({ stats, onDismiss }: GettingStartedGuidePro
             lineHeight: 1,
           }}
         >
-          ✕
+          <span aria-hidden="true">✕</span>
         </button>
       </div>
     </div>

--- a/clawjournal/web/frontend/src/components/GettingStartedGuide.tsx
+++ b/clawjournal/web/frontend/src/components/GettingStartedGuide.tsx
@@ -1,0 +1,128 @@
+import { Link } from 'react-router-dom';
+import type { Stats } from '../types.ts';
+import { colors } from '../theme.ts';
+
+interface GettingStartedGuideProps {
+  stats: Stats;
+  onDismiss: () => void;
+}
+
+export function GettingStartedGuide({ stats, onDismiss }: GettingStartedGuideProps) {
+  const approved = stats.by_status['approved'] ?? 0;
+  const toReview = (stats.by_status['new'] ?? 0) + (stats.by_status['shortlisted'] ?? 0);
+  const steps = [
+    { label: 'Review', detail: toReview > 0 ? `${toReview} waiting` : 'Scan the list' },
+    { label: 'Approve', detail: approved > 0 ? `${approved} approved` : 'Pick traces' },
+    { label: 'Redact', detail: 'Local preview' },
+    { label: 'Share', detail: 'Submit or zip' },
+  ];
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: 14,
+      alignItems: 'center',
+      margin: '2px 0 12px',
+      padding: '12px 14px',
+      border: `1px solid ${colors.primary200}`,
+      borderRadius: 8,
+      background: colors.primary50,
+    }}>
+      <div style={{ minWidth: 220, flex: '1 1 240px' }}>
+        <div style={{ fontSize: 13.5, fontWeight: 700, color: colors.gray900, marginBottom: 2 }}>
+          New here? Turn your sessions into shareable traces.
+        </div>
+        <div style={{ fontSize: 12, color: colors.gray600, lineHeight: 1.45 }}>
+          Triage your sessions here, then Share redacts and lets you review locally. Nothing leaves your machine until you approve it.
+        </div>
+      </div>
+
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(132px, 1fr))',
+        gap: 6,
+        flex: '999 1 440px',
+        minWidth: 280,
+      }}>
+        {steps.map((step, idx) => (
+          <div
+            key={step.label}
+            style={{
+              display: 'flex',
+              gap: 7,
+              alignItems: 'center',
+              minWidth: 0,
+              padding: '7px 8px',
+              border: `1px solid ${colors.gray200}`,
+              borderRadius: 6,
+              background: colors.white,
+            }}
+          >
+            <span style={{
+              width: 20,
+              height: 20,
+              borderRadius: '50%',
+              display: 'inline-grid',
+              placeItems: 'center',
+              flexShrink: 0,
+              background: colors.gray800,
+              color: colors.white,
+              fontSize: 11,
+              fontWeight: 700,
+              fontVariantNumeric: 'tabular-nums',
+            }}>
+              {idx + 1}
+            </span>
+            <span style={{ minWidth: 0 }}>
+              <span style={{ display: 'block', fontSize: 12, fontWeight: 600, color: colors.gray800, whiteSpace: 'nowrap' }}>
+                {step.label}
+              </span>
+              <span style={{ display: 'block', fontSize: 11, color: colors.gray500, lineHeight: 1.25 }}>
+                {step.detail}
+              </span>
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', justifyContent: 'flex-end', marginLeft: 'auto' }}>
+        <Link to="/share" style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          padding: '7px 12px',
+          background: colors.gray900,
+          color: colors.white,
+          borderRadius: 6,
+          fontSize: 12.5,
+          fontWeight: 600,
+          textDecoration: 'none',
+          whiteSpace: 'nowrap',
+        }}>
+          Open Share
+        </Link>
+        <button
+          type="button"
+          onClick={onDismiss}
+          aria-label="Dismiss"
+          title="Dismiss"
+          style={{
+            width: 28,
+            height: 28,
+            display: 'grid',
+            placeItems: 'center',
+            border: `1px solid ${colors.primary200}`,
+            borderRadius: 6,
+            background: 'transparent',
+            color: colors.gray500,
+            cursor: 'pointer',
+            fontSize: 15,
+            lineHeight: 1,
+          }}
+        >
+          ✕
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/clawjournal/web/frontend/src/components/GettingStartedGuide.tsx
+++ b/clawjournal/web/frontend/src/components/GettingStartedGuide.tsx
@@ -8,13 +8,12 @@ interface GettingStartedGuideProps {
 }
 
 export function GettingStartedGuide({ stats, onDismiss }: GettingStartedGuideProps) {
-  const approved = stats.by_status['approved'] ?? 0;
   const toReview = (stats.by_status['new'] ?? 0) + (stats.by_status['shortlisted'] ?? 0);
   const steps = [
-    { label: 'Review', detail: toReview > 0 ? `${toReview} waiting` : 'Scan the list' },
-    { label: 'Approve', detail: approved > 0 ? `${approved} approved` : 'Pick traces' },
-    { label: 'Redact', detail: 'Local preview' },
-    { label: 'Share', detail: 'Submit or zip' },
+    { label: 'Review', detail: toReview > 0 ? `${toReview} waiting` : 'Scan sessions' },
+    { label: 'Pick', detail: 'In Share' },
+    { label: 'Redact', detail: 'Local review' },
+    { label: 'Package', detail: 'Submit or zip' },
   ];
 
   return (
@@ -34,7 +33,7 @@ export function GettingStartedGuide({ stats, onDismiss }: GettingStartedGuidePro
           New here? Turn your sessions into shareable traces.
         </div>
         <div style={{ fontSize: 12, color: colors.gray600, lineHeight: 1.45 }}>
-          Triage your sessions here, then Share redacts and lets you review locally. Nothing leaves your machine until you approve it.
+          Inspect captured sessions here, then open Share to pick traces, redact, and review locally. Nothing leaves your machine until you approve sharing.
         </div>
       </div>
 
@@ -87,7 +86,7 @@ export function GettingStartedGuide({ stats, onDismiss }: GettingStartedGuidePro
       </div>
 
       <div style={{ display: 'flex', gap: 8, alignItems: 'center', justifyContent: 'flex-end', marginLeft: 'auto' }}>
-        <Link to="/share" style={{
+        <Link to="/share" onClick={onDismiss} style={{
           display: 'inline-flex',
           alignItems: 'center',
           padding: '7px 12px',

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -112,9 +112,9 @@ function ShareWorkflowGuide({
   const approved = stats.by_status['approved'] ?? 0;
   const toReview = (stats.by_status['new'] ?? 0) + (stats.by_status['shortlisted'] ?? 0);
   const steps = [
-    { label: 'Review', detail: toReview > 0 ? `${toReview} waiting` : 'Scan the list' },
-    { label: 'Select', detail: approved > 0 ? `${approved} approved` : 'Pick traces' },
-    { label: 'Redact', detail: 'Local preview' },
+    { label: 'Review', detail: toReview > 0 ? `${toReview} waiting` : 'Inspect traces' },
+    { label: 'Select', detail: approved > 0 ? `${approved} approved` : 'Choose traces' },
+    { label: 'Redact', detail: 'Before upload' },
     { label: 'Package', detail: 'Submit or zip' },
   ];
 
@@ -132,10 +132,10 @@ function ShareWorkflowGuide({
     }}>
       <div style={{ minWidth: 220, flex: '1 1 240px' }}>
         <div style={{ fontSize: 13.5, fontWeight: 700, color: colors.gray900, marginBottom: 2 }}>
-          Ready to share a trace?
+          Start with your local traces
         </div>
         <div style={{ fontSize: 12, color: colors.gray600, lineHeight: 1.45 }}>
-          Share walks you through local redaction, review, then submit or download.
+          Review traces here. Share redacts and reviews them locally before anything leaves your machine.
         </div>
       </div>
 
@@ -176,7 +176,7 @@ function ShareWorkflowGuide({
               {idx + 1}
             </span>
             <span style={{ minWidth: 0 }}>
-              <span style={{ display: 'block', fontSize: 12, fontWeight: 650, color: colors.gray800, whiteSpace: 'nowrap' }}>
+              <span style={{ display: 'block', fontSize: 12, fontWeight: 600, color: colors.gray800, whiteSpace: 'nowrap' }}>
                 {step.label}
               </span>
               <span style={{ display: 'block', fontSize: 11, color: colors.gray500, lineHeight: 1.25 }}>
@@ -196,7 +196,7 @@ function ShareWorkflowGuide({
           color: colors.white,
           borderRadius: 6,
           fontSize: 12.5,
-          fontWeight: 650,
+          fontWeight: 600,
           textDecoration: 'none',
           whiteSpace: 'nowrap',
         }}>
@@ -205,6 +205,7 @@ function ShareWorkflowGuide({
         <button
           type="button"
           onClick={onDismiss}
+          aria-label="Dismiss"
           title="Dismiss"
           style={{
             width: 28,
@@ -220,7 +221,7 @@ function ShareWorkflowGuide({
             lineHeight: 1,
           }}
         >
-          x
+          &times;
         </button>
       </div>
     </div>
@@ -444,7 +445,7 @@ export function Inbox() {
         </div>
       </div>
 
-      {showShareGuide && stats.total > 0 && !typeFilter && (
+      {showShareGuide && stats.total > 0 && sessions.length > 0 && !typeFilter && (
         <ShareWorkflowGuide stats={stats} onDismiss={dismissShareGuide} />
       )}
 

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -9,6 +9,7 @@ import { LABELS } from '../components/BadgeChip.tsx';
 import { colors, selectStyle } from '../theme.ts';
 
 const PAGE_SIZE = 10;
+const SHARE_GUIDE_DISMISSED_KEY = 'cj.shareGuideDismissed';
 
 function failureBadge(score: number | null): string {
   if (score == null) return '\u2014';
@@ -101,10 +102,142 @@ function hexAlpha(hex: string, alpha: number): string {
   return `rgba(${r},${g},${b},${alpha})`;
 }
 
+function ShareWorkflowGuide({
+  stats,
+  onDismiss,
+}: {
+  stats: Stats;
+  onDismiss: () => void;
+}) {
+  const approved = stats.by_status['approved'] ?? 0;
+  const toReview = (stats.by_status['new'] ?? 0) + (stats.by_status['shortlisted'] ?? 0);
+  const steps = [
+    { label: 'Review', detail: toReview > 0 ? `${toReview} waiting` : 'Scan the list' },
+    { label: 'Select', detail: approved > 0 ? `${approved} approved` : 'Pick traces' },
+    { label: 'Redact', detail: 'Local preview' },
+    { label: 'Package', detail: 'Submit or zip' },
+  ];
+
+  return (
+    <div style={{
+      display: 'flex',
+      flexWrap: 'wrap',
+      gap: 14,
+      alignItems: 'center',
+      margin: '2px 0 12px',
+      padding: '12px 14px',
+      border: `1px solid ${colors.primary200}`,
+      borderRadius: 8,
+      background: colors.primary50,
+    }}>
+      <div style={{ minWidth: 220, flex: '1 1 240px' }}>
+        <div style={{ fontSize: 13.5, fontWeight: 700, color: colors.gray900, marginBottom: 2 }}>
+          Ready to share a trace?
+        </div>
+        <div style={{ fontSize: 12, color: colors.gray600, lineHeight: 1.45 }}>
+          Share walks you through local redaction, review, then submit or download.
+        </div>
+      </div>
+
+      <div style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(132px, 1fr))',
+        gap: 6,
+        flex: '999 1 440px',
+        minWidth: 280,
+      }}>
+        {steps.map((step, idx) => (
+          <div
+            key={step.label}
+            style={{
+              display: 'flex',
+              gap: 7,
+              alignItems: 'center',
+              minWidth: 0,
+              padding: '7px 8px',
+              border: `1px solid ${colors.gray200}`,
+              borderRadius: 6,
+              background: colors.white,
+            }}
+          >
+            <span style={{
+              width: 20,
+              height: 20,
+              borderRadius: '50%',
+              display: 'inline-grid',
+              placeItems: 'center',
+              flexShrink: 0,
+              background: colors.gray800,
+              color: colors.white,
+              fontSize: 11,
+              fontWeight: 700,
+              fontVariantNumeric: 'tabular-nums',
+            }}>
+              {idx + 1}
+            </span>
+            <span style={{ minWidth: 0 }}>
+              <span style={{ display: 'block', fontSize: 12, fontWeight: 650, color: colors.gray800, whiteSpace: 'nowrap' }}>
+                {step.label}
+              </span>
+              <span style={{ display: 'block', fontSize: 11, color: colors.gray500, lineHeight: 1.25 }}>
+                {step.detail}
+              </span>
+            </span>
+          </div>
+        ))}
+      </div>
+
+      <div style={{ display: 'flex', gap: 8, alignItems: 'center', justifyContent: 'flex-end', marginLeft: 'auto' }}>
+        <Link to="/share" style={{
+          display: 'inline-flex',
+          alignItems: 'center',
+          padding: '7px 12px',
+          background: colors.gray900,
+          color: colors.white,
+          borderRadius: 6,
+          fontSize: 12.5,
+          fontWeight: 650,
+          textDecoration: 'none',
+          whiteSpace: 'nowrap',
+        }}>
+          Open Share
+        </Link>
+        <button
+          type="button"
+          onClick={onDismiss}
+          title="Dismiss"
+          style={{
+            width: 28,
+            height: 28,
+            display: 'grid',
+            placeItems: 'center',
+            border: `1px solid ${colors.primary200}`,
+            borderRadius: 6,
+            background: 'transparent',
+            color: colors.gray500,
+            cursor: 'pointer',
+            fontSize: 15,
+            lineHeight: 1,
+          }}
+        >
+          x
+        </button>
+      </div>
+    </div>
+  );
+}
+
 export function Inbox() {
   const { toast } = useToast();
   const [sessions, setSessions] = useState<Session[]>([]);
   const [stats, setStats] = useState<Stats>({ total: 0, by_status: {}, by_source: {}, by_project: {}, by_task_type: {} });
+  const [showShareGuide, setShowShareGuide] = useState(() => {
+    try {
+      return localStorage.getItem(SHARE_GUIDE_DISMISSED_KEY) !== '1';
+    } catch {
+      return true;
+    }
+  });
   const [loading, setLoading] = useState(false);
   const [offset, setOffset] = useState(0);
   const [expandedId, setExpandedId] = useState<string | null>(null);
@@ -280,6 +413,13 @@ export function Inbox() {
   const taskTypes = Object.entries(stats.by_task_type ?? {})
     .sort(([, a], [, b]) => b - a);
 
+  const dismissShareGuide = () => {
+    setShowShareGuide(false);
+    try {
+      localStorage.setItem(SHARE_GUIDE_DISMISSED_KEY, '1');
+    } catch { /* ignore */ }
+  };
+
   return (
     <div style={{ padding: '14px 20px' }}>
       {/* Header */}
@@ -303,6 +443,10 @@ export function Inbox() {
           </button>
         </div>
       </div>
+
+      {showShareGuide && stats.total > 0 && !typeFilter && (
+        <ShareWorkflowGuide stats={stats} onDismiss={dismissShareGuide} />
+      )}
 
       {showFilters && (
         <div style={{ display: 'flex', gap: '6px', marginBottom: '8px' }}>

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -10,8 +10,8 @@ import { GettingStartedGuide } from '../components/GettingStartedGuide.tsx';
 import { colors, selectStyle } from '../theme.ts';
 
 const PAGE_SIZE = 10;
-const GETTING_STARTED_DISMISSED_KEY = 'cj.gettingStartedDismissed';
-const LEGACY_SHARE_GUIDE_DISMISSED_KEY = 'cj.shareGuideDismissed';
+const TYPE_CHIP_PREVIEW_LIMIT = 16;
+const GETTING_STARTED_DISMISSED_KEY = 'cj.gettingStartedGuideV2Dismissed';
 
 function failureBadge(score: number | null): string {
   if (score == null) return '\u2014';
@@ -110,10 +110,7 @@ export function Inbox() {
   const [stats, setStats] = useState<Stats>({ total: 0, by_status: {}, by_source: {}, by_project: {}, by_task_type: {} });
   const [showGettingStartedGuide, setShowGettingStartedGuide] = useState(() => {
     try {
-      return (
-        localStorage.getItem(GETTING_STARTED_DISMISSED_KEY) !== '1'
-        && localStorage.getItem(LEGACY_SHARE_GUIDE_DISMISSED_KEY) !== '1'
-      );
+      return localStorage.getItem(GETTING_STARTED_DISMISSED_KEY) !== '1';
     } catch {
       return true;
     }
@@ -129,6 +126,7 @@ export function Inbox() {
   const [recoveryFilter, setRecoveryFilter] = useState<string | null>(null);
   const [attributionFilter, setAttributionFilter] = useState<string | null>(null);
   const [modeFilter, setModeFilter] = useState<string | null>(null);
+  const [showAllTaskTypes, setShowAllTaskTypes] = useState(false);
 
   // Agent-classified type filter (dynamic, not hardcoded)
   const [typeFilter, setTypeFilter] = useState<string | null>(null);
@@ -292,10 +290,15 @@ export function Inbox() {
   // Derive agent-classified types from stats (dynamic, not hardcoded)
   const taskTypes = Object.entries(stats.by_task_type ?? {})
     .sort(([, a], [, b]) => b - a);
-
-  const approved = stats.by_status['approved'] ?? 0;
-  const blocked = stats.by_status['blocked'] ?? 0;
-  const hasTriageProgress = approved + blocked > 0;
+  const visibleTaskTypes = showAllTaskTypes ? taskTypes : (() => {
+    const top = taskTypes.slice(0, TYPE_CHIP_PREVIEW_LIMIT);
+    if (typeFilter && !top.some(([type]) => type === typeFilter)) {
+      const active = taskTypes.find(([type]) => type === typeFilter);
+      return active ? [...top, active] : top;
+    }
+    return top;
+  })();
+  const hiddenTaskTypeCount = Math.max(0, taskTypes.length - TYPE_CHIP_PREVIEW_LIMIT);
 
   const dismissGettingStartedGuide = () => {
     setShowGettingStartedGuide(false);
@@ -328,7 +331,7 @@ export function Inbox() {
         </div>
       </div>
 
-      {showGettingStartedGuide && stats.total > 0 && sessions.length > 0 && !hasTriageProgress && !typeFilter && (
+      {showGettingStartedGuide && stats.total > 0 && sessions.length > 0 && !typeFilter && (
         <GettingStartedGuide stats={stats} onDismiss={dismissGettingStartedGuide} />
       )}
 
@@ -417,7 +420,7 @@ export function Inbox() {
           >
             All ({stats.total})
           </button>
-          {taskTypes.map(([type, count]) => {
+          {visibleTaskTypes.map(([type, count]) => {
             const active = typeFilter === type;
             const c = typeColor(type);
             return (
@@ -449,6 +452,23 @@ export function Inbox() {
               </button>
             );
           })}
+          {hiddenTaskTypeCount > 0 && (
+            <button
+              onClick={() => setShowAllTaskTypes(prev => !prev)}
+              style={{
+                padding: '4px 12px',
+                borderRadius: 9999,
+                fontSize: 13,
+                fontWeight: 600,
+                cursor: 'pointer',
+                border: `1px solid ${colors.gray300}`,
+                background: colors.gray50,
+                color: colors.gray600,
+              }}
+            >
+              {showAllTaskTypes ? 'Show fewer' : `More (${hiddenTaskTypeCount})`}
+            </button>
+          )}
         </div>
       )}
 

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -6,10 +6,12 @@ import { useToast } from '../components/Toast.tsx';
 import { ConfirmDialog } from '../components/ConfirmDialog.tsx';
 import { Spinner } from '../components/Spinner.tsx';
 import { LABELS } from '../components/BadgeChip.tsx';
+import { GettingStartedGuide } from '../components/GettingStartedGuide.tsx';
 import { colors, selectStyle } from '../theme.ts';
 
 const PAGE_SIZE = 10;
-const SHARE_GUIDE_DISMISSED_KEY = 'cj.shareGuideDismissed';
+const GETTING_STARTED_DISMISSED_KEY = 'cj.gettingStartedDismissed';
+const LEGACY_SHARE_GUIDE_DISMISSED_KEY = 'cj.shareGuideDismissed';
 
 function failureBadge(score: number | null): string {
   if (score == null) return '\u2014';
@@ -102,139 +104,16 @@ function hexAlpha(hex: string, alpha: number): string {
   return `rgba(${r},${g},${b},${alpha})`;
 }
 
-function ShareWorkflowGuide({
-  stats,
-  onDismiss,
-}: {
-  stats: Stats;
-  onDismiss: () => void;
-}) {
-  const approved = stats.by_status['approved'] ?? 0;
-  const toReview = (stats.by_status['new'] ?? 0) + (stats.by_status['shortlisted'] ?? 0);
-  const steps = [
-    { label: 'Review', detail: toReview > 0 ? `${toReview} waiting` : 'Inspect traces' },
-    { label: 'Select', detail: approved > 0 ? `${approved} approved` : 'Choose traces' },
-    { label: 'Redact', detail: 'Before upload' },
-    { label: 'Package', detail: 'Submit or zip' },
-  ];
-
-  return (
-    <div style={{
-      display: 'flex',
-      flexWrap: 'wrap',
-      gap: 14,
-      alignItems: 'center',
-      margin: '2px 0 12px',
-      padding: '12px 14px',
-      border: `1px solid ${colors.primary200}`,
-      borderRadius: 8,
-      background: colors.primary50,
-    }}>
-      <div style={{ minWidth: 220, flex: '1 1 240px' }}>
-        <div style={{ fontSize: 13.5, fontWeight: 700, color: colors.gray900, marginBottom: 2 }}>
-          Start with your local traces
-        </div>
-        <div style={{ fontSize: 12, color: colors.gray600, lineHeight: 1.45 }}>
-          Review traces here. Share redacts and reviews them locally before anything leaves your machine.
-        </div>
-      </div>
-
-      <div style={{
-        display: 'grid',
-        gridTemplateColumns: 'repeat(auto-fit, minmax(132px, 1fr))',
-        gap: 6,
-        flex: '999 1 440px',
-        minWidth: 280,
-      }}>
-        {steps.map((step, idx) => (
-          <div
-            key={step.label}
-            style={{
-              display: 'flex',
-              gap: 7,
-              alignItems: 'center',
-              minWidth: 0,
-              padding: '7px 8px',
-              border: `1px solid ${colors.gray200}`,
-              borderRadius: 6,
-              background: colors.white,
-            }}
-          >
-            <span style={{
-              width: 20,
-              height: 20,
-              borderRadius: '50%',
-              display: 'inline-grid',
-              placeItems: 'center',
-              flexShrink: 0,
-              background: colors.gray800,
-              color: colors.white,
-              fontSize: 11,
-              fontWeight: 700,
-              fontVariantNumeric: 'tabular-nums',
-            }}>
-              {idx + 1}
-            </span>
-            <span style={{ minWidth: 0 }}>
-              <span style={{ display: 'block', fontSize: 12, fontWeight: 600, color: colors.gray800, whiteSpace: 'nowrap' }}>
-                {step.label}
-              </span>
-              <span style={{ display: 'block', fontSize: 11, color: colors.gray500, lineHeight: 1.25 }}>
-                {step.detail}
-              </span>
-            </span>
-          </div>
-        ))}
-      </div>
-
-      <div style={{ display: 'flex', gap: 8, alignItems: 'center', justifyContent: 'flex-end', marginLeft: 'auto' }}>
-        <Link to="/share" style={{
-          display: 'inline-flex',
-          alignItems: 'center',
-          padding: '7px 12px',
-          background: colors.gray900,
-          color: colors.white,
-          borderRadius: 6,
-          fontSize: 12.5,
-          fontWeight: 600,
-          textDecoration: 'none',
-          whiteSpace: 'nowrap',
-        }}>
-          Open Share
-        </Link>
-        <button
-          type="button"
-          onClick={onDismiss}
-          aria-label="Dismiss"
-          title="Dismiss"
-          style={{
-            width: 28,
-            height: 28,
-            display: 'grid',
-            placeItems: 'center',
-            border: `1px solid ${colors.primary200}`,
-            borderRadius: 6,
-            background: 'transparent',
-            color: colors.gray500,
-            cursor: 'pointer',
-            fontSize: 15,
-            lineHeight: 1,
-          }}
-        >
-          &times;
-        </button>
-      </div>
-    </div>
-  );
-}
-
 export function Inbox() {
   const { toast } = useToast();
   const [sessions, setSessions] = useState<Session[]>([]);
   const [stats, setStats] = useState<Stats>({ total: 0, by_status: {}, by_source: {}, by_project: {}, by_task_type: {} });
-  const [showShareGuide, setShowShareGuide] = useState(() => {
+  const [showGettingStartedGuide, setShowGettingStartedGuide] = useState(() => {
     try {
-      return localStorage.getItem(SHARE_GUIDE_DISMISSED_KEY) !== '1';
+      return (
+        localStorage.getItem(GETTING_STARTED_DISMISSED_KEY) !== '1'
+        && localStorage.getItem(LEGACY_SHARE_GUIDE_DISMISSED_KEY) !== '1'
+      );
     } catch {
       return true;
     }
@@ -414,10 +293,14 @@ export function Inbox() {
   const taskTypes = Object.entries(stats.by_task_type ?? {})
     .sort(([, a], [, b]) => b - a);
 
-  const dismissShareGuide = () => {
-    setShowShareGuide(false);
+  const approved = stats.by_status['approved'] ?? 0;
+  const blocked = stats.by_status['blocked'] ?? 0;
+  const hasTriageProgress = approved + blocked > 0;
+
+  const dismissGettingStartedGuide = () => {
+    setShowGettingStartedGuide(false);
     try {
-      localStorage.setItem(SHARE_GUIDE_DISMISSED_KEY, '1');
+      localStorage.setItem(GETTING_STARTED_DISMISSED_KEY, '1');
     } catch { /* ignore */ }
   };
 
@@ -445,8 +328,8 @@ export function Inbox() {
         </div>
       </div>
 
-      {showShareGuide && stats.total > 0 && sessions.length > 0 && !typeFilter && (
-        <ShareWorkflowGuide stats={stats} onDismiss={dismissShareGuide} />
+      {showGettingStartedGuide && stats.total > 0 && sessions.length > 0 && !hasTriageProgress && !typeFilter && (
+        <GettingStartedGuide stats={stats} onDismiss={dismissGettingStartedGuide} />
       )}
 
       {showFilters && (


### PR DESCRIPTION
## Summary

Closes #61.

Adds a compact first-run guide to the Sessions page so new users understand the local ClawJournal loop without adding a new home route. Sessions remains the default landing surface; the guide orients users to review captured sessions, then open Share to pick traces, redact/review locally, and package for submit or ZIP download.

The copy explicitly preserves the local-first guarantee: nothing leaves the machine until the user approves sharing.

## Low-noise behavior

- Renders when sessions exist, visible results are non-empty, no task-type filter is active, and the current browser has not dismissed this version of the guide.
- Hides on empty filtered result sets, so it does not sit above the empty-state card.
- Dismissal persists in `localStorage` via `cj.gettingStartedGuideV2Dismissed`.
- Clicking `Open Share` also dismisses the guide, because following the guide is onboarding engagement.
- The task-type chip row shows the top task types first and collapses the long tail behind a `More` control.

## Validation

- `npm run build`
- `git diff --check`
- In-app browser at `http://localhost:8384/`: rebuilt PR bundle is served, the guide renders, the task-type row is collapsed, and no console errors are reported.
- Headless Playwright against a temporary local workbench: fresh guide renders, task-type drilldown hides/returns it, empty filtered results hide it, dismiss persists, `Open Share` navigates to `/share` and stays dismissed on return/reload, and no console errors are reported.

## Notes

No route, backend, Share redaction, findings, allowlist, or hold-state behavior changes. Security/redaction surfaces remain in the Share workflow.