### PR TITLE
[codex] Document terminal share wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ clawjournal set-score <id> --failure-value 4 --failure-evidence "User corrected 
 clawjournal set-score <id> --quality 4               # legacy productivity override
 ```
 
-Scoring uses the current agent's automation CLI by default (`codex exec` in Codex, the Claude CLI in Claude Code); backends are `claude`, `codex`, `hermes`, `openclaw` (override with `--backend`). For Codex specifically, run `codex login` or set `CODEX_API_KEY` for headless scoring. The workbench can also auto-score share-ready traces in the background, but only after you confirm a backend once; confirm it headlessly with `clawjournal config --scorer-backend <backend>` (`none` clears it).
+Scoring uses the current agent's automation CLI by default (`codex exec` in Codex, the Claude CLI in Claude Code); backends are `claude`, `codex`, `hermes`, `openclaw` (override with `--backend`). Claude-backed AI features default to `claude-sonnet-4-6` for speed unless you pass `--model`. For Codex specifically, run `codex login` or set `CODEX_API_KEY` for headless scoring. The workbench can also auto-score share-ready traces in the background, but only after you confirm a backend once; confirm it headlessly with `clawjournal config --scorer-backend <backend>` (`none` clears it).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -221,6 +221,15 @@ Packaging is **100% local** — it writes a redacted ZIP to your computer. Uploa
 
 Seeing **Done** instead of **Submit** is normal — submissions just aren't open right now.
 
+**Sharing from a remote machine or SSH session.** If the browser workbench is inconvenient, use the terminal wizard:
+
+```bash
+clawjournal share --interactive --weekly
+# or: clawshare --weekly
+```
+
+It lists shareable traces, prioritizes AI-scored high-failure-value sessions, shows the redacted preview, asks for consent, then uploads when hosted submission is available or saves a ZIP for manual upload. Useful filters: `--all`, `--source codex`, `--source claude`, `--search "text"`, and `--ai-pii-review` for the optional AI PII pass.
+
 > ⚠️ **`clawjournal bundle-share` is NOT the Rayward path.** It only uploads to a **self-hosted** ingest server you configure via `CLAWJOURNAL_INGEST_URL`; without it, it reports *"Hosted sharing is not configured."* Rayward / STEM Data Program participants should ignore it and use the workbench above.
 
 <details>
@@ -312,6 +321,7 @@ clawjournal bundle-share <bundle_id>
 | `clawjournal verify-email you@university.edu` | Request a code for the hosted submission flow (a code is emailed; confirm with `clawjournal verify-email you@university.edu --code <CODE>`) |
 | `clawjournal share --preview --status approved` | Preview what would be packaged |
 | `clawjournal share --status approved [--ai-pii-review]` | Package locally + print the Share URL; hosted upload happens in the browser |
+| `clawjournal share --interactive --weekly` / `clawshare --weekly` | Terminal Share wizard for remote/SSH sessions; review redactions, consent, upload or save ZIP |
 | `clawjournal card <id> [--depth workflow\|full]` | Generate a share card (`workflow` is safe for public channels) |
 
 ### Configuration & maintenance

--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ clawjournal set-score <id> --failure-value 4 --failure-evidence "User corrected 
 clawjournal set-score <id> --quality 4               # legacy productivity override
 ```
 
-Scoring uses the current agent's automation CLI by default (`codex exec` in Codex, the Claude CLI in Claude Code); backends are `claude`, `codex`, `hermes`, `openclaw` (override with `--backend`). Claude-backed AI features default to `claude-sonnet-4-6` for speed unless you pass `--model`. For Codex specifically, run `codex login` or set `CODEX_API_KEY` for headless scoring. The workbench can also auto-score share-ready traces in the background, but only after you confirm a backend once; confirm it headlessly with `clawjournal config --scorer-backend <backend>` (`none` clears it).
+Scoring uses the current agent's automation CLI by default (`codex exec` in Codex, the Claude CLI in Claude Code); backends are `claude`, `codex`, `hermes`, `openclaw` (override with `--backend`). Claude Code-backed AI features default to `claude-sonnet-4-6`, Codex-backed AI features default to `gpt-5.4-mini`, and the other backends use their own agent defaults unless you pass `--model`. For Codex specifically, run `codex login` or set `CODEX_API_KEY` for headless scoring. The workbench can also auto-score share-ready traces in the background, but only after you confirm a backend once; confirm it headlessly with `clawjournal config --scorer-backend <backend>` (`none` clears it).
 
 </details>
 

--- a/README.md
+++ b/README.md
@@ -230,6 +230,10 @@ clawjournal share --interactive --weekly
 
 It lists shareable traces, prioritizes AI-scored high-failure-value sessions, shows the redacted preview, asks for consent, then uploads when hosted submission is available or saves a ZIP for manual upload. Useful filters: `--all`, `--source codex`, `--source claude`, `--search "text"`, and `--ai-pii-review` for the optional AI PII pass.
 
