### PR TITLE
Add clawjournal share --interactive (terminal share wizard MVP)

### DIFF
--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -4398,6 +4398,14 @@ def main() -> None:
             from .share_cli import run as _run_share_cli
             _run_share_cli(args)
         else:
+            # Interactive-only flags must not be silently ignored by the
+            # non-interactive one-step share.
+            from .share_cli import noninteractive_share_rejections
+            bad = noninteractive_share_rejections(args)
+            if bad:
+                print("These options only apply with --interactive: "
+                      + ", ".join(bad), file=sys.stderr)
+                sys.exit(2)
             _run_share(args)
         return
 

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -4156,6 +4156,14 @@ def main() -> None:
                     help="Opt in to AI-assisted PII review while packaging")
     sh.add_argument("--json", action="store_true", help="Output JSON")
 
+    # Interactive share wizard (also exposed as the standalone `clawshare` command)
+    from .share_cli import add_share_cli_args
+    shc = sub.add_parser(
+        "share-cli",
+        help="Interactive share wizard in the terminal (alias: `clawshare`)",
+    )
+    add_share_cli_args(shc)
+
     ve = sub.add_parser("verify-email", help="Verify an academic email address for a short-lived upload token")
     ve.add_argument("email", nargs="?", help="Your academic email address")
     ve.add_argument("--code", type=str, default=None, help="Verification code from email")
@@ -4389,6 +4397,11 @@ def main() -> None:
 
     if command == "share":
         _run_share(args)
+        return
+
+    if command == "share-cli":
+        from .share_cli import run as _run_share_cli
+        _run_share_cli(args)
         return
 
     if command == "verify-email":

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -4145,8 +4145,9 @@ def main() -> None:
 
     # Share command (one-step: create + export + share)
     sh = sub.add_parser("share", help="Bundle and share sessions in one step")
-    sh.add_argument("session_ids", nargs="*", help="Session IDs (omit to use --status)")
-    sh.add_argument("--status", choices=["approved", "shortlisted"],
+    sh.add_argument("session_ids", nargs="*",
+                    help="Session IDs (omit to use --status); in --interactive mode, the list #s")
+    sh.add_argument("--status", choices=["new", "shortlisted", "approved", "blocked"],
                     help="Auto-select sessions with this review status")
     sh.add_argument("--note", type=str, default=None, help="Submission note")
     sh.add_argument("--force", action="store_true", help="Override duplicate check")
@@ -4155,14 +4156,11 @@ def main() -> None:
     sh.add_argument("--ai-pii-review", action="store_true",
                     help="Opt in to AI-assisted PII review while packaging")
     sh.add_argument("--json", action="store_true", help="Output JSON")
-
-    # Interactive share wizard (also exposed as the standalone `clawshare` command)
-    from .share_cli import add_share_cli_args
-    shc = sub.add_parser(
-        "share-cli",
-        help="Interactive share wizard in the terminal (alias: `clawshare`)",
-    )
-    add_share_cli_args(shc)
+    # Interactive terminal share wizard (also exposed as the `clawshare` alias).
+    sh.add_argument("-i", "--interactive", action="store_true",
+                    help="Run the interactive terminal share wizard")
+    from .share_cli import add_interactive_flags
+    add_interactive_flags(sh)
 
     ve = sub.add_parser("verify-email", help="Verify an academic email address for a short-lived upload token")
     ve.add_argument("email", nargs="?", help="Your academic email address")
@@ -4396,12 +4394,11 @@ def main() -> None:
         return
 
     if command == "share":
-        _run_share(args)
-        return
-
-    if command == "share-cli":
-        from .share_cli import run as _run_share_cli
-        _run_share_cli(args)
+        if getattr(args, "interactive", False):
+            from .share_cli import run as _run_share_cli
+            _run_share_cli(args)
+        else:
+            _run_share(args)
         return
 
     if command == "verify-email":

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -409,15 +409,19 @@ def step_queue(conn, settings, args) -> list[dict]:
     do_summary = args.summary or bool(args.summary_model)
     ensure_titles(conn, rows, do_summary, summary_model=args.summary_model)
 
-    print(f"\n  {'#':>3}  {'Last turn':<11} {'Source':<8} {'Msgs':>5} {'Tokens':>9}  Title")
-    print("  " + "-" * 100)
+    print(f"\n  {'#':>3}  {'Last turn':<11} {'Source':<8} {'Msgs':>5} {'Tokens':>9} "
+          f"{'Tools':>5} {'Fail':>4}  Title")
+    print("  " + "-" * 108)
     for i, r in enumerate(rows, 1):
         msgs = (r.get("user_messages") or 0) + (r.get("assistant_messages") or 0)
         toks = (r.get("input_tokens") or 0) + (r.get("output_tokens") or 0)
+        tools = r.get("tool_uses") or 0
+        fv = r.get("ai_failure_value_score")
+        fv_str = str(fv) if fv is not None else "—"
         dt = _parse_ts(r.get("end_time"))
         when = dt.astimezone().strftime("%m-%d %H:%M") if dt else "—"
         print(f"  {i:>3}  {when:<11} {r.get('source', ''):<8} "
-              f"{msgs:>5} {toks:>9,}  {trace_title(r)}")
+              f"{msgs:>5} {toks:>9,} {tools:>5} {fv_str:>4}  {trace_title(r)}")
     print()
 
     if args.indices:

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -810,6 +810,8 @@ def add_interactive_flags(parser: argparse.ArgumentParser) -> argparse.ArgumentP
                         help="non-interactively certify the bundle is yours to submit")
     parser.add_argument("--download", action="store_true",
                         help="with --yes, also write the bundle zip to ~/Downloads")
+    parser.add_argument("--no-refresh", action="store_true",
+                        help="skip the startup index scan (use the existing index as-is)")
     parser.add_argument("-y", "--yes", action="store_true",
                         help="assume yes for preview/review/download prompts (NOT consent)")
     return parser
@@ -829,6 +831,15 @@ def add_share_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     return parser
 
 
+def refresh_index(source_filter: str | None = None) -> int:
+    """One-shot incremental scan (same as `clawjournal scan` / the daemon's
+    initial scan), so the wizard sees fresh traces without a running
+    `clawjournal serve`. Returns the number of newly indexed sessions."""
+    from .workbench.daemon import Scanner
+    results = Scanner(source_filter=source_filter).scan_once()
+    return sum(results.values())
+
+
 def _normalize_indices(args):
     """Accept indices either as the wizard's int positional or as `share`'s
     string `session_ids` positional (interpreted as list #s)."""
@@ -844,6 +855,17 @@ def _normalize_indices(args):
 def run(args) -> None:
     """Run the interactive share wizard against a parsed argparse namespace."""
     _normalize_indices(args)
+    # Refresh the index first so the wizard reflects recent traces even when
+    # `clawjournal serve` isn't running (its background scanner is the only other
+    # thing that ingests). Incremental, so it's cheap on repeat.
+    if not getattr(args, "no_refresh", False):
+        print(f"{DIM}Refreshing trace index…{RST}")
+        try:
+            n = refresh_index(args.source)
+            print(f"{DIM}{('Indexed %d new session(s).' % n) if n else 'Index already up to date.'}"
+                  f"{RST}")
+        except Exception as exc:  # noqa: BLE001
+            print(f"{YEL}Index refresh skipped: {exc}{RST}")
     config = load_config()
     conn = open_index()
     try:

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -618,18 +618,23 @@ def step_package(conn, settings, included: list[dict], package_ai: bool, args):
         blocked = res.get("blocked_sessions") or []
         if blocked:
             blocked_ids = {b if isinstance(b, str) else b.get("session_id") for b in blocked}
-            print(f"{RED}Packaging blocked — secrets/PII detected in:{RST}")
+            reason = res.get("error") or "TruffleHog blocked the share."
+            print(f"{RED}Packaging blocked by the final secret scan:{RST}")
+            print(f"  {DIM}{reason}{RST}")
+            # Same as the web: a blocked trace can't be submitted, so it is removed
+            # (not retained) and the rest are retried.
+            print(f"  {RED}Removed blocked trace(s):{RST}")
             for s in recs:
                 if s["row"]["session_id"] in blocked_ids:
                     print(f"  • {s['row']['session_id'][:12]}  {trace_title(s['row'], 50)}")
             remaining = [s for s in recs if s["row"]["session_id"] not in blocked_ids]
             if not remaining:
-                die("All included traces were blocked — nothing to package.")
-            if args.yes or yesno(f"  Remove the {len(blocked_ids)} blocked trace(s) and retry "
-                                 f"with the remaining {len(remaining)}?", default_yes=True):
-                recs = remaining
-                continue
-            die("Aborted — blocked traces not removed.")
+                die("All included traces were blocked by the final secret scan — nothing to "
+                    "package. To keep one, go back and add a redaction rule (allowlist / custom "
+                    "string) so the secret is scrubbed, then retry.")
+            print(f"  {DIM}Retrying with the remaining {len(remaining)}…{RST}")
+            recs = remaining
+            continue
         die(res.get("error", "Packaging failed."))
 
 

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -309,6 +309,15 @@ def ensure_titles(conn, rows: list[dict], do_summarize: bool, summary_model: str
 
 # ---- step 1: queue ----------------------------------------------------------
 
+def _parse_selection(raw: str, count: int) -> list[int]:
+    """Parse the queue selection input into 1-based indices. 'all' (or 'a'/'*')
+    selects every listed trace; otherwise space/comma-separated numbers."""
+    low = raw.strip().lower()
+    if low in ("all", "a", "*"):
+        return list(range(1, count + 1))
+    return [int(x) for x in raw.replace(",", " ").split()]  # raises ValueError if not numbers
+
+
 def select_queue_rows(rows: list[dict], settings: dict, args) -> list[dict]:
     """Filter to shareable, in-window traces (+ optional search/project/min-fv),
     then rank by failure value descending with unscored (None) last — the web
@@ -381,14 +390,14 @@ def step_queue(conn, settings, args) -> list[dict]:
     if args.indices:
         idxs = args.indices
     else:
-        raw = ask(f"{BOLD}Enter trace #(s) to share{RST} (space/comma separated; "
-                  f"order = bundle order): ")
+        raw = ask(f"{BOLD}Enter trace #(s) to share{RST} (space/comma separated, "
+                  f"or {BOLD}all{RST}; order = bundle order): ")
         if not raw:
             die("Nothing selected.")
         try:
-            idxs = [int(x) for x in raw.replace(",", " ").split()]
+            idxs = _parse_selection(raw, len(rows))
         except ValueError:
-            die("Indices must be numbers.")
+            die("Enter trace numbers, or 'all'.")
     chosen = []
     for n in idxs:
         if n < 1 or n > len(rows):

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -1,0 +1,883 @@
+"""clawshare — the full ClawJournal "Share" wizard, as a keyboard-only CLI.
+
+Faithfully mirrors every step of the `clawjournal serve` web Share wizard,
+in order, with no skipping:
+
+    1. QUEUE    pick traces by # from a list
+    2. REDACT   scrub PII (deterministic); OPTIONAL preview of scrubbed transcript (skippable)
+    3. REVIEW   review redaction summary per trace; must approve before packaging
+    4. PACKAGE  create + seal the bundle (writes sessions.jsonl/manifest/trufflehog*)
+    5. SUBMIT   accept terms + certify ownership, then upload to hosted research
+    6. DONE     receipt; OPTIONAL download of the bundle zip
+
+Exposed two ways (both ship with the package):
+    clawshare                 # standalone console script
+    clawjournal share-cli     # subcommand alias
+
+Usage:
+    clawshare                      # today's traces (default, fast; no LLM summaries)
+    clawshare --summary            # generate LLM summary titles (Haiku)
+    clawshare --weekly             # this week's traces
+    clawshare --all                # every trace, any date/status
+    clawshare --codex              # only Codex traces
+    clawshare --claude --limit 60  # this many Claude traces (default cap 40)
+    clawshare --summary-model haiku  # pick the model used for --summary titles
+    clawshare --ai-pii-review      # run AI-assisted PII pass during packaging
+    clawshare -y 3 7               # non-interactive: traces 3 & 7, assume yes
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import textwrap
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+from .config import load_config
+from .workbench.index import (
+    apply_share_redactions,
+    create_share,
+    get_effective_share_settings,
+    get_session_detail,
+    get_share,
+    open_index,
+    query_sessions,
+    release_gate_blockers,
+    session_matches_excluded_projects,
+    update_session,
+)
+from .workbench.daemon import (
+    _build_share_zip,
+    _prepare_share_export_for_upload,
+    confirm_email_verification,
+    fetch_hosted_consent,
+    hosted_upload_status,
+    request_email_verification,
+    submit_share_to_hosted,
+)
+
+# ---- tty helpers ------------------------------------------------------------
+
+BOLD = "\033[1m"; DIM = "\033[2m"; GRN = "\033[32m"; YEL = "\033[33m"; RED = "\033[31m"
+CYN = "\033[36m"; RST = "\033[0m"
+_ANSI_RE = re.compile(r"(\033\[[0-9;]*m)")
+NSTEPS = 6
+
+
+def _rl(prompt: str) -> str:
+    """Wrap ANSI escapes in readline ignore-markers so cursor width stays correct."""
+    return _ANSI_RE.sub("\001\\1\002", prompt)
+
+
+def ask(prompt: str, default: str = "") -> str:
+    try:
+        val = input(_rl(prompt)).strip()
+    except (EOFError, KeyboardInterrupt):
+        print("\nAborted.")
+        sys.exit(130)
+    return val or default
+
+
+def yesno(prompt: str, default_yes: bool = False) -> bool:
+    val = ask(prompt + (" [Y/n] " if default_yes else " [y/N] ")).lower()
+    return default_yes if not val else val in {"y", "yes"}
+
+
+def step(n: int, title: str):
+    print(f"\n{CYN}{BOLD}── Step {n}/{NSTEPS}: {title} {'─' * max(0, 46 - len(title))}{RST}")
+
+
+def die(msg: str, code: int = 1):
+    print(f"{RED}✗ {msg}{RST}")
+    sys.exit(code)
+
+
+_SYS_PROMPT_PREFIXES = (
+    "you are", "you're", "your task", "act as", "system:", "<",
+    "base directory for this skill", "# ",
+)
+_NO_TITLE = "⟨no summary — run with --summary⟩"
+
+
+def _looks_like_system_prompt(text: str) -> bool:
+    s = (text or "").strip().lower()
+    if not s:
+        return True
+    return s.startswith(_SYS_PROMPT_PREFIXES) or "you are an ai" in s[:40]
+
+
+def trace_title(r: dict, width: int = 52) -> str:
+    """Best title for a trace. Prefers an LLM summary (ai_display_title); falls
+    back to the raw first-message title — but never shows a system prompt, since
+    that tells the user nothing about the trace."""
+    ai = (r.get("ai_display_title") or "").strip()
+    if ai:
+        t = ai
+    else:
+        raw = (r.get("display_title") or "").strip().replace("\n", " ")
+        if _looks_like_system_prompt(raw):
+            return _NO_TITLE
+        t = raw
+    t = t.replace("\n", " ")
+    return (t[: width - 1] + "…") if len(t) > width else t
+
+
+# ---- redaction bucketing / status (mirrors web `li`, `gi`, `hi`) ------------
+
+def _bucket_for(type_str: str) -> str:
+    """Classify a redaction_log entry type into one of the 6 display buckets.
+    Mirrors the web frontend `li()` classifier exactly."""
+    t = (type_str or "").lower()
+    if "email" in t:
+        return "emails"
+    if "url" in t:
+        return "urls"
+    if "path" in t or "username" in t or "home" in t:
+        return "paths"
+    if "time" in t or "date" in t:
+        return "timestamps"
+    if t.startswith("trufflehog") or any(k in t for k in ("token", "key", "secret", "jwt", "cred", "auth")):
+        return "tokens"
+    return "other"
+
+
+def _plural(n: int) -> str:
+    return "" if n == 1 else "s"
+
+
+def what_was_redacted(rec: dict) -> list[str]:
+    """Per-category redaction breakdown for a trace, using the web's category
+    labels (Secrets & credentials / Email addresses / File paths & usernames /
+    Timestamps coarsened / URLs) with the TruffleHog subset called out."""
+    b = rec["buckets"]
+    th = rec.get("th_hits", 0)
+    out: list[str] = []
+    if b["tokens"]:
+        label = "Secrets & credentials"
+        if th:
+            label += f" (incl. {th} via TruffleHog)"
+        out.append(f"{label}: {b['tokens']}")
+    if b["emails"]:
+        out.append(f"Email addresses: {b['emails']}")
+    if b["paths"]:
+        out.append(f"File paths & usernames: {b['paths']}")
+    if b["urls"]:
+        out.append(f"URLs: {b['urls']}")
+    if b["timestamps"]:
+        out.append(f"Timestamps coarsened: {b['timestamps']}")
+    if b["other"]:
+        out.append(f"Other: {b['other']}")
+    counts: dict[str, int] = {}
+    for f in rec.get("ai_findings") or []:
+        name = (f.get("entity_type") or "").replace("_", " ").strip() or "pii"
+        counts[name] = counts.get(name, 0) + 1
+    for name, c in sorted(counts.items(), key=lambda kv: -kv[1]):
+        out.append(f"AI-flagged {name}: {c}")
+    return out
+
+
+def trace_status(rec: dict) -> str:
+    """'clear' or 'review' — mirrors web `hi()`."""
+    cov = rec.get("ai_coverage", "disabled")
+    if cov in ("rules_only", "disabled"):
+        return "review"
+    if any((f.get("confidence", 0) or 0) < 0.85 for f in (rec.get("ai_findings") or [])):
+        return "review"
+    return "clear"
+
+
+# ---- time-range filtering (by last message / end_time) ----------------------
+
+def _parse_ts(ts):
+    """Parse an ISO timestamp into an aware datetime (mirrors index._parse_score_ts)."""
+    if not isinstance(ts, str) or not ts.strip():
+        return None
+    try:
+        dt = datetime.fromisoformat(ts.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return dt if dt.tzinfo else dt.replace(tzinfo=timezone.utc)
+
+
+def _in_time_range(row: dict, time_range: str) -> bool:
+    """True if the trace's LAST turn (end_time) falls in the range. Compared in
+    local time so 'today'/'this week' match the user's wall clock."""
+    if time_range == "all":
+        return True
+    dt = _parse_ts(row.get("end_time")) or _parse_ts(row.get("start_time"))
+    if dt is None:
+        return False
+    day = dt.astimezone().date()
+    today = datetime.now().date()
+    if time_range == "today":
+        return day == today
+    if time_range == "weekly":
+        return day >= today - timedelta(days=today.weekday())  # since Monday
+    return True
+
+
+# ---- LLM trace summaries (for titles) ---------------------------------------
+
+def summarize_trace(session_detail: dict, *, backend: str = "auto",
+                    model: str | None = None) -> str:
+    """Return a short one-line title summarizing the whole trace, via
+    clawjournal's agent backend. Returns '' on any failure."""
+    import tempfile
+    from .scoring.backends import run_default_agent_task
+    from .scoring.scoring import _anonymize_for_scoring, get_message_text
+
+    messages = session_detail.get("messages", []) or []
+    try:
+        _detail, messages = _anonymize_for_scoring(session_detail, messages)
+    except Exception:  # noqa: BLE001
+        pass
+
+    lines = []
+    for m in messages[:60]:
+        try:
+            text = get_message_text(m).strip()
+        except Exception:  # noqa: BLE001
+            text = ""
+        if not text or text == "None":
+            continue
+        lines.append(f"{m.get('role', '')}: {text[:600]}")
+    transcript = "\n".join(lines)
+    if not transcript:
+        return ""
+
+    prompt = (
+        "Read transcript.md in the current directory — a coding-agent session. "
+        "Reply with ONE short line (under 60 characters), imperative mood, "
+        "summarizing what the user was actually trying to do. Ignore boilerplate "
+        "system/skill preamble. Output only the title — no quotes, no extra text."
+    )
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp_path = Path(tmp)
+            (tmp_path / "transcript.md").write_text(transcript, encoding="utf-8")
+            result = run_default_agent_task(
+                backend=backend,
+                cwd=tmp_path,
+                task_prompt=prompt,
+                model=model,
+                timeout_seconds=60,
+                codex_sandbox="read-only",
+                openclaw_message=prompt + f"\nRead: {tmp_path / 'transcript.md'}",
+            )
+    except Exception:  # noqa: BLE001
+        return ""
+    out = (result.stdout or "").strip()
+    if not out:
+        return ""
+    # Take the last non-empty line (agents sometimes print preamble first).
+    title = [ln.strip() for ln in out.splitlines() if ln.strip()][-1]
+    return title.strip().strip('"').strip("'")[:80]
+
+
+# Fast/cheap default model per backend for one-line title summaries.
+_LIGHT_SUMMARY_MODEL = {"claude": "haiku"}
+
+
+def _title_cache_path() -> Path:
+    from .config import CONFIG_DIR
+    return Path(CONFIG_DIR) / "clawshare_titles.json"
+
+
+def _load_title_cache() -> dict:
+    try:
+        return json.loads(_title_cache_path().read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _save_title_cache(cache: dict) -> None:
+    try:
+        _title_cache_path().write_text(json.dumps(cache, ensure_ascii=False), encoding="utf-8")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def ensure_titles(conn, rows: list[dict], do_summarize: bool, summary_model: str | None = None):
+    """Only runs with --summary. Fills an LLM summary title (in-memory + a local
+    clawshare cache, NOT the scoring column) for any listed trace that lacks a
+    real title. Summaries run concurrently with live progress and can be skipped
+    with Ctrl-C. Uses a light model per backend by default (e.g. claude/haiku)."""
+    if not do_summarize:
+        return
+    # Reuse previously generated clawshare summaries from the local cache.
+    cache = _load_title_cache()
+    for r in rows:
+        if not (r.get("ai_display_title") or "").strip():
+            cached = cache.get(r["session_id"])
+            if cached:
+                r["ai_display_title"] = cached
+    need = [r for r in rows if not (r.get("ai_display_title") or "").strip()]
+    if not need:
+        return
+
+    import shutil
+    from .scoring.backends import resolve_backend
+    # Summaries are a tiny side task — prefer claude/haiku (fast & cheap) whenever
+    # claude is installed, regardless of the main backend, unless an explicit
+    # --summary-model is given.
+    if not summary_model and shutil.which("claude"):
+        backend, model = "claude", "haiku"
+    else:
+        try:
+            backend = resolve_backend("auto")
+        except Exception:  # noqa: BLE001
+            print(f"  {DIM}(no agent backend available — using raw titles; "
+                  f"run `clawjournal score` or pass --no-summarize to silence){RST}")
+            return
+        model = summary_model or _LIGHT_SUMMARY_MODEL.get(backend)
+
+    label = f"{backend}/{model}" if model else backend
+    print(f"  {DIM}Summarizing {len(need)} title(s) with {label} "
+          f"— Ctrl-C to skip and keep raw titles…{RST}")
+    details = {r["session_id"]: get_session_detail(conn, r["session_id"]) for r in need}
+
+    from concurrent.futures import as_completed
+    titles: dict[str, str] = {}
+    pool = ThreadPoolExecutor(max_workers=min(8, len(need)))
+    futures = {
+        pool.submit(summarize_trace, details[r["session_id"]], backend=backend, model=model):
+            r["session_id"]
+        for r in need if details.get(r["session_id"])
+    }
+    done = 0
+    try:
+        for fut in as_completed(futures):
+            sid = futures[fut]
+            try:
+                titles[sid] = fut.result()
+            except Exception:  # noqa: BLE001
+                titles[sid] = ""
+            done += 1
+            print(f"\r  {DIM}  …summarized {done}/{len(futures)}{RST}", end="", flush=True)
+        print()
+    except KeyboardInterrupt:
+        print(f"\n  {YEL}Skipped remaining summaries — keeping raw titles for those.{RST}")
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
+
+    changed = False
+    for r in need:
+        title = titles.get(r["session_id"]) or ""
+        if title:
+            r["ai_display_title"] = title
+            cache[r["session_id"]] = title
+            changed = True
+    if changed:
+        _save_title_cache(cache)
+
+
+# ---- step 1: queue ----------------------------------------------------------
+
+def step_queue(conn, settings, args) -> list[dict]:
+    step(1, "Queue — select traces")
+    rows = query_sessions(
+        conn,
+        status=args.status,
+        source=args.source,
+        limit=5000,
+        sort="end_time",
+        order="desc",
+    )
+    rows = [
+        r for r in rows
+        if not session_matches_excluded_projects(r, settings["excluded_projects"])
+        and r.get("hold_state") in (None, "auto_redacted", "released")
+        and not r.get("shared_at")
+        and _in_time_range(r, args.time_range)
+    ]
+    if not rows:
+        ranges = {"today": "today", "weekly": "this week", "all": "the index"}
+        hint = "" if args.time_range == "all" else "  (try --weekly or --all)"
+        die(f"No shareable traces found in {ranges[args.time_range]}.{hint}")
+
+    rows = rows[:args.limit]
+    label = {"today": "today", "weekly": "this week", "all": "all time"}[args.time_range]
+    print(f"  {DIM}Showing {len(rows)} shareable trace(s) — {label}"
+          f" (limit {args.limit}; use --limit to change).{RST}")
+
+    # Optionally summarize titles (--summary). Default is off for speed; without
+    # it, system-prompt-looking titles are hidden behind a placeholder instead.
+    do_summary = args.summary or bool(args.summary_model)
+    ensure_titles(conn, rows, do_summary, summary_model=args.summary_model)
+
+    print(f"\n  {'#':>3}  {'Last turn':<11} {'Source':<8} {'Msgs':>5} {'Tokens':>9}  Title")
+    print("  " + "-" * 100)
+    for i, r in enumerate(rows, 1):
+        msgs = (r.get("user_messages") or 0) + (r.get("assistant_messages") or 0)
+        toks = (r.get("input_tokens") or 0) + (r.get("output_tokens") or 0)
+        dt = _parse_ts(r.get("end_time"))
+        when = dt.astimezone().strftime("%m-%d %H:%M") if dt else "—"
+        print(f"  {i:>3}  {when:<11} {r.get('source', ''):<8} "
+              f"{msgs:>5} {toks:>9,}  {trace_title(r)}")
+    print()
+
+    if args.indices:
+        idxs = args.indices
+    else:
+        raw = ask(f"{BOLD}Enter trace #(s) to share{RST} (space/comma separated, e.g. 1 3 5): ")
+        if not raw:
+            die("Nothing selected.")
+        try:
+            idxs = [int(x) for x in raw.replace(",", " ").split()]
+        except ValueError:
+            die("Indices must be numbers.")
+    chosen = []
+    for n in idxs:
+        if n < 1 or n > len(rows):
+            die(f"Index {n} out of range (1–{len(rows)}).")
+        chosen.append(rows[n - 1])
+    print(f"{GRN}✓ {len(chosen)} trace(s) queued{RST}")
+    return chosen
+
+
+# ---- step 2: redact (scrub + optional preview) ------------------------------
+
+def render_transcript(redacted_session: dict, max_msgs: int | None = None,
+                      max_chars: int = 2000):
+    """Print a scrubbed transcript. Empty / thinking-only messages (no textual
+    content) are skipped. Newlines are preserved; each message body is capped at
+    max_chars so one giant message can't flood the terminal. max_msgs=None shows
+    every message; otherwise only the first max_msgs are shown."""
+    all_msgs = redacted_session.get("messages") or []
+    msgs, hidden = [], 0
+    for m in all_msgs:
+        c = m.get("content")
+        if not isinstance(c, str) or not c.strip() or c.strip() == "None":
+            hidden += 1
+            continue
+        msgs.append(m)
+
+    shown = msgs if max_msgs is None else msgs[:max_msgs]
+    head = f"all {len(msgs)}" if max_msgs is None else f"first {len(shown)} of {len(msgs)}"
+    note = f"({head} content message{_plural(len(msgs))}"
+    if hidden:
+        note += f", {hidden} empty/thinking hidden"
+    note += " — already scrubbed)"
+    print(f"  {DIM}{note}{RST}")
+
+    for m in shown:
+        role = m.get("role", "?")
+        content = m["content"]
+        color = CYN if role == "user" else (YEL if role == "assistant" else DIM)
+        body = content
+        if len(body) > max_chars:
+            body = body[:max_chars] + f"  …(+{len(content) - max_chars} more chars)"
+        lines = body.split("\n")
+        print(f"  {color}{role:>9}{RST}  {lines[0] if lines else ''}")
+        for ln in lines[1:]:
+            print(f"             {ln}")
+    if max_msgs is not None and len(msgs) > max_msgs:
+        print(f"  {DIM}… {len(msgs) - max_msgs} more message(s) — press [v] for the full transcript{RST}")
+
+
+def step_redact(conn, settings, chosen: list[dict], assume_yes: bool, ai_pii: bool) -> list[dict]:
+    step(2, "Redact — scrub PII")
+    ai_fns = None
+    if ai_pii:
+        try:
+            from ..redaction.pii import review_session_pii_with_agent, apply_findings_to_session
+            ai_fns = (review_session_pii_with_agent, apply_findings_to_session)
+        except Exception:  # noqa: BLE001
+            ai_fns = None
+        print(f"  {DIM}AI PII review enabled — analysing each trace (may take a moment)…{RST}")
+
+    scrubbed = []
+    for r in chosen:
+        detail = get_session_detail(conn, r["session_id"])
+        if detail is None:
+            die(f"Session {r['session_id']} not found.")
+        red, count, log = apply_share_redactions(
+            conn, detail,
+            custom_strings=settings["custom_strings"],
+            user_allowlist=settings["allowlist_entries"],
+            extra_usernames=settings["extra_usernames"],
+            blocked_domains=settings["blocked_domains"],
+        )
+        buckets = {k: 0 for k in ("tokens", "emails", "paths", "timestamps", "urls", "other")}
+        th_hits = 0
+        for e in log:
+            etype = e.get("type", "")
+            buckets[_bucket_for(etype)] += 1
+            if str(etype).lower().startswith("trufflehog"):
+                th_hits += 1
+
+        ai_findings: list[dict] = []
+        ai_coverage = "disabled"
+        if ai_pii:
+            ai_coverage = "rules_only"
+            if ai_fns is not None:
+                review_fn, apply_fn = ai_fns
+                try:
+                    findings = review_fn(red, ignore_errors=False, backend="auto")
+                    ai_coverage = "full"
+                    if findings:
+                        red, ai_count = apply_fn(red, findings)
+                        count += ai_count
+                        ai_findings = findings
+                except Exception:  # noqa: BLE001
+                    ai_coverage = "rules_only"
+
+        rec = {"row": r, "redacted": red, "count": count, "buckets": buckets,
+               "th_hits": th_hits, "ai_findings": ai_findings, "ai_coverage": ai_coverage}
+        rec["status"] = trace_status(rec)
+        scrubbed.append(rec)
+
+    print(f"  {DIM}Redacting your traces — categories flagged per trace:{RST}")
+    for i, s in enumerate(scrubbed, 1):
+        verdict = (f"{GRN}clear{RST}" if s["status"] == "clear"
+                   else f"{YEL}needs review{RST}")
+        print(f"\n  {BOLD}[{i}]{RST} {verdict} · {s['count']} redaction{_plural(s['count'])}"
+              f" · {trace_title(s['row'])}")
+        cats = what_was_redacted(s)
+        if cats:
+            for c in cats:
+                print(f"        {DIM}•{RST} {c}")
+        else:
+            print(f"        {DIM}nothing matched the deterministic rules{RST}")
+
+    # OPTIONAL preview — skippable
+    if not assume_yes:
+        while True:
+            raw = ask(f"\n{BOLD}Preview a scrubbed transcript?{RST} "
+                      f"Enter trace # ({DIM}blank = skip{RST}): ")
+            if not raw:
+                break
+            try:
+                n = int(raw)
+                assert 1 <= n <= len(scrubbed)
+            except (ValueError, AssertionError):
+                print(f"{YEL}Enter a # between 1 and {len(scrubbed)}, or blank to skip.{RST}")
+                continue
+            print()
+            render_transcript(scrubbed[n - 1]["redacted"])
+    print(f"{GRN}✓ scrubbed {len(scrubbed)} trace(s){RST}")
+    return scrubbed
+
+
+# ---- step 3: review ---------------------------------------------------------
+
+def _show_redaction_detail(rec: dict):
+    """Print the 'What was redacted' panel for one trace (mirrors web `gi()`)."""
+    items = what_was_redacted(rec)
+    print(f"  {BOLD}What was redacted:{RST}")
+    if items:
+        for it in items:
+            print(f"    • {it}")
+    else:
+        print(f"    {DIM}Nothing matched the deterministic rules.{RST}")
+        cov = rec.get("ai_coverage", "disabled")
+        if cov == "disabled":
+            print(f"    {DIM}AI review off.{RST}")
+        elif cov == "rules_only":
+            print(f"    {DIM}AI review unavailable.{RST}")
+
+
+def step_review(conn, scrubbed: list[dict], assume_yes: bool) -> list[dict]:
+    step(3, "Review — inspect & approve before packaging")
+    print(f"  {'#':>3}  {'Status':<14} Title")
+    print("  " + "-" * 80)
+    for i, s in enumerate(scrubbed, 1):
+        verdict = (f"{GRN}clear{RST}        " if s["status"] == "clear"
+                   else f"{YEL}needs review{RST} ")
+        print(f"  {i:>3}  {verdict:<23} {trace_title(s['row'])}")
+
+    clear = [s for s in scrubbed if s["status"] == "clear"]
+    review = [s for s in scrubbed if s["status"] != "clear"]
+    approved_ids: set[str] = set()
+
+    if assume_yes:
+        # Non-interactive: include everything.
+        approved_ids = {s["row"]["session_id"] for s in scrubbed}
+    else:
+        # Clean traces may be bulk-included (mirrors "Include all clean").
+        if clear and yesno(f"\n{BOLD}Include all {len(clear)} clear trace(s)?{RST}", default_yes=True):
+            approved_ids |= {s["row"]["session_id"] for s in clear}
+
+        # Needs-review traces MUST be inspected & decided individually.
+        if review:
+            print(f"\n  {YEL}{len(review)} trace(s) need review — inspect each before packaging.{RST}")
+            for n, s in enumerate(review, 1):
+                print(f"\n{CYN}  ── review {n}/{len(review)} ─ {trace_title(s['row'], 60)}{RST}")
+                _show_redaction_detail(s)
+                # Always show a short preview so the user knows which trace this is,
+                # even when nothing was redacted.
+                print(f"  {BOLD}Preview:{RST}")
+                render_transcript(s["redacted"], max_msgs=6, max_chars=700)
+                while True:
+                    choice = ask(f"  {BOLD}[v]{RST}iew full transcript  "
+                                 f"{BOLD}[i]{RST}nclude  {BOLD}[r]{RST}emove: ").lower()
+                    if choice in ("v", "view"):
+                        print()
+                        render_transcript(s["redacted"])
+                        continue
+                    if choice in ("i", "include", "y", "yes"):
+                        approved_ids.add(s["row"]["session_id"])
+                        print(f"  {GRN}✓ included{RST}")
+                        break
+                    if choice in ("r", "remove", "n", "no", "skip"):
+                        print(f"  {DIM}removed from bundle{RST}")
+                        break
+                    print(f"  {YEL}Please enter v, i, or r.{RST}")
+
+    approved = [s for s in scrubbed if s["row"]["session_id"] in approved_ids]
+    if not approved:
+        die("No traces included — nothing to package.")
+
+    for s in approved:
+        if s["row"].get("review_status") != "approved":
+            update_session(conn, s["row"]["session_id"], status="approved", reason="clawshare CLI review")
+    conn.commit()
+    dropped = len(scrubbed) - len(approved)
+    print(f"{GRN}✓ {len(approved)} trace(s) approved"
+          + (f", {dropped} dropped" if dropped else "") + RST)
+    return approved
+
+
+# ---- step 4: package --------------------------------------------------------
+
+def step_package(conn, settings, approved: list[dict], ai_pii: bool, args):
+    step(4, "Package — create + seal bundle")
+    session_ids = [s["row"]["session_id"] for s in approved]
+
+    blockers = release_gate_blockers(conn, session_ids)
+    if blockers:
+        print(f"{RED}Release gate blocked these traces:{RST}")
+        for b in blockers:
+            print(f"  • {b.get('session_id', '?')[:12]}  {b.get('reason', b)}")
+        die("Resolve hold/embargo state (e.g. `clawjournal release <id>`) and retry.")
+
+    share_id = create_share(conn, session_ids, note=args.note)
+    share = get_share(conn, share_id)
+    if share is None:
+        die("Share row could not be loaded after creation.")
+
+    print(f"  {DIM}sealing… (redact → TruffleHog → PII pass → re-scan){RST}")
+    export_dir, manifest, error = _prepare_share_export_for_upload(
+        conn, share_id, share, settings,
+        reuse_finalized=True, ai_pii_review_enabled=ai_pii,
+    )
+    if error:
+        msg = error.get("error", "Packaging failed.")
+        blocked = error.get("blocked_sessions") or []
+        if blocked:
+            print(f"{RED}Packaging blocked — secrets detected in:{RST}")
+            for sid in blocked:
+                print(f"  • {sid[:12] if isinstance(sid, str) else sid}")
+            die("Remove/redact the flagged trace(s) and retry.")
+        die(msg)
+    if export_dir is None:
+        die("Packaging failed: no bundle produced.")
+    if manifest.get("blocked"):
+        print(f"{RED}Bundle marked blocked: {manifest.get('blocked_sessions')}{RST}")
+        die("Cannot submit a blocked bundle.")
+
+    try:
+        zip_size = len(_build_share_zip(export_dir))
+    except Exception:
+        zip_size = 0
+    rsum = manifest.get("redaction_summary", {})
+    print(f"{GRN}✓ packaged{RST}")
+    print(f"  bundle:   {share_id[:8]}   sessions: {len(manifest.get('sessions', []))}")
+    print(f"  path:     {export_dir}")
+    print(f"  zip size: {zip_size / 1024:.1f} KiB")
+    if rsum:
+        print(f"  privacy:  {DIM}{rsum}{RST}")
+    return share_id, export_dir
+
+
+# ---- step 5: submit (accept terms) ------------------------------------------
+
+def ensure_email(assume_yes: bool):
+    st = hosted_upload_status()
+    if st.get("token_valid"):
+        print(f"  {GRN}✓ upload token valid for {st['verified_email']}{RST}")
+        return
+    print(f"  {YEL}Upload token missing/expired — verify your academic email.{RST}")
+    default_email = st.get("verified_email") or ""
+    email = ask(f"  Academic email{f' [{default_email}]' if default_email else ''}: ", default_email)
+    if not email:
+        die("Email required for hosted submission.")
+    try:
+        request_email_verification(email)
+    except Exception as exc:  # noqa: BLE001
+        die(f"Could not send verification code: {exc}")
+    print(f"  {DIM}A 6-digit code was emailed to {email}.{RST}")
+    code = ask("  Enter the code: ")
+    if not code:
+        die("No code entered.")
+    try:
+        confirm_email_verification(email, code)
+    except Exception as exc:  # noqa: BLE001
+        die(f"Verification failed: {exc}")
+    if not hosted_upload_status().get("token_valid"):
+        die("Verification did not yield a valid token.")
+    print(f"  {GRN}✓ email verified{RST}")
+
+
+def step_submit(conn, settings, share_id: str, ai_pii: bool, assume_yes: bool):
+    step(5, "Submit — accept terms & upload")
+    try:
+        doc = fetch_hosted_consent()
+    except Exception as exc:  # noqa: BLE001
+        die(f"Could not load consent terms: {exc}")
+    cv = doc.get("consent_version") or ""
+    rv = doc.get("retention_policy_version") or ""
+    if not cv or not rv:
+        die("Hosted service did not return consent/retention versions.")
+
+    consent_text = (doc.get("consent_text") or "").strip()
+    retention_text = (doc.get("retention_text") or "").strip()
+    if not consent_text and not retention_text:
+        die("Hosted service did not return the consent terms text.")
+
+    print(f"\n  {BOLD}Consent and retention{RST}  {DIM}(consent {cv} · retention {rv}){RST}")
+    print(f"  {DIM}{'─' * 60}{RST}")
+    for para in (consent_text, retention_text):
+        if not para:
+            continue
+        for ln in para.split("\n"):
+            for wrapped in (textwrap.wrap(ln, 78) or [""]):
+                print(f"  {wrapped}")
+        print()
+    print(f"  {DIM}{'─' * 60}{RST}")
+
+    if not assume_yes:
+        if not yesno(f"  {BOLD}I accept the displayed consent and data-use terms.{RST}"):
+            print(f"{YEL}Terms not accepted — bundle packaged but not submitted.{RST}")
+            return None
+        if not yesno(f"  {BOLD}I certify this bundle is mine to submit and contains no "
+                     f"third-party confidential material.{RST}"):
+            print(f"{YEL}Ownership not certified — bundle packaged but not submitted.{RST}")
+            return None
+
+    ensure_email(assume_yes)
+    print(f"  {DIM}uploading to hosted research…{RST}")
+    result = submit_share_to_hosted(
+        conn, share_id,
+        accept_terms=True, ownership_certification=True,
+        consent_version=cv, retention_policy_version=rv,
+        settings=settings, ai_pii_review_enabled=ai_pii,
+    )
+    if not result.get("ok"):
+        suffix = f"  (status {result['status']})" if result.get("status") else ""
+        die(result.get("error", "Upload failed.") + suffix)
+    print(f"  {GRN}✓ uploaded{RST}")
+    return result
+
+
+# ---- step 6: done (+ optional download) -------------------------------------
+
+def step_done(share_id: str, export_dir: Path, result, assume_yes: bool):
+    step(6, "Done")
+    if result:
+        print(f"  {GRN}{BOLD}✓ Shared to hosted research!{RST}")
+        print(f"  receipt:    {result.get('receipt_id')}")
+        if result.get("hosted_submission_url"):
+            print(f"  submission: {result['hosted_submission_url']}")
+        print(f"  sessions:   {result.get('session_count')}")
+    else:
+        print(f"  {YEL}Bundle packaged but not submitted.{RST}")
+    print(f"  bundle dir: {export_dir}")
+
+    # OPTIONAL download of the zip — single prompt so a stray "y" can't become
+    # the filename: Enter/y = default path, n = skip, anything else = a path.
+    fname = f"clawjournal-share-{share_id[:8]}.zip"
+    default = Path("~/Downloads").expanduser() / fname
+    if assume_yes:
+        dest = default
+    else:
+        ans = ask(f"\n  {BOLD}Download the bundle zip?{RST} "
+                  f"{DIM}[Enter/y = {default}, n = skip, or type a path]{RST}\n  > ").strip()
+        low = ans.lower()
+        if low in ("n", "no", "q", "skip"):
+            return
+        dest = default if low in ("", "y", "yes") else Path(ans).expanduser()
+    if dest.is_dir() or str(dest).endswith(os.sep):
+        dest = dest / fname
+    try:
+        data = _build_share_zip(export_dir)
+        dest.parent.mkdir(parents=True, exist_ok=True)
+        dest.write_bytes(data)
+        print(f"  {GRN}✓ saved {len(data) / 1024:.1f} KiB → {dest}{RST}")
+    except Exception as exc:  # noqa: BLE001
+        print(f"  {RED}Download failed: {exc}{RST}")
+
+
+# ---- arg wiring (single source of truth) ------------------------------------
+
+def add_share_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Define the clawshare wizard flags. Shared by the `clawshare` console
+    script and the `clawjournal share-cli` subcommand."""
+    parser.add_argument("indices", nargs="*", type=int,
+                        help="trace #(s) from the list (non-interactive)")
+    # Time range — default is today (last turn happened today).
+    when = parser.add_mutually_exclusive_group()
+    when.add_argument("--weekly", dest="time_range", action="store_const", const="weekly",
+                      help="traces from this week (default: today only)")
+    when.add_argument("--all", dest="time_range", action="store_const", const="all",
+                      help="all traces, any date and any status")
+    parser.set_defaults(time_range="today")
+    parser.add_argument("--status", default=None,
+                        choices=["new", "shortlisted", "approved", "blocked"],
+                        help="filter by review status (default: any)")
+    src = parser.add_mutually_exclusive_group()
+    src.add_argument("--source", default=None,
+                     help="only this source (claude, codex, gemini, …)")
+    src.add_argument("--codex", dest="source", action="store_const", const="codex",
+                     help="only Codex traces (shortcut for --source codex)")
+    src.add_argument("--claude", dest="source", action="store_const", const="claude",
+                     help="only Claude traces (shortcut for --source claude)")
+    parser.add_argument("--limit", type=int, default=40,
+                        help="max traces to list (default 40)")
+    parser.add_argument("--summary", action="store_true",
+                        help="generate LLM summary titles (Haiku; default: off, faster)")
+    parser.add_argument("--summary-model", default=None, metavar="MODEL",
+                        help="model for --summary titles (default: a light model per "
+                             "backend, e.g. claude/haiku; implies --summary)")
+    parser.add_argument("--note", default=None, help="optional submission note")
+    parser.add_argument("--ai-pii-review", action="store_true",
+                        help="run AI-assisted PII pass during packaging")
+    parser.add_argument("-y", "--yes", action="store_true",
+                        help="assume yes for preview-skip / review / terms / download prompts")
+    return parser
+
+
+def run(args) -> None:
+    """Run the full 6-step share wizard against a parsed argparse namespace."""
+    config = load_config()
+    conn = open_index()
+    try:
+        settings = get_effective_share_settings(conn, config)
+        ai_pii = bool(args.ai_pii_review or settings.get("ai_pii_review_enabled"))
+        chosen = step_queue(conn, settings, args)
+        scrubbed = step_redact(conn, settings, chosen, args.yes, ai_pii)
+        approved = step_review(conn, scrubbed, args.yes)
+        share_id, export_dir = step_package(conn, settings, approved, ai_pii, args)
+        result = step_submit(conn, settings, share_id, ai_pii, args.yes)
+        step_done(share_id, export_dir, result, args.yes)
+    finally:
+        conn.close()
+
+
+def main(argv: list[str] | None = None) -> None:
+    """Console-script entry point for the standalone `clawshare` command."""
+    parser = argparse.ArgumentParser(
+        prog="clawshare",
+        description="Full ClawJournal Share wizard, keyboard-only "
+                    "(queue → redact → review → package → submit → done).",
+    )
+    add_share_cli_args(parser)
+    run(parser.parse_args(argv))
+
+
+if __name__ == "__main__":
+    main()

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -1,29 +1,23 @@
-"""clawshare — the full ClawJournal "Share" wizard, as a keyboard-only CLI.
+"""Interactive terminal Share wizard for ClawJournal.
 
-Faithfully mirrors every step of the `clawjournal serve` web Share wizard,
-in order, with no skipping:
+A keyboard-driven MVP of the `clawjournal serve` web Share flow, for sharing
+traces without a browser:
 
-    1. QUEUE    pick traces by # from a list
-    2. REDACT   scrub PII (deterministic); OPTIONAL preview of scrubbed transcript (skippable)
-    3. REVIEW   review redaction summary per trace; must approve before packaging
-    4. PACKAGE  create + seal the bundle (writes sessions.jsonl/manifest/trufflehog*)
-    5. SUBMIT   accept terms + certify ownership, then upload to hosted research
-    6. DONE     receipt; OPTIONAL download of the bundle zip
+    1. QUEUE    pick traces from a time-scoped, filterable list
+    2. REDACT   scrub PII (rules; optional AI pass) + per-category breakdown
+    3. REVIEW   inspect & include traces (share-local; does NOT touch triage)
+    4. PACKAGE  seal the bundle (with blocked-trace removal/retry)
+    5. SUBMIT   accept consent explicitly, then upload — or fall back to download
+    6. DONE     receipt and/or bundle-zip download
 
-Exposed two ways (both ship with the package):
-    clawshare                 # standalone console script
-    clawjournal share-cli     # subcommand alias
+This is a terminal front-end only: all share logic lives in `share_flow`
+(shared with the daemon); this module handles presentation and prompts.
 
-Usage:
-    clawshare                      # past 24h; original (non-AI) titles, fast
-    clawshare --summary            # AI-summarized titles (Haiku)
-    clawshare --weekly             # past 7 days (168h) of traces
-    clawshare --all                # every trace, any date/status
-    clawshare --codex              # only Codex traces
-    clawshare --claude --limit 60  # this many Claude traces (default cap 40)
-    clawshare --summary-model haiku  # pick the model used for --summary titles
-    clawshare --ai-pii-review      # run AI-assisted PII pass during packaging
-    clawshare -y 3 7               # non-interactive: traces 3 & 7, assume yes
+Primary entry point:  `clawjournal share --interactive`
+Thin alias:           `clawshare`
+
+It does NOT yet reach full parity with the web wizard (richer queue
+add/remove/reorder, the complete AI interaction model). See the PR notes.
 """
 from __future__ import annotations
 
@@ -39,25 +33,20 @@ from pathlib import Path
 
 from .config import load_config
 from .workbench.index import (
-    apply_share_redactions,
-    create_share,
     get_effective_share_settings,
     get_session_detail,
-    get_share,
     open_index,
     query_sessions,
-    release_gate_blockers,
     session_matches_excluded_projects,
-    update_session,
 )
-from .workbench.daemon import (
-    _build_share_zip,
-    _prepare_share_export_for_upload,
-    confirm_email_verification,
-    fetch_hosted_consent,
-    hosted_upload_status,
-    request_email_verification,
-    submit_share_to_hosted,
+from . import share_flow
+from .share_flow import (
+    build_redaction_record,
+    build_zip,
+    category_breakdown,
+    effective_ai_pii,
+    gate_blockers,
+    hosted_destination,
 )
 
 # ---- tty helpers ------------------------------------------------------------
@@ -96,6 +85,12 @@ def die(msg: str, code: int = 1):
     sys.exit(code)
 
 
+def _plural(n: int) -> str:
+    return "" if n == 1 else "s"
+
+
+# ---- titles -----------------------------------------------------------------
+
 _SYS_PROMPT_PREFIXES = (
     "you are", "you're", "your task", "act as", "system:",
     "base directory for this skill",
@@ -109,9 +104,7 @@ def _looks_like_system_prompt(text: str) -> bool:
 
 def user_prompt_title(conn, row: dict) -> str | None:
     """Pull a meaningful title from the first user message, skipping a leading
-    system-prompt / instruction preamble (so e.g. eval-judge traces show the
-    actual content being judged instead of the identical 'You are a … judge'
-    boilerplate). Returns None if no usable user message is found."""
+    system-prompt / instruction preamble."""
     detail = get_session_detail(conn, row["session_id"])
     for m in (detail or {}).get("messages") or []:
         if m.get("role") != "user":
@@ -128,13 +121,6 @@ def user_prompt_title(conn, row: dict) -> str | None:
 
 
 def resolve_title(r: dict, summarized: bool) -> str:
-    """Title to display for a trace, by mode:
-    - default (summarized=False): the raw ``display_title`` (or "Untitled").
-      step_queue replaces system-prompt-looking titles with the underlying
-      user prompt (see user_prompt_title) before display.
-    - --summary (summarized=True): the AI-summarized title — scoring's
-      ai_display_title, or a clawshare summary ensure_titles placed on the row;
-      falls back to the raw title if no AI summary is available."""
     raw = (r.get("display_title") or "").strip().replace("\n", " ") or "Untitled"
     if summarized:
         return (r.get("ai_display_title") or "").strip() or raw
@@ -142,8 +128,6 @@ def resolve_title(r: dict, summarized: bool) -> str:
 
 
 def trace_title(r: dict, width: int = 52) -> str:
-    """Truncated title for display. Uses the mode-aware title precomputed onto
-    the row (``_clawshare_title``); falls back to the raw/original title."""
     t = r.get("_clawshare_title")
     if t is None:
         t = resolve_title(r, False)
@@ -151,74 +135,15 @@ def trace_title(r: dict, width: int = 52) -> str:
     return (t[: width - 1] + "…") if len(t) > width else t
 
 
-# ---- redaction bucketing / status (mirrors web `li`, `gi`, `hi`) ------------
-
-def _bucket_for(type_str: str) -> str:
-    """Classify a redaction_log entry type into one of the 6 display buckets.
-    Mirrors the web frontend `li()` classifier exactly."""
-    t = (type_str or "").lower()
-    if "email" in t:
-        return "emails"
-    if "url" in t:
-        return "urls"
-    if "path" in t or "username" in t or "home" in t:
-        return "paths"
-    if "time" in t or "date" in t:
-        return "timestamps"
-    if t.startswith("trufflehog") or any(k in t for k in ("token", "key", "secret", "jwt", "cred", "auth")):
-        return "tokens"
-    return "other"
+def _coverage_label(rec: dict) -> str:
+    return {"full": f"{GRN}AI-reviewed{RST}",
+            "rules_only": f"{YEL}AI unavailable · rules-only{RST}",
+            "disabled": f"{DIM}rules-only{RST}"}.get(rec.get("ai_coverage", "disabled"), "")
 
 
-def _plural(n: int) -> str:
-    return "" if n == 1 else "s"
-
-
-def what_was_redacted(rec: dict) -> list[str]:
-    """Per-category redaction breakdown for a trace, using the web's category
-    labels (Secrets & credentials / Email addresses / File paths & usernames /
-    Timestamps coarsened / URLs) with the TruffleHog subset called out."""
-    b = rec["buckets"]
-    th = rec.get("th_hits", 0)
-    out: list[str] = []
-    if b["tokens"]:
-        label = "Secrets & credentials"
-        if th:
-            label += f" (incl. {th} via TruffleHog)"
-        out.append(f"{label}: {b['tokens']}")
-    if b["emails"]:
-        out.append(f"Email addresses: {b['emails']}")
-    if b["paths"]:
-        out.append(f"File paths & usernames: {b['paths']}")
-    if b["urls"]:
-        out.append(f"URLs: {b['urls']}")
-    if b["timestamps"]:
-        out.append(f"Timestamps coarsened: {b['timestamps']}")
-    if b["other"]:
-        out.append(f"Other: {b['other']}")
-    counts: dict[str, int] = {}
-    for f in rec.get("ai_findings") or []:
-        name = (f.get("entity_type") or "").replace("_", " ").strip() or "pii"
-        counts[name] = counts.get(name, 0) + 1
-    for name, c in sorted(counts.items(), key=lambda kv: -kv[1]):
-        out.append(f"AI-flagged {name}: {c}")
-    return out
-
-
-def trace_status(rec: dict) -> str:
-    """'clear' or 'review' — mirrors web `hi()`."""
-    cov = rec.get("ai_coverage", "disabled")
-    if cov in ("rules_only", "disabled"):
-        return "review"
-    if any((f.get("confidence", 0) or 0) < 0.85 for f in (rec.get("ai_findings") or [])):
-        return "review"
-    return "clear"
-
-
-# ---- time-range filtering (by last message / end_time) ----------------------
+# ---- time-range filtering ---------------------------------------------------
 
 def _parse_ts(ts):
-    """Parse an ISO timestamp into an aware datetime (mirrors index._parse_score_ts)."""
     if not isinstance(ts, str) or not ts.strip():
         return None
     try:
@@ -229,9 +154,7 @@ def _parse_ts(ts):
 
 
 def _in_time_range(row: dict, time_range: str) -> bool:
-    """True if the trace's LAST turn (end_time) falls in the range. Uses rolling
-    windows (not calendar boundaries) so the list doesn't empty out at midnight:
-    'today' = the past 24h, 'weekly' = the past 168h (7 days)."""
+    """Rolling windows (not calendar): 'today' = past 24h, 'weekly' = past 168h."""
     if time_range == "all":
         return True
     dt = _parse_ts(row.get("end_time")) or _parse_ts(row.get("start_time"))
@@ -245,12 +168,10 @@ def _in_time_range(row: dict, time_range: str) -> bool:
     return True
 
 
-# ---- LLM trace summaries (for titles) ---------------------------------------
+# ---- LLM trace summaries (for --summary titles) -----------------------------
 
 def summarize_trace(session_detail: dict, *, backend: str = "auto",
                     model: str | None = None) -> str:
-    """Return a short one-line title summarizing the whole trace, via
-    clawjournal's agent backend. Returns '' on any failure."""
     import tempfile
     from .scoring.backends import run_default_agent_task
     from .scoring.scoring import _anonymize_for_scoring, get_message_text
@@ -285,12 +206,8 @@ def summarize_trace(session_detail: dict, *, backend: str = "auto",
             tmp_path = Path(tmp)
             (tmp_path / "transcript.md").write_text(transcript, encoding="utf-8")
             result = run_default_agent_task(
-                backend=backend,
-                cwd=tmp_path,
-                task_prompt=prompt,
-                model=model,
-                timeout_seconds=60,
-                codex_sandbox="read-only",
+                backend=backend, cwd=tmp_path, task_prompt=prompt, model=model,
+                timeout_seconds=60, codex_sandbox="read-only",
                 openclaw_message=prompt + f"\nRead: {tmp_path / 'transcript.md'}",
             )
     except Exception:  # noqa: BLE001
@@ -298,12 +215,10 @@ def summarize_trace(session_detail: dict, *, backend: str = "auto",
     out = (result.stdout or "").strip()
     if not out:
         return ""
-    # Take the last non-empty line (agents sometimes print preamble first).
     title = [ln.strip() for ln in out.splitlines() if ln.strip()][-1]
     return title.strip().strip('"').strip("'")[:80]
 
 
-# Fast/cheap default model per backend for one-line title summaries.
 _LIGHT_SUMMARY_MODEL = {"claude": "haiku"}
 
 
@@ -327,13 +242,10 @@ def _save_title_cache(cache: dict) -> None:
 
 
 def ensure_titles(conn, rows: list[dict], do_summarize: bool, summary_model: str | None = None):
-    """Only runs with --summary. Fills an LLM summary title (in-memory + a local
-    clawshare cache, NOT the scoring column) for any listed trace that lacks a
-    real title. Summaries run concurrently with live progress and can be skipped
-    with Ctrl-C. Uses a light model per backend by default (e.g. claude/haiku)."""
+    """--summary only. Fills an LLM summary title (in-memory + a local clawshare
+    cache, NOT the scoring column). Concurrent with live progress; Ctrl-C skips."""
     if not do_summarize:
         return
-    # Reuse previously generated clawshare summaries from the local cache.
     cache = _load_title_cache()
     for r in rows:
         if not (r.get("ai_display_title") or "").strip():
@@ -346,23 +258,18 @@ def ensure_titles(conn, rows: list[dict], do_summarize: bool, summary_model: str
 
     import shutil
     from .scoring.backends import resolve_backend
-    # Summaries are a tiny side task — prefer claude/haiku (fast & cheap) whenever
-    # claude is installed, regardless of the main backend, unless an explicit
-    # --summary-model is given.
     if not summary_model and shutil.which("claude"):
         backend, model = "claude", "haiku"
     else:
         try:
             backend = resolve_backend("auto")
         except Exception:  # noqa: BLE001
-            print(f"  {DIM}(no agent backend available — using raw titles; "
-                  f"run `clawjournal score` or pass --no-summarize to silence){RST}")
+            print(f"  {DIM}(no agent backend available — using raw titles){RST}")
             return
         model = summary_model or _LIGHT_SUMMARY_MODEL.get(backend)
 
     label = f"{backend}/{model}" if model else backend
-    print(f"  {DIM}Summarizing {len(need)} title(s) with {label} "
-          f"— Ctrl-C to skip and keep raw titles…{RST}")
+    print(f"  {DIM}Summarizing {len(need)} title(s) with {label} — Ctrl-C to skip…{RST}")
     details = {r["session_id"]: get_session_detail(conn, r["session_id"]) for r in need}
 
     from concurrent.futures import as_completed
@@ -385,7 +292,7 @@ def ensure_titles(conn, rows: list[dict], do_summarize: bool, summary_model: str
             print(f"\r  {DIM}  …summarized {done}/{len(futures)}{RST}", end="", flush=True)
         print()
     except KeyboardInterrupt:
-        print(f"\n  {YEL}Skipped remaining summaries — keeping raw titles for those.{RST}")
+        print(f"\n  {YEL}Skipped remaining summaries.{RST}")
     finally:
         pool.shutdown(wait=False, cancel_futures=True)
 
@@ -404,14 +311,8 @@ def ensure_titles(conn, rows: list[dict], do_summarize: bool, summary_model: str
 
 def step_queue(conn, settings, args) -> list[dict]:
     step(1, "Queue — select traces")
-    rows = query_sessions(
-        conn,
-        status=args.status,
-        source=args.source,
-        limit=5000,
-        sort="end_time",
-        order="desc",
-    )
+    rows = query_sessions(conn, status=args.status, source=args.source,
+                          limit=5000, sort="end_time", order="desc")
     rows = [
         r for r in rows
         if not session_matches_excluded_projects(r, settings["excluded_projects"])
@@ -419,6 +320,18 @@ def step_queue(conn, settings, args) -> list[dict]:
         and not r.get("shared_at")
         and _in_time_range(r, args.time_range)
     ]
+    # extra queue filters (#4)
+    if args.project:
+        rows = [r for r in rows if args.project.lower() in (r.get("project") or "").lower()]
+    if args.min_failure_value is not None:
+        rows = [r for r in rows
+                if (r.get("ai_failure_value_score") or 0) >= args.min_failure_value]
+    if args.search:
+        q = args.search.lower()
+        rows = [r for r in rows if q in (
+            (r.get("display_title") or "") + " " + (r.get("ai_display_title") or "")
+            + " " + (r.get("project") or "")).lower()]
+
     if not rows:
         ranges = {"today": "the past 24h", "weekly": "the past 7 days", "all": "the index"}
         hint = "" if args.time_range == "all" else "  (try --weekly or --all)"
@@ -426,40 +339,48 @@ def step_queue(conn, settings, args) -> list[dict]:
 
     rows = rows[:args.limit]
     label = {"today": "past 24h", "weekly": "past 7 days", "all": "all time"}[args.time_range]
-    print(f"  {DIM}Showing {len(rows)} shareable trace(s) — {label}"
-          f" (limit {args.limit}; use --limit to change).{RST}")
+    unscored = sum(1 for r in rows if r.get("ai_failure_value_score") is None)
+    recommended = sum(1 for r in rows if (r.get("ai_failure_value_score") or 0) >= 4)
+    print(f"  {DIM}Showing {len(rows)} shareable trace(s) — {label} (limit {args.limit}).{RST}")
+    note = []
+    if recommended:
+        note.append(f"★ = recommended (failure value ≥4): {recommended}")
+    if unscored:
+        note.append(f"{unscored} unscored (run `clawjournal score` for value/title)")
+    if note:
+        print(f"  {DIM}{'  ·  '.join(note)}{RST}")
 
-    # Optionally summarize titles (--summary). Default is off for speed; without
-    # it, system-prompt-looking titles are hidden behind a placeholder instead.
     do_summary = args.summary or bool(args.summary_model)
     ensure_titles(conn, rows, do_summary, summary_model=args.summary_model)
     for r in rows:
         title = resolve_title(r, do_summary)
-        # In default mode, never surface a system-prompt title — fall back to the
-        # underlying user prompt (loads the trace only for those rows).
         if not do_summary and _looks_like_system_prompt(title):
             title = user_prompt_title(conn, r) or title
         r["_clawshare_title"] = title
 
-    print(f"\n  {'#':>3}  {'Last turn':<11} {'Source':<8} {'Msgs':>5} {'Tokens':>9} "
+    print(f"\n  {'#':>3} {'★':<1} {'Last turn':<11} {'Source':<8} {'Msgs':>5} {'Tokens':>9} "
           f"{'Tools':>5} {'Fail':>4}  Title")
-    print("  " + "-" * 108)
+    print("  " + "-" * 110)
     for i, r in enumerate(rows, 1):
         msgs = (r.get("user_messages") or 0) + (r.get("assistant_messages") or 0)
         toks = (r.get("input_tokens") or 0) + (r.get("output_tokens") or 0)
         tools = r.get("tool_uses") or 0
         fv = r.get("ai_failure_value_score")
         fv_str = str(fv) if fv is not None else "—"
+        star = "★" if (fv or 0) >= 4 else " "
         dt = _parse_ts(r.get("end_time"))
         when = dt.astimezone().strftime("%m-%d %H:%M") if dt else "—"
-        print(f"  {i:>3}  {when:<11} {r.get('source', ''):<8} "
+        print(f"  {i:>3} {star:<1} {when:<11} {r.get('source', ''):<8} "
               f"{msgs:>5} {toks:>9,} {tools:>5} {fv_str:>4}  {trace_title(r)}")
     print()
+    print(f"  {DIM}Tip: filter with --search/--project/--min-failure-value, widen with "
+          f"--weekly/--all, more with --limit.{RST}")
 
     if args.indices:
         idxs = args.indices
     else:
-        raw = ask(f"{BOLD}Enter trace #(s) to share{RST} (space/comma separated, e.g. 1 3 5): ")
+        raw = ask(f"{BOLD}Enter trace #(s) to share{RST} (space/comma separated; "
+                  f"order = bundle order): ")
         if not raw:
             die("Nothing selected.")
         try:
@@ -475,14 +396,9 @@ def step_queue(conn, settings, args) -> list[dict]:
     return chosen
 
 
-# ---- step 2: redact (scrub + optional preview) ------------------------------
+# ---- step 2: redact ---------------------------------------------------------
 
-def render_transcript(redacted_session: dict, max_msgs: int | None = None,
-                      max_chars: int = 2000):
-    """Print a scrubbed transcript. Empty / thinking-only messages (no textual
-    content) are skipped. Newlines are preserved; each message body is capped at
-    max_chars so one giant message can't flood the terminal. max_msgs=None shows
-    every message; otherwise only the first max_msgs are shown."""
+def render_transcript(redacted_session: dict, max_msgs: int | None = None, max_chars: int = 2000):
     all_msgs = redacted_session.get("messages") or []
     msgs, hidden = [], 0
     for m in all_msgs:
@@ -491,7 +407,6 @@ def render_transcript(redacted_session: dict, max_msgs: int | None = None,
             hidden += 1
             continue
         msgs.append(m)
-
     shown = msgs if max_msgs is None else msgs[:max_msgs]
     head = f"all {len(msgs)}" if max_msgs is None else f"first {len(shown)} of {len(msgs)}"
     note = f"({head} content message{_plural(len(msgs))}"
@@ -499,7 +414,6 @@ def render_transcript(redacted_session: dict, max_msgs: int | None = None,
         note += f", {hidden} empty/thinking hidden"
     note += " — already scrubbed)"
     print(f"  {DIM}{note}{RST}")
-
     for m in shown:
         role = m.get("role", "?")
         content = m["content"]
@@ -512,75 +426,66 @@ def render_transcript(redacted_session: dict, max_msgs: int | None = None,
         for ln in lines[1:]:
             print(f"             {ln}")
     if max_msgs is not None and len(msgs) > max_msgs:
-        print(f"  {DIM}… {len(msgs) - max_msgs} more message(s) — press [v] for the full transcript{RST}")
+        print(f"  {DIM}… {len(msgs) - max_msgs} more — press [v] for the full transcript{RST}")
 
 
-def step_redact(conn, settings, chosen: list[dict], assume_yes: bool, ai_pii: bool) -> list[dict]:
-    step(2, "Redact — scrub PII")
-    ai_fns = None
-    if ai_pii:
-        try:
-            from ..redaction.pii import review_session_pii_with_agent, apply_findings_to_session
-            ai_fns = (review_session_pii_with_agent, apply_findings_to_session)
-        except Exception:  # noqa: BLE001
-            ai_fns = None
-        print(f"  {DIM}AI PII review enabled — analysing each trace (may take a moment)…{RST}")
-
-    scrubbed = []
+def _build_records(conn, settings, chosen, ai_pii):
+    recs = []
     for r in chosen:
         detail = get_session_detail(conn, r["session_id"])
         if detail is None:
             die(f"Session {r['session_id']} not found.")
-        red, count, log = apply_share_redactions(
-            conn, detail,
-            custom_strings=settings["custom_strings"],
-            user_allowlist=settings["allowlist_entries"],
-            extra_usernames=settings["extra_usernames"],
-            blocked_domains=settings["blocked_domains"],
-        )
-        buckets = {k: 0 for k in ("tokens", "emails", "paths", "timestamps", "urls", "other")}
-        th_hits = 0
-        for e in log:
-            etype = e.get("type", "")
-            buckets[_bucket_for(etype)] += 1
-            if str(etype).lower().startswith("trufflehog"):
-                th_hits += 1
+        rec = build_redaction_record(conn, detail, settings, ai_pii)
+        rec["row"] = r
+        recs.append(rec)
+    return recs
 
-        ai_findings: list[dict] = []
-        ai_coverage = "disabled"
-        if ai_pii:
-            ai_coverage = "rules_only"
-            if ai_fns is not None:
-                review_fn, apply_fn = ai_fns
-                try:
-                    findings = review_fn(red, ignore_errors=False, backend="auto")
-                    ai_coverage = "full"
-                    if findings:
-                        red, ai_count = apply_fn(red, findings)
-                        count += ai_count
-                        ai_findings = findings
-                except Exception:  # noqa: BLE001
-                    ai_coverage = "rules_only"
 
-        rec = {"row": r, "redacted": red, "count": count, "buckets": buckets,
-               "th_hits": th_hits, "ai_findings": ai_findings, "ai_coverage": ai_coverage}
-        rec["status"] = trace_status(rec)
-        scrubbed.append(rec)
+def step_redact(conn, settings, chosen, assume_yes, ai_pii_requested) -> tuple[list[dict], bool]:
+    step(2, "Redact — scrub PII")
+    # AI on/off disclosure (#3)
+    if ai_pii_requested:
+        print(f"  {BOLD}AI PII review: ON{RST} {DIM}— each trace is analysed by an agent "
+              f"(may take a moment).{RST}")
+    else:
+        print(f"  {BOLD}AI PII review: OFF{RST} {DIM}— deterministic rules only "
+              f"(enable with --ai-pii-review).{RST}")
 
-    print(f"  {DIM}Redacting your traces — categories flagged per trace:{RST}")
+    scrubbed = _build_records(conn, settings, chosen, ai_pii_requested)
+    package_ai, uniform = effective_ai_pii(scrubbed, ai_pii_requested)
+
+    # Keep preview == shipped: if AI was requested but couldn't run everywhere,
+    # let the user retry or degrade ALL traces to rules-only before continuing (#2,#3).
+    while ai_pii_requested and not uniform:
+        n_missing = sum(1 for s in scrubbed if s.get("ai_coverage") != "full")
+        print(f"  {YEL}AI PII review was unavailable for {n_missing}/{len(scrubbed)} "
+              f"trace(s).{RST}")
+        choice = "p" if assume_yes else ask(
+            f"  {BOLD}[r]{RST}etry AI  {BOLD}[p]{RST}roceed rules-only "
+            f"(what you'll review is what ships)  {BOLD}[a]{RST}bort: ").lower()
+        if choice in ("r", "retry"):
+            scrubbed = _build_records(conn, settings, chosen, True)
+            package_ai, uniform = effective_ai_pii(scrubbed, True)
+        elif choice in ("a", "abort"):
+            die("Aborted before packaging.")
+        else:  # proceed rules-only — rebuild uniformly so the preview matches
+            scrubbed = _build_records(conn, settings, chosen, False)
+            package_ai = False
+            print(f"  {DIM}Proceeding rules-only.{RST}")
+            break
+
+    print(f"\n  {DIM}Redacting your traces — categories flagged per trace:{RST}")
     for i, s in enumerate(scrubbed, 1):
-        verdict = (f"{GRN}clear{RST}" if s["status"] == "clear"
-                   else f"{YEL}needs review{RST}")
-        print(f"\n  {BOLD}[{i}]{RST} {verdict} · {s['count']} redaction{_plural(s['count'])}"
-              f" · {trace_title(s['row'])}")
-        cats = what_was_redacted(s)
+        verdict = (f"{GRN}clear{RST}" if s["status"] == "clear" else f"{YEL}needs review{RST}")
+        print(f"\n  {BOLD}[{i}]{RST} {verdict} · {_coverage_label(s)} · "
+              f"{s['count']} redaction{_plural(s['count'])} · {trace_title(s['row'])}")
+        cats = category_breakdown(s)
         if cats:
             for c in cats:
                 print(f"        {DIM}•{RST} {c}")
         else:
             print(f"        {DIM}nothing matched the deterministic rules{RST}")
 
-    # OPTIONAL preview — skippable
     if not assume_yes:
         while True:
             raw = ask(f"\n{BOLD}Preview a scrubbed transcript?{RST} "
@@ -596,15 +501,14 @@ def step_redact(conn, settings, chosen: list[dict], assume_yes: bool, ai_pii: bo
             print()
             render_transcript(scrubbed[n - 1]["redacted"])
     print(f"{GRN}✓ scrubbed {len(scrubbed)} trace(s){RST}")
-    return scrubbed
+    return scrubbed, package_ai
 
 
-# ---- step 3: review ---------------------------------------------------------
+# ---- step 3: review (share-local; does NOT mutate review_status) ------------
 
 def _show_redaction_detail(rec: dict):
-    """Print the 'What was redacted' panel for one trace (mirrors web `gi()`)."""
-    items = what_was_redacted(rec)
-    print(f"  {BOLD}What was redacted:{RST}")
+    items = category_breakdown(rec)
+    print(f"  {BOLD}What was redacted{RST} ({_coverage_label(rec)}):")
     if items:
         for it in items:
             print(f"    • {it}")
@@ -618,8 +522,10 @@ def _show_redaction_detail(rec: dict):
 
 
 def step_review(conn, scrubbed: list[dict], assume_yes: bool) -> list[dict]:
-    step(3, "Review — inspect & approve before packaging")
-    print(f"  {'#':>3}  {'Status':<14} Title")
+    step(3, "Review — inspect & include before packaging")
+    print(f"  {DIM}Including a trace here affects this bundle only — it does not change "
+          f"its local review status.{RST}")
+    print(f"\n  {'#':>3}  {'Status':<14} Title")
     print("  " + "-" * 80)
     for i, s in enumerate(scrubbed, 1):
         verdict = (f"{GRN}clear{RST}        " if s["status"] == "clear"
@@ -628,24 +534,18 @@ def step_review(conn, scrubbed: list[dict], assume_yes: bool) -> list[dict]:
 
     clear = [s for s in scrubbed if s["status"] == "clear"]
     review = [s for s in scrubbed if s["status"] != "clear"]
-    approved_ids: set[str] = set()
+    included_ids: set[str] = set()
 
     if assume_yes:
-        # Non-interactive: include everything.
-        approved_ids = {s["row"]["session_id"] for s in scrubbed}
+        included_ids = {s["row"]["session_id"] for s in scrubbed}
     else:
-        # Clean traces may be bulk-included (mirrors "Include all clean").
         if clear and yesno(f"\n{BOLD}Include all {len(clear)} clear trace(s)?{RST}", default_yes=True):
-            approved_ids |= {s["row"]["session_id"] for s in clear}
-
-        # Needs-review traces MUST be inspected & decided individually.
+            included_ids |= {s["row"]["session_id"] for s in clear}
         if review:
             print(f"\n  {YEL}{len(review)} trace(s) need review — inspect each before packaging.{RST}")
             for n, s in enumerate(review, 1):
                 print(f"\n{CYN}  ── review {n}/{len(review)} ─ {trace_title(s['row'], 60)}{RST}")
                 _show_redaction_detail(s)
-                # Always show a short preview so the user knows which trace this is,
-                # even when nothing was redacted.
                 print(f"  {BOLD}Preview:{RST}")
                 render_transcript(s["redacted"], max_msgs=6, max_chars=700)
                 while True:
@@ -656,7 +556,7 @@ def step_review(conn, scrubbed: list[dict], assume_yes: bool) -> list[dict]:
                         render_transcript(s["redacted"])
                         continue
                     if choice in ("i", "include", "y", "yes"):
-                        approved_ids.add(s["row"]["session_id"])
+                        included_ids.add(s["row"]["session_id"])
                         print(f"  {GRN}✓ included{RST}")
                         break
                     if choice in ("r", "remove", "n", "no", "skip"):
@@ -664,116 +564,123 @@ def step_review(conn, scrubbed: list[dict], assume_yes: bool) -> list[dict]:
                         break
                     print(f"  {YEL}Please enter v, i, or r.{RST}")
 
-    approved = [s for s in scrubbed if s["row"]["session_id"] in approved_ids]
-    if not approved:
+    included = [s for s in scrubbed if s["row"]["session_id"] in included_ids]
+    if not included:
         die("No traces included — nothing to package.")
-
-    for s in approved:
-        if s["row"].get("review_status") != "approved":
-            update_session(conn, s["row"]["session_id"], status="approved", reason="clawshare CLI review")
-    conn.commit()
-    dropped = len(scrubbed) - len(approved)
-    print(f"{GRN}✓ {len(approved)} trace(s) approved"
+    dropped = len(scrubbed) - len(included)
+    print(f"{GRN}✓ {len(included)} trace(s) included"
           + (f", {dropped} dropped" if dropped else "") + RST)
-    return approved
+    return included
 
 
-# ---- step 4: package --------------------------------------------------------
+# ---- step 4: package (with blocked-trace removal/retry, #7) -----------------
 
-def step_package(conn, settings, approved: list[dict], ai_pii: bool, args):
+def step_package(conn, settings, included: list[dict], package_ai: bool, args):
     step(4, "Package — create + seal bundle")
-    session_ids = [s["row"]["session_id"] for s in approved]
+    recs = list(included)
+    while True:
+        session_ids = [s["row"]["session_id"] for s in recs]
+        blockers = gate_blockers(conn, session_ids)
+        if blockers:
+            print(f"{RED}Release gate blocked these traces (hold/embargo):{RST}")
+            for b in blockers:
+                print(f"  • {b.get('session_id', '?')[:12]}  {b.get('reason', '')}")
+            die("Resolve hold/embargo state (e.g. `clawjournal release <id>`) and retry.")
 
-    blockers = release_gate_blockers(conn, session_ids)
-    if blockers:
-        print(f"{RED}Release gate blocked these traces:{RST}")
-        for b in blockers:
-            print(f"  • {b.get('session_id', '?')[:12]}  {b.get('reason', b)}")
-        die("Resolve hold/embargo state (e.g. `clawjournal release <id>`) and retry.")
+        print(f"  {DIM}sealing… (redact → TruffleHog → PII pass → re-scan){RST}")
+        res = share_flow.package(conn, session_ids, settings, ai_pii=package_ai, note=args.note)
+        if res["ok"]:
+            export_dir, manifest, share_id = res["export_dir"], res["manifest"], res["share_id"]
+            try:
+                zip_size = len(build_zip(export_dir))
+            except Exception:  # noqa: BLE001
+                zip_size = 0
+            print(f"{GRN}✓ packaged{RST}")
+            print(f"  bundle:   {share_id[:8]}   sessions: {len(manifest.get('sessions', []))}")
+            print(f"  path:     {export_dir}")
+            print(f"  zip size: {zip_size / 1024:.1f} KiB")
+            rsum = manifest.get("redaction_summary", {})
+            if rsum:
+                print(f"  privacy:  {DIM}{rsum}{RST}")
+            return share_id, export_dir
 
-    share_id = create_share(conn, session_ids, note=args.note)
-    share = get_share(conn, share_id)
-    if share is None:
-        die("Share row could not be loaded after creation.")
-
-    print(f"  {DIM}sealing… (redact → TruffleHog → PII pass → re-scan){RST}")
-    export_dir, manifest, error = _prepare_share_export_for_upload(
-        conn, share_id, share, settings,
-        reuse_finalized=True, ai_pii_review_enabled=ai_pii,
-    )
-    if error:
-        msg = error.get("error", "Packaging failed.")
-        blocked = error.get("blocked_sessions") or []
+        blocked = res.get("blocked_sessions") or []
         if blocked:
-            print(f"{RED}Packaging blocked — secrets detected in:{RST}")
-            for sid in blocked:
-                print(f"  • {sid[:12] if isinstance(sid, str) else sid}")
-            die("Remove/redact the flagged trace(s) and retry.")
-        die(msg)
-    if export_dir is None:
-        die("Packaging failed: no bundle produced.")
-    if manifest.get("blocked"):
-        print(f"{RED}Bundle marked blocked: {manifest.get('blocked_sessions')}{RST}")
-        die("Cannot submit a blocked bundle.")
-
-    try:
-        zip_size = len(_build_share_zip(export_dir))
-    except Exception:
-        zip_size = 0
-    rsum = manifest.get("redaction_summary", {})
-    print(f"{GRN}✓ packaged{RST}")
-    print(f"  bundle:   {share_id[:8]}   sessions: {len(manifest.get('sessions', []))}")
-    print(f"  path:     {export_dir}")
-    print(f"  zip size: {zip_size / 1024:.1f} KiB")
-    if rsum:
-        print(f"  privacy:  {DIM}{rsum}{RST}")
-    return share_id, export_dir
+            blocked_ids = {b if isinstance(b, str) else b.get("session_id") for b in blocked}
+            print(f"{RED}Packaging blocked — secrets/PII detected in:{RST}")
+            for s in recs:
+                if s["row"]["session_id"] in blocked_ids:
+                    print(f"  • {s['row']['session_id'][:12]}  {trace_title(s['row'], 50)}")
+            remaining = [s for s in recs if s["row"]["session_id"] not in blocked_ids]
+            if not remaining:
+                die("All included traces were blocked — nothing to package.")
+            if args.yes or yesno(f"  Remove the {len(blocked_ids)} blocked trace(s) and retry "
+                                 f"with the remaining {len(remaining)}?", default_yes=True):
+                recs = remaining
+                continue
+            die("Aborted — blocked traces not removed.")
+        die(res.get("error", "Packaging failed."))
 
 
-# ---- step 5: submit (accept terms) ------------------------------------------
+# ---- step 5: submit (explicit consent #6; hosted fallback #8) ---------------
 
-def ensure_email(assume_yes: bool):
-    st = hosted_upload_status()
+def _ensure_email(assume_yes: bool) -> bool:
+    st = share_flow.upload_status()
     if st.get("token_valid"):
         print(f"  {GRN}✓ upload token valid for {st['verified_email']}{RST}")
-        return
+        return True
+    if assume_yes:
+        print(f"  {YEL}No valid upload token (email verification is interactive). "
+              f"Skipping submit.{RST}")
+        return False
     print(f"  {YEL}Upload token missing/expired — verify your academic email.{RST}")
     default_email = st.get("verified_email") or ""
     email = ask(f"  Academic email{f' [{default_email}]' if default_email else ''}: ", default_email)
     if not email:
-        die("Email required for hosted submission.")
+        print(f"  {YEL}No email — skipping submit.{RST}")
+        return False
     try:
-        request_email_verification(email)
+        share_flow.request_email_verification(email)
     except Exception as exc:  # noqa: BLE001
-        die(f"Could not send verification code: {exc}")
+        print(f"  {RED}Could not send verification code: {exc}{RST}")
+        return False
     print(f"  {DIM}A 6-digit code was emailed to {email}.{RST}")
     code = ask("  Enter the code: ")
     if not code:
-        die("No code entered.")
+        return False
     try:
-        confirm_email_verification(email, code)
+        share_flow.confirm_email_verification(email, code)
     except Exception as exc:  # noqa: BLE001
-        die(f"Verification failed: {exc}")
-    if not hosted_upload_status().get("token_valid"):
-        die("Verification did not yield a valid token.")
-    print(f"  {GRN}✓ email verified{RST}")
+        print(f"  {RED}Verification failed: {exc}{RST}")
+        return False
+    return bool(share_flow.upload_status().get("token_valid"))
 
 
-def step_submit(conn, settings, share_id: str, ai_pii: bool, assume_yes: bool):
-    step(5, "Submit — accept terms & upload")
+def step_submit(conn, settings, share_id: str, package_ai: bool, args):
+    step(5, "Submit — consent & upload")
+
+    # #8: check destination; fall back to download-only when hosted isn't available.
+    dest = hosted_destination()
+    if not dest["can_submit"]:
+        print(f"  {YEL}{dest.get('message') or 'Hosted submission is unavailable.'}{RST}")
+        if dest.get("support_contact"):
+            print(f"  {DIM}Support: {dest['support_contact']}{RST}")
+        print(f"  {DIM}→ Bundle is packaged; you can still download it below.{RST}")
+        return None
+
     try:
-        doc = fetch_hosted_consent()
+        doc = share_flow.consent()
     except Exception as exc:  # noqa: BLE001
-        die(f"Could not load consent terms: {exc}")
+        print(f"  {YEL}Could not load consent terms ({exc}) — skipping submit; "
+              f"download still available.{RST}")
+        return None
     cv = doc.get("consent_version") or ""
     rv = doc.get("retention_policy_version") or ""
-    if not cv or not rv:
-        die("Hosted service did not return consent/retention versions.")
-
     consent_text = (doc.get("consent_text") or "").strip()
     retention_text = (doc.get("retention_text") or "").strip()
-    if not consent_text and not retention_text:
-        die("Hosted service did not return the consent terms text.")
+    if not cv or not rv or not (consent_text or retention_text):
+        print(f"  {YEL}Hosted service did not return consent terms — skipping submit.{RST}")
+        return None
 
     print(f"\n  {BOLD}Consent and retention{RST}  {DIM}(consent {cv} · retention {rv}){RST}")
     print(f"  {DIM}{'─' * 60}{RST}")
@@ -786,7 +693,15 @@ def step_submit(conn, settings, share_id: str, ai_pii: bool, assume_yes: bool):
         print()
     print(f"  {DIM}{'─' * 60}{RST}")
 
-    if not assume_yes:
+    # #6: consent must be explicit. -y/--yes does NOT auto-accept.
+    if args.accept_terms and args.certify_ownership:
+        print(f"  {DIM}Consent provided via --accept-terms --certify-ownership.{RST}")
+    elif args.yes:
+        print(f"  {YEL}Consent is required and is never auto-accepted by --yes. "
+              f"Re-run with --accept-terms --certify-ownership, or run interactively. "
+              f"Bundle packaged but not submitted.{RST}")
+        return None
+    else:
         if not yesno(f"  {BOLD}I accept the displayed consent and data-use terms.{RST}"):
             print(f"{YEL}Terms not accepted — bundle packaged but not submitted.{RST}")
             return None
@@ -795,24 +710,26 @@ def step_submit(conn, settings, share_id: str, ai_pii: bool, assume_yes: bool):
             print(f"{YEL}Ownership not certified — bundle packaged but not submitted.{RST}")
             return None
 
-    ensure_email(assume_yes)
+    if not _ensure_email(args.yes):
+        return None
+
     print(f"  {DIM}uploading to hosted research…{RST}")
-    result = submit_share_to_hosted(
-        conn, share_id,
-        accept_terms=True, ownership_certification=True,
-        consent_version=cv, retention_policy_version=rv,
-        settings=settings, ai_pii_review_enabled=ai_pii,
+    result = share_flow.submit(
+        conn, share_id, accept_terms=True, ownership_certification=True,
+        consent_version=cv, retention_policy_version=rv, settings=settings, ai_pii=package_ai,
     )
     if not result.get("ok"):
         suffix = f"  (status {result['status']})" if result.get("status") else ""
-        die(result.get("error", "Upload failed.") + suffix)
+        print(f"  {RED}Upload failed: {result.get('error', 'unknown')}{suffix}{RST}")
+        print(f"  {DIM}→ Bundle is packaged; you can still download it below.{RST}")
+        return None
     print(f"  {GRN}✓ uploaded{RST}")
     return result
 
 
 # ---- step 6: done (+ optional download) -------------------------------------
 
-def step_done(share_id: str, export_dir: Path, result, assume_yes: bool):
+def step_done(share_id: str, export_dir: Path, result, assume_yes: bool, download_default: bool):
     step(6, "Done")
     if result:
         print(f"  {GRN}{BOLD}✓ Shared to hosted research!{RST}")
@@ -824,13 +741,14 @@ def step_done(share_id: str, export_dir: Path, result, assume_yes: bool):
         print(f"  {YEL}Bundle packaged but not submitted.{RST}")
     print(f"  bundle dir: {export_dir}")
 
-    # OPTIONAL download of the zip — single prompt so a stray "y" can't become
-    # the filename: Enter/y = default path, n = skip, anything else = a path.
     fname = f"clawjournal-share-{share_id[:8]}.zip"
     default = Path("~/Downloads").expanduser() / fname
     if assume_yes:
+        if not download_default:
+            return
         dest = default
     else:
+        # Default to yes when there's no hosted receipt (download is the outcome).
         ans = ask(f"\n  {BOLD}Download the bundle zip?{RST} "
                   f"{DIM}[Enter/y = {default}, n = skip, or type a path]{RST}\n  > ").strip()
         low = ans.lower()
@@ -840,7 +758,7 @@ def step_done(share_id: str, export_dir: Path, result, assume_yes: bool):
     if dest.is_dir() or str(dest).endswith(os.sep):
         dest = dest / fname
     try:
-        data = _build_share_zip(export_dir)
+        data = build_zip(export_dir)
         dest.parent.mkdir(parents=True, exist_ok=True)
         dest.write_bytes(data)
         print(f"  {GRN}✓ saved {len(data) / 1024:.1f} KiB → {dest}{RST}")
@@ -848,69 +766,95 @@ def step_done(share_id: str, export_dir: Path, result, assume_yes: bool):
         print(f"  {RED}Download failed: {exc}{RST}")
 
 
-# ---- arg wiring (single source of truth) ------------------------------------
+# ---- arg wiring -------------------------------------------------------------
 
-def add_share_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
-    """Define the clawshare wizard flags. Shared by the `clawshare` console
-    script and the `clawjournal share-cli` subcommand."""
-    parser.add_argument("indices", nargs="*", type=int,
-                        help="trace #(s) from the list (non-interactive)")
-    # Time range — default is today (last turn happened today).
+def add_interactive_flags(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Interactive-wizard options (no positional, no --status/--note/--ai-pii-review,
+    which the `share` subcommand already defines). Reused by both entry points."""
     when = parser.add_mutually_exclusive_group()
     when.add_argument("--weekly", dest="time_range", action="store_const", const="weekly",
                       help="traces from the past 7 days (default: past 24h)")
     when.add_argument("--all", dest="time_range", action="store_const", const="all",
-                      help="all traces, any date and any status")
+                      help="all traces, any date")
     parser.set_defaults(time_range="today")
-    parser.add_argument("--status", default=None,
-                        choices=["new", "shortlisted", "approved", "blocked"],
-                        help="filter by review status (default: any)")
     src = parser.add_mutually_exclusive_group()
-    src.add_argument("--source", default=None,
-                     help="only this source (claude, codex, gemini, …)")
+    src.add_argument("--source", default=None, help="only this source (claude, codex, …)")
     src.add_argument("--codex", dest="source", action="store_const", const="codex",
-                     help="only Codex traces (shortcut for --source codex)")
+                     help="only Codex traces")
     src.add_argument("--claude", dest="source", action="store_const", const="claude",
-                     help="only Claude traces (shortcut for --source claude)")
-    parser.add_argument("--limit", type=int, default=40,
-                        help="max traces to list (default 40)")
+                     help="only Claude traces")
+    parser.add_argument("--search", default=None, metavar="TEXT",
+                        help="only traces whose title/project contains TEXT")
+    parser.add_argument("--project", default=None, help="only traces in this project")
+    parser.add_argument("--min-failure-value", type=int, default=None, metavar="N",
+                        help="only traces with failure value >= N (1-5)")
+    parser.add_argument("--limit", type=int, default=40, help="max traces to list (default 40)")
     parser.add_argument("--summary", action="store_true",
-                        help="show AI-summarized titles (Haiku); default shows the "
-                             "original, non-AI titles (faster)")
+                        help="show AI-summarized titles (Haiku); default shows original titles")
     parser.add_argument("--summary-model", default=None, metavar="MODEL",
-                        help="model for --summary titles (default: a light model per "
-                             "backend, e.g. claude/haiku; implies --summary)")
-    parser.add_argument("--note", default=None, help="optional submission note")
-    parser.add_argument("--ai-pii-review", action="store_true",
-                        help="run AI-assisted PII pass during packaging")
+                        help="model for --summary titles (implies --summary)")
+    parser.add_argument("--accept-terms", action="store_true",
+                        help="non-interactively accept the hosted consent/data-use terms")
+    parser.add_argument("--certify-ownership", action="store_true",
+                        help="non-interactively certify the bundle is yours to submit")
+    parser.add_argument("--download", action="store_true",
+                        help="with --yes, also write the bundle zip to ~/Downloads")
     parser.add_argument("-y", "--yes", action="store_true",
-                        help="assume yes for preview-skip / review / terms / download prompts")
+                        help="assume yes for preview/review/download prompts (NOT consent)")
     return parser
 
 
+def add_share_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
+    """Full flag set for the standalone `clawshare` alias."""
+    parser.add_argument("indices", nargs="*", type=int,
+                        help="trace #(s) from the list (non-interactive)")
+    parser.add_argument("--status", default=None,
+                        choices=["new", "shortlisted", "approved", "blocked"],
+                        help="filter by review status (default: any)")
+    parser.add_argument("--note", default=None, help="optional submission note")
+    parser.add_argument("--ai-pii-review", action="store_true",
+                        help="run an AI-assisted PII pass (preview + packaging stay consistent)")
+    add_interactive_flags(parser)
+    return parser
+
+
+def _normalize_indices(args):
+    """Accept indices either as the wizard's int positional or as `share`'s
+    string `session_ids` positional (interpreted as list #s)."""
+    if getattr(args, "indices", None):
+        return
+    raw = getattr(args, "session_ids", None) or []
+    try:
+        args.indices = [int(x) for x in raw]
+    except (TypeError, ValueError):
+        die("Interactive selectors must be the trace #s shown in the list.")
+
+
 def run(args) -> None:
-    """Run the full 6-step share wizard against a parsed argparse namespace."""
+    """Run the interactive share wizard against a parsed argparse namespace."""
+    _normalize_indices(args)
     config = load_config()
     conn = open_index()
     try:
         settings = get_effective_share_settings(conn, config)
-        ai_pii = bool(args.ai_pii_review or settings.get("ai_pii_review_enabled"))
+        ai_pii_requested = bool(args.ai_pii_review or settings.get("ai_pii_review_enabled"))
         chosen = step_queue(conn, settings, args)
-        scrubbed = step_redact(conn, settings, chosen, args.yes, ai_pii)
-        approved = step_review(conn, scrubbed, args.yes)
-        share_id, export_dir = step_package(conn, settings, approved, ai_pii, args)
-        result = step_submit(conn, settings, share_id, ai_pii, args.yes)
-        step_done(share_id, export_dir, result, args.yes)
+        scrubbed, package_ai = step_redact(conn, settings, chosen, args.yes, ai_pii_requested)
+        included = step_review(conn, scrubbed, args.yes)
+        share_id, export_dir = step_package(conn, settings, included, package_ai, args)
+        result = step_submit(conn, settings, share_id, package_ai, args)
+        step_done(share_id, export_dir, result, args.yes,
+                  download_default=getattr(args, "download", False) or result is None)
     finally:
         conn.close()
 
 
 def main(argv: list[str] | None = None) -> None:
-    """Console-script entry point for the standalone `clawshare` command."""
+    """Console-script entry point for the thin `clawshare` alias."""
     parser = argparse.ArgumentParser(
         prog="clawshare",
-        description="Full ClawJournal Share wizard, keyboard-only "
-                    "(queue → redact → review → package → submit → done).",
+        description="Interactive ClawJournal Share wizard "
+                    "(alias for `clawjournal share --interactive`).",
     )
     add_share_cli_args(parser)
     run(parser.parse_args(argv))

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -15,8 +15,8 @@ Exposed two ways (both ship with the package):
     clawjournal share-cli     # subcommand alias
 
 Usage:
-    clawshare                      # past 24h of traces (default, fast; no LLM summaries)
-    clawshare --summary            # generate LLM summary titles (Haiku)
+    clawshare                      # past 24h; original (non-AI) titles, fast
+    clawshare --summary            # AI-summarized titles (Haiku)
     clawshare --weekly             # past 7 days (168h) of traces
     clawshare --all                # every trace, any date/status
     clawshare --codex              # only Codex traces
@@ -100,7 +100,8 @@ _SYS_PROMPT_PREFIXES = (
     "you are", "you're", "your task", "act as", "system:", "<",
     "base directory for this skill", "# ",
 )
-_NO_TITLE = "⟨no summary — run with --summary⟩"
+_NO_TITLE = "⟨system prompt — run with --summary for a title⟩"
+_NO_AI_TITLE = "⟨no AI summary⟩"
 
 
 def _looks_like_system_prompt(text: str) -> bool:
@@ -110,19 +111,29 @@ def _looks_like_system_prompt(text: str) -> bool:
     return s.startswith(_SYS_PROMPT_PREFIXES) or "you are an ai" in s[:40]
 
 
-def trace_title(r: dict, width: int = 52) -> str:
-    """Best title for a trace. Prefers an LLM summary (ai_display_title); falls
-    back to the raw first-message title — but never shows a system prompt, since
-    that tells the user nothing about the trace."""
-    ai = (r.get("ai_display_title") or "").strip()
-    if ai:
-        t = ai
-    else:
+def resolve_title(r: dict, summarized: bool) -> str:
+    """Title to display for a trace, by mode:
+    - default (summarized=False): the original, NON-AI title (raw first message);
+      a system-prompt-looking title is hidden behind a placeholder.
+    - --summary (summarized=True): the AI-summarized title — scoring's
+      ai_display_title, or a clawshare summary ensure_titles placed on the row."""
+    if summarized:
+        ai = (r.get("ai_display_title") or "").strip()
+        if ai:
+            return ai
         raw = (r.get("display_title") or "").strip().replace("\n", " ")
-        if _looks_like_system_prompt(raw):
-            return _NO_TITLE
-        t = raw
-    t = t.replace("\n", " ")
+        return _NO_AI_TITLE if _looks_like_system_prompt(raw) else raw
+    raw = (r.get("display_title") or "").strip().replace("\n", " ")
+    return _NO_TITLE if _looks_like_system_prompt(raw) else raw
+
+
+def trace_title(r: dict, width: int = 52) -> str:
+    """Truncated title for display. Uses the mode-aware title precomputed onto
+    the row (``_clawshare_title``); falls back to the raw/original title."""
+    t = r.get("_clawshare_title")
+    if t is None:
+        t = resolve_title(r, False)
+    t = (t or "").replace("\n", " ")
     return (t[: width - 1] + "…") if len(t) > width else t
 
 
@@ -408,6 +419,8 @@ def step_queue(conn, settings, args) -> list[dict]:
     # it, system-prompt-looking titles are hidden behind a placeholder instead.
     do_summary = args.summary or bool(args.summary_model)
     ensure_titles(conn, rows, do_summary, summary_model=args.summary_model)
+    for r in rows:
+        r["_clawshare_title"] = resolve_title(r, do_summary)
 
     print(f"\n  {'#':>3}  {'Last turn':<11} {'Source':<8} {'Msgs':>5} {'Tokens':>9} "
           f"{'Tools':>5} {'Fail':>4}  Title")
@@ -843,7 +856,8 @@ def add_share_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     parser.add_argument("--limit", type=int, default=40,
                         help="max traces to list (default 40)")
     parser.add_argument("--summary", action="store_true",
-                        help="generate LLM summary titles (Haiku; default: off, faster)")
+                        help="show AI-summarized titles (Haiku); default shows the "
+                             "original, non-AI titles (faster)")
     parser.add_argument("--summary-model", default=None, metavar="MODEL",
                         help="model for --summary titles (default: a light model per "
                              "backend, e.g. claude/haiku; implies --summary)")

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -309,46 +309,49 @@ def ensure_titles(conn, rows: list[dict], do_summarize: bool, summary_model: str
 
 # ---- step 1: queue ----------------------------------------------------------
 
-def step_queue(conn, settings, args) -> list[dict]:
-    step(1, "Queue — select traces")
-    rows = query_sessions(conn, status=args.status, source=args.source,
-                          limit=5000, sort="end_time", order="desc")
-    rows = [
+def select_queue_rows(rows: list[dict], settings: dict, args) -> list[dict]:
+    """Filter to shareable, in-window traces (+ optional search/project/min-fv),
+    then rank by failure value descending with unscored (None) last — the web
+    Queue ordering. Returns at most args.limit rows."""
+    out = [
         r for r in rows
         if not session_matches_excluded_projects(r, settings["excluded_projects"])
         and r.get("hold_state") in (None, "auto_redacted", "released")
         and not r.get("shared_at")
         and _in_time_range(r, args.time_range)
     ]
-    # extra queue filters (#4)
     if args.project:
-        rows = [r for r in rows if args.project.lower() in (r.get("project") or "").lower()]
+        out = [r for r in out if args.project.lower() in (r.get("project") or "").lower()]
     if args.min_failure_value is not None:
-        rows = [r for r in rows
-                if (r.get("ai_failure_value_score") or 0) >= args.min_failure_value]
+        out = [r for r in out if (r.get("ai_failure_value_score") or 0) >= args.min_failure_value]
     if args.search:
         q = args.search.lower()
-        rows = [r for r in rows if q in (
+        out = [r for r in out if q in (
             (r.get("display_title") or "") + " " + (r.get("ai_display_title") or "")
             + " " + (r.get("project") or "")).lower()]
+    out.sort(key=lambda r: (r.get("ai_failure_value_score") is None,
+                            -(r.get("ai_failure_value_score") or 0)))
+    return out[:args.limit]
 
+
+def step_queue(conn, settings, args) -> list[dict]:
+    step(1, "Queue — select traces")
+    # Fetch recent candidates (so time windows are accurate), then rank by value.
+    candidates = query_sessions(conn, status=args.status, source=args.source,
+                                limit=5000, sort="end_time", order="desc")
+    rows = select_queue_rows(candidates, settings, args)
     if not rows:
         ranges = {"today": "the past 24h", "weekly": "the past 7 days", "all": "the index"}
         hint = "" if args.time_range == "all" else "  (try --weekly or --all)"
         die(f"No shareable traces found in {ranges[args.time_range]}.{hint}")
 
-    rows = rows[:args.limit]
     label = {"today": "past 24h", "weekly": "past 7 days", "all": "all time"}[args.time_range]
     unscored = sum(1 for r in rows if r.get("ai_failure_value_score") is None)
-    recommended = sum(1 for r in rows if (r.get("ai_failure_value_score") or 0) >= 4)
-    print(f"  {DIM}Showing {len(rows)} shareable trace(s) — {label} (limit {args.limit}).{RST}")
-    note = []
-    if recommended:
-        note.append(f"★ = recommended (failure value ≥4): {recommended}")
+    print(f"  {DIM}Showing {len(rows)} shareable trace(s) — {label}, ranked by failure "
+          f"value (limit {args.limit}).{RST}")
     if unscored:
-        note.append(f"{unscored} unscored (run `clawjournal score` for value/title)")
-    if note:
-        print(f"  {DIM}{'  ·  '.join(note)}{RST}")
+        print(f"  {DIM}{unscored} unscored (run `clawjournal score` for value/title); "
+              f"listed last.{RST}")
 
     do_summary = args.summary or bool(args.summary_model)
     ensure_titles(conn, rows, do_summary, summary_model=args.summary_model)
@@ -358,20 +361,19 @@ def step_queue(conn, settings, args) -> list[dict]:
             title = user_prompt_title(conn, r) or title
         r["_clawshare_title"] = title
 
-    print(f"\n  {'#':>3} {'★':<1} {'Last turn':<11} {'Source':<8} {'Msgs':>5} {'Tokens':>9} "
-          f"{'Tools':>5} {'Fail':>4}  Title")
-    print("  " + "-" * 110)
+    print(f"\n  {'#':>3}  {'Fail':>4} {'Last turn':<11} {'Source':<8} {'Msgs':>5} "
+          f"{'Tokens':>9} {'Tools':>5}  Title")
+    print("  " + "-" * 108)
     for i, r in enumerate(rows, 1):
         msgs = (r.get("user_messages") or 0) + (r.get("assistant_messages") or 0)
         toks = (r.get("input_tokens") or 0) + (r.get("output_tokens") or 0)
         tools = r.get("tool_uses") or 0
         fv = r.get("ai_failure_value_score")
         fv_str = str(fv) if fv is not None else "—"
-        star = "★" if (fv or 0) >= 4 else " "
         dt = _parse_ts(r.get("end_time"))
         when = dt.astimezone().strftime("%m-%d %H:%M") if dt else "—"
-        print(f"  {i:>3} {star:<1} {when:<11} {r.get('source', ''):<8} "
-              f"{msgs:>5} {toks:>9,} {tools:>5} {fv_str:>4}  {trace_title(r)}")
+        print(f"  {i:>3}  {fv_str:>4} {when:<11} {r.get('source', ''):<8} "
+              f"{msgs:>5} {toks:>9,} {tools:>5}  {trace_title(r)}")
     print()
     print(f"  {DIM}Tip: filter with --search/--project/--min-failure-value, widen with "
           f"--weekly/--all, more with --limit.{RST}")
@@ -729,6 +731,19 @@ def step_submit(conn, settings, share_id: str, package_ai: bool, args):
 
 # ---- step 6: done (+ optional download) -------------------------------------
 
+def _resolve_download_dest(ans: str, default: Path, fname: str):
+    """Resolve the download prompt answer to a destination Path, or None to skip.
+    Enter/y/yes = default; n/no/skip = None; anything else = a path (a directory
+    gets the filename appended). Guards against a stray 'y' becoming the filename."""
+    low = ans.strip().lower()
+    if low in ("n", "no", "q", "skip"):
+        return None
+    dest = default if low in ("", "y", "yes") else Path(ans.strip()).expanduser()
+    if dest.is_dir() or str(dest).endswith(os.sep):
+        dest = dest / fname
+    return dest
+
+
 def step_done(share_id: str, export_dir: Path, result, assume_yes: bool, download_default: bool):
     step(6, "Done")
     if result:
@@ -748,15 +763,11 @@ def step_done(share_id: str, export_dir: Path, result, assume_yes: bool, downloa
             return
         dest = default
     else:
-        # Default to yes when there's no hosted receipt (download is the outcome).
         ans = ask(f"\n  {BOLD}Download the bundle zip?{RST} "
-                  f"{DIM}[Enter/y = {default}, n = skip, or type a path]{RST}\n  > ").strip()
-        low = ans.lower()
-        if low in ("n", "no", "q", "skip"):
+                  f"{DIM}[Enter/y = {default}, n = skip, or type a path]{RST}\n  > ")
+        dest = _resolve_download_dest(ans, default, fname)
+        if dest is None:
             return
-        dest = default if low in ("", "y", "yes") else Path(ans).expanduser()
-    if dest.is_dir() or str(dest).endswith(os.sep):
-        dest = dest / fname
     try:
         data = build_zip(export_dir)
         dest.parent.mkdir(parents=True, exist_ok=True)

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -15,9 +15,9 @@ Exposed two ways (both ship with the package):
     clawjournal share-cli     # subcommand alias
 
 Usage:
-    clawshare                      # today's traces (default, fast; no LLM summaries)
+    clawshare                      # past 24h of traces (default, fast; no LLM summaries)
     clawshare --summary            # generate LLM summary titles (Haiku)
-    clawshare --weekly             # this week's traces
+    clawshare --weekly             # past 7 days (168h) of traces
     clawshare --all                # every trace, any date/status
     clawshare --codex              # only Codex traces
     clawshare --claude --limit 60  # this many Claude traces (default cap 40)
@@ -204,19 +204,19 @@ def _parse_ts(ts):
 
 
 def _in_time_range(row: dict, time_range: str) -> bool:
-    """True if the trace's LAST turn (end_time) falls in the range. Compared in
-    local time so 'today'/'this week' match the user's wall clock."""
+    """True if the trace's LAST turn (end_time) falls in the range. Uses rolling
+    windows (not calendar boundaries) so the list doesn't empty out at midnight:
+    'today' = the past 24h, 'weekly' = the past 168h (7 days)."""
     if time_range == "all":
         return True
     dt = _parse_ts(row.get("end_time")) or _parse_ts(row.get("start_time"))
     if dt is None:
         return False
-    day = dt.astimezone().date()
-    today = datetime.now().date()
+    now = datetime.now(timezone.utc)
     if time_range == "today":
-        return day == today
+        return dt >= now - timedelta(hours=24)
     if time_range == "weekly":
-        return day >= today - timedelta(days=today.weekday())  # since Monday
+        return dt >= now - timedelta(hours=168)
     return True
 
 
@@ -395,12 +395,12 @@ def step_queue(conn, settings, args) -> list[dict]:
         and _in_time_range(r, args.time_range)
     ]
     if not rows:
-        ranges = {"today": "today", "weekly": "this week", "all": "the index"}
+        ranges = {"today": "the past 24h", "weekly": "the past 7 days", "all": "the index"}
         hint = "" if args.time_range == "all" else "  (try --weekly or --all)"
         die(f"No shareable traces found in {ranges[args.time_range]}.{hint}")
 
     rows = rows[:args.limit]
-    label = {"today": "today", "weekly": "this week", "all": "all time"}[args.time_range]
+    label = {"today": "past 24h", "weekly": "past 7 days", "all": "all time"}[args.time_range]
     print(f"  {DIM}Showing {len(rows)} shareable trace(s) — {label}"
           f" (limit {args.limit}; use --limit to change).{RST}")
 
@@ -822,7 +822,7 @@ def add_share_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     # Time range — default is today (last turn happened today).
     when = parser.add_mutually_exclusive_group()
     when.add_argument("--weekly", dest="time_range", action="store_const", const="weekly",
-                      help="traces from this week (default: today only)")
+                      help="traces from the past 7 days (default: past 24h)")
     when.add_argument("--all", dest="time_range", action="store_const", const="all",
                       help="all traces, any date and any status")
     parser.set_defaults(time_range="today")

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -33,6 +33,8 @@ from pathlib import Path
 
 from .config import load_config
 from .workbench.index import (
+    SHAREABLE_HOLD_STATES,
+    effective_hold_state,
     get_effective_share_settings,
     get_session_detail,
     open_index,
@@ -325,7 +327,9 @@ def select_queue_rows(rows: list[dict], settings: dict, args) -> list[dict]:
     out = [
         r for r in rows
         if not session_matches_excluded_projects(r, settings["excluded_projects"])
-        and r.get("hold_state") in (None, "auto_redacted", "released")
+        # Use the same effective hold-state as the web/release gate so EXPIRED
+        # embargoes are shareable (raw hold_state would wrongly drop them).
+        and effective_hold_state(r.get("hold_state"), r.get("embargo_until")) in SHAREABLE_HOLD_STATES
         and not r.get("shared_at")
         and _in_time_range(r, args.time_range)
     ]
@@ -532,7 +536,8 @@ def _show_redaction_detail(rec: dict):
             print(f"    {DIM}AI review unavailable.{RST}")
 
 
-def step_review(conn, scrubbed: list[dict], assume_yes: bool) -> list[dict]:
+def step_review(conn, scrubbed: list[dict], assume_yes: bool,
+                include_needs_review: bool = False) -> list[dict]:
     step(3, "Review — inspect & include before packaging")
     print(f"  {DIM}Including a trace here affects this bundle only — it does not change "
           f"its local review status.{RST}")
@@ -548,7 +553,19 @@ def step_review(conn, scrubbed: list[dict], assume_yes: bool) -> list[dict]:
     included_ids: set[str] = set()
 
     if assume_yes:
-        included_ids = {s["row"]["session_id"] for s in scrubbed}
+        # Non-interactive: include clear traces. Needs-review traces are NOT
+        # silently included (we can't show their redacted preview here) — they
+        # require the explicit --include-needs-review opt-in.
+        included_ids = {s["row"]["session_id"] for s in clear}
+        if review:
+            if include_needs_review:
+                included_ids |= {s["row"]["session_id"] for s in review}
+                print(f"  {YEL}Including {len(review)} needs-review trace(s) unreviewed "
+                      f"(--include-needs-review).{RST}")
+            else:
+                die(f"{len(review)} trace(s) need review and --yes can't show their redacted "
+                    f"preview. Re-run interactively to inspect them, or pass "
+                    f"--include-needs-review to include them unreviewed.")
     else:
         if clear and yesno(f"\n{BOLD}Include all {len(clear)} clear trace(s)?{RST}", default_yes=True):
             included_ids |= {s["row"]["session_id"] for s in clear}
@@ -606,6 +623,13 @@ def step_package(conn, settings, included: list[dict], package_ai: bool, args):
                 zip_size = len(build_zip(export_dir))
             except Exception:  # noqa: BLE001
                 zip_size = 0
+            # #2: refuse to ship a sealed bundle whose AI coverage differs from
+            # the preview the user reviewed (seal can silently fall back to rules-only).
+            ok, why = share_flow.verify_coverage(manifest, package_ai)
+            if not ok:
+                die(f"AI coverage mismatch — {why}. Refusing to share a bundle that differs "
+                    f"from what you reviewed. Re-run (the seal will retry AI), or run without "
+                    f"--ai-pii-review to review and ship rules-only consistently.")
             print(f"{GRN}✓ packaged{RST}")
             print(f"  bundle:   {share_id[:8]}   sessions: {len(manifest.get('sessions', []))}")
             print(f"  path:     {export_dir}")
@@ -826,9 +850,44 @@ def add_interactive_flags(parser: argparse.ArgumentParser) -> argparse.ArgumentP
                         help="with --yes, also write the bundle zip to ~/Downloads")
     parser.add_argument("--no-refresh", action="store_true",
                         help="skip the startup index scan (use the existing index as-is)")
+    parser.add_argument("--include-needs-review", action="store_true",
+                        help="with --yes, include needs-review traces unreviewed (default: refuse)")
     parser.add_argument("-y", "--yes", action="store_true",
                         help="assume yes for preview/review/download prompts (NOT consent)")
     return parser
+
+
+# Interactive-only option dests + the flag spelling to show when misused outside
+# `--interactive`. Used to reject silently-ignored flags on non-interactive share.
+_INTERACTIVE_ONLY_CHECKS = (
+    ("time_range", lambda v: v not in (None, "today"), "--weekly/--all"),
+    ("source", lambda v: bool(v), "--source/--codex/--claude"),
+    ("search", lambda v: bool(v), "--search"),
+    ("project", lambda v: bool(v), "--project"),
+    ("min_failure_value", lambda v: v is not None, "--min-failure-value"),
+    ("limit", lambda v: v not in (None, 40), "--limit"),
+    ("summary", lambda v: bool(v), "--summary"),
+    ("summary_model", lambda v: bool(v), "--summary-model"),
+    ("yes", lambda v: bool(v), "--yes"),
+    ("accept_terms", lambda v: bool(v), "--accept-terms"),
+    ("certify_ownership", lambda v: bool(v), "--certify-ownership"),
+    ("download", lambda v: bool(v), "--download"),
+    ("no_refresh", lambda v: bool(v), "--no-refresh"),
+    ("include_needs_review", lambda v: bool(v), "--include-needs-review"),
+)
+
+
+def noninteractive_share_rejections(args) -> list[str]:
+    """Flags/values that are only meaningful in the interactive wizard and would
+    be silently ignored by non-interactive `clawjournal share`. Returns the list
+    of offending flag descriptions (empty = fine)."""
+    bad = [label for dest, is_set, label in _INTERACTIVE_ONLY_CHECKS
+           if is_set(getattr(args, dest, None))]
+    # #5: non-interactive one-step share must not auto-package new/blocked sessions.
+    if getattr(args, "status", None) in ("new", "blocked"):
+        bad.append("--status new/blocked (interactive only; non-interactive supports "
+                   "approved/shortlisted)")
+    return bad
 
 
 def add_share_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentParser:
@@ -887,7 +946,8 @@ def run(args) -> None:
         ai_pii_requested = bool(args.ai_pii_review or settings.get("ai_pii_review_enabled"))
         chosen = step_queue(conn, settings, args)
         scrubbed, package_ai = step_redact(conn, settings, chosen, args.yes, ai_pii_requested)
-        included = step_review(conn, scrubbed, args.yes)
+        included = step_review(conn, scrubbed, args.yes,
+                               include_needs_review=getattr(args, "include_needs_review", False))
         share_id, export_dir = step_package(conn, settings, included, package_ai, args)
         result = step_submit(conn, settings, share_id, package_ai, args)
         step_done(share_id, export_dir, result, args.yes,

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -395,7 +395,7 @@ def step_queue(conn, settings, args) -> list[dict]:
         idxs = args.indices
     else:
         raw = ask(f"{BOLD}Enter trace #(s) to share{RST} (space/comma separated, "
-                  f"or {BOLD}all{RST}; order = bundle order): ")
+                  f"or {BOLD}all{RST}): ")
         if not raw:
             die("Nothing selected.")
         try:

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -96,35 +96,17 @@ def die(msg: str, code: int = 1):
     sys.exit(code)
 
 
-_SYS_PROMPT_PREFIXES = (
-    "you are", "you're", "your task", "act as", "system:", "<",
-    "base directory for this skill", "# ",
-)
-_NO_TITLE = "⟨system prompt — run with --summary for a title⟩"
-_NO_AI_TITLE = "⟨no AI summary⟩"
-
-
-def _looks_like_system_prompt(text: str) -> bool:
-    s = (text or "").strip().lower()
-    if not s:
-        return True
-    return s.startswith(_SYS_PROMPT_PREFIXES) or "you are an ai" in s[:40]
-
-
 def resolve_title(r: dict, summarized: bool) -> str:
     """Title to display for a trace, by mode:
-    - default (summarized=False): the original, NON-AI title (raw first message);
-      a system-prompt-looking title is hidden behind a placeholder.
+    - default (summarized=False): exactly what the web Queue step shows —
+      the raw ``display_title`` (or "Untitled"), system prompts and all.
     - --summary (summarized=True): the AI-summarized title — scoring's
-      ai_display_title, or a clawshare summary ensure_titles placed on the row."""
+      ai_display_title, or a clawshare summary ensure_titles placed on the row;
+      falls back to the raw web title if no AI summary is available."""
+    raw = (r.get("display_title") or "").strip().replace("\n", " ") or "Untitled"
     if summarized:
-        ai = (r.get("ai_display_title") or "").strip()
-        if ai:
-            return ai
-        raw = (r.get("display_title") or "").strip().replace("\n", " ")
-        return _NO_AI_TITLE if _looks_like_system_prompt(raw) else raw
-    raw = (r.get("display_title") or "").strip().replace("\n", " ")
-    return _NO_TITLE if _looks_like_system_prompt(raw) else raw
+        return (r.get("ai_display_title") or "").strip() or raw
+    return raw
 
 
 def trace_title(r: dict, width: int = 52) -> str:

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -96,13 +96,45 @@ def die(msg: str, code: int = 1):
     sys.exit(code)
 
 
+_SYS_PROMPT_PREFIXES = (
+    "you are", "you're", "your task", "act as", "system:",
+    "base directory for this skill",
+)
+
+
+def _looks_like_system_prompt(text: str) -> bool:
+    s = (text or "").strip().lower()
+    return s.startswith(_SYS_PROMPT_PREFIXES) or "you are an ai" in s[:40]
+
+
+def user_prompt_title(conn, row: dict) -> str | None:
+    """Pull a meaningful title from the first user message, skipping a leading
+    system-prompt / instruction preamble (so e.g. eval-judge traces show the
+    actual content being judged instead of the identical 'You are a … judge'
+    boilerplate). Returns None if no usable user message is found."""
+    detail = get_session_detail(conn, row["session_id"])
+    for m in (detail or {}).get("messages") or []:
+        if m.get("role") != "user":
+            continue
+        c = m.get("content")
+        if not isinstance(c, str) or not c.strip():
+            continue
+        text = c.strip()
+        head, sep, tail = text.partition("\n\n")
+        if sep and _looks_like_system_prompt(head) and tail.strip():
+            text = tail.strip()
+        return text.replace("\n", " ")
+    return None
+
+
 def resolve_title(r: dict, summarized: bool) -> str:
     """Title to display for a trace, by mode:
-    - default (summarized=False): exactly what the web Queue step shows —
-      the raw ``display_title`` (or "Untitled"), system prompts and all.
+    - default (summarized=False): the raw ``display_title`` (or "Untitled").
+      step_queue replaces system-prompt-looking titles with the underlying
+      user prompt (see user_prompt_title) before display.
     - --summary (summarized=True): the AI-summarized title — scoring's
       ai_display_title, or a clawshare summary ensure_titles placed on the row;
-      falls back to the raw web title if no AI summary is available."""
+      falls back to the raw title if no AI summary is available."""
     raw = (r.get("display_title") or "").strip().replace("\n", " ") or "Untitled"
     if summarized:
         return (r.get("ai_display_title") or "").strip() or raw
@@ -402,7 +434,12 @@ def step_queue(conn, settings, args) -> list[dict]:
     do_summary = args.summary or bool(args.summary_model)
     ensure_titles(conn, rows, do_summary, summary_model=args.summary_model)
     for r in rows:
-        r["_clawshare_title"] = resolve_title(r, do_summary)
+        title = resolve_title(r, do_summary)
+        # In default mode, never surface a system-prompt title — fall back to the
+        # underlying user prompt (loads the trace only for those rows).
+        if not do_summary and _looks_like_system_prompt(title):
+            title = user_prompt_title(conn, r) or title
+        r["_clawshare_title"] = title
 
     print(f"\n  {'#':>3}  {'Last turn':<11} {'Source':<8} {'Msgs':>5} {'Tokens':>9} "
           f"{'Tools':>5} {'Fail':>4}  Title")

--- a/clawjournal/share_flow.py
+++ b/clawjournal/share_flow.py
@@ -235,6 +235,26 @@ def package(conn, session_ids: list[str], settings: dict, *, ai_pii: bool,
             "blocked_sessions": []}
 
 
+def verify_coverage(manifest: dict, package_ai: bool) -> tuple[bool, str]:
+    """CLI-side guard (no daemon change): the sealed artifact's AI coverage must
+    match the preview decision, so we never ship something LESS redacted than
+    what the user reviewed. The seal pass uses ignore_llm_errors=True and can
+    silently fall back to rules-only; this catches that divergence.
+
+    Returns (ok, message). ok=True means the sealed bundle is consistent."""
+    if not package_ai:
+        return True, ""  # rules-only preview -> rules-only seal is consistent
+    summary = (manifest or {}).get("redaction_summary") or {}
+    pr = summary.get("pii_review") or {}
+    if not pr.get("ai_enabled"):
+        return False, "preview was AI-reviewed but the sealed bundle ran rules-only"
+    rules_only = (pr.get("coverage") or {}).get("rules_only", 0)
+    if rules_only:
+        return False, (f"preview was AI-reviewed but AI review failed for {rules_only} "
+                       f"trace(s) during sealing (those shipped rules-only)")
+    return True, ""
+
+
 def build_zip(export_dir: Path) -> bytes:
     return _daemon_build_zip(export_dir)
 

--- a/clawjournal/share_flow.py
+++ b/clawjournal/share_flow.py
@@ -1,0 +1,265 @@
+"""Shared share-flow service used by the CLI (and available to the daemon).
+
+This module is the single sanctioned home for the share-flow logic that the
+terminal UI and the web/daemon both need: the redaction classifiers/labels
+(ported once from the web's `li`/`gi`/`hi`), a single redaction-record builder
+used for BOTH the review preview and packaging coverage, hosted-destination
+capability resolution, and thin wrappers over the packaging/submit/zip helpers.
+
+The terminal layer (``share_cli``) depends only on this module — it does not
+reach into daemon-private helpers or re-implement the classifiers. The daemon
+can adopt these same helpers over time.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from .workbench.index import (
+    apply_share_redactions,
+    create_share,
+    get_share,
+    release_gate_blockers,
+)
+
+# Wrapped daemon helpers — imported here so callers depend on share_flow, not on
+# daemon-private names directly.
+from .workbench.daemon import (
+    _build_share_zip as _daemon_build_zip,
+    _fetch_hosted_share_capabilities,
+    _prepare_share_export_for_upload,
+    confirm_email_verification as _confirm_email_verification,
+    fetch_hosted_consent as _fetch_hosted_consent,
+    hosted_upload_status as _hosted_upload_status,
+    request_email_verification as _request_email_verification,
+    submit_share_to_hosted,
+)
+
+# ---- redaction classifiers / labels (single Python source; mirrors web) -----
+
+BUCKET_KEYS = ("tokens", "emails", "paths", "timestamps", "urls", "other")
+
+# bucket -> human label used in the per-trace breakdown ("Redacting your traces").
+CATEGORY_LABELS = {
+    "tokens": "Secrets & credentials",
+    "emails": "Email addresses",
+    "paths": "File paths & usernames",
+    "urls": "URLs",
+    "timestamps": "Timestamps coarsened",
+    "other": "Other",
+}
+
+
+def bucket_for(type_str: str) -> str:
+    """Classify a redaction_log entry type into a display bucket (web `li`)."""
+    t = (type_str or "").lower()
+    if "email" in t:
+        return "emails"
+    if "url" in t:
+        return "urls"
+    if "path" in t or "username" in t or "home" in t:
+        return "paths"
+    if "time" in t or "date" in t:
+        return "timestamps"
+    if t.startswith("trufflehog") or any(k in t for k in ("token", "key", "secret", "jwt", "cred", "auth")):
+        return "tokens"
+    return "other"
+
+
+def redaction_buckets(log: list[dict]) -> tuple[dict[str, int], int]:
+    """Aggregate a redaction_log into the 6 buckets + the TruffleHog hit count."""
+    buckets = {k: 0 for k in BUCKET_KEYS}
+    th_hits = 0
+    for e in log or []:
+        etype = e.get("type", "")
+        buckets[bucket_for(etype)] += 1
+        if str(etype).lower().startswith("trufflehog"):
+            th_hits += 1
+    return buckets, th_hits
+
+
+def _plural(n: int) -> str:
+    return "" if n == 1 else "s"
+
+
+def category_breakdown(rec: dict) -> list[str]:
+    """Per-category redaction breakdown (web `gi`), TruffleHog subset called out."""
+    b = rec["buckets"]
+    th = rec.get("th_hits", 0)
+    out: list[str] = []
+    if b["tokens"]:
+        label = CATEGORY_LABELS["tokens"]
+        if th:
+            label += f" (incl. {th} via TruffleHog)"
+        out.append(f"{label}: {b['tokens']}")
+    for key in ("emails", "paths", "urls", "timestamps", "other"):
+        if b[key]:
+            out.append(f"{CATEGORY_LABELS[key]}: {b[key]}")
+    counts: dict[str, int] = {}
+    for f in rec.get("ai_findings") or []:
+        name = (f.get("entity_type") or "").replace("_", " ").strip() or "pii"
+        counts[name] = counts.get(name, 0) + 1
+    for name, c in sorted(counts.items(), key=lambda kv: -kv[1]):
+        out.append(f"AI-flagged {name}: {c}")
+    return out
+
+
+def trace_status(rec: dict) -> str:
+    """'clear' or 'review' (web `hi`). Anything not fully AI-reviewed, or with a
+    low-confidence AI finding, needs human review."""
+    cov = rec.get("ai_coverage", "disabled")
+    if cov in ("rules_only", "disabled"):
+        return "review"
+    if any((f.get("confidence", 0) or 0) < 0.85 for f in (rec.get("ai_findings") or [])):
+        return "review"
+    return "clear"
+
+
+# ---- the one redaction-record builder (preview == packaging contract) -------
+
+def build_redaction_record(conn, session_detail: dict, settings: dict,
+                           ai_pii: bool, *, backend: str = "auto") -> dict:
+    """Build the redaction record for one trace — the SAME computation used for
+    the review preview. Returns:
+        {redacted, count, buckets, th_hits, ai_findings, ai_coverage, status}
+    ai_coverage is one of: 'disabled' (AI off), 'full' (AI ran), 'rules_only'
+    (AI requested but unavailable/failed). Callers must keep packaging coverage
+    consistent with what was previewed (see effective_ai_pii)."""
+    red, count, log = apply_share_redactions(
+        conn, session_detail,
+        custom_strings=settings["custom_strings"],
+        user_allowlist=settings["allowlist_entries"],
+        extra_usernames=settings["extra_usernames"],
+        blocked_domains=settings["blocked_domains"],
+    )
+    buckets, th_hits = redaction_buckets(log)
+
+    ai_findings: list[dict] = []
+    ai_coverage = "disabled"
+    if ai_pii:
+        ai_coverage = "rules_only"
+        try:
+            from .redaction.pii import review_session_pii_with_agent, apply_findings_to_session
+            findings = review_session_pii_with_agent(red, ignore_errors=False, backend=backend)
+            ai_coverage = "full"
+            if findings:
+                red, ai_count = apply_findings_to_session(red, findings)
+                count += ai_count
+                ai_findings = findings
+        except Exception:  # noqa: BLE001
+            ai_coverage = "rules_only"
+
+    rec = {"redacted": red, "count": count, "buckets": buckets, "th_hits": th_hits,
+           "ai_findings": ai_findings, "ai_coverage": ai_coverage}
+    rec["status"] = trace_status(rec)
+    return rec
+
+
+def effective_ai_pii(records: list[dict], requested: bool) -> tuple[bool, bool]:
+    """Decide the packaging AI-PII flag so that what shipped == what was shown.
+
+    Returns (package_ai_pii, uniform):
+      - requested False           -> (False, True)
+      - all records 'full'        -> (True, True)
+      - any record 'rules_only'   -> (False, False)  # AI unavailable somewhere;
+        degrade everywhere to rules-only so the bundle matches a rules-only view.
+    The 'uniform' flag is False when AI was requested but could not be applied
+    everywhere, so the caller can warn / offer a retry before continuing.
+    """
+    if not requested:
+        return False, True
+    coverages = [r.get("ai_coverage") for r in records]
+    if coverages and all(c == "full" for c in coverages):
+        return True, True
+    return False, False
+
+
+# ---- hosted destination (capabilities + graceful fallback) ------------------
+
+def hosted_destination() -> dict[str, Any]:
+    """Resolve what the hosted destination supports right now, so the CLI can
+    fall back to download-only instead of stranding users on a hosted path.
+    Returns {reachable, submissions_open, can_submit, can_download, message,
+    support_contact, maximum_bundle_size}."""
+    info: dict[str, Any] = {
+        "reachable": False, "submissions_open": False, "can_submit": False,
+        "can_download": True, "message": "", "support_contact": None,
+        "maximum_bundle_size": None,
+    }
+    try:
+        caps = _fetch_hosted_share_capabilities()
+    except Exception as exc:  # noqa: BLE001
+        info["message"] = f"Hosted submission service unreachable ({exc}); download-only."
+        return info
+    info["reachable"] = True
+    info["support_contact"] = caps.get("contact_email") or caps.get("support_contact")
+    info["maximum_bundle_size"] = caps.get("maximum_bundle_size")
+    if caps.get("submissions_open") is False:
+        info["message"] = "Hosted submissions are currently closed; download-only."
+        return info
+    info["submissions_open"] = True
+    info["can_submit"] = True
+    return info
+
+
+# ---- packaging / submit / zip (thin wrappers) -------------------------------
+
+def gate_blockers(conn, session_ids: list[str]) -> list[dict]:
+    return release_gate_blockers(conn, session_ids)
+
+
+def package(conn, session_ids: list[str], settings: dict, *, ai_pii: bool,
+            note: str | None = None) -> dict:
+    """Create a share row and seal the bundle. Returns:
+        {ok, share_id, export_dir, manifest, blocked_sessions, error}
+    blocked_sessions is the list of sessions TruffleHog/PII blocked (for recovery).
+    """
+    share_id = create_share(conn, session_ids, note=note)
+    share = get_share(conn, share_id)
+    if share is None:
+        return {"ok": False, "error": "Share row could not be loaded after creation."}
+    export_dir, manifest, error = _prepare_share_export_for_upload(
+        conn, share_id, share, settings, reuse_finalized=True, ai_pii_review_enabled=ai_pii,
+    )
+    if error:
+        return {"ok": False, "share_id": share_id, "error": error.get("error", "Packaging failed."),
+                "blocked_sessions": error.get("blocked_sessions") or []}
+    if export_dir is None:
+        return {"ok": False, "share_id": share_id, "error": "Packaging failed: no bundle produced."}
+    if manifest.get("blocked"):
+        return {"ok": False, "share_id": share_id, "error": "Bundle marked blocked.",
+                "blocked_sessions": manifest.get("blocked_sessions") or []}
+    return {"ok": True, "share_id": share_id, "export_dir": export_dir, "manifest": manifest,
+            "blocked_sessions": []}
+
+
+def build_zip(export_dir: Path) -> bytes:
+    return _daemon_build_zip(export_dir)
+
+
+def submit(conn, share_id: str, *, accept_terms: bool, ownership_certification: bool,
+           consent_version: str, retention_policy_version: str, settings: dict,
+           ai_pii: bool) -> dict:
+    return submit_share_to_hosted(
+        conn, share_id,
+        accept_terms=accept_terms, ownership_certification=ownership_certification,
+        consent_version=consent_version, retention_policy_version=retention_policy_version,
+        settings=settings, ai_pii_review_enabled=ai_pii,
+    )
+
+
+# Thin re-exports so the CLI never imports daemon-private names.
+def upload_status() -> dict:
+    return _hosted_upload_status()
+
+
+def consent() -> dict:
+    return _fetch_hosted_consent()
+
+
+def request_email_verification(email: str) -> dict:
+    return _request_email_verification(email)
+
+
+def confirm_email_verification(email: str, code: str) -> dict:
+    return _confirm_email_verification(email, code)

--- a/clawjournal/share_flow.py
+++ b/clawjournal/share_flow.py
@@ -227,7 +227,9 @@ def package(conn, session_ids: list[str], settings: dict, *, ai_pii: bool,
     if export_dir is None:
         return {"ok": False, "share_id": share_id, "error": "Packaging failed: no bundle produced."}
     if manifest.get("blocked"):
-        return {"ok": False, "share_id": share_id, "error": "Bundle marked blocked.",
+        return {"ok": False, "share_id": share_id,
+                "error": manifest.get("block_message") or manifest.get("block_reason")
+                or "Bundle marked blocked.",
                 "blocked_sessions": manifest.get("blocked_sessions") or []}
     return {"ok": True, "share_id": share_id, "export_dir": export_dir, "manifest": manifest,
             "blocked_sessions": []}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ Issues = "https://github.com/rayward-external/clawjournal/issues"
 
 [project.scripts]
 clawjournal = "clawjournal.cli:main"
+clawshare = "clawjournal.share_cli:main"
 
 [tool.setuptools.packages.find]
 include = ["clawjournal*"]

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -411,3 +411,16 @@ def test_verify_coverage_consistency():
     m_partial = {"redaction_summary": {"pii_review": {"ai_enabled": True,
                                                       "coverage": {"full": 1, "rules_only": 1}}}}
     assert sf.verify_coverage(m_partial, package_ai=True)[0] is False
+
+
+# ---- #7/#9: CLI depends on share_flow, not daemon-private helpers ------------
+
+def test_cli_uses_share_flow_not_daemon_private():
+    import inspect
+    src = inspect.getsource(share_cli)
+    # Daemon-private share helpers must be reached via share_flow, not the CLI.
+    for name in ("_prepare_share_export_for_upload", "_build_share_zip",
+                 "submit_share_to_hosted", "_fetch_hosted_share_capabilities",
+                 "fetch_hosted_consent", "hosted_upload_status"):
+        assert name not in src, f"{name} should be accessed via share_flow, not in the CLI"
+    assert "order = bundle order" not in src, "dropped the false bundle-order claim"

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -315,3 +315,17 @@ def test_refresh_index_counts_new_sessions(monkeypatch):
     monkeypatch.setattr(d, "Scanner", FakeScanner)
     assert share_cli.refresh_index() == 3
     assert share_cli.refresh_index("codex") == 3
+
+
+# ---- queue selection input ('all') ------------------------------------------
+
+def test_parse_selection_all_and_numbers():
+    assert share_cli._parse_selection("all", 4) == [1, 2, 3, 4]
+    assert share_cli._parse_selection("ALL", 3) == [1, 2, 3]
+    assert share_cli._parse_selection("a", 2) == [1, 2]
+    assert share_cli._parse_selection("*", 2) == [1, 2]
+    assert share_cli._parse_selection("5 1 3", 9) == [5, 1, 3]   # order preserved
+    assert share_cli._parse_selection("1,3, 5", 9) == [1, 3, 5]
+    import pytest
+    with pytest.raises(ValueError):
+        share_cli._parse_selection("nope", 4)

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -298,3 +298,20 @@ def test_resolve_download_dest(tmp_path):
     assert share_cli._resolve_download_dest(str(custom), default, fname) == custom
     d = tmp_path / "adir"; d.mkdir()
     assert share_cli._resolve_download_dest(str(d), default, fname) == d / fname
+
+
+# ---- startup index refresh (so the wizard works without `clawjournal serve`) -
+
+def test_refresh_index_counts_new_sessions(monkeypatch):
+    import clawjournal.workbench.daemon as d
+
+    class FakeScanner:
+        def __init__(self, source_filter=None):
+            self.source_filter = source_filter
+
+        def scan_once(self):
+            return {"claude": 2, "codex": 1}
+
+    monkeypatch.setattr(d, "Scanner", FakeScanner)
+    assert share_cli.refresh_index() == 3
+    assert share_cli.refresh_index("codex") == 3

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -1,5 +1,7 @@
 """Tests for the interactive share wizard CLI surface."""
 import argparse
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
@@ -158,3 +160,141 @@ def test_blocked_all_blocked_aborts(monkeypatch):
     with pytest.raises(SystemExit):
         share_cli.step_package(conn=None, settings={}, included=_recs("a", "b"),
                                package_ai=False, args=args)
+
+
+# ---- time-range windows (rolling 24h / 168h) --------------------------------
+
+def _row(fv=None, end_delta_hours=None, **extra):
+    r = {"hold_state": None, "shared_at": None, "ai_failure_value_score": fv}
+    if end_delta_hours is not None:
+        r["end_time"] = (datetime.now(timezone.utc) - timedelta(hours=end_delta_hours)).isoformat()
+    r.update(extra)
+    r.setdefault("session_id", "s")
+    return r
+
+
+def test_in_time_range_rolling_windows():
+    assert share_cli._in_time_range(_row(end_delta_hours=1), "today")
+    assert not share_cli._in_time_range(_row(end_delta_hours=30), "today")
+    assert share_cli._in_time_range(_row(end_delta_hours=30), "weekly")
+    assert not share_cli._in_time_range(_row(end_delta_hours=200), "weekly")
+    assert share_cli._in_time_range(_row(end_delta_hours=200), "all")
+    assert not share_cli._in_time_range({"end_time": None}, "today")
+    assert share_cli._in_time_range({"end_time": None}, "all")
+
+
+# ---- queue selection: filtering + failure-value ranking (#4) ----------------
+
+_SETTINGS = {"excluded_projects": []}
+
+
+def _qargs(**kw):
+    base = dict(time_range="all", project=None, min_failure_value=None, search=None, limit=40)
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def test_select_excludes_shared_and_held():
+    rows = [_row(fv=5, session_id="ok"),
+            _row(fv=5, session_id="shared", shared_at="2026-01-01"),
+            _row(fv=5, session_id="held", hold_state="pending_review")]
+    out = share_cli.select_queue_rows(rows, _SETTINGS, _qargs())
+    assert [r["session_id"] for r in out] == ["ok"]
+
+
+def test_select_ranked_by_failure_value_nulls_last():
+    rows = [_row(fv=2, session_id="b"), _row(fv=5, session_id="a"),
+            _row(fv=None, session_id="z"), _row(fv=4, session_id="c")]
+    out = share_cli.select_queue_rows(rows, _SETTINGS, _qargs())
+    assert [r["session_id"] for r in out] == ["a", "c", "b", "z"]
+
+
+def test_select_filters_search_project_minfv():
+    rows = [
+        _row(fv=5, session_id="a", display_title="fix the judge", project="evalproj"),
+        _row(fv=1, session_id="b", display_title="hello world", project="evalproj"),
+        _row(fv=5, session_id="c", display_title="judge again", project="other"),
+    ]
+    assert {r["session_id"] for r in share_cli.select_queue_rows(rows, _SETTINGS, _qargs(search="judge"))} == {"a", "c"}
+    assert {r["session_id"] for r in share_cli.select_queue_rows(rows, _SETTINGS, _qargs(min_failure_value=4))} == {"a", "c"}
+    assert {r["session_id"] for r in share_cli.select_queue_rows(rows, _SETTINGS, _qargs(project="evalproj"))} == {"a", "b"}
+
+
+def test_select_limit():
+    rows = [_row(fv=5, session_id=str(i)) for i in range(10)]
+    assert len(share_cli.select_queue_rows(rows, _SETTINGS, _qargs(limit=3))) == 3
+
+
+# ---- title logic ------------------------------------------------------------
+
+def test_resolve_title_modes():
+    r = {"display_title": "raw first msg", "ai_display_title": "AI Title"}
+    assert share_cli.resolve_title(r, summarized=False) == "raw first msg"
+    assert share_cli.resolve_title(r, summarized=True) == "AI Title"
+    assert share_cli.resolve_title({"display_title": ""}, False) == "Untitled"
+    assert share_cli.resolve_title({"display_title": "x"}, True) == "x"  # falls back when no AI title
+
+
+def test_looks_like_system_prompt():
+    assert share_cli._looks_like_system_prompt("You are a strict evaluation judge")
+    assert share_cli._looks_like_system_prompt("Your task is to ...")
+    assert not share_cli._looks_like_system_prompt("哪些 benchmark 适合做成 RL 环境")
+    assert not share_cli._looks_like_system_prompt("Read the file and fix the bug")
+
+
+def test_user_prompt_title_strips_preamble(monkeypatch):
+    detail = {"messages": [
+        {"role": "user", "content": 'You are a judge. Compare.\n\n{"candidate": 2}'},
+    ]}
+    monkeypatch.setattr(share_cli, "get_session_detail", lambda conn, sid: detail)
+    assert share_cli.user_prompt_title(None, {"session_id": "x"}) == '{"candidate": 2}'
+
+
+# ---- step_redact AI consistency (preview == shipped, #2/#3) -----------------
+
+def _fake_rec(coverage, status="review"):
+    return {"redacted": {"messages": []}, "count": 0,
+            "buckets": {k: 0 for k in share_cli.share_flow.BUCKET_KEYS},
+            "th_hits": 0, "ai_findings": [], "ai_coverage": coverage, "status": status}
+
+
+def test_step_redact_degrades_to_rules_only_when_ai_unavailable(monkeypatch):
+    monkeypatch.setattr(share_cli, "get_session_detail", lambda conn, sid: {"messages": []})
+    seen = []
+
+    def fake_build(conn, detail, settings, use_ai, **k):
+        seen.append(use_ai)
+        return _fake_rec("rules_only" if use_ai else "disabled")
+    monkeypatch.setattr(share_cli, "build_redaction_record", fake_build)
+
+    chosen = [{"session_id": "a", "display_title": "A"}]
+    scrubbed, package_ai = share_cli.step_redact(None, {}, chosen, assume_yes=True,
+                                                 ai_pii_requested=True)
+    assert package_ai is False                       # degraded so what ships == what was shown
+    assert scrubbed[0]["ai_coverage"] == "disabled"  # rebuilt rules-only
+    assert seen == [True, False]                     # tried AI, then rebuilt without
+
+
+def test_step_redact_keeps_ai_when_uniformly_full(monkeypatch):
+    monkeypatch.setattr(share_cli, "get_session_detail", lambda conn, sid: {"messages": []})
+    monkeypatch.setattr(share_cli, "build_redaction_record",
+                        lambda conn, detail, settings, use_ai, **k: _fake_rec("full", "clear"))
+    chosen = [{"session_id": "a", "display_title": "A"}]
+    _scrubbed, package_ai = share_cli.step_redact(None, {}, chosen, assume_yes=True,
+                                                  ai_pii_requested=True)
+    assert package_ai is True
+
+
+# ---- download path resolution (regression: a stray 'y' must not be a path) --
+
+def test_resolve_download_dest(tmp_path):
+    default = tmp_path / "bundle.zip"
+    fname = "bundle.zip"
+    assert share_cli._resolve_download_dest("y", default, fname) == default
+    assert share_cli._resolve_download_dest("", default, fname) == default
+    assert share_cli._resolve_download_dest("yes", default, fname) == default
+    assert share_cli._resolve_download_dest("n", default, fname) is None
+    custom = tmp_path / "sub" / "out.zip"
+    assert share_cli._resolve_download_dest(str(custom), default, fname) == custom
+    d = tmp_path / "adir"; d.mkdir()
+    assert share_cli._resolve_download_dest(str(d), default, fname) == d / fname

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -141,7 +141,8 @@ def test_blocked_recovery_removes_and_retries(monkeypatch):
                 "manifest": {"sessions": session_ids}}
     monkeypatch.setattr(share_cli.share_flow, "package", _package)
 
-    args = SimpleNamespace(yes=True, note=None)
+    # yes=False: blocked traces are auto-removed (no keep-prompt), same as the web.
+    args = SimpleNamespace(yes=False, note=None)
     share_id, export_dir = share_cli.step_package(
         conn=None, settings={}, included=_recs("good", "bad"), package_ai=False, args=args)
     assert share_id == "share123"

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -1,0 +1,160 @@
+"""Tests for the interactive share wizard CLI surface."""
+import argparse
+from types import SimpleNamespace
+
+import pytest
+
+from clawjournal import share_cli
+
+
+# ---- argument parsing -------------------------------------------------------
+
+def _parse(argv):
+    p = argparse.ArgumentParser()
+    share_cli.add_share_cli_args(p)
+    return p.parse_args(argv)
+
+
+def test_arg_parsing_defaults():
+    a = _parse([])
+    assert a.time_range == "today"
+    assert a.limit == 40
+    assert a.summary is False
+    assert a.accept_terms is False
+    assert a.certify_ownership is False
+    assert a.yes is False
+    assert a.indices == []
+
+
+def test_arg_parsing_flags():
+    a = _parse(["--weekly", "--min-failure-value", "4", "--search", "judge",
+                "--accept-terms", "--certify-ownership", "3", "7"])
+    assert a.time_range == "weekly"
+    assert a.min_failure_value == 4
+    assert a.search == "judge"
+    assert a.accept_terms and a.certify_ownership
+    assert a.indices == [3, 7]
+
+
+def test_codex_claude_shortcuts():
+    assert _parse(["--codex"]).source == "codex"
+    assert _parse(["--claude"]).source == "claude"
+
+
+# ---- review must not mutate global review_status (#5) -----------------------
+
+def test_review_does_not_import_update_session():
+    import inspect
+    src = inspect.getsource(share_cli)
+    assert "update_session" not in src, "share wizard must not touch review_status"
+
+
+def test_review_is_share_local(monkeypatch):
+    # assume_yes includes everything and returns the in-memory selection; no DB write.
+    recs = [
+        {"row": {"session_id": "a", "display_title": "A"}, "status": "clear"},
+        {"row": {"session_id": "b", "display_title": "B"}, "status": "review"},
+    ]
+    included = share_cli.step_review(conn=None, scrubbed=recs, assume_yes=True)
+    assert {s["row"]["session_id"] for s in included} == {"a", "b"}
+
+
+# ---- consent handling (#6): --yes must NOT auto-accept ----------------------
+
+def _consent_doc():
+    return {
+        "consent_version": "c1", "retention_policy_version": "r1",
+        "consent_text": "I understand.", "retention_text": "We keep a hash.",
+    }
+
+
+def test_yes_does_not_auto_accept_consent(monkeypatch):
+    monkeypatch.setattr(share_cli, "hosted_destination",
+                        lambda: {"can_submit": True, "message": "", "support_contact": None})
+    monkeypatch.setattr(share_cli.share_flow, "consent", _consent_doc)
+
+    def _fail_submit(*a, **k):
+        raise AssertionError("submit must not be called without explicit consent")
+    monkeypatch.setattr(share_cli.share_flow, "submit", _fail_submit)
+
+    args = SimpleNamespace(yes=True, accept_terms=False, certify_ownership=False)
+    result = share_cli.step_submit(conn=None, settings={}, share_id="s1",
+                                   package_ai=False, args=args)
+    assert result is None  # packaged but not submitted
+
+
+def test_explicit_consent_flags_allow_submit(monkeypatch):
+    monkeypatch.setattr(share_cli, "hosted_destination",
+                        lambda: {"can_submit": True, "message": "", "support_contact": None})
+    monkeypatch.setattr(share_cli.share_flow, "consent", _consent_doc)
+    monkeypatch.setattr(share_cli.share_flow, "upload_status",
+                        lambda: {"token_valid": True, "verified_email": "me@uni.edu"})
+    called = {}
+
+    def _ok_submit(conn, share_id, **k):
+        called.update(k)
+        return {"ok": True, "receipt_id": "R1", "session_count": 1}
+    monkeypatch.setattr(share_cli.share_flow, "submit", _ok_submit)
+
+    args = SimpleNamespace(yes=True, accept_terms=True, certify_ownership=True)
+    result = share_cli.step_submit(conn=None, settings={}, share_id="s1",
+                                   package_ai=False, args=args)
+    assert result and result["receipt_id"] == "R1"
+    assert called["accept_terms"] is True and called["ownership_certification"] is True
+
+
+# ---- hosted unavailable -> download-only fallback (#8) ----------------------
+
+def test_hosted_unavailable_skips_submit(monkeypatch):
+    monkeypatch.setattr(share_cli, "hosted_destination",
+                        lambda: {"can_submit": False, "message": "closed",
+                                 "support_contact": "x@y.edu"})
+
+    def _fail_consent():
+        raise AssertionError("consent must not be fetched when submit unavailable")
+    monkeypatch.setattr(share_cli.share_flow, "consent", _fail_consent)
+
+    args = SimpleNamespace(yes=False, accept_terms=False, certify_ownership=False)
+    result = share_cli.step_submit(conn=None, settings={}, share_id="s1",
+                                   package_ai=False, args=args)
+    assert result is None
+
+
+# ---- blocked-package recovery (#7) ------------------------------------------
+
+def _recs(*ids):
+    return [{"row": {"session_id": i, "display_title": i}} for i in ids]
+
+
+def test_blocked_recovery_removes_and_retries(monkeypatch):
+    monkeypatch.setattr(share_cli, "gate_blockers", lambda conn, ids: [])
+    monkeypatch.setattr(share_cli, "build_zip", lambda d: b"zip")
+    calls = []
+
+    def _package(conn, session_ids, settings, *, ai_pii, note=None):
+        calls.append(list(session_ids))
+        if "bad" in session_ids:  # first attempt: block "bad"
+            return {"ok": False, "blocked_sessions": ["bad"], "error": "blocked"}
+        return {"ok": True, "share_id": "share123", "export_dir": "/tmp/x",
+                "manifest": {"sessions": session_ids}}
+    monkeypatch.setattr(share_cli.share_flow, "package", _package)
+
+    args = SimpleNamespace(yes=True, note=None)
+    share_id, export_dir = share_cli.step_package(
+        conn=None, settings={}, included=_recs("good", "bad"), package_ai=False, args=args)
+    assert share_id == "share123"
+    assert len(calls) == 2  # retried after removing "bad"
+    assert "bad" not in calls[1]
+
+
+def test_blocked_all_blocked_aborts(monkeypatch):
+    monkeypatch.setattr(share_cli, "gate_blockers", lambda conn, ids: [])
+
+    def _package(conn, session_ids, settings, *, ai_pii, note=None):
+        return {"ok": False, "blocked_sessions": list(session_ids), "error": "blocked"}
+    monkeypatch.setattr(share_cli.share_flow, "package", _package)
+
+    args = SimpleNamespace(yes=True, note=None)
+    with pytest.raises(SystemExit):
+        share_cli.step_package(conn=None, settings={}, included=_recs("a", "b"),
+                               package_ai=False, args=args)

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -51,13 +51,28 @@ def test_review_does_not_import_update_session():
     assert "update_session" not in src, "share wizard must not touch review_status"
 
 
-def test_review_is_share_local(monkeypatch):
-    # assume_yes includes everything and returns the in-memory selection; no DB write.
-    recs = [
-        {"row": {"session_id": "a", "display_title": "A"}, "status": "clear"},
-        {"row": {"session_id": "b", "display_title": "B"}, "status": "review"},
-    ]
+def _rec(sid, status):
+    return {"row": {"session_id": sid, "display_title": sid}, "status": status}
+
+
+def test_review_is_share_local_clear_only():
+    # assume_yes includes the clear traces; returns in-memory selection, no DB write.
+    recs = [_rec("a", "clear"), _rec("b", "clear")]
     included = share_cli.step_review(conn=None, scrubbed=recs, assume_yes=True)
+    assert {s["row"]["session_id"] for s in included} == {"a", "b"}
+
+
+def test_review_yes_refuses_needs_review():
+    # #3: --yes must NOT silently include needs-review traces.
+    recs = [_rec("a", "clear"), _rec("b", "review")]
+    with pytest.raises(SystemExit):
+        share_cli.step_review(conn=None, scrubbed=recs, assume_yes=True)
+
+
+def test_review_yes_include_needs_review_optin():
+    recs = [_rec("a", "clear"), _rec("b", "review")]
+    included = share_cli.step_review(conn=None, scrubbed=recs, assume_yes=True,
+                                     include_needs_review=True)
     assert {s["row"]["session_id"] for s in included} == {"a", "b"}
 
 
@@ -330,3 +345,69 @@ def test_parse_selection_all_and_numbers():
     import pytest
     with pytest.raises(ValueError):
         share_cli._parse_selection("nope", 4)
+
+
+# ---- #4/#5: non-interactive share must reject interactive-only flags --------
+
+def test_noninteractive_rejections_flags_and_status():
+    # interactive-only flags flagged
+    a = SimpleNamespace(time_range="weekly", source="codex", search=None, project=None,
+                        min_failure_value=None, limit=40, summary=False, summary_model=None,
+                        yes=False, accept_terms=False, certify_ownership=False, download=False,
+                        no_refresh=False, include_needs_review=False, status="approved")
+    bad = share_cli.noninteractive_share_rejections(a)
+    assert any("weekly" in b for b in bad) and any("source" in b for b in bad)
+
+    # status new/blocked rejected non-interactively (#5)
+    b = SimpleNamespace(time_range="today", source=None, search=None, project=None,
+                        min_failure_value=None, limit=40, summary=False, summary_model=None,
+                        yes=False, accept_terms=False, certify_ownership=False, download=False,
+                        no_refresh=False, include_needs_review=False, status="new")
+    assert any("new/blocked" in x for x in share_cli.noninteractive_share_rejections(b))
+
+    # plain non-interactive share is fine
+    c = SimpleNamespace(time_range="today", source=None, search=None, project=None,
+                        min_failure_value=None, limit=40, summary=False, summary_model=None,
+                        yes=False, accept_terms=False, certify_ownership=False, download=False,
+                        no_refresh=False, include_needs_review=False, status="approved")
+    assert share_cli.noninteractive_share_rejections(c) == []
+
+
+# ---- #6: expired embargo is shareable (effective hold state) ----------------
+
+def test_queue_includes_expired_embargo_excludes_active(monkeypatch):
+    past = (datetime.now(timezone.utc) - timedelta(days=1)).isoformat()
+    future = (datetime.now(timezone.utc) + timedelta(days=30)).isoformat()
+    rows = [
+        _row(fv=5, session_id="released", hold_state="released"),
+        _row(fv=5, session_id="expired_embargo", hold_state="embargoed", embargo_until=past),
+        _row(fv=5, session_id="active_embargo", hold_state="embargoed", embargo_until=future),
+        _row(fv=5, session_id="pending", hold_state="pending_review"),
+    ]
+    out = share_cli.select_queue_rows(rows, _SETTINGS, _qargs())
+    ids = {r["session_id"] for r in out}
+    assert "released" in ids
+    assert "expired_embargo" in ids       # expired embargo -> effectively released
+    assert "active_embargo" not in ids    # still embargoed
+    assert "pending" not in ids
+
+
+# ---- #2: sealed-coverage verification (preview == shipped) ------------------
+
+def test_verify_coverage_consistency():
+    from clawjournal import share_flow as sf
+    # AI off -> always consistent
+    assert sf.verify_coverage({}, package_ai=False)[0] is True
+    # AI on + sealed fully AI -> ok
+    m_full = {"redaction_summary": {"pii_review": {"ai_enabled": True,
+                                                   "coverage": {"full": 2, "rules_only": 0}}}}
+    assert sf.verify_coverage(m_full, package_ai=True)[0] is True
+    # AI on but sealed ran rules-only -> mismatch
+    m_off = {"redaction_summary": {"pii_review": {"ai_enabled": False,
+                                                  "coverage": {"full": 0, "rules_only": 2}}}}
+    ok, why = sf.verify_coverage(m_off, package_ai=True)
+    assert ok is False and "rules-only" in why
+    # AI on but some traces fell back to rules-only during seal -> mismatch
+    m_partial = {"redaction_summary": {"pii_review": {"ai_enabled": True,
+                                                      "coverage": {"full": 1, "rules_only": 1}}}}
+    assert sf.verify_coverage(m_partial, package_ai=True)[0] is False

--- a/tests/test_share_flow.py
+++ b/tests/test_share_flow.py
@@ -1,0 +1,88 @@
+"""Tests for the shared share-flow service (classifiers, coverage, destination)."""
+from clawjournal import share_flow as sf
+
+
+def test_bucket_for_classification():
+    assert sf.bucket_for("email_address") == "emails"
+    assert sf.bucket_for("private_url") == "urls"
+    assert sf.bucket_for("file_path") == "paths"
+    assert sf.bucket_for("username") == "paths"
+    assert sf.bucket_for("timestamp") == "timestamps"
+    assert sf.bucket_for("high_entropy_secret") == "tokens"
+    assert sf.bucket_for("trufflehog.AWS") == "tokens"
+    assert sf.bucket_for("something_else") == "other"
+
+
+def test_redaction_buckets_counts_trufflehog():
+    log = [
+        {"type": "email"}, {"type": "email"},
+        {"type": "file_path"},
+        {"type": "trufflehog.AWS"}, {"type": "trufflehog.GCP"},
+        {"type": "api_token"},
+        {"type": "weird"},
+    ]
+    buckets, th = sf.redaction_buckets(log)
+    assert buckets["emails"] == 2
+    assert buckets["paths"] == 1
+    assert buckets["tokens"] == 3  # 2 trufflehog + 1 token
+    assert buckets["other"] == 1
+    assert th == 2
+
+
+def test_category_breakdown_labels_and_trufflehog_callout():
+    rec = {
+        "buckets": {"tokens": 5, "emails": 1, "paths": 0, "urls": 0,
+                    "timestamps": 0, "other": 0},
+        "th_hits": 4,
+        "ai_findings": [{"entity_type": "person_name"}, {"entity_type": "person_name"}],
+    }
+    out = sf.category_breakdown(rec)
+    assert "Secrets & credentials (incl. 4 via TruffleHog): 5" in out
+    assert "Email addresses: 1" in out
+    assert "AI-flagged person name: 2" in out
+
+
+def test_trace_status():
+    assert sf.trace_status({"ai_coverage": "disabled"}) == "review"
+    assert sf.trace_status({"ai_coverage": "rules_only"}) == "review"
+    assert sf.trace_status({"ai_coverage": "full", "ai_findings": []}) == "clear"
+    assert sf.trace_status({"ai_coverage": "full",
+                            "ai_findings": [{"confidence": 0.5}]}) == "review"
+    assert sf.trace_status({"ai_coverage": "full",
+                            "ai_findings": [{"confidence": 0.95}]}) == "clear"
+
+
+def test_effective_ai_pii_keeps_preview_consistent():
+    # not requested -> off, uniform
+    assert sf.effective_ai_pii([{"ai_coverage": "disabled"}], False) == (False, True)
+    # all full -> on, uniform
+    assert sf.effective_ai_pii([{"ai_coverage": "full"}, {"ai_coverage": "full"}], True) == (True, True)
+    # any rules_only -> degrade off, not uniform (caller must reconcile)
+    assert sf.effective_ai_pii([{"ai_coverage": "full"}, {"ai_coverage": "rules_only"}], True) == (False, False)
+
+
+def test_hosted_destination_unreachable(monkeypatch):
+    def boom():
+        raise RuntimeError("network down")
+    monkeypatch.setattr(sf, "_fetch_hosted_share_capabilities", boom)
+    info = sf.hosted_destination()
+    assert info["reachable"] is False
+    assert info["can_submit"] is False
+    assert info["can_download"] is True
+
+
+def test_hosted_destination_closed(monkeypatch):
+    monkeypatch.setattr(sf, "_fetch_hosted_share_capabilities",
+                        lambda: {"submissions_open": False, "contact_email": "x@y.edu"})
+    info = sf.hosted_destination()
+    assert info["reachable"] is True
+    assert info["can_submit"] is False
+    assert info["support_contact"] == "x@y.edu"
+
+
+def test_hosted_destination_open(monkeypatch):
+    monkeypatch.setattr(sf, "_fetch_hosted_share_capabilities",
+                        lambda: {"submissions_open": True, "maximum_bundle_size": 100})
+    info = sf.hosted_destination()
+    assert info["can_submit"] is True
+    assert info["maximum_bundle_size"] == 100


### PR DESCRIPTION
## What

A keyboard-only terminal version of the web **Share** wizard, so traces can be shared without a browser.

- Primary entry point: **`clawjournal share --interactive`**
- Thin alias: **`clawshare`**

A presentation/prompt layer over a shared `share_flow` service — a terminal **MVP**, not full web parity (see "Known gaps").

## Workflow walkthrough

Example trace: *“Install or refresh ClawJournal”*. (Plain-text capture; colored HTML available on request.)

<details><summary>queue → redact → review → submit → done (click to expand)</summary>

```text
========================================================================
STEP 1 · Queue — pick traces
------------------------------------------------------------------------
Lists shareable traces, ranked by failure value (most useful for failure analysis first), like the web Queue. Scope with --search / --project / --min-failure-value / --source and widen time with --weekly / --all (default: past 24h). Type the #s to include, or “all”.
========================================================================
── Step 1/6: Queue — select traces ─────────────────────────
  Showing 1 shareable trace(s) — all time, ranked by failure value (limit 40).

    #  Fail Last turn   Source    Msgs    Tokens Tools  Title
  ------------------------------------------------------------------------------------------------------------
    1     4 06-01 17:35 claude      61    31,809    40  Install or refresh ClawJournal from https://github.…

  Tip: filter with --search/--project/--min-failure-value, widen with --weekly/--all, more with --limit.
^A^BEnter trace #(s) to share^A^B (space/comma separated, or ^A^Ball^A^B): ✗ Nothing selected.

========================================================================
STEP 2 · Redact — scrub PII
------------------------------------------------------------------------
Every selected trace is scrubbed. The per-trace breakdown shows exactly what was removed, by category (Secrets & credentials incl. a TruffleHog count, Email addresses, File paths & usernames, URLs, Timestamps) — same categories as the web. “rules-only” = deterministic scrub; add --ai-pii-review for an AI PII pass (preview and the shipped bundle are kept consistent).
========================================================================
── Step 2/6: Redact — scrub PII ────────────────────────────
  AI PII review: OFF — deterministic rules only (enable with --ai-pii-review).

  Redacting your traces — categories flagged per trace:

  [1] needs review · rules-only · 70 redactions · Install or refresh ClawJournal from https://github.…
        • Secrets & credentials: 6
        • Email addresses: 11
        • File paths & usernames: 14
        • URLs: 5
        • Other: 12

^A^B

========================================================================
STEP 3 · Review — inspect before packaging
------------------------------------------------------------------------
Each needs-review trace shows what was redacted plus an auto-preview of the already-scrubbed transcript (note the live redaction, e.g. https://github.com/[REDACTED_PROJECT]). Decide per trace: [v]iew full transcript, [i]nclude, or [r]emove. Including a trace affects this bundle only — it never changes the trace’s triage/review status.
========================================================================
── Step 3/6: Review — inspect & include before packaging ───
  Including a trace here affects this bundle only — it does not change its local review status.

    #  Status         Title
  --------------------------------------------------------------------------------
    1  needs review   Install or refresh ClawJournal from https://github.…

  1 trace(s) need review — inspect each before packaging.

  ── review 1/1 ─ Install or refresh ClawJournal from https://github.com/rayw…
  What was redacted (rules-only):
    • Secrets & credentials: 6
    • Email addresses: 11
    • File paths & usernames: 14
    • URLs: 5
    • Other: 12
  Preview:
  (first 6 of 21 content messages, 40 empty/thinking hidden — already scrubbed)
       user  Install or refresh ClawJournal from https://github.com/[REDACTED_PROJECT] Read its README and follow the instructions for my operating system. If ClawJournal is already installed, update it from the public GitHub repo and rebuild the browser workbench. Install any missing prerequisites. Verify it works at the end.
  assistant  ClawJournal 0.1.13 is installed (editable from `~/Downloads/clawjournal`, with venv at `~/.clawjournal-venv`). The README asks me to git-update and re-run `install.sh --with-frontend` to rebuild the workbench. Let me check the current checkout state.
  assistant  Fast-forwarded from 0746b9d to accab5d. Now running the installer with `--with-frontend` to rebuild the workbench bundle.
  assistant  Install succeeded: ClawJournal **0.1.16** with workbench bundle rebuilt (424 kB JS, 0.72 kB index.html). Now verifying.
  assistant  **ClawJournal 0.1.16 installed and verified.**
             
             - Source `~/Downloads/clawjournal` fast-forwarded `0746b9d → accab5d` on `main` (commits: standardize project names across agents, first-run Sessions guide).
             - `scripts/install.sh --with-frontend` rebuilt the Vite workbench → `clawjournal/web/frontend/dist/` (424 kB JS bundle).
             - Canonical CLI at `~/.clawjournal-venv/bin/clawjournal` reports version **0.1.16**; `bundle-export --help` shows the `--zip` flag (the README's tell for "up to date").
             - All prereqs already present (git, Python 3.13, Node 24.9.0) — nothing else to install.
             
             Note: a second editable install exists in your system anaconda (`[REDACTED_PATH]`); it's what plain `clawjournal`   …(+338 more chars)
       user  Kai让我测试，现在是成功了对吧？Kai Du  [9:08 PM]
             @Alex Cheung @Char @Tim Ye please help to test the clawjournal:
             https://github.com/[REDACTED_PROJECT]
             
             Just paste this into codex or claude code
             Install or refresh ClawJournal from https://github.com/[REDACTED_PROJECT] Read its README and follow the instructions for my operating system. If ClawJournal is already installed, update it from the public GitHub repo and rebuild the browser workbench. Install any missing prerequisites. Verify it works at the end.
  … 15 more — press [v] for the full transcript
  ^A^B[v]^A^Biew full transcript  ^A^B[i]^A^Bnclude  ^A^B[r]^A^Bemove:   removed from bundle
✗ No traces included — nothing to package.


========================================================================
STEP 4 · --yes safety guard
------------------------------------------------------------------------
For automation, --yes still refuses to silently include needs-review traces (it can’t show their redacted preview). Re-run interactively to inspect them, or pass --include-needs-review to opt in explicitly. Consent is likewise never auto-accepted by --yes.
========================================================================
── Step 3/6: Review — inspect & include before packaging ───
  Including a trace here affects this bundle only — it does not change its local review status.

    #  Status         Title
  --------------------------------------------------------------------------------
    1  needs review   Install or refresh ClawJournal from https://github.…
✗ 1 trace(s) need review and --yes can't show their redacted preview. Re-run interactively to inspect them, or pass --include-needs-review to include them unreviewed.


========================================================================
STEP 5 · Submit — explicit consent
------------------------------------------------------------------------
Before any upload, the real hosted consent + retention terms are shown and must be explicitly accepted (two confirmations, or the --accept-terms / --certify-ownership flags). If the hosted destination is closed or unreachable, the wizard falls back to download-only instead of stranding you.
========================================================================
── Step 5/6: Submit — consent & upload ─────────────────────

  Consent and retention  (consent consent-v1 · retention retention-v1)
  ────────────────────────────────────────────────────────────
  I understand that I am uploading a redacted ClawJournal bundle for model
  evaluation and research. Local redaction is best-effort and user-reviewed. I
  confirm I reviewed the bundle before upload.

  The service keeps a verified email hash, receipt ID, manifest, bundle, consent
  version, and retention version. To request deletion, re-verify the same email
  and provide the receipt ID.

  ────────────────────────────────────────────────────────────
  I accept the displayed consent and data-use terms. [y/N]
  I certify this bundle is mine to submit and contains no third-party confidential material. [y/N]

========================================================================
STEP 6 · Done — receipt + optional download
------------------------------------------------------------------------
On success you get a receipt and submission URL. You can always save the sealed bundle zip locally via one prompt (Enter/y = default ~/Downloads path, n = skip, or type a path; a directory gets the filename appended). (Representative — a real receipt requires an actual upload.)
========================================================================
── Step 6/6: Done ──────────────────────────────────────────
  ✓ Shared to hosted research!
  receipt:    rcpt_8f31c2…
  submission: https://data.rayward.ai/share/s/8f31c2
  sessions:   1
  bundle dir: ~/.clawjournal/shares/fe56b109…

  Download the bundle zip? [Enter/y = ~/Downloads/clawjournal-share-fe56b109.zip, n = skip, or type a path]
  > 

```
</details>

## Review feedback — resolutions

**Round 1**
| # | Feedback | Resolution |
|---|---|---|
| AI parity | preview ≠ shipped payload | one `build_redaction_record`; `effective_ai_pii` keeps packaging consistent with the preview |
| AI UX | on/off disclosure, coverage labels, retry | added |
| Queue | thin vs web | ranked by failure value (web-like); `--search`/`--project`/`--min-failure-value` filters; unscored guidance; type `all` to select everything |
| Review | mutated `review_status` | removed — inclusion is share-local |
| Consent | `--yes` auto-accepted | `--yes` never accepts consent; explicit `--accept-terms`/`--certify-ownership` or interactive |
| Blocked | weak recovery | prints TruffleHog reason; auto-removes blocked trace + retries (web parity) |
| Submit | no fallback | capability check → download-only when closed/unreachable |
| Service | daemon-private coupling | extracted `clawjournal/share_flow.py`; CLI depends on it |
| Command | `clawshare` premature | `clawjournal share --interactive` is primary; `clawshare` a thin alias |
| Tests | missing | `tests/test_share_flow.py` + `tests/test_share_cli.py` |

**Round 2**
| # | Feedback | Resolution |
|---|---|---|
| 1 | bundle order not preserved | **No CLI change** — verified the web doesn't preserve selection order either (`create_share` collapses to a `set()`, `get_share` exports `ORDER BY start_time`), so order isn't significant. Removed the inaccurate “order = bundle order” wording. Adding a `share_sessions.position` column would touch shared backend/schema — proposed as a separate PR. |
| 2 | preview can still diverge from sealed | `share_flow.verify_coverage()` checks the sealed manifest's AI coverage against the preview decision; packaging refuses to ship a divergent bundle (CLI-only check, no daemon change) |
| 3 | `--yes` bypassed trace review | `--yes` no longer includes needs-review traces; refuses unless `--include-needs-review` |
| 4 | interactive flags leak into non-interactive `share` | non-interactive `share` now errors on interactive-only flags instead of silently ignoring them |
| 5 | broadened `--status` is a regression | non-interactive `share --status new/blocked` rejected (interactive only) |
| 6 | expired-embargo gate mismatch | queue uses `effective_hold_state()` / `SHAREABLE_HOLD_STATES` — expired embargoes are shareable, like the web |
| 7 | shared service only partial | stated as MVP; daemon adoption of `share_flow` is a follow-up |

## Known gaps (MVP)

- `share_flow` is used by the CLI; migrating the **daemon** onto it is a follow-up.
- Queue ranks by `ai_failure_value_score` (close to the web), without the web's exact `recommended_session_ids` API or a full add/remove/reorder TUI.
- `share_sessions.position` (true bundle ordering) deferred to a separate PR.

## Tests

`pytest tests/` — **1919 passed** (3 pre-existing `tests.workbench` collection errors are unrelated to this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Screen shots:

## Screenshots

**Step 1 · Queue** — pick traces, ranked by failure value (web-like); filter with `--search`/`--project`/`--min-failure-value`/`--source`, widen with `--weekly`/`--all`, or type `all`.

<img width="1816" height="532" alt="step1" src="https://github.com/user-attachments/assets/ff01b3a0-9624-4073-9cc6-2bbbb33578d6" />

**Step 2 · Redact** — per-trace PII breakdown by category (Secrets & credentials incl. TruffleHog count, Email addresses, File paths & usernames, URLs, Timestamps).

<img width="1688" height="668" alt="step2" src="https://github.com/user-attachments/assets/2e4cbca5-79e3-46b7-9c0e-48d49c640e48" />

**Step 3 · Review** — inspect each needs-review trace (what was redacted + an auto-preview of the scrubbed transcript); `[v]`iew / `[i]`nclude / `[r]`emove. Inclusion is share-local — it never changes triage status.

<img width="1912" height="2912" alt="step3" src="https://github.com/user-attachments/assets/fb227a1b-1530-47ba-9ed5-c12b2b0d66b1" />

**Step 4 · `--yes` safety guard** — automation refuses to silently include needs-review traces unless `--include-needs-review`; consent is never auto-accepted by `--yes`.

<img width="1912" height="1348" alt="step4" src="https://github.com/user-attachments/assets/adc25e1a-c1b1-4e25-ac53-4c06abf2fcbf" />

**Step 5 · Submit** — the real hosted consent + retention terms are shown and must be explicitly accepted; falls back to download-only if hosted submission is closed/unreachable.

<img width="1624" height="736" alt="step5" src="https://github.com/user-attachments/assets/6cf597d1-eb41-4c59-8700-37fc7931efe1" />

**Step 6 · Done** — receipt + submission URL, plus an optional bundle-zip download (Enter/y = default path, n = skip, or type a path).

<img width="1768" height="532" alt="step6" src="https://github.com/user-attachments/assets/98c121ef-fb8c-4f7d-9f2a-40e88c0fc08d" />



