### PR TITLE
feat(workbench): finish #74 label-clarity on deferred surfaces + share queue UX

### DIFF
--- a/clawjournal/web/frontend/package-lock.json
+++ b/clawjournal/web/frontend/package-lock.json
@@ -58,6 +58,7 @@
       "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.29.0",
         "@babel/generator": "^7.29.0",
@@ -265,29 +266,6 @@
       },
       "engines": {
         "node": ">=6.9.0"
-      }
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/wasi-threads": {
@@ -884,6 +862,7 @@
       "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -894,6 +873,7 @@
       "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -953,6 +933,7 @@
       "integrity": "sha512-k4eNDan0EIMTT/dUKc/g+rsJ6wcHYhNPdY19VoX/EOtaAG8DLtKCykhrUnuHPYvinn5jhAPgD2Qw9hXBwrahsw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.57.1",
         "@typescript-eslint/types": "8.57.1",
@@ -1235,6 +1216,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1343,6 +1325,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1545,6 +1528,7 @@
       "integrity": "sha512-XoMjdBOwe/esVgEvLmNsD3IRHkm7fbKIUGvrleloJXUZgDHig2IPWNniv+GwjyJXzuNqVjlr5+4yVUZjycJwfQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2492,6 +2476,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2553,6 +2538,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.4.tgz",
       "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2562,6 +2548,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.4.tgz",
       "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2796,6 +2783,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2882,6 +2870,7 @@
       "integrity": "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