+Or paste this into Claude Code, Codex, or another AI coding assistant on the remote machine:
+
+> *Install or update ClawJournal from https://github.com/rayward-external/clawjournal. Read its README and follow it for my operating system. Then help me share my recent coding-agent sessions from this terminal. If needed, configure source `all`, confirm projects, and scan first. Then run `clawjournal share --interactive --weekly`; guide me through selecting sessions, reviewing redactions, and consenting. Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP and tell me where it is so I can upload it at https://data.rayward.ai/share.*
+
 > ⚠️ **`clawjournal bundle-share` is NOT the Rayward path.** It only uploads to a **self-hosted** ingest server you configure via `CLAWJOURNAL_INGEST_URL`; without it, it reports *"Hosted sharing is not configured."* Rayward / STEM Data Program participants should ignore it and use the workbench above.
 
 <details>

--- a/clawjournal/benchmark/generate.py
+++ b/clawjournal/benchmark/generate.py
@@ -33,7 +33,7 @@ from pathlib import Path
 from typing import Any, Callable, Protocol
 
 from ..redaction.anonymizer import Anonymizer
-from ..scoring.backends import resolve_backend, run_default_agent_task
+from ..scoring.backends import default_model_for_backend, resolve_backend, run_default_agent_task
 from . import schema as bm
 from .select import DEFAULT_DEEPREAD_CAP, DEFAULT_WINDOW_DAYS, FailureCandidate, WeekSlice, select_week_failures
 
@@ -42,11 +42,9 @@ logger = logging.getLogger(__name__)
 DEFAULT_MAX_WORKERS = 4
 BLOB_EXTRACT_MAX_CHARS = 8000
 
-# Generation makes ~40+ calls; default each backend to a fast, inexpensive model
-# (still through the CLI/subscription — no raw API). Only claude exposes a stable
-# alias; codex model slugs vary, so leave it at the CLI default (override with
-# `--model`). `None` means "the CLI's default model".
-_DEFAULT_GEN_MODEL: dict[str, str] = {"claude": "sonnet"}
+# Generation makes ~40+ calls; default each backend to ClawJournal's fast model
+# choice (still through the CLI/subscription — no raw API). Codex model slugs
+# vary, so it stays at the CLI default unless the caller passes `--model`.
 
 # Per-stage subprocess ceilings (seconds). The architect call synthesises ALL
 # deep-read seeds in one shot — the heaviest single call — and was timing out
@@ -158,7 +156,7 @@ class AgentBackendCaller:
         self.resolved = resolve_backend(self.backend)
         # Fall back to the per-backend fast default unless the caller named a model.
         if self.model is None:
-            self.model = _DEFAULT_GEN_MODEL.get(self.resolved)
+            self.model = default_model_for_backend(self.resolved)
 
     def __call__(self, *, stage: str, system_prompt: str, task_prompt: str) -> dict[str, Any]:
         import tempfile

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -15,7 +15,7 @@ from typing import Any, Mapping, cast
 from .redaction.anonymizer import Anonymizer
 from .config import CONFIG_FILE, ClawJournalConfig, load_config, normalize_excluded_project_names, save_config
 from .parsing.parser import CLAUDE_DIR, CODEX_DIR, COPILOT_DIR, CURSOR_DIR, CUSTOM_DIR, GEMINI_DIR, KIMI_DIR, LOCAL_AGENT_DIR, OPENCODE_DIR, OPENCLAW_DIR, discover_projects, parse_project_sessions
-from .scoring.backends import BACKEND_CHOICES
+from .scoring.backends import BACKEND_CHOICES, DEFAULT_CLAUDE_MODEL
 from .redaction.pii import apply_findings_to_session, load_findings, load_jsonl_sessions, review_session_pii, review_session_pii_hybrid, review_session_pii_with_agent, write_findings, write_jsonl_sessions
 from .scoring.scoring import SCORING_BACKEND_CHOICES
 from .redaction.secrets import _has_mixed_char_types, _shannon_entropy, redact_session
@@ -4020,7 +4020,10 @@ def main() -> None:
     bench_p.add_argument("--window", type=int, default=7, help="Coverage window in days (default 7)")
     bench_p.add_argument("--cap", type=int, default=15, help="Max sessions to deep-read (cost bound)")
     bench_p.add_argument("--backend", default="auto", help="Scoring backend (auto|claude|codex|...)")
-    bench_p.add_argument("--model", help="Model override for generation (default: a fast model per backend — sonnet for Claude)")
+    bench_p.add_argument(
+        "--model",
+        help="Model override for generation (default: a fast model per backend — Sonnet 4.6 for Claude)",
+    )
     bench_p.add_argument("--list", action="store_true", help="List stored benchmarks")
     bench_p.add_argument("--show", metavar="ID", help="Render a stored benchmark as markdown (ID or 'latest')")
     bench_p.add_argument("--export", metavar="ID", help="Export a benchmark to a local file (ID or 'latest')")
