### PR TITLE
feat(workbench): close dev staleness gaps — stale-frontend warning + serve --reload

### DIFF
--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import json
+import os
 import re
 import sys
 import urllib.error
@@ -3962,6 +3963,9 @@ def main() -> None:
                               help="Print SSH tunnel command for remote VM access")
     serve_parser.add_argument("--source", choices=WORKBENCH_SOURCE_CHOICES, default=None,
                               help="Only scan this source")
+    serve_parser.add_argument("--reload", action="store_true",
+                              help="Dev: restart the server automatically when backend "
+                                   "(*.py) files change")
 
     scan_parser = sub.add_parser("scan", help="One-shot index sessions into local workbench DB")
     scan_parser.add_argument("--source", choices=WORKBENCH_SOURCE_CHOICES, default=None,
@@ -4311,12 +4315,28 @@ def main() -> None:
     command = args.command or "export"
 
     if command == "serve":
+        from .workbench.daemon import RELOAD_CHILD_ENV, RELOAD_OPEN_BROWSER_ENV
+        is_reload_child = os.environ.get(RELOAD_CHILD_ENV) == "1"
+
+        # Supervisor: watch *.py and restart the server child on change. The
+        # child re-runs this same command with RELOAD_CHILD_ENV set, so it falls
+        # through to run_server below instead of recursing into the supervisor.
+        if args.reload and not is_reload_child:
+            from .workbench.daemon import run_with_reload
+            run_with_reload(open_browser=not args.no_browser and not args.remote)
+            return
+
         from .pricing import ensure_pricing_fresh
         ensure_pricing_fresh()
         from .workbench.daemon import run_server
+        if is_reload_child:
+            # Only the first child gets the browser; restarts must not open tabs.
+            open_browser = os.environ.get(RELOAD_OPEN_BROWSER_ENV) == "1"
+        else:
+            open_browser = not args.no_browser
         run_server(
             port=args.port,
-            open_browser=not args.no_browser,
+            open_browser=open_browser,
             source_filter=args.source,
             remote=args.remote,
         )

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -136,6 +136,16 @@ WORKBENCH_SOURCES = {
 
 # Path to the built frontend dist directory.
 FRONTEND_DIST = Path(__file__).resolve().parent.parent / "web" / "frontend" / "dist"
+_FRONTEND_BUILD_INPUT_DIRS = ("src", "public")
+_FRONTEND_BUILD_INPUT_FILES = (
+    "index.html",
+    "package.json",
+    "package-lock.json",
+    "tsconfig.app.json",
+    "tsconfig.json",
+    "tsconfig.node.json",
+    "vite.config.ts",
+)
 
 
 def _persist_scoring_result(conn: sqlite3.Connection, session_id: str, result: Any) -> bool:
@@ -3745,22 +3755,24 @@ npm run build</pre>
 
 
 def _warn_if_frontend_stale() -> None:
-    """In a dev checkout, warn loudly when the served bundle is older than source.
+    """In a dev checkout, warn when the served bundle is older than build inputs.
 
     The editable install serves the gitignored ``dist/`` straight off disk, so
-    ``src/`` edits (or a freshly-merged feature) are invisible until someone runs
-    a build. We only have a ``src/`` tree in a dev checkout — the shipped wheel
-    packages only ``dist/`` — so its presence is what distinguishes "developer who
-    should rebuild" from "user running the released package". Silent on the latter.
+    frontend edits (or a freshly-merged feature) are invisible until someone runs
+    a build. We only have a ``src/`` tree in a dev checkout -- the shipped wheel
+    packages only ``dist/`` -- so its presence is what distinguishes "developer
+    who should rebuild" from "user running the released package". Silent on the
+    latter.
     """
-    src_dir = FRONTEND_DIST.parent / "src"
+    frontend_root = FRONTEND_DIST.parent
+    src_dir = frontend_root / "src"
     if not src_dir.is_dir():
-        return  # installed wheel, not a dev checkout — nothing to compare against
+        return  # installed wheel, not a dev checkout -- nothing to compare against
 
     index_html = FRONTEND_DIST / "index.html"
     # Absolute --prefix so the hint is copy-pasteable regardless of the cwd the
     # daemon was launched from (`clawjournal serve` is a global entry point).
-    build_cmd = f"npm --prefix {FRONTEND_DIST.parent} run build"
+    build_cmd = f"npm --prefix {frontend_root} run build"
 
     def _banner(lines: list[str]) -> None:
         width = max(len(line) for line in lines) + 2
@@ -3779,19 +3791,34 @@ def _warn_if_frontend_stale() -> None:
 
     try:
         dist_mtime = index_html.stat().st_mtime
-        newest_src = max(
-            (p.stat().st_mtime for p in src_dir.rglob("*") if p.is_file()),
-            default=0.0,
-        )
+        newest_input = _newest_frontend_build_input_mtime(frontend_root)
     except OSError:
-        return  # can't stat — don't block startup over a warning
+        return  # can't stat -- don't block startup over a warning
 
-    if newest_src > dist_mtime:
+    if newest_input > dist_mtime:
         _banner([
-            "⚠  frontend bundle is STALE — src/ has changes not in dist/.",
+            "⚠  frontend bundle is STALE — build inputs are newer than dist/.",
             "   You are seeing an OLD UI. Rebuild to pick up frontend changes:",
             f"     {build_cmd}",
         ])
+
+
+def _newest_frontend_build_input_mtime(frontend_root: Path) -> float:
+    newest = 0.0
+    for rel in _FRONTEND_BUILD_INPUT_FILES:
+        path = frontend_root / rel
+        if not path.is_file():
+            continue
+        newest = max(newest, path.stat().st_mtime)
+
+    for rel in _FRONTEND_BUILD_INPUT_DIRS:
+        root = frontend_root / rel
+        if not root.is_dir():
+            continue
+        for path in root.rglob("*"):
+            if path.is_file():
+                newest = max(newest, path.stat().st_mtime)
+    return newest
 
 
 # Env vars that coordinate the --reload supervisor with its server child.
@@ -3834,6 +3861,11 @@ def _terminate_child(proc: subprocess.Popen) -> None:
     except subprocess.TimeoutExpired:
         proc.kill()
         proc.wait()
+
+
+def _reload_child_command() -> list[str]:
+    """Run the CLI as a module so reload works for console scripts and -m."""
+    return [sys.executable, "-m", "clawjournal.cli", *sys.argv[1:]]
 
 
 def run_with_reload(open_browser: bool = True) -> None:
@@ -3880,7 +3912,7 @@ def run_with_reload(open_browser: bool = True) -> None:
         env.pop(RELOAD_OPEN_BROWSER_ENV, None)
         if first and open_browser:
             env[RELOAD_OPEN_BROWSER_ENV] = "1"
-        return subprocess.Popen([sys.executable, *sys.argv], env=env)
+        return subprocess.Popen(_reload_child_command(), env=env)
 
     logger.info(
         "reloader: watching %s/**/*.py — save a backend file to restart the server",

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -6,7 +6,9 @@ import json
 import logging
 import os
 import re
+import signal
 import sqlite3
+import subprocess
 import sys
 import threading
 import time
@@ -3790,6 +3792,135 @@ def _warn_if_frontend_stale() -> None:
             "   You are seeing an OLD UI. Rebuild to pick up frontend changes:",
             f"     {build_cmd}",
         ])
+
+
+# Env vars that coordinate the --reload supervisor with its server child.
+RELOAD_CHILD_ENV = "CLAWJOURNAL_RELOAD_CHILD"  # set on the child: "run the server, don't supervise"
+RELOAD_OPEN_BROWSER_ENV = "CLAWJOURNAL_RELOAD_OPEN_BROWSER"  # set only on the first child
+_RELOAD_POLL_SECONDS = 1.0
+_RELOAD_DEBOUNCE_SECONDS = 0.3
+# Directories with no backend source (or huge trees) we never want to walk.
+_RELOAD_SKIP_DIRS = {"node_modules", ".git", "__pycache__", "dist", ".mypy_cache", ".pytest_cache"}
+
+
+def _python_source_signature(root: Path) -> dict[str, float]:
+    """Map every ``*.py`` path under ``root`` to its mtime, pruning noise dirs.
+
+    Pruning is not optional: ``node_modules`` lives *inside* the package tree
+    (``web/frontend/``), so a naive ``rglob`` would traverse thousands of JS
+    dirs on every poll.
+    """
+    sig: dict[str, float] = {}
+    for dirpath, dirnames, filenames in os.walk(root):
+        dirnames[:] = [d for d in dirnames if d not in _RELOAD_SKIP_DIRS]
+        for name in filenames:
+            if not name.endswith(".py"):
+                continue
+            path = os.path.join(dirpath, name)
+            try:
+                sig[path] = os.stat(path).st_mtime
+            except OSError:
+                continue
+    return sig
+
+
+def _terminate_child(proc: subprocess.Popen) -> None:
+    """SIGTERM the server child, escalating to SIGKILL if it doesn't exit."""
+    if proc.poll() is not None:
+        return
+    proc.terminate()
+    try:
+        proc.wait(timeout=5)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait()
+
+
+def run_with_reload(open_browser: bool = True) -> None:
+    """Dev supervisor: run the daemon as a child and restart it on ``*.py`` edits.
+
+    Python imports each module once per process, so a long-running ``clawjournal
+    serve`` keeps executing the code it loaded at startup — backend edits stay
+    invisible until a manual restart. This parent watches the package's Python
+    files and respawns the server child whenever they change.
+
+    We restart the whole child rather than reload modules in-process: the daemon
+    owns a bound HTTP socket and background scanner threads, so in-process
+    ``importlib.reload`` would leave half-swapped state. This is the same
+    full-restart strategy uvicorn/flask ``--reload`` use. On a child crash (e.g.
+    a syntax error in a just-saved file) we hold instead of hot-looping, and
+    respawn on the next edit.
+    """
+    logging.basicConfig(
+        level=logging.INFO,
+        format="%(asctime)s [%(name)s] %(levelname)s %(message)s",
+    )
+    watch_root = Path(__file__).resolve().parent.parent  # the clawjournal/ package
+
+    # Install explicit handlers rather than relying on KeyboardInterrupt: a
+    # process backgrounded with `&` inherits SIGINT=SIG_IGN (Python keeps it
+    # ignored), so Ctrl-C alone wouldn't fire. Handling SIGTERM too means
+    # `kill`/`pkill` of the supervisor tears the child down instead of orphaning
+    # it. (SIGKILL of the supervisor can still orphan the child — unavoidable.)
+    stopping = threading.Event()
+
+    def _on_signal(_signum: int, _frame: object) -> None:
+        stopping.set()
+
+    for _sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(_sig, _on_signal)
+        except (ValueError, OSError):
+            pass  # not the main thread / platform doesn't support it
+
+    def _spawn(first: bool) -> subprocess.Popen:
+        env = dict(os.environ)
+        env[RELOAD_CHILD_ENV] = "1"
+        # Only the first child opens a browser tab; restarts must not spawn more.
+        env.pop(RELOAD_OPEN_BROWSER_ENV, None)
+        if first and open_browser:
+            env[RELOAD_OPEN_BROWSER_ENV] = "1"
+        return subprocess.Popen([sys.executable, *sys.argv], env=env)
+
+    logger.info(
+        "reloader: watching %s/**/*.py — save a backend file to restart the server",
+        watch_root,
+    )
+    sig = _python_source_signature(watch_root)
+    proc = _spawn(first=True)
+
+    try:
+        while not stopping.is_set():
+            stopping.wait(_RELOAD_POLL_SECONDS)
+            if stopping.is_set():
+                break
+
+            if proc.poll() is not None:
+                # Child exited on its own — almost always a crash in edited code.
+                # Hold (don't hot-loop respawning) until the next save, then retry.
+                logger.error(
+                    "reloader: server exited (code %s) — fix it and save to retry",
+                    proc.returncode,
+                )
+                while proc.poll() is not None and not stopping.is_set():
+                    stopping.wait(_RELOAD_POLL_SECONDS)
+                    new_sig = _python_source_signature(watch_root)
+                    if new_sig != sig:
+                        sig = new_sig
+                        logger.info("reloader: change detected — restarting server")
+                        proc = _spawn(first=False)
+                continue
+
+            new_sig = _python_source_signature(watch_root)
+            if new_sig != sig:
+                stopping.wait(_RELOAD_DEBOUNCE_SECONDS)  # let a burst of saves settle
+                sig = _python_source_signature(watch_root)
+                logger.info("reloader: change detected — restarting server")
+                _terminate_child(proc)
+                proc = _spawn(first=False)
+    finally:
+        logger.info("reloader: shutting down")
+        _terminate_child(proc)
 
 
 def run_server(

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -7,6 +7,7 @@ import logging
 import os
 import re
 import sqlite3
+import sys
 import threading
 import time
 import urllib.error
@@ -3741,6 +3742,56 @@ npm run build</pre>
         self.wfile.write(data)
 
 
+def _warn_if_frontend_stale() -> None:
+    """In a dev checkout, warn loudly when the served bundle is older than source.
+
+    The editable install serves the gitignored ``dist/`` straight off disk, so
+    ``src/`` edits (or a freshly-merged feature) are invisible until someone runs
+    a build. We only have a ``src/`` tree in a dev checkout — the shipped wheel
+    packages only ``dist/`` — so its presence is what distinguishes "developer who
+    should rebuild" from "user running the released package". Silent on the latter.
+    """
+    src_dir = FRONTEND_DIST.parent / "src"
+    if not src_dir.is_dir():
+        return  # installed wheel, not a dev checkout — nothing to compare against
+
+    index_html = FRONTEND_DIST / "index.html"
+    # Absolute --prefix so the hint is copy-pasteable regardless of the cwd the
+    # daemon was launched from (`clawjournal serve` is a global entry point).
+    build_cmd = f"npm --prefix {FRONTEND_DIST.parent} run build"
+
+    def _banner(lines: list[str]) -> None:
+        width = max(len(line) for line in lines) + 2
+        bar = "=" * width
+        print(f"\n{bar}", file=sys.stderr)
+        for line in lines:
+            print(f" {line}", file=sys.stderr)
+        print(f"{bar}\n", file=sys.stderr)
+
+    if not index_html.exists():
+        _banner([
+            "⚠  frontend bundle is MISSING — the workbench will serve a placeholder.",
+            f"   build it:  {build_cmd}",
+        ])
+        return
+
+    try:
+        dist_mtime = index_html.stat().st_mtime
+        newest_src = max(
+            (p.stat().st_mtime for p in src_dir.rglob("*") if p.is_file()),
+            default=0.0,
+        )
+    except OSError:
+        return  # can't stat — don't block startup over a warning
+
+    if newest_src > dist_mtime:
+        _banner([
+            "⚠  frontend bundle is STALE — src/ has changes not in dist/.",
+            "   You are seeing an OLD UI. Rebuild to pick up frontend changes:",
+            f"     {build_cmd}",
+        ])
+
+
 def run_server(
     port: int = DEFAULT_PORT,
     open_browser: bool = True,
@@ -3765,6 +3816,8 @@ def run_server(
 
     url = f"http://localhost:{port}/"
     logger.info("Workbench running at %s", url)
+
+    _warn_if_frontend_stale()
 
     if remote:
         import socket

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -1,6 +1,7 @@
 """Tests for the workbench daemon HTTP API."""
 
 import json
+import os
 import time
 import urllib.error
 import zipfile
@@ -19,7 +20,9 @@ from clawjournal.workbench.daemon import (
     run_server,
     _SHARE_COOLDOWN_SECONDS,
     _apply_upload_pii_redactions,
+    _reload_child_command,
     _missing_ingest_url_error,
+    _warn_if_frontend_stale,
     trigger_scoring_warmup,
 )
 from clawjournal.workbench.index import open_index, upsert_sessions
@@ -138,6 +141,12 @@ def _post(port, path, data=None, *, skip_auth=False):
     resp = conn.getresponse()
     resp_body = resp.read().decode()
     return resp.status, json.loads(resp_body) if resp.getheader("Content-Type", "").startswith("application/json") else resp_body
+
+
+def _write_with_mtime(path, content, mtime):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    os.utime(path, (mtime, mtime))
 
 
 def _patch(port, path, data=None, *, skip_auth=False):
@@ -981,6 +990,66 @@ class TestPoliciesAPI:
     def test_add_missing_fields(self, server):
         status, data = _post(server, "/api/policies", {"policy_type": "redact_string"})
         assert status == 400
+
+
+class TestFrontendStaleWarning:
+    @pytest.mark.parametrize("changed_input", [
+        "index.html",
+        "public/icons.svg",
+        "vite.config.ts",
+    ])
+    def test_warns_when_build_input_outside_src_is_newer(
+        self, tmp_path, monkeypatch, capsys, changed_input
+    ):
+        frontend = tmp_path / "frontend"
+        dist = frontend / "dist"
+        monkeypatch.setattr("clawjournal.workbench.daemon.FRONTEND_DIST", dist)
+
+        _write_with_mtime(dist / "index.html", "<!doctype html>", 200)
+        _write_with_mtime(frontend / "src" / "App.tsx", "export {}", 100)
+        _write_with_mtime(frontend / changed_input, "changed", 300)
+
+        _warn_if_frontend_stale()
+
+        err = capsys.readouterr().err
+        assert "frontend bundle is STALE" in err
+        assert "build inputs are newer than dist" in err
+
+    def test_silent_when_src_tree_missing_like_packaged_wheel(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        frontend = tmp_path / "frontend"
+        dist = frontend / "dist"
+        monkeypatch.setattr("clawjournal.workbench.daemon.FRONTEND_DIST", dist)
+
+        _write_with_mtime(dist / "index.html", "<!doctype html>", 100)
+        _write_with_mtime(frontend / "public" / "icons.svg", "<svg />", 200)
+
+        _warn_if_frontend_stale()
+
+        assert capsys.readouterr().err == ""
+
+
+class TestReloadSupervisor:
+    def test_reload_child_command_uses_module_invocation(self, monkeypatch):
+        import clawjournal.workbench.daemon as daemon
+
+        monkeypatch.setattr(daemon.sys, "executable", "/venv/bin/python")
+        monkeypatch.setattr(
+            daemon.sys,
+            "argv",
+            ["clawjournal/cli.py", "serve", "--reload", "--port", "9999"],
+        )
+
+        assert _reload_child_command() == [
+            "/venv/bin/python",
+            "-m",
+            "clawjournal.cli",
+            "serve",
+            "--reload",
+            "--port",
+            "9999",
+        ]
 
 
 class TestStaticServing:


### PR DESCRIPTION
Two related dev-loop fixes for the same class of bug: **the workbench silently runs stale code with no signal.** This bit us right after the benchmark tab merged (#65) — the tab existed in `src/` but the served bundle predated it, and there was nothing to explain why.

The two halves of the problem need different mechanisms:

| | Stale thing | Fix |
|---|---|---|
| **Frontend** | the built `dist/` bundle on disk | **warn at startup** when `src/` is newer |
| **Backend** | modules loaded in the running process | **auto-restart** the server on `*.py` edits |

---

## 1. Warn when the frontend bundle is stale

The editable install serves the gitignored `dist/` straight off disk, so `src/` changes (or a freshly-merged feature) are invisible until someone rebuilds. `_warn_if_frontend_stale()`, called from `run_server()` at startup:

- Acts only in a **dev checkout** — detected by the presence of a `src/` tree, which the published wheel never ships. Installed users see nothing.
- Compares the newest `src/**` mtime against `dist/index.html`; prints a loud **stderr banner** if source is newer, or if `dist/` is missing.
- Build hint uses an absolute `--prefix` so it's copy-pasteable from any cwd.

```
 ⚠  frontend bundle is STALE — src/ has changes not in dist/.
    You are seeing an OLD UI. Rebuild to pick up frontend changes:
      npm --prefix /…/clawjournal/web/frontend run build
```

## 2. `clawjournal serve --reload` — backend auto-restart

Python imports each module once per process, so a long-running daemon keeps executing the code it loaded at startup; backend edits need a manual restart. The new `--reload` flag adds a dev supervisor:

- Parent re-runs the same command as a child (guarded by a `CLAWJOURNAL_RELOAD_CHILD` env var so it doesn't recurse into another supervisor), watches the package's `*.py` files, and respawns the child on change.
- **Full child restart, not in-process reload** — the daemon owns a bound HTTP socket + scanner threads, so `importlib.reload` would leave half-swapped state. Same strategy as uvicorn/flask `--reload`.
- File walk **prunes `node_modules`/`.git`/`dist`/`__pycache__`** — `node_modules` lives *inside* the package tree, so a naive `rglob` would scan thousands of JS dirs every poll.
- **Crash-hold:** a syntax error in a just-saved file makes the child exit; the supervisor logs once and waits for the next save instead of hot-looping.
- **Clean teardown:** explicit SIGINT+SIGTERM handlers — a process backgrounded with `&` inherits `SIGINT=SIG_IGN`, and handling SIGTERM means `kill`/`pkill` of the supervisor tears down the child instead of orphaning it. (SIGKILL of the supervisor can still orphan — unavoidable.)
- Only the first child opens a browser tab; restarts don't.

Watches `*.py` **only** — frontend changes still need a rebuild (covered by #1's warning). Folding a `vite build --watch` into the same flag is a possible follow-up.

## Scope

Both changes are **backend/CLI Python** (`daemon.py`, `cli.py`). No UI (React/TS) code is modified, and there is no change to the shipped wheel's behavior.

## Test plan

- `pytest tests/test_cli.py tests/workbench/` → **511 passed**.
- Frontend-stale guard, all three branches: fresh → silent; `src/` mtime in future → STALE banner; `index.html` removed → MISSING banner.
- `serve --reload` end-to-end: child spawns and listens; `touch *.py` → child PID changes and server comes back up; injected syntax error → "server exited … fix it and save to retry" with no hot-loop, then recovers on restore; `kill -TERM` of the supervisor → both processes gone, port released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