@@ -3006,6 +2995,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/clawjournal/web/frontend/src/components/TraceCard.tsx
+++ b/clawjournal/web/frontend/src/components/TraceCard.tsx
@@ -120,24 +120,27 @@ export function TraceCard({
             {session.display_title}
           </span>
           {session.ai_failure_value_score != null && (
-            <span style={{
-              display: 'inline-flex',
-              alignItems: 'center',
-              justifyContent: 'center',
-              padding: '2px 7px',
-              borderRadius: 9999,
-              fontSize: 11,
-              fontWeight: 700,
-              color: '#991b1b',
-              background: '#fee2e2',
-              flexShrink: 0,
-            }}>
-              {session.ai_failure_value_score} failure value
+            <span
+              title="Failure value (1–5): how useful this trace is for studying agent failure behavior — not how badly the session failed"
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '2px 7px',
+                borderRadius: 9999,
+                fontSize: 11,
+                fontWeight: 700,
+                color: '#7a5508',
+                background: '#fdf3d4',
+                flexShrink: 0,
+              }}
+            >
+              Failure value {session.ai_failure_value_score}/5
             </span>
           )}
           {session.ai_quality_score != null && (
             <span
-              title="Productivity score"
+              title="Productivity (1–5): how much useful work this session accomplished"
               style={{
                 display: 'inline-flex',
                 alignItems: 'center',
@@ -151,7 +154,7 @@ export function TraceCard({
                 flexShrink: 0,
               }}
             >
-              Prod {session.ai_quality_score}/5
+              Productivity {session.ai_quality_score}/5
             </span>
           )}
           <span style={{ fontSize: 12, color: '#9ca3af', flexShrink: 0 }}>

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -44,6 +44,24 @@ function outcomeText(badge: string | null): string {
   return '';
 }
 
+// Plain-English gloss for each outcome badge, shown on hover so the
+// similar-looking states (notably failed vs errored) are distinguishable.
+function outcomeTooltip(badge: string | null): string {
+  if (!badge) return '';
+  const b = badge.toLowerCase();
+  if (b === 'resolved') return 'Outcome: the task was resolved successfully.';
+  if (b === 'partial') return 'Outcome: interrupted — the user spoke last and the agent never replied.';
+  if (b === 'abandoned') return 'Outcome: abandoned before reaching a result.';
+  if (b === 'exploratory') return 'Outcome: exploratory — no concrete change was expected.';
+  if (b === 'trivial') return 'Outcome: trivial — minimal work.';
+  if (b.includes('pass')) return 'Outcome: a test run reported passing tests.';
+  if (b.includes('fail')) return 'Outcome: a test or build explicitly failed.';
+  if (b.includes('analysis')) return 'Outcome: analysis only — no code changes.';
+  if (b.includes('completed')) return 'Outcome: ran to the end with no error or test-failure signals.';
+  if (b.includes('errored')) return 'Outcome: hit a runtime error (exception, traceback, etc.) near the end — distinct from a test/build failure.';
+  return 'How this session ended (heuristic, not a score).';
+}
+
 function riskFlags(session: Session): string[] {
   const flags: string[] = [];
   const risks = session.risk_level;
@@ -706,7 +724,7 @@ export function Inbox() {
                     }}>{sourceInfo(s).label}</span>
                     <span>
                       {s.project} &middot; {s.user_messages + s.assistant_messages} msgs
-                      {s.outcome_label ? ` · ${outcomeText(s.outcome_label)}` : ''}
+                      {s.outcome_label ? <> &middot; <span title={outcomeTooltip(s.outcome_label)}>{outcomeText(s.outcome_label)}</span></> : ''}
                       {s.ai_failure_attribution ? ` · ${s.ai_failure_attribution.replace(/_/g, ' ')}` : ''}
                     </span>
                   </div>

--- a/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
@@ -6,7 +6,7 @@ import { colors } from '../../theme.ts';
 import { SessionDrawer } from '../../components/SessionDrawer.tsx';
 import { TraceCard } from '../../components/TraceCard.tsx';
 import type { ReadySession, ShareReadyStats } from './types.ts';
-import { autoDescription, formatDate, formatTokens, outcomeBadge, sessionTotalTokens } from './helpers.ts';
+import { autoDescription, formatDate, formatTokens, outcomeBadge, outcomeTooltip, sessionTotalTokens } from './helpers.ts';
 import { SHARE_SHELL_WIDTH, btnGhost, btnPrimary, btnSecondary } from './styles.tsx';
 import { CheckboxRow, HelpModal, Icon, SourceBadge, UsageDisclosure } from './shared.tsx';
 
@@ -270,10 +270,13 @@ export function QueueStep(p: QueueStepProps) {
 
           {/* Bundle summary */}
           <div style={{
-            display: 'flex', alignItems: 'center', justifyContent: 'space-between',
-            padding: '12px 14px', background: colors.gray50,
+            background: colors.gray50,
             border: `1px solid ${colors.gray200}`, borderRadius: 8, marginBottom: 10,
           }}>
+            <div style={{
+              display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+              padding: '12px 14px 8px',
+            }}>
             <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
               <div style={{ fontSize: 13, color: colors.gray900, fontWeight: 500 }}>draft-bundle</div>
               <div style={{ fontSize: 12, color: colors.gray500, fontVariantNumeric: 'tabular-nums' }}>
@@ -291,6 +294,18 @@ export function QueueStep(p: QueueStepProps) {
               <Icon name="grip" size={12} />
               Drag to reorder
             </span>
+            </div>
+            <div style={{
+              padding: '7px 14px 10px',
+              fontSize: 11, color: colors.gray400,
+              borderTop: `1px solid ${colors.gray200}`,
+              display: 'flex', flexDirection: 'column', gap: 3,
+            }}>
+              <div><span style={{ fontWeight: 600 }}>Failure value N/5</span>{' — how instructive this trace is for AI training (not how badly the session went)'}</div>
+              <div><span style={{ fontWeight: 600 }}>Productivity N/5</span>{' — how much useful work the session accomplished'}</div>
+              <div><span style={{ fontWeight: 600 }}>Who caused it</span>{': agent caused = the AI made a mistake · environment = external tool/infra problem · preexisting problem = bug existed before · user redirect = user changed direction · unclear = ambiguous'}</div>
+              <div><span style={{ fontWeight: 600 }}>Outcome</span>{': ✓ passed/completed · ✗ failed (test or build said no) · ✗ errored (runtime exception near the end) · ~ partial (session was interrupted)'}</div>
+            </div>
           </div>
 
           {/* Trace list */}
@@ -325,46 +340,52 @@ export function QueueStep(p: QueueStepProps) {
                     }}>
                       {s.display_title || 'Untitled'}
                     </div>
-                    <div style={{ fontSize: 11.5, color: colors.gray500, display: 'flex', gap: 10, alignItems: 'center', marginTop: 2 }}>
+                    {/* Row 1: source · project · tokens · tools */}
+                    <div style={{ fontSize: 11.5, color: colors.gray500, display: 'flex', gap: 8, alignItems: 'center', marginTop: 2, flexWrap: 'nowrap', overflow: 'hidden' }}>
                       <SourceBadge s={s} />
-                      <span>{s.project}</span>
-                      <span style={{ opacity: 0.5 }}>&middot;</span>
-                      <span>{formatTokens(sessionTotalTokens(s))} tokens</span>
+                      <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0, flexShrink: 1 }}>{s.project}</span>
+                      <span style={{ opacity: 0.5, flexShrink: 0 }}>&middot;</span>
+                      <span style={{ flexShrink: 0, whiteSpace: 'nowrap' }}>{formatTokens(sessionTotalTokens(s))} tokens</span>
                       {s.tool_uses > 0 && (<>
-                        <span style={{ opacity: 0.5 }}>&middot;</span>
-                        <span>{s.tool_uses} tools</span>
+                        <span style={{ opacity: 0.5, flexShrink: 0 }}>&middot;</span>
+                        <span style={{ flexShrink: 0, whiteSpace: 'nowrap' }}>{s.tool_uses} tools</span>
                       </>)}
-                      {s.ai_failure_value_score != null && (<>
-                        <span style={{ opacity: 0.5 }}>&middot;</span>
-                        <span style={{ color: '#991b1b', fontWeight: 700 }}>{s.ai_failure_value_score} failure value</span>
-                      </>)}
-                      {s.ai_quality_score != null && (<>
-                        <span style={{ opacity: 0.5 }}>&middot;</span>
+                    </div>
+                    {/* Row 2: scores · attribution · outcome */}
+                    <div style={{ fontSize: 11.5, color: colors.gray500, display: 'flex', gap: 8, alignItems: 'center', marginTop: 2, flexWrap: 'nowrap' }}>
+                      {s.ai_failure_value_score != null ? (
                         <span
-                          style={{ color: colors.gray500 }}
-                          title="Productivity score"
+                          style={{ color: colors.yellow700, fontWeight: 700, whiteSpace: 'nowrap' }}
+                          title="Failure value (1–5): how useful this trace is for studying agent failure behavior — not how badly the session failed"
                         >
-                          Productivity {s.ai_quality_score}/5
+                          Failure value {s.ai_failure_value_score}/5
                         </span>
-                      </>)}
-                      {s.ai_failure_attribution && (<>
-                        <span style={{ opacity: 0.5 }}>&middot;</span>
-                        <span>{s.ai_failure_attribution.replace(/_/g, ' ')}</span>
-                      </>)}
-                      {s.ai_failure_value_score == null && (<>
-                        <span style={{ opacity: 0.5 }}>&middot;</span>
+                      ) : (
                         <span
-                          style={{ color: colors.gray500, fontStyle: 'italic' }}
+                          style={{ color: colors.gray500, fontStyle: 'italic', whiteSpace: 'nowrap' }}
                           title={s.ai_quality_score == null
                             ? "This session hasn't been scored yet. Click Preview → Score with AI, or run `clawjournal score` from a terminal."
                             : "This legacy-scored session is missing failure value. Re-score it with AI before sharing."}
                         >
                           {s.ai_quality_score == null ? 'unscored' : 'failure value missing'}
                         </span>
+                      )}
+                      {s.ai_quality_score != null && (<>
+                        <span style={{ opacity: 0.5 }}>&middot;</span>
+                        <span
+                          style={{ whiteSpace: 'nowrap' }}
+                          title="Productivity (1–5): how much useful work this session accomplished"
+                        >
+                          Productivity {s.ai_quality_score}/5
+                        </span>
+                      </>)}
+                      {s.ai_failure_attribution && (<>
+                        <span style={{ opacity: 0.5 }}>&middot;</span>
+                        <span style={{ whiteSpace: 'nowrap' }}>{s.ai_failure_attribution.replace(/_/g, ' ')}</span>
                       </>)}
                       {s.outcome_badge && (<>
                         <span style={{ opacity: 0.5 }}>&middot;</span>
-                        <span>{outcomeBadge(s.outcome_badge)}</span>
+                        <span style={{ whiteSpace: 'nowrap' }} title={outcomeTooltip(s.outcome_badge)}>{outcomeBadge(s.outcome_badge)}</span>
                       </>)}
                     </div>
                   </div>

--- a/clawjournal/web/frontend/src/views/Share/helpers.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.ts
@@ -72,6 +72,25 @@ export function outcomeBadge(outcome: string | null): string {
   return '';
 }
 
+// Plain-English gloss for each outcome badge — surfaced as a hover tooltip so
+// users can tell the similar-looking states apart (notably failed vs errored).
+// "Outcome" describes how the session *ended*; it is a heuristic, not an AI score.
+export function outcomeTooltip(outcome: string | null): string {
+  if (!outcome) return '';
+  const b = outcome.toLowerCase();
+  if (b === 'resolved') return 'Outcome: the task was resolved successfully.';
+  if (b === 'partial') return 'Outcome: interrupted — the user spoke last and the agent never replied.';
+  if (b === 'abandoned') return 'Outcome: abandoned before reaching a result.';
+  if (b === 'exploratory') return 'Outcome: exploratory — no concrete change was expected.';
+  if (b === 'trivial') return 'Outcome: trivial — minimal work.';
+  if (b.includes('pass')) return 'Outcome: a test run reported passing tests.';
+  if (b.includes('fail')) return 'Outcome: a test or build explicitly failed.';
+  if (b.includes('analysis')) return 'Outcome: analysis only — no code changes.';
+  if (b.includes('completed')) return 'Outcome: ran to the end with no error or test-failure signals.';
+  if (b.includes('errored')) return 'Outcome: hit a runtime error (exception, traceback, etc.) near the end — distinct from a test/build failure.';
+  return 'How this session ended (heuristic, not a score).';
+}
+
 export const formatTokens = (t: number) => t >= 1_000_000 ? `${(t / 1_000_000).toFixed(1)}M` : `${(t / 1000).toFixed(0)}k`;
 export const formatBytes = (bytes: number) => {
   if (bytes >= 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;

--- a/clawjournal/web/frontend/src/views/Share/shared.tsx
+++ b/clawjournal/web/frontend/src/views/Share/shared.tsx
@@ -5,7 +5,7 @@ import { hexAlpha, sourceFullLabel } from './helpers.ts';
 
 export function SourceBadge({ s }: { s: { source: string; client_origin?: string | null; runtime_channel?: string | null } }) {
   const { label, color } = sourceFullLabel(s);
-  return <span style={{ fontSize: 10, fontWeight: 600, padding: '1px 6px', borderRadius: 4, background: hexAlpha(color, 0.10), color, marginRight: 3 }}>{label}</span>;
+  return <span style={{ fontSize: 10, fontWeight: 600, padding: '1px 6px', borderRadius: 4, background: hexAlpha(color, 0.10), color, marginRight: 3, whiteSpace: 'nowrap', flexShrink: 0 }}>{label}</span>;
 }
 
 export function ThinkingBlock({ text }: { text: string }) {

--- a/clawjournal/web/frontend/src/views/Share/styles.tsx
+++ b/clawjournal/web/frontend/src/views/Share/styles.tsx
@@ -1,6 +1,6 @@
 import { colors } from '../../theme.ts';
 
-export const SHARE_SHELL_WIDTH = '1120px';
+export const SHARE_SHELL_WIDTH = '1360px';
 
 export const btnPrimary = {
   display: 'inline-flex', alignItems: 'center', gap: 8,


### PR DESCRIPTION
## Summary

Continues the label-clarity work from #74, which fixed the session list but explicitly deferred the Share queue, TraceCard (Search), and outcome badge tooltips.

- **Label alignment** — deferred surfaces now match #74:
  - Share queue chip: `5 failure value` (red) → `Failure value 5/5` (amber)
  - TraceCard (Search + Share drawer): same fix + `Prod 4/5` → `Productivity 4/5`
  - Tooltips added to both score chips explaining the 1–5 scale

- **Outcome badge tooltips** — hover on any outcome badge now shows a plain-English gloss; specifically calls out `✗ failed` (test/build said no) vs `✗ errored` (runtime exception near the end), the pair users most confuse

- **Share queue legend** — 4-line always-visible key below the draft-bundle header:
  - Failure value N/5, Productivity N/5, Who caused it (all 5 attribution values), Outcome states

- **Row layout fix** — trace row metadata split into two dedicated lines:
  1. source · project (truncates with ellipsis) · tokens · tools
  2. Failure value · Productivity · attribution · outcome
  Also fixes `SourceBadge` (`whiteSpace: nowrap`) stopping "Claude Code" from splitting across lines

- **Container width** — `SHARE_SHELL_WIDTH` 1120px → 1360px

## Test plan

- [ ] Share queue chips: `Failure value N/5` amber, `Productivity N/5` gray, tooltips present
- [ ] Share queue legend visible below draft-bundle header (4 lines)
- [ ] Rows with long project names: no chip wrapping, project name truncates
- [ ] Outcome badges: hover tooltips on Share queue and session list
- [ ] TraceCard (Search): amber `Failure value N/5` pill, `Productivity N/5`
- [ ] `tsc -b` + `vite build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)