@@ -4117,7 +4120,7 @@ def main() -> None:
     sc.add_argument("--backend", choices=SCORING_BACKEND_CHOICES, default="auto",
                     help="Scoring backend (default: auto = current agent's automation CLI)")
     sc.add_argument("--model", type=str, default=None,
-                    help="Optional model override for the selected backend")
+                    help=f"Optional model override for the selected backend (Claude default: {DEFAULT_CLAUDE_MODEL})")
     sc.add_argument("--dry-run", action="store_true", help="Show score-view without calling a scoring backend")
     sc.add_argument("--auto-triage", action="store_true",
                     help="After scoring, auto-archive 1/5 noise sessions")
@@ -4148,7 +4151,7 @@ def main() -> None:
         "--model",
         type=str,
         default=None,
-        help="Optional model override for the selected backend",
+        help=f"Optional model override for the selected backend (Claude default: {DEFAULT_CLAUDE_MODEL})",
     )
     rs.add_argument(
         "--dry-run",

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -15,7 +15,7 @@ from typing import Any, Mapping, cast
 from .redaction.anonymizer import Anonymizer
 from .config import CONFIG_FILE, ClawJournalConfig, load_config, normalize_excluded_project_names, save_config
 from .parsing.parser import CLAUDE_DIR, CODEX_DIR, COPILOT_DIR, CURSOR_DIR, CUSTOM_DIR, GEMINI_DIR, KIMI_DIR, LOCAL_AGENT_DIR, OPENCODE_DIR, OPENCLAW_DIR, discover_projects, parse_project_sessions
-from .scoring.backends import BACKEND_CHOICES, DEFAULT_CLAUDE_MODEL
+from .scoring.backends import BACKEND_CHOICES, DEFAULT_CLAUDE_MODEL, DEFAULT_CODEX_MODEL
 from .redaction.pii import apply_findings_to_session, load_findings, load_jsonl_sessions, review_session_pii, review_session_pii_hybrid, review_session_pii_with_agent, write_findings, write_jsonl_sessions
 from .scoring.scoring import SCORING_BACKEND_CHOICES
 from .redaction.secrets import _has_mixed_char_types, _shannon_entropy, redact_session
@@ -4020,9 +4020,14 @@ def main() -> None:
     bench_p.add_argument("--window", type=int, default=7, help="Coverage window in days (default 7)")
     bench_p.add_argument("--cap", type=int, default=15, help="Max sessions to deep-read (cost bound)")
     bench_p.add_argument("--backend", default="auto", help="Scoring backend (auto|claude|codex|...)")
+    model_default_help = (
+        f"Optional model override (defaults: Claude {DEFAULT_CLAUDE_MODEL}, "
+        f"Codex {DEFAULT_CODEX_MODEL}; others use agent default)"
+    )
+
     bench_p.add_argument(
         "--model",
-        help="Model override for generation (default: a fast model per backend — Sonnet 4.6 for Claude)",
+        help=model_default_help,
     )
     bench_p.add_argument("--list", action="store_true", help="List stored benchmarks")
     bench_p.add_argument("--show", metavar="ID", help="Render a stored benchmark as markdown (ID or 'latest')")
@@ -4120,7 +4125,7 @@ def main() -> None:
     sc.add_argument("--backend", choices=SCORING_BACKEND_CHOICES, default="auto",
                     help="Scoring backend (default: auto = current agent's automation CLI)")
     sc.add_argument("--model", type=str, default=None,
-                    help=f"Optional model override for the selected backend (Claude default: {DEFAULT_CLAUDE_MODEL})")
+                    help=model_default_help)
     sc.add_argument("--dry-run", action="store_true", help="Show score-view without calling a scoring backend")
     sc.add_argument("--auto-triage", action="store_true",
                     help="After scoring, auto-archive 1/5 noise sessions")
@@ -4151,7 +4156,7 @@ def main() -> None:
         "--model",
         type=str,
         default=None,
-        help=f"Optional model override for the selected backend (Claude default: {DEFAULT_CLAUDE_MODEL})",
+        help=model_default_help,
     )
     rs.add_argument(
         "--dry-run",

--- a/clawjournal/scoring/backends.py
+++ b/clawjournal/scoring/backends.py
@@ -22,7 +22,11 @@ SUPPORTED_BACKENDS = ("claude", "codex", "hermes", "openclaw")
 BACKEND_CHOICES = ("auto", *SUPPORTED_BACKENDS)
 AUTO_BACKEND_FALLBACK_ORDER = ("codex", "claude", "hermes", "openclaw")
 DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-6"
-DEFAULT_BACKEND_MODELS: dict[str, str] = {"claude": DEFAULT_CLAUDE_MODEL}
+DEFAULT_CODEX_MODEL = "gpt-5.4-mini"
+DEFAULT_BACKEND_MODELS: dict[str, str] = {
+    "claude": DEFAULT_CLAUDE_MODEL,
+    "codex": DEFAULT_CODEX_MODEL,
+}
 
 # Prefix of the RuntimeError raised by resolve_backend() when no usable backend
 # can be found. Kept as a constant so callers (e.g. the daemon's auto-score
@@ -421,9 +425,9 @@ def run_default_agent_task(
         task_prompt: The task instruction. Delivered via stdin (Claude),
             positional arg (Codex), scripted one-shot (Hermes), or
             ``--message`` (OpenClaw).
-        model: Optional model override for Claude/Codex. Claude defaults to
-            ``DEFAULT_CLAUDE_MODEL`` when not provided so AI features do not
-            inherit a slower Opus CLI default.
+        model: Optional model override for Claude/Codex. Claude and Codex use
+            fast backend-specific defaults when not provided; other backends
+            keep their agent CLI default.
         timeout_seconds: Subprocess timeout.
         codex_sandbox: Codex sandbox mode ("read-only" or None for
             full access). Ignored by other backends.

--- a/clawjournal/scoring/backends.py
+++ b/clawjournal/scoring/backends.py
@@ -21,6 +21,8 @@ logger = logging.getLogger(__name__)
 SUPPORTED_BACKENDS = ("claude", "codex", "hermes", "openclaw")
 BACKEND_CHOICES = ("auto", *SUPPORTED_BACKENDS)
 AUTO_BACKEND_FALLBACK_ORDER = ("codex", "claude", "hermes", "openclaw")
+DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-6"
+DEFAULT_BACKEND_MODELS: dict[str, str] = {"claude": DEFAULT_CLAUDE_MODEL}
 
 # Prefix of the RuntimeError raised by resolve_backend() when no usable backend
 # can be found. Kept as a constant so callers (e.g. the daemon's auto-score
@@ -54,6 +56,16 @@ BACKEND_COMMAND_ALIASES: dict[str, tuple[str, ...]] = {
     "hermes": ("hermes",),
     "openclaw": ("openclaw",),
 }
+
+
+def default_model_for_backend(backend: str) -> str | None:
+    """Return ClawJournal's fast default model for a resolved backend."""
+    return DEFAULT_BACKEND_MODELS.get(backend)
+
+
+def resolve_model_for_backend(backend: str, model: str | None) -> str | None:
+    """Use an explicit model when provided, otherwise the backend fast default."""
+    return model if model else default_model_for_backend(backend)
 
 
 def _detect_current_agent_from_env(env: dict[str, str] | None = None) -> str | None:
@@ -409,7 +421,9 @@ def run_default_agent_task(
         task_prompt: The task instruction. Delivered via stdin (Claude),
             positional arg (Codex), scripted one-shot (Hermes), or
             ``--message`` (OpenClaw).
-        model: Optional model override for Claude/Codex.
+        model: Optional model override for Claude/Codex. Claude defaults to
+            ``DEFAULT_CLAUDE_MODEL`` when not provided so AI features do not
+            inherit a slower Opus CLI default.
         timeout_seconds: Subprocess timeout.
         codex_sandbox: Codex sandbox mode ("read-only" or None for
             full access). Ignored by other backends.
@@ -428,6 +442,7 @@ def run_default_agent_task(
     check_backend_runtime(resolved)
     command = require_backend_command(resolved)
     agent_env = _agent_subprocess_env()
+    effective_model = resolve_model_for_backend(resolved, model)
 
     if codex_output_file and ("/" in codex_output_file or "\\" in codex_output_file):
         raise ValueError(
@@ -438,7 +453,7 @@ def run_default_agent_task(
         cmd = _build_claude_cmd(
             command,
             system_prompt_file=system_prompt_file,
-            model=model,
+            model=effective_model,
             bare=claude_bare,
         )
         try:
@@ -478,7 +493,7 @@ def run_default_agent_task(
         cmd = _build_codex_cmd(
             command,
             cwd=cwd,
-            model=model,
+            model=effective_model,
             sandbox=codex_sandbox,
             output_schema_path=schema_path,
             output_file_path=output_path,
@@ -513,7 +528,7 @@ def run_default_agent_task(
         )
 
     if resolved == "openclaw":
-        if model:
+        if effective_model:
             raise RuntimeError(
                 "OpenClaw backend does not support --model override from clawjournal"
             )
@@ -547,7 +562,7 @@ def run_default_agent_task(
         )
 
     if resolved == "hermes":
-        cmd = _build_hermes_cmd(command, message=task_prompt, model=model)
+        cmd = _build_hermes_cmd(command, message=task_prompt, model=effective_model)
         try:
             proc = subprocess.run(
                 cmd,

--- a/clawjournal/scoring/scoring.py
+++ b/clawjournal/scoring/scoring.py
@@ -29,6 +29,7 @@ from .backends import (
     SUPPORTED_BACKENDS,
     detect_current_agent,
     resolve_backend,
+    resolve_model_for_backend,
     run_default_agent_task,
 )
 
@@ -906,6 +907,7 @@ def call_judge(
     """Call the resolved scoring backend and return a validated judge result."""
     rubric = load_scoring_rubric()
     resolved = resolve_backend(backend)
+    effective_model = resolve_model_for_backend(resolved, model)
     session_payload = session_data or {}
     metadata_payload = metadata or {}
 
@@ -947,7 +949,7 @@ def call_judge(
             cwd=tmp_path,
             system_prompt_file=_SCORER_PROMPT_FILE,
             task_prompt=task_prompt,
-            model=model,
+            model=effective_model,
             timeout_seconds=120,
             codex_sandbox="read-only",
             codex_output_schema=JUDGE_SCHEMA,
@@ -959,7 +961,7 @@ def call_judge(
         return _attach_scorer_metadata(
             parsed,
             backend=resolved,
-            model=model,
+            model=effective_model,
             rubric=rubric,
         )
 

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -832,7 +832,7 @@ def add_interactive_flags(parser: argparse.ArgumentParser) -> argparse.ArgumentP
                         help="only traces with failure value >= N (1-5)")
     parser.add_argument("--limit", type=int, default=40, help="max traces to list (default 40)")
     parser.add_argument("--summary", action="store_true",
-                        help="show AI-summarized titles (Haiku); default shows original titles")
+                        help="show AI-summarized titles using the selected backend default; default shows original titles")
     parser.add_argument("--summary-model", default=None, metavar="MODEL",
                         help="model for --summary titles (implies --summary)")
     parser.add_argument("--accept-terms", action="store_true",

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -32,6 +32,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from .config import load_config
+from .scoring.backends import DEFAULT_CLAUDE_MODEL
 from .workbench.index import (
     SHAREABLE_HOLD_STATES,
     effective_hold_state,
@@ -221,7 +222,7 @@ def summarize_trace(session_detail: dict, *, backend: str = "auto",
     return title.strip().strip('"').strip("'")[:80]
 
 
-_LIGHT_SUMMARY_MODEL = {"claude": "haiku"}
+_LIGHT_SUMMARY_MODEL = {"claude": DEFAULT_CLAUDE_MODEL}
 
 
 def _title_cache_path() -> Path:
@@ -261,7 +262,7 @@ def ensure_titles(conn, rows: list[dict], do_summarize: bool, summary_model: str
     import shutil
     from .scoring.backends import resolve_backend
     if not summary_model and shutil.which("claude"):
-        backend, model = "claude", "haiku"
+        backend, model = "claude", DEFAULT_CLAUDE_MODEL
     else:
         try:
             backend = resolve_backend("auto")

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -32,7 +32,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from .config import load_config
-from .scoring.backends import DEFAULT_CLAUDE_MODEL
+from .scoring.backends import default_model_for_backend, resolve_backend
 from .workbench.index import (
     SHAREABLE_HOLD_STATES,
     effective_hold_state,
@@ -222,9 +222,6 @@ def summarize_trace(session_detail: dict, *, backend: str = "auto",
     return title.strip().strip('"').strip("'")[:80]
 
 
-_LIGHT_SUMMARY_MODEL = {"claude": DEFAULT_CLAUDE_MODEL}
-
-
 def _title_cache_path() -> Path:
     from .config import CONFIG_DIR
     return Path(CONFIG_DIR) / "clawshare_titles.json"
@@ -259,17 +256,12 @@ def ensure_titles(conn, rows: list[dict], do_summarize: bool, summary_model: str
     if not need:
         return
 
-    import shutil
-    from .scoring.backends import resolve_backend
-    if not summary_model and shutil.which("claude"):
-        backend, model = "claude", DEFAULT_CLAUDE_MODEL
-    else:
-        try:
-            backend = resolve_backend("auto")
-        except Exception:  # noqa: BLE001
-            print(f"  {DIM}(no agent backend available — using raw titles){RST}")
-            return
-        model = summary_model or _LIGHT_SUMMARY_MODEL.get(backend)
+    try:
+        backend = resolve_backend("auto")
+    except Exception:  # noqa: BLE001
+        print(f"  {DIM}(no agent backend available — using raw titles){RST}")
+        return
+    model = summary_model or default_model_for_backend(backend)
 
     label = f"{backend}/{model}" if model else backend
     print(f"  {DIM}Summarizing {len(need)} title(s) with {label} — Ctrl-C to skip…{RST}")

--- a/tests/benchmark/test_generate.py
+++ b/tests/benchmark/test_generate.py
@@ -15,6 +15,7 @@ from clawjournal.benchmark.generate import (
     generate_benchmark,
 )
 from clawjournal.redaction.anonymizer import Anonymizer
+from clawjournal.scoring.backends import DEFAULT_CLAUDE_MODEL
 
 NOW = datetime(2026, 5, 31, 12, 0, 0, tzinfo=timezone.utc)
 NO_ANON = Anonymizer(enabled=False)
@@ -294,9 +295,9 @@ class TestBlobExtract:
 
 
 class TestDefaultModel:
-    def test_claude_defaults_to_sonnet(self, monkeypatch):
+    def test_claude_defaults_to_sonnet_46(self, monkeypatch):
         monkeypatch.setattr("clawjournal.benchmark.generate.resolve_backend", lambda b: "claude")
-        assert AgentBackendCaller(backend="auto").model == "sonnet"
+        assert AgentBackendCaller(backend="auto").model == DEFAULT_CLAUDE_MODEL
 
     def test_codex_keeps_cli_default(self, monkeypatch):
         monkeypatch.setattr("clawjournal.benchmark.generate.resolve_backend", lambda b: "codex")

--- a/tests/benchmark/test_generate.py
+++ b/tests/benchmark/test_generate.py
@@ -15,7 +15,7 @@ from clawjournal.benchmark.generate import (
     generate_benchmark,
 )
 from clawjournal.redaction.anonymizer import Anonymizer
-from clawjournal.scoring.backends import DEFAULT_CLAUDE_MODEL
+from clawjournal.scoring.backends import DEFAULT_CLAUDE_MODEL, DEFAULT_CODEX_MODEL
 
 NOW = datetime(2026, 5, 31, 12, 0, 0, tzinfo=timezone.utc)
 NO_ANON = Anonymizer(enabled=False)
@@ -299,9 +299,9 @@ class TestDefaultModel:
         monkeypatch.setattr("clawjournal.benchmark.generate.resolve_backend", lambda b: "claude")
         assert AgentBackendCaller(backend="auto").model == DEFAULT_CLAUDE_MODEL
 
-    def test_codex_keeps_cli_default(self, monkeypatch):
+    def test_codex_defaults_to_gpt_54_mini(self, monkeypatch):
         monkeypatch.setattr("clawjournal.benchmark.generate.resolve_backend", lambda b: "codex")
-        assert AgentBackendCaller(backend="auto").model is None
+        assert AgentBackendCaller(backend="auto").model == DEFAULT_CODEX_MODEL
 
     def test_explicit_model_overrides_default(self, monkeypatch):
         monkeypatch.setattr("clawjournal.benchmark.generate.resolve_backend", lambda b: "claude")

--- a/tests/scoring/test_backends.py
+++ b/tests/scoring/test_backends.py
@@ -11,6 +11,7 @@ from clawjournal.scoring.backends import (
     AgentResult,
     BACKEND_CHOICES,
     DEFAULT_CLAUDE_MODEL,
+    DEFAULT_CODEX_MODEL,
     SUPPORTED_BACKENDS,
     _agent_subprocess_env,
     _build_claude_cmd,
@@ -40,11 +41,15 @@ class TestConstants:
     def test_supported_backends(self):
         assert set(SUPPORTED_BACKENDS) == {"claude", "codex", "hermes", "openclaw"}
 
-    def test_default_claude_model(self):
+    def test_default_backend_models(self):
         assert DEFAULT_CLAUDE_MODEL == "claude-sonnet-4-6"
+        assert DEFAULT_CODEX_MODEL == "gpt-5.4-mini"
         assert default_model_for_backend("claude") == DEFAULT_CLAUDE_MODEL
-        assert default_model_for_backend("codex") is None
+        assert default_model_for_backend("codex") == DEFAULT_CODEX_MODEL
+        assert default_model_for_backend("hermes") is None
+        assert default_model_for_backend("openclaw") is None
         assert resolve_model_for_backend("claude", None) == DEFAULT_CLAUDE_MODEL
+        assert resolve_model_for_backend("codex", None) == DEFAULT_CODEX_MODEL
         assert resolve_model_for_backend("claude", "opus") == "opus"
 
 
@@ -455,6 +460,20 @@ class TestRunDefaultAgentTaskCodex:
         )
         assert result.stdout == "done"
         assert result.returncode == 0
+
+    def test_default_model_forwarded(self, monkeypatch, tmp_path):
+        _stub_which(monkeypatch)
+        captured_cmd = []
+
+        def spy_run(cmd, **kw):
+            captured_cmd.extend(cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("clawjournal.scoring.backends.subprocess.run", spy_run)
+        run_default_agent_task(
+            backend="codex", cwd=tmp_path, task_prompt="review",
+        )
+        assert captured_cmd[captured_cmd.index("--model") + 1] == DEFAULT_CODEX_MODEL
 
     def test_nonzero_exit_raises(self, monkeypatch, tmp_path):
         _stub_which(monkeypatch)

--- a/tests/scoring/test_backends.py
+++ b/tests/scoring/test_backends.py
@@ -10,6 +10,7 @@ import pytest
 from clawjournal.scoring.backends import (
     AgentResult,
     BACKEND_CHOICES,
+    DEFAULT_CLAUDE_MODEL,
     SUPPORTED_BACKENDS,
     _agent_subprocess_env,
     _build_claude_cmd,
@@ -21,10 +22,12 @@ from clawjournal.scoring.backends import (
     _detect_current_agent_from_process_tree,
     _get_process_field,
     check_backend_runtime,
+    default_model_for_backend,
     detect_available_backend,
     format_codex_runtime_error,
     require_backend_command,
     resolve_backend,
+    resolve_model_for_backend,
     run_default_agent_task,
     summarize_process_error,
 )
@@ -36,6 +39,13 @@ class TestConstants:
 
     def test_supported_backends(self):
         assert set(SUPPORTED_BACKENDS) == {"claude", "codex", "hermes", "openclaw"}
+
+    def test_default_claude_model(self):
+        assert DEFAULT_CLAUDE_MODEL == "claude-sonnet-4-6"
+        assert default_model_for_backend("claude") == DEFAULT_CLAUDE_MODEL
+        assert default_model_for_backend("codex") is None
+        assert resolve_model_for_backend("claude", None) == DEFAULT_CLAUDE_MODEL
+        assert resolve_model_for_backend("claude", "opus") == "opus"
 
 
 class TestDetection:
@@ -371,6 +381,34 @@ class TestRunDefaultAgentTaskClaude:
         assert result.stdout == '{"result": "ok"}'
         assert result.returncode == 0
         assert result.cwd == tmp_path
+
+    def test_default_model_forwarded(self, monkeypatch, tmp_path):
+        _stub_which(monkeypatch)
+        captured_cmd = []
+
+        def spy_run(cmd, **kw):
+            captured_cmd.extend(cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("clawjournal.scoring.backends.subprocess.run", spy_run)
+        run_default_agent_task(
+            backend="claude", cwd=tmp_path, task_prompt="score this",
+        )
+        assert captured_cmd[captured_cmd.index("--model") + 1] == DEFAULT_CLAUDE_MODEL
+
+    def test_explicit_model_overrides_default(self, monkeypatch, tmp_path):
+        _stub_which(monkeypatch)
+        captured_cmd = []
+
+        def spy_run(cmd, **kw):
+            captured_cmd.extend(cmd)
+            return subprocess.CompletedProcess(args=cmd, returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr("clawjournal.scoring.backends.subprocess.run", spy_run)
+        run_default_agent_task(
+            backend="claude", cwd=tmp_path, task_prompt="score this", model="opus",
+        )
+        assert captured_cmd[captured_cmd.index("--model") + 1] == "opus"
 
     def test_nonzero_exit_raises(self, monkeypatch, tmp_path):
         _stub_which(monkeypatch)

--- a/tests/scoring/test_scoring.py
+++ b/tests/scoring/test_scoring.py
@@ -9,6 +9,7 @@ from clawjournal.redaction.pii import _PII_PROMPT_FILE
 from clawjournal.scoring.backends import (
     AgentResult,
     DEFAULT_CLAUDE_MODEL,
+    DEFAULT_CODEX_MODEL,
     _classify_process_command,
     _detect_current_agent_from_env,
     check_backend_runtime as _check_backend_runtime,
@@ -566,6 +567,7 @@ class TestBackendSelection:
         def fake_run(*, backend, cwd, task_prompt=None, **kw):
             captured["task_prompt"] = task_prompt
             captured["backend"] = backend
+            captured["model"] = kw.get("model")
             captured["codex_output_schema"] = kw.get("codex_output_schema")
             scoring = {
                 "substance": 4,
@@ -593,6 +595,7 @@ class TestBackendSelection:
         assert result["substance"] == 4
         assert result["task_type"] == "debugging"
         assert captured["backend"] == "codex"
+        assert captured["model"] == DEFAULT_CODEX_MODEL
         assert captured["task_prompt"] == _SCORE_TASK_PROMPT_CODEX
         assert captured["codex_output_schema"] is not None
 

--- a/tests/scoring/test_scoring.py
+++ b/tests/scoring/test_scoring.py
@@ -8,6 +8,7 @@ import pytest
 from clawjournal.redaction.pii import _PII_PROMPT_FILE
 from clawjournal.scoring.backends import (
     AgentResult,
+    DEFAULT_CLAUDE_MODEL,
     _classify_process_command,
     _detect_current_agent_from_env,
     check_backend_runtime as _check_backend_runtime,
@@ -641,6 +642,39 @@ class TestBackendSelection:
         assert "blob_path" not in captured["session_payload"]
         assert "raw_source_path" not in captured["session_payload"]
         assert len(captured["session_payload"]["commands_run"][0]) == 240
+
+    def test_call_judge_defaults_claude_to_sonnet_46(self, monkeypatch):
+        monkeypatch.setattr("clawjournal.scoring.scoring.load_scoring_rubric", lambda: "rubric")
+        captured = {}
+
+        def fake_run(*, backend, cwd, model=None, **kw):
+            captured["backend"] = backend
+            captured["model"] = model
+            scoring = {
+                "substance": 4,
+                **_failure_fields(ai_quality_score=4),
+                "reasoning": "Good session",
+                "display_title": "Fix auth tests",
+                "summary": "Fixed auth tests.",
+                "resolution": "resolved",
+                "effort_estimate": 0.4,
+                "task_type": "debugging",
+                "session_tags": [],
+                "privacy_flags": [],
+                "project_areas": [],
+            }
+            (cwd / "scoring.json").write_text(json.dumps(scoring))
+            return AgentResult(stdout="", stderr="", returncode=0, cwd=cwd)
+
+        monkeypatch.setattr("clawjournal.scoring.scoring.run_default_agent_task", fake_run)
+        result = call_judge(
+            "prompt",
+            session_data={"messages": []},
+            metadata={"total_steps": 1},
+            backend="claude",
+        )
+        assert captured == {"backend": "claude", "model": DEFAULT_CLAUDE_MODEL}
+        assert result["_scorer_model"] == DEFAULT_CLAUDE_MODEL
 
     def test_codex_judge_schema_forbids_additional_properties(self):
         assert JUDGE_SCHEMA["type"] == "object"

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from clawjournal import share_cli
+from clawjournal.scoring.backends import DEFAULT_CLAUDE_MODEL
 
 
 # ---- argument parsing -------------------------------------------------------
@@ -41,6 +42,10 @@ def test_arg_parsing_flags():
 def test_codex_claude_shortcuts():
     assert _parse(["--codex"]).source == "codex"
     assert _parse(["--claude"]).source == "claude"
+
+
+def test_claude_summary_titles_use_fast_default():
+    assert share_cli._LIGHT_SUMMARY_MODEL["claude"] == DEFAULT_CLAUDE_MODEL
 
 
 # ---- review must not mutate global review_status (#5) -----------------------

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -7,7 +7,7 @@ from types import SimpleNamespace
 import pytest
 
 from clawjournal import share_cli
-from clawjournal.scoring.backends import DEFAULT_CLAUDE_MODEL
+from clawjournal.scoring.backends import DEFAULT_CODEX_MODEL
 
 
 # ---- argument parsing -------------------------------------------------------
@@ -44,8 +44,25 @@ def test_codex_claude_shortcuts():
     assert _parse(["--claude"]).source == "claude"
 
 
-def test_claude_summary_titles_use_fast_default():
-    assert share_cli._LIGHT_SUMMARY_MODEL["claude"] == DEFAULT_CLAUDE_MODEL
+def test_summary_titles_use_resolved_backend_default(monkeypatch):
+    rows = [{"session_id": "s1", "ai_display_title": "", "display_title": "raw"}]
+    captured = {}
+
+    monkeypatch.setattr(share_cli, "resolve_backend", lambda backend: "codex")
+    monkeypatch.setattr(share_cli, "get_session_detail", lambda conn, sid: {"messages": []})
+    monkeypatch.setattr(share_cli, "_load_title_cache", lambda: {})
+    monkeypatch.setattr(share_cli, "_save_title_cache", lambda cache: None)
+
+    def fake_summary(detail, *, backend="auto", model=None):
+        captured["backend"] = backend
+        captured["model"] = model
+        return "Short title"
+
+    monkeypatch.setattr(share_cli, "summarize_trace", fake_summary)
+    share_cli.ensure_titles(None, rows, do_summarize=True)
+
+    assert captured == {"backend": "codex", "model": DEFAULT_CODEX_MODEL}
+    assert rows[0]["ai_display_title"] == "Short title"
 
 
 # ---- review must not mutate global review_status (#5) -----------------------


### PR DESCRIPTION
## What

- Add a small README note for sharing from remote machines or SSH sessions with `clawjournal share --interactive --weekly` / `clawshare --weekly`.
- Add the terminal Share wizard command to the Bundles & share command reference.

## Why

PhD students can use the CLI wizard to review redactions, consent, upload when hosted submission is available, or save a ZIP for manual upload without needing the browser workbench.

## Checks

- `git diff --check -- README.md`

Docs-only change; no test suite run.