### PR TITLE
Add clawjournal trufflehog install (managed, pinned, checksum-verified share-gate binary)

### DIFF
--- a/.github/workflows/trufflehog-pin.yml
+++ b/.github/workflows/trufflehog-pin.yml
@@ -1,0 +1,65 @@
+name: TruffleHog Pin Integrity
+
+# Verifies that the sha256 checksums vendored in
+# clawjournal/redaction/trufflehog_install.py still match the upstream
+# release they pin. Unit tests are hermetic and cannot see this — only a
+# real fetch of upstream's checksums.txt catches a bad pin bump or a
+# release asset that was silently re-uploaded.
+#
+# IMPORTANT: do NOT add this workflow's check to branch-protection
+# required checks. It is path-filtered at the trigger level, so on PRs
+# that do not touch the pinned files it produces no check run at all — a
+# required status would then sit "Expected" forever and block the PR.
+
+on:
+  pull_request:
+    paths:
+      - 'clawjournal/redaction/trufflehog_install.py'
+      - 'scripts/check_trufflehog_pin.py'
+      - '.github/workflows/trufflehog-pin.yml'
+  schedule:
+    # Mondays 06:17 UTC — off the top of the hour, which GitHub delays
+    # under load. Note: scheduled runs fire only from the default branch
+    # (so this activates after merge), and GitHub auto-disables crons on
+    # public repos after 60 days with no repository activity. Cron
+    # failure emails go to whoever last edited this file.
+    - cron: '17 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: trufflehog-pin-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pin-integrity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Fetch upstream checksums.txt (authenticated, retried)
+        env:
+          # Authenticated so we get this repo's GITHUB_TOKEN rate limit
+          # rather than the shared runner-IP unauthenticated limit.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PINNED=$(python -c "from clawjournal.redaction.trufflehog_install import PINNED_VERSION; print(PINNED_VERSION)")
+          echo "Pinned TruffleHog version: v$PINNED"
+          for attempt in 1 2 3; do
+            if gh release download "v$PINNED" \
+                 -R trufflesecurity/trufflehog \
+                 -p '*checksums.txt' -O checksums.txt --clobber; then
+              break
+            fi
+            echo "fetch attempt $attempt failed; retrying..." >&2
+            sleep $((attempt * 5))
+          done
+          test -s checksums.txt
+      - name: Compare vendored checksums against upstream
+        run: python scripts/check_trufflehog_pin.py checksums.txt

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -65,8 +65,8 @@ The scan is mandatory. Outcomes:
 Install:
 
 ```bash
-# Any platform — pinned version, sha256-verified against the official
-# release, installed to ~/.clawjournal/bin (preferred over PATH):
+# macOS / Linux / Windows (x86-64 and ARM64) — pinned version, sha256-verified
+# against the official release, installed to ~/.clawjournal/bin (preferred over PATH):
 clawjournal trufflehog install
 
 # Or install it yourself:

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -65,12 +65,16 @@ The scan is mandatory. Outcomes:
 Install:
 
 ```bash
-# macOS
-brew install trufflehog
+# Any platform — pinned version, sha256-verified against the official
+# release, installed to ~/.clawjournal/bin (preferred over PATH):
+clawjournal trufflehog install
 
-# Linux / Windows
-# https://github.com/trufflesecurity/trufflehog#floppy_disk-installation
+# Or install it yourself:
+brew install trufflehog          # macOS
+# Linux / Windows: https://github.com/trufflesecurity/trufflehog#floppy_disk-installation
 ```
+
+The managed copy is downloaded from TruffleHog's own GitHub release artifacts at your explicit request and is only ever invoked as a subprocess. `clawjournal trufflehog status` shows which binary the gate will use.
 
 For the upload path, the scan runs at least **twice at share time**: once inside `export_share_to_disk` on the merged `sessions.jsonl`, and again after the final PII pass rewrites the file. Either scan finding something aborts the upload. The final PII pass always runs deterministic rules. If you opt in to AI-assisted review for a bundle, it also reviews sessions in a small bounded worker pool and falls back to deterministic PII rules when an AI backend errors or times out; the manifest records `redaction_summary.pii_review.ai_enabled` plus `redaction_summary.coverage.full` vs. `rules_only`. TruffleHog also participates as a deterministic findings engine at scan-ingest time, so a session's existing `findings` rows already carry its detections before any share step — the share-time gates are the final check, not the first.
 

--- a/README.md
+++ b/README.md
@@ -132,7 +132,8 @@ Use [Quickstart](#quickstart) above (or the install prompt at the top). TruffleH
 <summary><b>Show TruffleHog install commands</b></summary>
 
 ```bash
-# Any platform — pinned version, sha256-verified, installed to ~/.clawjournal/bin, no root needed:
+# macOS / Linux / Windows (x86-64 and ARM64) — pinned version, sha256-verified,
+# installed to ~/.clawjournal/bin, no root needed:
 clawjournal trufflehog install
 
 # Or install it yourself:

--- a/README.md
+++ b/README.md
@@ -132,6 +132,10 @@ Use [Quickstart](#quickstart) above (or the install prompt at the top). TruffleH
 <summary><b>Show TruffleHog install commands</b></summary>
 
 ```bash
+# Any platform — pinned version, sha256-verified, installed to ~/.clawjournal/bin, no root needed:
+clawjournal trufflehog install
+
+# Or install it yourself:
 brew install trufflehog                                    # macOS
 curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin   # Linux
 # Windows: download a release binary from https://github.com/trufflesecurity/trufflehog/releases
@@ -357,6 +361,8 @@ clawjournal bundle-share <bundle_id>
 | `clawjournal list` / `clawjournal status` | List projects with exclusion status / show current stage (JSON) |
 | `clawjournal update-skill <agent>` | Install/update the clawjournal skill for an agent |
 | `clawjournal selfupdate [--check] [--force]` | Fast-forward to latest from `rayward-external/clawjournal` |
+| `clawjournal trufflehog install [--force]` | Download the pinned, checksum-verified TruffleHog (share-gate dependency) into `~/.clawjournal/bin` |
+| `clawjournal trufflehog status [--json]` | Show which TruffleHog binary the share gate will use |
 
 ### Export & sanitize (advanced)
 

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -5170,19 +5170,28 @@ def _run_trufflehog_command(args) -> None:
         return
 
     # Default (and explicit `status`): report what the share gate will use.
+    import shutil
+
     resolved = trufflehog.resolve_binary()
     managed = managed_binary_path()
     fingerprint = trufflehog.engine_fingerprint()
     version_match = trufflehog._VERSION_RE.search(fingerprint)
+    off_pin = trufflehog.managed_off_pin()
+    is_managed = resolved == str(managed)
+    shadowed_path = shutil.which("trufflehog") if is_managed else None
     payload = {
         "resolved_path": resolved,
-        "managed": resolved == str(managed),
+        "managed": is_managed,
         "managed_path": str(managed),
         # Bare version (e.g. "3.95.5") to match install --json; the raw
         # engine fingerprint (e.g. "trufflehog 3.95.5") rides alongside.
         "version": version_match.group(1) if version_match else None,
         "fingerprint": fingerprint,
         "pinned_version": PINNED_VERSION,
+        # True when the managed copy drifted from the source pin (e.g.
+        # selfupdate bumped PINNED_VERSION but install was never re-run).
+        "managed_off_pin": off_pin is not None,
+        "shadowed_path_binary": shadowed_path,
         "available": resolved is not None,
     }
     if getattr(args, "json", False):
@@ -5195,9 +5204,14 @@ def _run_trufflehog_command(args) -> None:
         print("Run `clawjournal trufflehog install` to install "
               f"the pinned v{PINNED_VERSION}.")
         sys.exit(1)
-    origin = "managed install" if payload["managed"] else "PATH"
+    origin = "managed install" if is_managed else "PATH"
     print(f"TruffleHog: {fingerprint} ({origin}: {resolved})")
-    if not payload["managed"]:
+    if off_pin is not None:
+        print(f"Warning: the managed copy is v{off_pin[0]} but this clawjournal "
+              f"pins v{off_pin[1]} — run `clawjournal trufflehog install` to update.")
+    if shadowed_path:
+        print(f"(The managed copy takes precedence over the PATH copy at {shadowed_path}.)")
+    if not is_managed:
         print(f"A pinned v{PINNED_VERSION} can be installed with "
               "`clawjournal trufflehog install` (managed copy takes precedence).")
 

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3660,6 +3660,19 @@ def main() -> None:
                     help="Discard local changes on main before applying a fast-forward update")
     su.add_argument("--json", action="store_true", help="Output result as JSON")
 
+    th = sub.add_parser("trufflehog",
+                        help="Manage the TruffleHog binary required by the share gate")
+    th_sub = th.add_subparsers(dest="trufflehog_command")
+    th_install = th_sub.add_parser(
+        "install",
+        help="Download the pinned, checksum-verified TruffleHog into ~/.clawjournal/bin")
+    th_install.add_argument("--force", action="store_true",
+                            help="Reinstall even if a managed binary already exists")
+    th_install.add_argument("--json", action="store_true", help="Output result as JSON")
+    th_status = th_sub.add_parser(
+        "status", help="Show which TruffleHog binary clawjournal will use")
+    th_status.add_argument("--json", action="store_true", help="Output result as JSON")
+
     cfg = sub.add_parser("config", help="View or set config")
     cfg.add_argument("--repo", type=str, help=argparse.SUPPRESS)
     cfg.add_argument("--source", choices=sorted(EXPLICIT_SOURCE_CHOICES),
@@ -4636,6 +4649,10 @@ def main() -> None:
                 print(f"selfupdate status: {selfupdate_status}")
         return
 
+    if command == "trufflehog":
+        _run_trufflehog_command(args)
+        return
+
     if command == "list":
         config = load_config()
         resolved_source_choice, _ = _resolve_source_choice(args.source, config)
@@ -5120,6 +5137,60 @@ def _run_events_doctor(args) -> None:
             )
         )
     sys.exit(exit_code_for(report))
+
+
+def _run_trufflehog_command(args) -> None:
+    """`clawjournal trufflehog install|status` — manage the share-gate binary."""
+    from .redaction import trufflehog
+    from .redaction.trufflehog_install import PINNED_VERSION, install, managed_binary_path
+
+    sub_command = getattr(args, "trufflehog_command", None)
+
+    if sub_command == "install":
+        result = install(force=args.force)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            status = result["status"]
+            if status == "installed":
+                print(f"Installed TruffleHog {result['version']} at {result['path']}.")
+            elif status == "already-installed":
+                version = result.get("version") or "unknown version"
+                print(
+                    f"Already installed ({version}) at {result['path']}. "
+                    "Pass --force to reinstall."
+                )
+            else:
+                print(f"Install failed ({status}): {result.get('error', '')}")
+        if result["status"] not in ("installed", "already-installed"):
+            sys.exit(1)
+        return
+
+    # Default (and explicit `status`): report what the share gate will use.
+    resolved = trufflehog.resolve_binary()
+    managed = managed_binary_path()
+    fingerprint = trufflehog.engine_fingerprint()
+    payload = {
+        "resolved_path": resolved,
+        "managed": resolved == str(managed),
+        "managed_path": str(managed),
+        "version": fingerprint,
+        "pinned_version": PINNED_VERSION,
+        "available": resolved is not None,
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2))
+        return
+    if resolved is None:
+        print("TruffleHog: not installed — share exports will be blocked.")
+        print("Run `clawjournal trufflehog install` to install "
+              f"the pinned v{PINNED_VERSION}.")
+        sys.exit(1)
+    origin = "managed install" if payload["managed"] else "PATH"
+    print(f"TruffleHog: {fingerprint} ({origin}: {resolved})")
+    if not payload["managed"]:
+        print(f"A pinned v{PINNED_VERSION} can be installed with "
+              "`clawjournal trufflehog install` (managed copy takes precedence).")
 
 
 def _run_events_features(args) -> None:

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -5147,7 +5147,7 @@ def _run_trufflehog_command(args) -> None:
     sub_command = getattr(args, "trufflehog_command", None)
 
     if sub_command == "install":
-        result = install(force=args.force)
+        result = install(force=args.force, progress=None if args.json else print)
         if args.json:
             print(json.dumps(result, indent=2))
         else:
@@ -5155,13 +5155,16 @@ def _run_trufflehog_command(args) -> None:
             if status == "installed":
                 print(f"Installed TruffleHog {result['version']} at {result['path']}.")
             elif status == "already-installed":
-                version = result.get("version") or "unknown version"
                 print(
-                    f"Already installed ({version}) at {result['path']}. "
+                    f"Already installed ({result['version']}) at {result['path']}. "
                     "Pass --force to reinstall."
                 )
             else:
                 print(f"Install failed ({status}): {result.get('error', '')}")
+                if result.get("url"):
+                    print(f"  URL: {result['url']}")
+                if result.get("hint"):
+                    print(f"  {result['hint']}")
         if result["status"] not in ("installed", "already-installed"):
             sys.exit(1)
         return
@@ -5170,16 +5173,22 @@ def _run_trufflehog_command(args) -> None:
     resolved = trufflehog.resolve_binary()
     managed = managed_binary_path()
     fingerprint = trufflehog.engine_fingerprint()
+    version_match = trufflehog._VERSION_RE.search(fingerprint)
     payload = {
         "resolved_path": resolved,
         "managed": resolved == str(managed),
         "managed_path": str(managed),
-        "version": fingerprint,
+        # Bare version (e.g. "3.95.5") to match install --json; the raw
+        # engine fingerprint (e.g. "trufflehog 3.95.5") rides alongside.
+        "version": version_match.group(1) if version_match else None,
+        "fingerprint": fingerprint,
         "pinned_version": PINNED_VERSION,
         "available": resolved is not None,
     }
     if getattr(args, "json", False):
         print(json.dumps(payload, indent=2))
+        if resolved is None:
+            sys.exit(1)
         return
     if resolved is None:
         print("TruffleHog: not installed — share exports will be blocked.")

--- a/clawjournal/events/doctor/probes.py
+++ b/clawjournal/events/doctor/probes.py
@@ -61,6 +61,10 @@ _FS_PROBES: tuple[tuple[str, str], ...] = (
 class TruffleHogStatus:
     state: str  # "present" | "missing" | "unparseable-version"
     version: str | None
+    # Pinned version this clawjournal expects, set only when the resolved
+    # binary is the managed copy AND it drifted off the pin (additive field;
+    # None for PATH binaries and pin-matched managed copies).
+    off_pin_expected: str | None = None
 
 
 @dataclass
@@ -139,9 +143,19 @@ def _trufflehog_status() -> TruffleHogStatus:
     if not th.is_available():
         return TruffleHogStatus(state="missing", version=None)
     fingerprint = th.engine_fingerprint()
+    off_pin = th.managed_off_pin()
+    off_pin_expected = off_pin[1] if off_pin else None
     if fingerprint.startswith("trufflehog "):
-        return TruffleHogStatus(state="present", version=fingerprint.split(" ", 1)[1])
-    return TruffleHogStatus(state="unparseable-version", version=fingerprint)
+        return TruffleHogStatus(
+            state="present",
+            version=fingerprint.split(" ", 1)[1],
+            off_pin_expected=off_pin_expected,
+        )
+    return TruffleHogStatus(
+        state="unparseable-version",
+        version=fingerprint,
+        off_pin_expected=off_pin_expected,
+    )
 
 
 def _detect_home_warning() -> dict[str, str] | None:

--- a/clawjournal/events/doctor/render.py
+++ b/clawjournal/events/doctor/render.py
@@ -82,7 +82,13 @@ def render_human(report: DoctorReport, *, stream: TextIO | None = None) -> str:
     )
     th = report.trufflehog
     if th.state == "present":
-        buf.write(f"TruffleHog:  {sanitize_for_human(th.version)} (present)\n")
+        off_pin = ""
+        if getattr(th, "off_pin_expected", None):
+            off_pin = (
+                f" — managed copy behind pin v{th.off_pin_expected}; "
+                "run `clawjournal trufflehog install` to update"
+            )
+        buf.write(f"TruffleHog:  {sanitize_for_human(th.version)} (present){off_pin}\n")
     elif th.state == "missing":
         buf.write(
             "TruffleHog:  missing — install via `clawjournal trufflehog install` "

--- a/clawjournal/events/doctor/render.py
+++ b/clawjournal/events/doctor/render.py
@@ -84,7 +84,10 @@ def render_human(report: DoctorReport, *, stream: TextIO | None = None) -> str:
     if th.state == "present":
         buf.write(f"TruffleHog:  {sanitize_for_human(th.version)} (present)\n")
     elif th.state == "missing":
-        buf.write("TruffleHog:  missing — install via `brew install trufflehog`\n")
+        buf.write(
+            "TruffleHog:  missing — install via `clawjournal trufflehog install` "
+            "(or `brew install trufflehog`)\n"
+        )
     else:
         buf.write(
             f"TruffleHog:  {sanitize_for_human(th.version) or 'unknown'} "

--- a/clawjournal/redaction/trufflehog.py
+++ b/clawjournal/redaction/trufflehog.py
@@ -110,6 +110,11 @@ class TruffleHogReport:
     bypassed: bool = False
     binary_missing: bool = False
     scan_error: str | None = None
+    # Which engine actually scanned (engine_fingerprint() form, e.g.
+    # "trufflehog 3.95.5"). Stamped by the export chokepoints before the
+    # report is persisted — scan_file itself never spawns a second
+    # subprocess. "" means not stamped (preview scans).
+    engine: str = ""
 
     @property
     def blocking(self) -> bool:
@@ -144,6 +149,7 @@ class TruffleHogReport:
             "bypassed": self.bypassed,
             "binary_missing": self.binary_missing,
             "scan_error": self.scan_error,
+            "engine": self.engine,
             "examples": [
                 {
                     "detector": f.detector,
@@ -186,6 +192,32 @@ def resolve_binary() -> str | None:
 
 def is_available() -> bool:
     return resolve_binary() is not None
+
+
+def managed_off_pin() -> tuple[str, str] | None:
+    """``(actual_version, pinned_version)`` when the gate resolves the
+    managed copy and that copy is off the source pin; ``None`` otherwise.
+
+    Only the managed copy is judged against the pin — a PATH binary's
+    freshness is the user's package manager's business. This is the
+    drift signal: ``selfupdate`` moves ``PINNED_VERSION`` in source
+    within hours of a pin bump, but nothing re-installs the binary, so
+    status/doctor surface the mismatch and point at
+    ``clawjournal trufflehog install`` (warn, never block — an off-pin
+    scanner is still a working backstop).
+    """
+    from .trufflehog_install import PINNED_VERSION  # noqa: PLC0415 — avoid import cycle
+
+    resolved = resolve_binary()
+    if resolved is None or resolved != str(managed_binary_path()):
+        return None
+    match = _VERSION_RE.search(engine_fingerprint())
+    if match is None:
+        return None
+    actual = match.group(1)
+    if actual == PINNED_VERSION:
+        return None
+    return (actual, PINNED_VERSION)
 
 
 _version_cache: dict[tuple, str] = {}
@@ -509,6 +541,7 @@ def write_report(path: Path, report: TruffleHogReport) -> None:
         "bypassed": report.bypassed,
         "binary_missing": report.binary_missing,
         "scan_error": report.scan_error,
+        "engine": report.engine,
         "findings": [
             {
                 "detector": f.detector,

--- a/clawjournal/redaction/trufflehog.py
+++ b/clawjournal/redaction/trufflehog.py
@@ -7,11 +7,13 @@ unverified, or unknown) blocks the export and leaves the directory
 intact for debugging.
 
 TruffleHog is invoked as a subprocess — it is AGPL-3.0 and must not
-be linked in-process. Install via ``brew install trufflehog`` or the
-upstream Go binary. The escape hatch ``CLAWJOURNAL_SKIP_TRUFFLEHOG=1``
-exists for CI / development only and is recorded in the share
-manifest so downstream reviewers can tell a scanned share from a
-bypassed one.
+be linked in-process. The binary is resolved managed-install first
+(``~/.clawjournal/bin/``, populated by ``clawjournal trufflehog
+install`` — see ``trufflehog_install.py``), then ``PATH`` (e.g.
+``brew install trufflehog``). The escape hatch
+``CLAWJOURNAL_SKIP_TRUFFLEHOG=1`` exists for CI / development only
+and is recorded in the share manifest so downstream reviewers can
+tell a scanned share from a bypassed one.
 """
 
 import hashlib
@@ -74,8 +76,10 @@ def _scrubbed_subprocess_env() -> dict[str, str]:
 EXCLUDED_DETECTORS: tuple[str, ...] = ("refiner",)
 
 INSTALL_HINT = (
-    "TruffleHog is required to export shares but was not found on PATH.\n"
-    "Install it with:\n"
+    "TruffleHog is required to export shares but was not found.\n"
+    "Install a pinned, checksum-verified copy with:\n"
+    "  clawjournal trufflehog install\n"
+    "Or install it yourself:\n"
     "  macOS:  brew install trufflehog\n"
     "  Linux:  https://github.com/trufflesecurity/trufflehog#floppy_disk-installation\n"
     "Or set CLAWJOURNAL_SKIP_TRUFFLEHOG=1 to bypass (unsafe — the share "
@@ -152,8 +156,36 @@ class TruffleHogReport:
         }
 
 
+def managed_binary_path() -> Path:
+    """Path of the managed binary that ``clawjournal trufflehog install``
+    maintains. Reads ``config.CONFIG_DIR`` at call time (not import time)
+    so tests and future env overrides that monkeypatch the attribute see
+    the change.
+    """
+    from .. import config  # noqa: PLC0415 — call-time so CONFIG_DIR patches apply
+
+    name = "trufflehog.exe" if os.name == "nt" else "trufflehog"
+    return config.CONFIG_DIR / "bin" / name
+
+
+def resolve_binary() -> str | None:
+    """Resolve the TruffleHog binary: managed install first, then PATH.
+
+    The managed copy wins because its version is pinned and its archive
+    checksum was verified at install time; an unmanaged PATH binary is
+    whatever brew/go last put there.
+    """
+    managed = managed_binary_path()
+    try:
+        if managed.is_file() and os.access(managed, os.X_OK):
+            return str(managed)
+    except OSError:
+        pass
+    return shutil.which("trufflehog")
+
+
 def is_available() -> bool:
-    return shutil.which("trufflehog") is not None
+    return resolve_binary() is not None
 
 
 _version_cache: dict[tuple, str] = {}
@@ -165,11 +197,11 @@ def _binary_signature() -> tuple:
     """Stable per-binary key for the fingerprint cache.
 
     Folds the resolved path and its mtime+size so a ``brew upgrade``
-    (new inode, new size, new mtime) invalidates cached entries in
-    a long-running daemon without requiring a restart. Returns
-    ``("missing",)`` if the binary isn't on PATH.
+    or ``clawjournal trufflehog install`` (new inode, new size, new
+    mtime) invalidates cached entries in a long-running daemon without
+    requiring a restart. Returns ``("missing",)`` if no binary resolves.
     """
-    resolved = shutil.which("trufflehog")
+    resolved = resolve_binary()
     if resolved is None:
         return ("missing",)
     try:
@@ -195,9 +227,10 @@ def engine_fingerprint() -> str:
     if signature[0] == "missing":
         _version_cache[signature] = "missing"
         return "missing"
+    binary = signature[1] if signature[0] == "unknown" else signature[0]
     try:
         result = subprocess.run(
-            ["trufflehog", "--version"],
+            [binary, "--version"],
             capture_output=True,
             text=True,
             check=False,
@@ -352,8 +385,10 @@ def scan_file(path: Path) -> TruffleHogReport:
             binary_missing=True,
         )
 
+    # `or "trufflehog"` covers callers that stub is_available() without
+    # providing a real binary (tests); production always resolves a path.
     args = [
-        "trufflehog",
+        resolve_binary() or "trufflehog",
         "filesystem",
         str(path),
         "-j",
@@ -513,7 +548,7 @@ def _scan_text_for_raw_matches(text: str) -> list[dict]:
         return []
 
     args = [
-        "trufflehog",
+        resolve_binary() or "trufflehog",
         "stdin",
         "-j",
         "--results=verified,unknown,unverified",

--- a/clawjournal/redaction/trufflehog_install.py
+++ b/clawjournal/redaction/trufflehog_install.py
@@ -17,6 +17,7 @@ in-process and nothing is redistributed by us.
 
 from __future__ import annotations
 
+import gzip
 import hashlib
 import http.client
 import os
@@ -28,6 +29,7 @@ import tempfile
 import urllib.error
 import urllib.request
 from pathlib import Path
+from typing import Callable
 
 from .trufflehog import _VERSION_RE, _scrubbed_subprocess_env, managed_binary_path
 
@@ -43,6 +45,7 @@ _ARCHIVE_SHA256: dict[str, str] = {
     "linux_amd64": "8d151a19465973bec226be5992a2a11b053f4ab92c77861f642089892ae9aa58",
     "linux_arm64": "bb876c4e5a84fa4fdbda4fc24143ed2d12eac32cfd3f7e41c79cbd7d33607b4a",
     "windows_amd64": "4421ac2786b2a356d62d2f4c59798bba5069c7a9f4dc7af9558061568b642c4d",
+    "windows_arm64": "bfece06dcbb4e1b4d366376294e702fa548f782048b32501cb58f97d713b7110",
 }
 
 _DOWNLOAD_URL_TEMPLATE = (
@@ -53,6 +56,19 @@ _DOWNLOAD_URL_TEMPLATE = (
 _MAX_DOWNLOAD_BYTES = 200 * 1024 * 1024  # archives are ~30–60 MB
 _MAX_BINARY_BYTES = 500 * 1024 * 1024  # decompressed binary cap
 _DOWNLOAD_TIMEOUT_SECONDS = 120
+_PROGRESS_TICK_BYTES = 16 * 1024 * 1024
+
+DOWNLOAD_FAILED_HINT = (
+    "Check your network and proxy settings (HTTPS_PROXY/HTTP_PROXY are honored) "
+    "and retry. If this machine is offline, install TruffleHog manually: "
+    "https://github.com/trufflesecurity/trufflehog#floppy_disk-installation"
+)
+CHECKSUM_MISMATCH_HINT = (
+    "The downloaded archive does not match the checksum pinned in this clawjournal "
+    "release. Common causes: a TLS-intercepting (corporate/campus) proxy rewriting "
+    "the download, a truncated transfer, or an outdated clawjournal — run "
+    "`clawjournal selfupdate` and retry. Nothing was installed."
+)
 
 
 def platform_key() -> str | None:
@@ -83,16 +99,28 @@ def download_url(key: str) -> str:
     return _DOWNLOAD_URL_TEMPLATE.format(version=PINNED_VERSION, platform=key)
 
 
-def _download_archive(url: str, dest_fd: int) -> str:
+def _download_archive(
+    url: str,
+    dest_fd: int,
+    progress: Callable[[str], None] | None = None,
+) -> str:
     """Stream ``url`` into ``dest_fd``; return the payload's sha256 hex.
 
     Raises ``urllib.error.URLError``/``OSError`` on network trouble and
-    ``ValueError`` if the payload exceeds the size cap.
+    ``ValueError`` if the payload exceeds the size cap. ``progress``
+    (if given) receives a start line and a tick every ~16 MB so a slow
+    link doesn't look like a hang.
     """
     digest = hashlib.sha256()
     total = 0
     request = urllib.request.Request(url, headers={"User-Agent": "clawjournal"})
     with urllib.request.urlopen(request, timeout=_DOWNLOAD_TIMEOUT_SECONDS) as response:
+        if progress is not None:
+            length = getattr(response, "headers", None)
+            length = length.get("Content-Length") if length else None
+            size = f" ({int(length) // (1024 * 1024)} MB)" if length and str(length).isdigit() else ""
+            progress(f"Downloading TruffleHog v{PINNED_VERSION}{size} from GitHub releases…")
+        next_tick = _PROGRESS_TICK_BYTES
         while True:
             chunk = response.read(65536)
             if not chunk:
@@ -104,14 +132,22 @@ def _download_archive(url: str, dest_fd: int) -> str:
                 )
             digest.update(chunk)
             os.write(dest_fd, chunk)
+            if progress is not None and total >= next_tick:
+                progress(f"  … {total // (1024 * 1024)} MB")
+                next_tick += _PROGRESS_TICK_BYTES
     return digest.hexdigest()
 
 
-def _extract_binary(archive_path: Path, binary_name: str, dest_path: Path) -> None:
-    """Pull exactly the ``binary_name`` member out of the release tarball
-    into ``dest_path`` (parent must exist). Member names are matched
-    exactly — anything resembling a path (``/``, ``..``) is never written,
-    so a malicious archive cannot traverse out of the target directory.
+def _extract_binary(archive_path: Path, binary_name: str, dest_dir: Path) -> Path:
+    """Stage exactly the ``binary_name`` member of the release tarball
+    into a temp file under ``dest_dir`` and return its path. Member names
+    are matched exactly — anything resembling a path (``/``, ``..``) is
+    never written, so a malicious archive cannot traverse out of the
+    target directory.
+
+    The staged file is chmod 0o755 and fsynced but NOT published: the
+    caller verifies it executes before os.replace()-ing it into place,
+    so a bad download can never displace a working managed binary.
 
     Raises ``ValueError`` if the member is absent or oversized, and
     ``tarfile.TarError`` on a corrupt archive.
@@ -129,7 +165,7 @@ def _extract_binary(archive_path: Path, binary_name: str, dest_path: Path) -> No
         source = tar.extractfile(member)
         if source is None:
             raise ValueError(f"archive member '{binary_name}' is not readable")
-        fd, tmp_name = tempfile.mkstemp(dir=str(dest_path.parent), prefix=f".{binary_name}.")
+        fd, tmp_name = tempfile.mkstemp(dir=str(dest_dir), prefix=f".{binary_name}.")
         try:
             try:
                 with source:
@@ -138,18 +174,19 @@ def _extract_binary(archive_path: Path, binary_name: str, dest_path: Path) -> No
                         if not chunk:
                             break
                         os.write(fd, chunk)
+                os.fsync(fd)
             finally:
                 os.close(fd)
             # os.chmod on the path, not os.fchmod on the fd — fchmod doesn't
             # exist on Windows before Python 3.13 and this must run on 3.10+.
             os.chmod(tmp_name, 0o755)
-            os.replace(tmp_name, dest_path)
         except BaseException:
             try:
                 os.unlink(tmp_name)
             except OSError:
                 pass
             raise
+    return Path(tmp_name)
 
 
 def _verify_installed_binary(path: Path) -> str | None:
@@ -176,16 +213,24 @@ def _verify_installed_binary(path: Path) -> str | None:
     return match.group(1) if match else None
 
 
-def install(*, force: bool = False) -> dict:
+def install(
+    *,
+    force: bool = False,
+    progress: Callable[[str], None] | None = None,
+) -> dict:
     """Install the pinned TruffleHog into ``~/.clawjournal/bin``.
 
-    Returns a result dict with ``status`` plus context fields; never
-    raises. Statuses: ``installed``, ``already-installed``,
+    Returns a result dict with ``status`` plus context fields (and a
+    ``hint`` with remediation advice on network/checksum failures);
+    never raises. Statuses: ``installed``, ``already-installed``,
     ``unsupported-platform``, ``download-failed``, ``checksum-mismatch``,
     ``archive-invalid``, ``verify-failed``, ``install-failed``.
+
+    ``progress`` (if given) receives human-readable download progress
+    lines — the CLI passes ``print`` so a slow link doesn't look hung.
     """
     try:
-        return _install(force=force)
+        return _install(force=force, progress=progress)
     except Exception as exc:
         # Backstop for anything the specific handlers below don't name
         # (e.g. a stray file blocking the bin-dir mkdir). The CLI shows a
@@ -197,16 +242,26 @@ def install(*, force: bool = False) -> dict:
         }
 
 
-def _install(*, force: bool = False) -> dict:
+def _install(
+    *,
+    force: bool = False,
+    progress: Callable[[str], None] | None = None,
+) -> dict:
     target = managed_binary_path()
     binary_name = target.name
 
-    if target.exists() and not force:
-        return {
-            "status": "already-installed",
-            "path": str(target),
-            "version": _verify_installed_binary(target),
-        }
+    # "Already installed" must mean "the share gate will use it AND it
+    # is the pinned version" — an unexecutable file, a directory, or an
+    # off-pin copy from an older clawjournal falls through to a fresh
+    # install (the atomic publish below makes overwriting safe).
+    if not force and target.is_file() and os.access(target, os.X_OK):
+        current = _verify_installed_binary(target)
+        if current == PINNED_VERSION:
+            return {
+                "status": "already-installed",
+                "path": str(target),
+                "version": current,
+            }
 
     key = platform_key()
     if key is None:
@@ -227,14 +282,20 @@ def _install(*, force: bool = False) -> dict:
         dir=str(target.parent), prefix=".trufflehog-download.", suffix=".tar.gz"
     )
     archive_path = Path(archive_name)
+    staged: Path | None = None
     try:
         try:
-            actual_sha256 = _download_archive(url, archive_fd)
+            actual_sha256 = _download_archive(url, archive_fd, progress=progress)
         except (urllib.error.URLError, http.client.HTTPException, OSError, ValueError) as exc:
             # HTTPException covers e.g. IncompleteRead on a truncated
             # chunked response; URLError is already an OSError subclass
             # but is named for clarity.
-            return {"status": "download-failed", "url": url, "error": str(exc)}
+            return {
+                "status": "download-failed",
+                "url": url,
+                "error": str(exc),
+                "hint": DOWNLOAD_FAILED_HINT,
+            }
         finally:
             os.close(archive_fd)
 
@@ -247,29 +308,59 @@ def _install(*, force: bool = False) -> dict:
                     f"sha256 {actual_sha256} does not match the pinned "
                     f"checksum {expected_sha256} for {key}"
                 ),
+                "hint": CHECKSUM_MISMATCH_HINT,
+            }
+
+        # Failure domains are reported distinctly: a bad archive is
+        # "archive-invalid" (re-download might help), local file I/O is
+        # "install-failed" (the archive already passed its checksum).
+        # gzip.BadGzipFile and EOFError are raised by truncated/corrupt
+        # streams mid-extract; BadGzipFile subclasses OSError so it must
+        # be matched before the OSError clause.
+        try:
+            staged = _extract_binary(archive_path, binary_name, target.parent)
+        except (tarfile.TarError, gzip.BadGzipFile, EOFError, ValueError) as exc:
+            return {"status": "archive-invalid", "url": url, "error": str(exc)}
+        except OSError as exc:
+            return {
+                "status": "install-failed",
+                "error": f"local file I/O failed while staging the binary: {exc}",
+            }
+
+        # Verify BEFORE publish: a binary that doesn't run (wrong arch,
+        # truncation the checksum somehow missed) never displaces an
+        # existing working managed binary.
+        version = _verify_installed_binary(staged)
+        if version is None:
+            return {
+                "status": "verify-failed",
+                "path": str(target),
+                "error": (
+                    "downloaded binary failed to execute `--version`; "
+                    "the existing managed binary (if any) was left untouched"
+                ),
             }
 
         try:
-            _extract_binary(archive_path, binary_name, target)
-        except (tarfile.TarError, ValueError, OSError, EOFError) as exc:
-            # EOFError: gzip stream truncated mid-member.
-            return {"status": "archive-invalid", "url": url, "error": str(exc)}
+            os.replace(staged, target)
+        except OSError as exc:
+            # E.g. Windows refusing to replace a running .exe, or a
+            # directory squatting on the target path.
+            return {
+                "status": "install-failed",
+                "error": (
+                    f"could not move the verified binary into place at "
+                    f"{target}: {exc}"
+                ),
+            }
+        staged = None  # published — nothing to clean up
     finally:
-        try:
-            archive_path.unlink()
-        except OSError:
-            pass
-
-    version = _verify_installed_binary(target)
-    if version is None:
-        try:
-            target.unlink()
-        except OSError:
-            pass
-        return {
-            "status": "verify-failed",
-            "path": str(target),
-            "error": "installed binary failed to execute `--version`; removed it",
-        }
+        for leftover in (archive_path, staged):
+            if leftover is None:
+                continue
+            try:
+                leftover.unlink()
+            except OSError:
+                pass
 
     return {"status": "installed", "path": str(target), "version": version}

--- a/clawjournal/redaction/trufflehog_install.py
+++ b/clawjournal/redaction/trufflehog_install.py
@@ -1,0 +1,275 @@
+"""Managed TruffleHog binary install.
+
+``clawjournal trufflehog install`` downloads a pinned release archive
+from trufflesecurity/trufflehog's official GitHub releases, verifies
+it against the sha256 checksums vendored below (taken from the
+release's ``checksums.txt`` at pin time — verification never trusts
+what the network just served), extracts the single binary, and
+installs it atomically under ``~/.clawjournal/bin/``.
+
+``trufflehog.resolve_binary()`` prefers this managed copy over PATH.
+
+AGPL posture unchanged: the binary is fetched from upstream's own
+release artifacts at the user's explicit request and is only ever
+invoked as a subprocess (see ``trufflehog.py``); nothing is linked
+in-process and nothing is redistributed by us.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import http.client
+import os
+import platform
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+from .trufflehog import _VERSION_RE, _scrubbed_subprocess_env, managed_binary_path
+
+PINNED_VERSION = "3.95.5"
+
+# sha256 of the official release archives, copied from
+# trufflehog_3.95.5_checksums.txt on the v3.95.5 release page.
+# When bumping PINNED_VERSION, refresh every row from the new
+# release's checksums.txt — a stale row fails closed.
+_ARCHIVE_SHA256: dict[str, str] = {
+    "darwin_amd64": "8091a92ad3ef6c46244f5b6b9683c72296381d77f63e8a979e913d8d58df595d",
+    "darwin_arm64": "0a08b46f63d48ccb894689b68b5e7b91ac5efa09b9684a3457d388456887c213",
+    "linux_amd64": "8d151a19465973bec226be5992a2a11b053f4ab92c77861f642089892ae9aa58",
+    "linux_arm64": "bb876c4e5a84fa4fdbda4fc24143ed2d12eac32cfd3f7e41c79cbd7d33607b4a",
+    "windows_amd64": "4421ac2786b2a356d62d2f4c59798bba5069c7a9f4dc7af9558061568b642c4d",
+}
+
+_DOWNLOAD_URL_TEMPLATE = (
+    "https://github.com/trufflesecurity/trufflehog/releases/download/"
+    "v{version}/trufflehog_{version}_{platform}.tar.gz"
+)
+
+_MAX_DOWNLOAD_BYTES = 200 * 1024 * 1024  # archives are ~30–60 MB
+_MAX_BINARY_BYTES = 500 * 1024 * 1024  # decompressed binary cap
+_DOWNLOAD_TIMEOUT_SECONDS = 120
+
+
+def platform_key() -> str | None:
+    """``{os}_{arch}`` key into ``_ARCHIVE_SHA256``, or None if this
+    platform has no pinned archive."""
+    if sys.platform == "darwin":
+        os_part = "darwin"
+    elif sys.platform.startswith("linux"):
+        os_part = "linux"
+    elif os.name == "nt":
+        os_part = "windows"
+    else:
+        return None
+
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        arch = "amd64"
+    elif machine in ("arm64", "aarch64"):
+        arch = "arm64"
+    else:
+        return None
+
+    key = f"{os_part}_{arch}"
+    return key if key in _ARCHIVE_SHA256 else None
+
+
+def download_url(key: str) -> str:
+    return _DOWNLOAD_URL_TEMPLATE.format(version=PINNED_VERSION, platform=key)
+
+
+def _download_archive(url: str, dest_fd: int) -> str:
+    """Stream ``url`` into ``dest_fd``; return the payload's sha256 hex.
+
+    Raises ``urllib.error.URLError``/``OSError`` on network trouble and
+    ``ValueError`` if the payload exceeds the size cap.
+    """
+    digest = hashlib.sha256()
+    total = 0
+    request = urllib.request.Request(url, headers={"User-Agent": "clawjournal"})
+    with urllib.request.urlopen(request, timeout=_DOWNLOAD_TIMEOUT_SECONDS) as response:
+        while True:
+            chunk = response.read(65536)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > _MAX_DOWNLOAD_BYTES:
+                raise ValueError(
+                    f"download exceeded {_MAX_DOWNLOAD_BYTES // (1024 * 1024)} MB cap"
+                )
+            digest.update(chunk)
+            os.write(dest_fd, chunk)
+    return digest.hexdigest()
+
+
+def _extract_binary(archive_path: Path, binary_name: str, dest_path: Path) -> None:
+    """Pull exactly the ``binary_name`` member out of the release tarball
+    into ``dest_path`` (parent must exist). Member names are matched
+    exactly — anything resembling a path (``/``, ``..``) is never written,
+    so a malicious archive cannot traverse out of the target directory.
+
+    Raises ``ValueError`` if the member is absent or oversized, and
+    ``tarfile.TarError`` on a corrupt archive.
+    """
+    with tarfile.open(archive_path, mode="r:gz") as tar:
+        member = None
+        for candidate in tar:
+            if candidate.name == binary_name and candidate.isfile():
+                member = candidate
+                break
+        if member is None:
+            raise ValueError(f"archive has no '{binary_name}' member")
+        if member.size > _MAX_BINARY_BYTES:
+            raise ValueError("binary member exceeds size cap")
+        source = tar.extractfile(member)
+        if source is None:
+            raise ValueError(f"archive member '{binary_name}' is not readable")
+        fd, tmp_name = tempfile.mkstemp(dir=str(dest_path.parent), prefix=f".{binary_name}.")
+        try:
+            try:
+                with source:
+                    while True:
+                        chunk = source.read(65536)
+                        if not chunk:
+                            break
+                        os.write(fd, chunk)
+            finally:
+                os.close(fd)
+            # os.chmod on the path, not os.fchmod on the fd — fchmod doesn't
+            # exist on Windows before Python 3.13 and this must run on 3.10+.
+            os.chmod(tmp_name, 0o755)
+            os.replace(tmp_name, dest_path)
+        except BaseException:
+            try:
+                os.unlink(tmp_name)
+            except OSError:
+                pass
+            raise
+
+
+def _verify_installed_binary(path: Path) -> str | None:
+    """Run ``<path> --version`` as a post-install sanity check (catches a
+    wrong-arch or truncated binary before the share gate ever trusts it).
+    Returns the parsed version string, or None if the binary doesn't run.
+    """
+    try:
+        result = subprocess.run(
+            [str(path), "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+            stdin=subprocess.DEVNULL,
+            env=_scrubbed_subprocess_env(),
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    blob = (result.stdout or "") + "\n" + (result.stderr or "")
+    match = _VERSION_RE.search(blob)
+    return match.group(1) if match else None
+
+
+def install(*, force: bool = False) -> dict:
+    """Install the pinned TruffleHog into ``~/.clawjournal/bin``.
+
+    Returns a result dict with ``status`` plus context fields; never
+    raises. Statuses: ``installed``, ``already-installed``,
+    ``unsupported-platform``, ``download-failed``, ``checksum-mismatch``,
+    ``archive-invalid``, ``verify-failed``, ``install-failed``.
+    """
+    try:
+        return _install(force=force)
+    except Exception as exc:
+        # Backstop for anything the specific handlers below don't name
+        # (e.g. a stray file blocking the bin-dir mkdir). The CLI shows a
+        # status, not a traceback; failure direction is always "nothing
+        # installed".
+        return {
+            "status": "install-failed",
+            "error": f"{exc.__class__.__name__}: {exc}",
+        }
+
+
+def _install(*, force: bool = False) -> dict:
+    target = managed_binary_path()
+    binary_name = target.name
+
+    if target.exists() and not force:
+        return {
+            "status": "already-installed",
+            "path": str(target),
+            "version": _verify_installed_binary(target),
+        }
+
+    key = platform_key()
+    if key is None:
+        return {
+            "status": "unsupported-platform",
+            "error": (
+                f"no pinned TruffleHog v{PINNED_VERSION} archive for "
+                f"{sys.platform}/{platform.machine()}; install it manually "
+                "(https://github.com/trufflesecurity/trufflehog#floppy_disk-installation)"
+            ),
+        }
+
+    expected_sha256 = _ARCHIVE_SHA256[key]
+    url = download_url(key)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    archive_fd, archive_name = tempfile.mkstemp(
+        dir=str(target.parent), prefix=".trufflehog-download.", suffix=".tar.gz"
+    )
+    archive_path = Path(archive_name)
+    try:
+        try:
+            actual_sha256 = _download_archive(url, archive_fd)
+        except (urllib.error.URLError, http.client.HTTPException, OSError, ValueError) as exc:
+            # HTTPException covers e.g. IncompleteRead on a truncated
+            # chunked response; URLError is already an OSError subclass
+            # but is named for clarity.
+            return {"status": "download-failed", "url": url, "error": str(exc)}
+        finally:
+            os.close(archive_fd)
+
+        if actual_sha256 != expected_sha256:
+            # Fail closed: nothing is extracted or installed.
+            return {
+                "status": "checksum-mismatch",
+                "url": url,
+                "error": (
+                    f"sha256 {actual_sha256} does not match the pinned "
+                    f"checksum {expected_sha256} for {key}"
+                ),
+            }
+
+        try:
+            _extract_binary(archive_path, binary_name, target)
+        except (tarfile.TarError, ValueError, OSError, EOFError) as exc:
+            # EOFError: gzip stream truncated mid-member.
+            return {"status": "archive-invalid", "url": url, "error": str(exc)}
+    finally:
+        try:
+            archive_path.unlink()
+        except OSError:
+            pass
+
+    version = _verify_installed_binary(target)
+    if version is None:
+        try:
+            target.unlink()
+        except OSError:
+            pass
+        return {
+            "status": "verify-failed",
+            "path": str(target),
+            "error": "installed binary failed to execute `--version`; removed it",
+        }
+
+    return {"status": "installed", "path": str(target), "version": version}

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -1295,6 +1295,7 @@ def finalize_share_export_for_upload(
     # `trufflehog.json` is the authoritative report shipped in the zip.
     # `trufflehog.post-pii.json` is a compatibility/diagnostic marker that
     # proves the final artifact passed the post-PII gate.
+    post_pii_report.engine = trufflehog_scanner.engine_fingerprint()
     trufflehog_scanner.write_report(export_dir / "trufflehog.json", post_pii_report)
     trufflehog_scanner.write_report(export_dir / "trufflehog.post-pii.json", post_pii_report)
     if isinstance(redaction_summary, dict):

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -3956,6 +3956,10 @@ def export_share_to_disk(
     from ..redaction import trufflehog as trufflehog_scanner
 
     trufflehog_report = trufflehog_scanner.scan_file(sessions_file)
+    # Stamp which engine version scanned so the manifest/report make
+    # staleness auditable per share (the managed binary can drift from
+    # the source pin between installs).
+    trufflehog_report.engine = trufflehog_scanner.engine_fingerprint()
     trufflehog_scanner.write_report(export_dir / "trufflehog.json", trufflehog_report)
     manifest["redaction_summary"]["trufflehog"] = trufflehog_report.summary()
 

--- a/scripts/check_trufflehog_pin.py
+++ b/scripts/check_trufflehog_pin.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Verify the vendored TruffleHog checksums match upstream's release.
+
+Compares ``clawjournal/redaction/trufflehog_install.py``'s
+``_ARCHIVE_SHA256`` (and ``PINNED_VERSION``) against an upstream
+``checksums.txt``. Exits non-zero with a clear diff on any mismatch.
+
+This catches a fat-fingered or partial pin bump — a maintainer updating
+``PINNED_VERSION`` but forgetting a hash row, or pasting one platform's
+checksum into another's — that the hermetic unit tests cannot see
+because they never touch the network. The network fetch itself lives in
+the CI workflow (authenticated, with retry); this script is pure
+comparison so it stays unit-testable.
+
+Usage:
+    python scripts/check_trufflehog_pin.py path/to/checksums.txt
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Importable without `pip install` regardless of cwd: clawjournal/ lives
+# one level up from scripts/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from clawjournal.redaction.trufflehog_install import (  # noqa: E402
+    PINNED_VERSION,
+    _ARCHIVE_SHA256,
+)
+
+
+def parse_checksums(text: str) -> dict[str, str]:
+    """Parse upstream ``checksums.txt`` lines of the form ``<sha256>  <filename>``."""
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        sha, name = parts
+        out[name] = sha.lower()
+    return out
+
+
+def compare(upstream: dict[str, str]) -> list[str]:
+    """Return a list of human-readable mismatch messages (empty == OK)."""
+    errors: list[str] = []
+    for key, vendored in sorted(_ARCHIVE_SHA256.items()):
+        filename = f"trufflehog_{PINNED_VERSION}_{key}.tar.gz"
+        actual = upstream.get(filename)
+        if actual is None:
+            errors.append(f"{filename}: not present in upstream checksums.txt")
+        elif actual != vendored.lower():
+            errors.append(f"{filename}: vendored {vendored} != upstream {actual}")
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: check_trufflehog_pin.py <checksums.txt>", file=sys.stderr)
+        return 2
+    try:
+        text = Path(argv[1]).read_text()
+    except OSError as exc:
+        print(f"could not read {argv[1]}: {exc}", file=sys.stderr)
+        return 2
+
+    errors = compare(parse_checksums(text))
+    if errors:
+        print(f"TruffleHog pin mismatch for v{PINNED_VERSION}:", file=sys.stderr)
+        for err in errors:
+            print(f"  {err}", file=sys.stderr)
+        print(
+            "\nIf you bumped PINNED_VERSION, refresh every _ARCHIVE_SHA256 row "
+            "from the new release's checksums.txt. A stale row fails closed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"All {len(_ARCHIVE_SHA256)} vendored checksums match "
+        f"upstream TruffleHog v{PINNED_VERSION}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -165,8 +165,10 @@ elseif (Test-Path $FeSrcDir) {
     }
 }
 
-if (-not (Get-Command trufflehog -ErrorAction SilentlyContinue)) {
+$managedTrufflehog = Join-Path $HOME ".clawjournal\bin\trufflehog.exe"
+if (-not (Get-Command trufflehog -ErrorAction SilentlyContinue) -and -not (Test-Path $managedTrufflehog)) {
     Write-Host ""
     Write-Host "[i] TruffleHog is required when sharing exports."
-    Write-Host "    Download a release binary: https://github.com/trufflesecurity/trufflehog/releases"
+    Write-Host "    Install a pinned, checksum-verified copy: clawjournal trufflehog install"
+    Write-Host "    Or download a release binary: https://github.com/trufflesecurity/trufflehog/releases"
 }

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -169,6 +169,6 @@ $managedTrufflehog = Join-Path $HOME ".clawjournal\bin\trufflehog.exe"
 if (-not (Get-Command trufflehog -ErrorAction SilentlyContinue) -and -not (Test-Path $managedTrufflehog)) {
     Write-Host ""
     Write-Host "[i] TruffleHog is required when sharing exports."
-    Write-Host "    Install a pinned, checksum-verified copy: clawjournal trufflehog install"
+    Write-Host "    Install a pinned, checksum-verified copy: $ClawJournalExe trufflehog install"
     Write-Host "    Or download a release binary: https://github.com/trufflesecurity/trufflehog/releases"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -160,12 +160,11 @@ elif [ -d "$FE_SRC_DIR" ] && [ -n "$(find "$FE_SRC_DIR" -type f -newer "$FE_DIST
 EOF
 fi
 
-if ! command -v trufflehog >/dev/null 2>&1; then
+if ! command -v trufflehog >/dev/null 2>&1 && [ ! -x "$HOME/.clawjournal/bin/trufflehog" ]; then
   cat <<EOF
 
 [i] TruffleHog is required when sharing exports. Install it before 'bundle-export':
-    macOS:    brew install trufflehog
-    Linux:    curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin
-    Windows:  https://github.com/trufflesecurity/trufflehog/releases
+    clawjournal trufflehog install      (pinned version, sha256-verified, no root needed)
+    Or: brew install trufflehog (macOS) / https://github.com/trufflesecurity/trufflehog/releases
 EOF
 fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -164,7 +164,7 @@ if ! command -v trufflehog >/dev/null 2>&1 && [ ! -x "$HOME/.clawjournal/bin/tru
   cat <<EOF
 
 [i] TruffleHog is required when sharing exports. Install it before 'bundle-export':
-    clawjournal trufflehog install      (pinned version, sha256-verified, no root needed)
+    $VENV_BIN/clawjournal trufflehog install      (pinned version, sha256-verified, no root needed)
     Or: brew install trufflehog (macOS) / https://github.com/trufflesecurity/trufflehog/releases
 EOF
 fi

--- a/tests/events/doctor/test_render.py
+++ b/tests/events/doctor/test_render.py
@@ -60,6 +60,22 @@ def test_render_human_includes_versions():
     assert "security_schema_version" in text
 
 
+def test_render_human_flags_off_pin_managed_trufflehog():
+    report = _base_report(
+        trufflehog=TruffleHogStatus(
+            state="present", version="3.94.3", off_pin_expected="3.95.5"
+        )
+    )
+    text = render.render_human(report)
+    assert "behind pin v3.95.5" in text
+    assert "clawjournal trufflehog install" in text
+
+
+def test_render_human_no_off_pin_noise_when_pin_matched():
+    text = render.render_human(_base_report())
+    assert "behind pin" not in text
+
+
 def test_render_human_sanitizes_client_version():
     obs = ClientObservation(
         client="claude",

--- a/tests/redaction/test_trufflehog.py
+++ b/tests/redaction/test_trufflehog.py
@@ -1,6 +1,7 @@
 """Tests for the TruffleHog share-time gate."""
 
 import json
+import os
 import subprocess
 from pathlib import Path
 
@@ -946,6 +947,49 @@ class TestEngineFingerprint:
         sig[1] = 200
         trufflehog.engine_fingerprint()
         assert calls["n"] == 2
+
+    def test_invalidation_through_real_os_stat_seam(self, tmp_path, monkeypatch):
+        """Cache invalidation must work through the REAL `os.stat` path,
+        not just a stubbed `_binary_signature`. This is the seam the
+        daemon relies on to notice an in-place `trufflehog install` —
+        when a managed binary is overwritten, its size/mtime change and
+        the cached fingerprint must be recomputed.
+        """
+        trufflehog.reset_version_cache()
+        config_dir = tmp_path / ".clawjournal"
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+        managed = trufflehog.managed_binary_path()
+        managed.parent.mkdir(parents=True)
+        managed.write_bytes(b"v1")
+        managed.chmod(0o755)
+        # No PATH fallback so the managed copy is the resolved binary.
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog.shutil.which", lambda name: None
+        )
+
+        version = {"v": "3.90.0"}
+
+        def fake_run(args, **kwargs):
+            # Real argv resolves to the managed path — proves we went
+            # through resolve_binary()/os.stat, not a stub.
+            assert args[0] == str(managed)
+            return subprocess.CompletedProcess(
+                args, 0, stdout=f"trufflehog {version['v']}\n", stderr=""
+            )
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+
+        assert trufflehog.engine_fingerprint() == "trufflehog 3.90.0"
+
+        # Simulate an in-place upgrade: new bytes (new size), and bump the
+        # mtime explicitly so the change is observable even on filesystems
+        # with coarse mtime granularity.
+        version["v"] = "3.95.5"
+        managed.write_bytes(b"v2-which-is-longer")
+        st = managed.stat()
+        os.utime(managed, ns=(st.st_atime_ns, st.st_mtime_ns + 1_000_000_000))
+
+        assert trufflehog.engine_fingerprint() == "trufflehog 3.95.5"
 
 
 class TestFormatBlockMessage:

--- a/tests/redaction/test_trufflehog.py
+++ b/tests/redaction/test_trufflehog.py
@@ -115,6 +115,9 @@ class TestScanFile:
     def _enable_real_scan(self, monkeypatch):
         monkeypatch.delenv(trufflehog.SKIP_ENV_VAR, raising=False)
         monkeypatch.setattr(trufflehog, "is_available", lambda: True)
+        # Pin resolution so argv assertions don't depend on whether the
+        # machine running the tests has a real binary installed.
+        monkeypatch.setattr(trufflehog, "resolve_binary", lambda: "trufflehog")
 
     def test_bypass_env_var_short_circuits(self, tmp_path, monkeypatch):
         target = tmp_path / "sessions.jsonl"
@@ -835,6 +838,7 @@ class TestSubprocessHardening:
     def test_payload_streams_via_stdin_not_tempfile(self, tmp_path, monkeypatch):
         monkeypatch.delenv(trufflehog.SKIP_ENV_VAR, raising=False)
         monkeypatch.setattr(trufflehog, "is_available", lambda: True)
+        monkeypatch.setattr(trufflehog, "resolve_binary", lambda: "trufflehog")
 
         captured: dict = {}
 

--- a/tests/redaction/test_trufflehog.py
+++ b/tests/redaction/test_trufflehog.py
@@ -402,6 +402,27 @@ class TestWriteReport:
         assert payload["findings"][0]["masked"] == "ghp_a***4567"
         assert "raw" not in json.dumps(payload).lower() or "raw_sha256" in json.dumps(payload)
 
+    def test_engine_version_recorded_in_report_and_summary(self, tmp_path):
+        # The export chokepoints stamp `engine` before persisting so each
+        # share records which scanner version actually ran (the managed
+        # binary can drift from the source pin between installs).
+        report = trufflehog.TruffleHogReport(
+            scanned_path="/x",
+            scanned_sha256="sha256:abcd",
+            engine="trufflehog 3.95.5",
+        )
+        assert report.summary()["engine"] == "trufflehog 3.95.5"
+        out = tmp_path / "report.json"
+        trufflehog.write_report(out, report)
+        payload = json.loads(out.read_text())
+        assert payload["engine"] == "trufflehog 3.95.5"
+        assert payload["summary"]["engine"] == "trufflehog 3.95.5"
+
+    def test_engine_defaults_to_empty_for_unstamped_reports(self):
+        report = trufflehog.TruffleHogReport(scanned_path="/x", scanned_sha256="")
+        assert report.engine == ""
+        assert report.summary()["engine"] == ""
+
 
 class TestPlaceholderForDetector:
     def test_normalizes_to_upper_snake(self):

--- a/tests/redaction/test_trufflehog_install.py
+++ b/tests/redaction/test_trufflehog_install.py
@@ -1,0 +1,540 @@
+"""Tests for the managed TruffleHog install (`clawjournal trufflehog install`).
+
+Everything runs offline: the download is served from an in-memory fake
+response, the platform key and vendored checksum table are patched per
+test, and the post-install `--version` sanity check is stubbed.
+"""
+
+import hashlib
+import io
+import os
+import tarfile
+import urllib.error
+import urllib.request
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from clawjournal.redaction import trufflehog, trufflehog_install
+
+
+def _tar_gz(members: dict[str, bytes]) -> bytes:
+    """Build a .tar.gz archive holding ``members`` (name → content)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, content in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            info.mode = 0o755
+            tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+class _FakeResponse:
+    """Minimal stand-in for the urlopen response context manager."""
+
+    def __init__(self, payload: bytes):
+        self._stream = io.BytesIO(payload)
+
+    def read(self, n: int = -1) -> bytes:
+        return self._stream.read(n)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+BINARY_CONTENT = b"#!/bin/sh\necho fake-trufflehog\n"
+
+
+@pytest.fixture
+def install_env(tmp_path, monkeypatch):
+    """Isolated CONFIG_DIR + deterministic platform + stubbed verify.
+
+    Returns a dict the test can tweak: ``serve(payload)`` swaps what the
+    fake network returns; ``checksum_of(payload)`` pins the vendored
+    table to that payload.
+    """
+    config_dir = tmp_path / ".clawjournal"
+    monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+    monkeypatch.setattr(trufflehog_install, "platform_key", lambda: "testos_amd64")
+    monkeypatch.setattr(
+        trufflehog_install, "_verify_installed_binary", lambda path: "3.95.5"
+    )
+
+    state = {"payload": b"", "urls": []}
+
+    def fake_urlopen(request, timeout=None):
+        state["urls"].append(request.full_url)
+        return _FakeResponse(state["payload"])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    def serve(payload: bytes, *, pin_checksum: bool = True):
+        state["payload"] = payload
+        if pin_checksum:
+            monkeypatch.setattr(
+                trufflehog_install,
+                "_ARCHIVE_SHA256",
+                {"testos_amd64": hashlib.sha256(payload).hexdigest()},
+            )
+
+    def pin_checksum(payload: bytes):
+        monkeypatch.setattr(
+            trufflehog_install,
+            "_ARCHIVE_SHA256",
+            {"testos_amd64": hashlib.sha256(payload).hexdigest()},
+        )
+
+    state["serve"] = serve
+    state["pin_checksum"] = pin_checksum
+    state["config_dir"] = config_dir
+    state["target"] = config_dir / "bin" / trufflehog.managed_binary_path().name
+    return state
+
+
+class TestInstall:
+    def test_happy_path_installs_executable_binary(self, install_env):
+        archive = _tar_gz({"trufflehog": BINARY_CONTENT, "LICENSE": b"AGPL"})
+        install_env["serve"](archive)
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "installed"
+        assert result["version"] == "3.95.5"
+        target = Path(result["path"])
+        assert target == install_env["target"]
+        assert target.read_bytes() == BINARY_CONTENT
+        if os.name != "nt":
+            assert os.access(target, os.X_OK)
+        # The pinned release URL was requested.
+        assert install_env["urls"] == [
+            trufflehog_install.download_url("testos_amd64")
+        ]
+
+    def test_no_temp_files_left_behind(self, install_env):
+        install_env["serve"](_tar_gz({"trufflehog": BINARY_CONTENT}))
+        trufflehog_install.install()
+        leftovers = [
+            p for p in install_env["target"].parent.iterdir()
+            if p.name != install_env["target"].name
+        ]
+        assert leftovers == []
+
+    def test_checksum_mismatch_fails_closed(self, install_env):
+        archive = _tar_gz({"trufflehog": BINARY_CONTENT})
+        install_env["serve"](archive)
+        # Pin the table to different bytes than what the network serves.
+        install_env["pin_checksum"](b"something else entirely")
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "checksum-mismatch"
+        assert not install_env["target"].exists()
+        # Nothing left behind in the bin dir either.
+        bin_dir = install_env["target"].parent
+        assert not bin_dir.exists() or list(bin_dir.iterdir()) == []
+
+    def test_already_installed_without_force(self, install_env):
+        target = install_env["target"]
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"existing")
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "already-installed"
+        assert target.read_bytes() == b"existing"
+        assert install_env["urls"] == []  # no network touch
+
+    def test_force_reinstalls(self, install_env):
+        target = install_env["target"]
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"existing")
+        install_env["serve"](_tar_gz({"trufflehog": BINARY_CONTENT}))
+
+        result = trufflehog_install.install(force=True)
+
+        assert result["status"] == "installed"
+        assert target.read_bytes() == BINARY_CONTENT
+
+    def test_unsupported_platform(self, install_env, monkeypatch):
+        monkeypatch.setattr(trufflehog_install, "platform_key", lambda: None)
+        result = trufflehog_install.install()
+        assert result["status"] == "unsupported-platform"
+        assert "manually" in result["error"]
+
+    def test_download_failure_reported(self, install_env, monkeypatch):
+        def boom(request, timeout=None):
+            raise urllib.error.URLError("connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", boom)
+        install_env["pin_checksum"](b"irrelevant")
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "download-failed"
+        assert not install_env["target"].exists()
+
+    def test_oversized_download_aborts(self, install_env, monkeypatch):
+        monkeypatch.setattr(trufflehog_install, "_MAX_DOWNLOAD_BYTES", 10)
+        install_env["serve"](b"x" * 64)
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "download-failed"
+        assert "cap" in result["error"]
+        assert not install_env["target"].exists()
+
+    def test_archive_without_binary_member(self, install_env):
+        install_env["serve"](_tar_gz({"README.md": b"not a binary"}))
+        result = trufflehog_install.install()
+        assert result["status"] == "archive-invalid"
+        assert not install_env["target"].exists()
+
+    def test_archive_with_traversal_member_is_rejected(self, install_env, tmp_path):
+        # A member trying to escape the bin dir must never be written; the
+        # exact-name match means it is simply not found.
+        install_env["serve"](_tar_gz({"../evil": BINARY_CONTENT}))
+        result = trufflehog_install.install()
+        assert result["status"] == "archive-invalid"
+        assert not (install_env["config_dir"] / "evil").exists()
+        assert not (tmp_path / "evil").exists()
+
+    def test_corrupt_archive(self, install_env):
+        install_env["serve"](b"this is not a tarball")
+        result = trufflehog_install.install()
+        assert result["status"] == "archive-invalid"
+        assert not install_env["target"].exists()
+
+    def test_verify_failure_removes_binary(self, install_env, monkeypatch):
+        install_env["serve"](_tar_gz({"trufflehog": BINARY_CONTENT}))
+        monkeypatch.setattr(
+            trufflehog_install, "_verify_installed_binary", lambda path: None
+        )
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "verify-failed"
+        assert not install_env["target"].exists()
+
+
+class TestInstallNeverRaises:
+    """install() must return a status dict on every failure, never raise."""
+
+    def test_bin_dir_blocked_by_regular_file(self, install_env):
+        # ~/.clawjournal/bin exists as a *file* → mkdir raises
+        # FileExistsError despite exist_ok=True; the backstop converts it.
+        install_env["config_dir"].mkdir(parents=True)
+        (install_env["config_dir"] / "bin").write_bytes(b"not a directory")
+        install_env["serve"](_tar_gz({"trufflehog": BINARY_CONTENT}))
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "install-failed"
+        assert "FileExistsError" in result["error"]
+
+    def test_truncated_chunked_download_is_download_failed(self, install_env, monkeypatch):
+        import http.client
+
+        class _TruncatedResponse(_FakeResponse):
+            def read(self, n=-1):
+                raise http.client.IncompleteRead(b"partial")
+
+        monkeypatch.setattr(
+            urllib.request, "urlopen",
+            lambda request, timeout=None: _TruncatedResponse(b""),
+        )
+        install_env["pin_checksum"](b"irrelevant")
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "download-failed"
+        assert not install_env["target"].exists()
+
+    def test_truncated_gzip_archive_is_archive_invalid(self, install_env):
+        archive = _tar_gz({"trufflehog": BINARY_CONTENT * 50})
+        install_env["serve"](archive[: len(archive) // 2])
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "archive-invalid"
+        assert not install_env["target"].exists()
+        bin_dir = install_env["target"].parent
+        assert not bin_dir.exists() or list(bin_dir.iterdir()) == []
+
+    def test_oversized_decompressed_member_is_rejected(self, install_env, monkeypatch):
+        monkeypatch.setattr(trufflehog_install, "_MAX_BINARY_BYTES", 4)
+        install_env["serve"](_tar_gz({"trufflehog": BINARY_CONTENT}))
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "archive-invalid"
+        assert "size cap" in result["error"]
+        assert not install_env["target"].exists()
+
+
+class TestVerifyInstalledBinary:
+    """The real _verify_installed_binary implementation (stubbed elsewhere)."""
+
+    def _run(self, monkeypatch, *, returncode=0, stdout="", stderr="", raises=None):
+        import subprocess
+
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["argv"] = cmd
+            seen["env"] = kwargs.get("env")
+            if raises is not None:
+                raise raises
+            return subprocess.CompletedProcess(cmd, returncode, stdout=stdout, stderr=stderr)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        result = trufflehog_install._verify_installed_binary(Path("/x/trufflehog"))
+        return result, seen
+
+    def test_parses_version_banner(self, monkeypatch):
+        version, seen = self._run(monkeypatch, stdout="trufflehog 3.95.5\n")
+        assert version == "3.95.5"
+        assert seen["argv"] == ["/x/trufflehog", "--version"]
+        # Scrubbed env, not the parent's (None would inherit API keys).
+        assert isinstance(seen["env"], dict)
+
+    def test_version_on_stderr_is_accepted(self, monkeypatch):
+        version, _ = self._run(monkeypatch, stderr="trufflehog 3.95.5")
+        assert version == "3.95.5"
+
+    def test_nonzero_exit_fails(self, monkeypatch):
+        version, _ = self._run(monkeypatch, returncode=1, stdout="trufflehog 3.95.5")
+        assert version is None
+
+    def test_unparseable_banner_fails(self, monkeypatch):
+        version, _ = self._run(monkeypatch, stdout="something unexpected")
+        assert version is None
+
+    def test_timeout_fails(self, monkeypatch):
+        import subprocess
+
+        version, _ = self._run(
+            monkeypatch, raises=subprocess.TimeoutExpired(cmd="x", timeout=15)
+        )
+        assert version is None
+
+    def test_exec_failure_fails(self, monkeypatch):
+        version, _ = self._run(monkeypatch, raises=OSError("wrong arch"))
+        assert version is None
+
+
+class TestPlatformKey:
+    def test_real_platform_resolves_or_is_unsupported(self):
+        key = trufflehog_install.platform_key()
+        assert key is None or key in trufflehog_install._ARCHIVE_SHA256
+
+    @pytest.mark.parametrize(
+        ("sys_platform", "os_name", "machine", "expected"),
+        [
+            ("darwin", "posix", "arm64", "darwin_arm64"),
+            ("darwin", "posix", "x86_64", "darwin_amd64"),
+            ("linux", "posix", "x86_64", "linux_amd64"),
+            ("linux", "posix", "aarch64", "linux_arm64"),
+            ("win32", "nt", "AMD64", "windows_amd64"),
+            ("win32", "nt", "ARM64", None),  # no windows_arm64 release row
+            ("linux", "posix", "riscv64", None),
+            ("sunos5", "posix", "x86_64", None),
+        ],
+    )
+    def test_os_arch_matrix(self, monkeypatch, sys_platform, os_name, machine, expected):
+        import os as os_mod
+        import sys as sys_mod
+
+        monkeypatch.setattr(sys_mod, "platform", sys_platform)
+        monkeypatch.setattr(os_mod, "name", os_name)
+        monkeypatch.setattr(
+            trufflehog_install.platform, "machine", lambda: machine
+        )
+        assert trufflehog_install.platform_key() == expected
+
+    def test_checksum_table_covers_release_matrix(self):
+        assert set(trufflehog_install._ARCHIVE_SHA256) == {
+            "darwin_amd64", "darwin_arm64",
+            "linux_amd64", "linux_arm64",
+            "windows_amd64",
+        }
+        for value in trufflehog_install._ARCHIVE_SHA256.values():
+            assert len(value) == 64
+            int(value, 16)  # valid hex
+
+    def test_download_url_shape(self):
+        url = trufflehog_install.download_url("linux_amd64")
+        assert url == (
+            "https://github.com/trufflesecurity/trufflehog/releases/download/"
+            f"v{trufflehog_install.PINNED_VERSION}/"
+            f"trufflehog_{trufflehog_install.PINNED_VERSION}_linux_amd64.tar.gz"
+        )
+
+
+class TestBinaryResolution:
+    """resolve_binary(): managed install wins over PATH."""
+
+    def test_managed_binary_preferred_over_path(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / ".clawjournal"
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+        managed = trufflehog.managed_binary_path()
+        managed.parent.mkdir(parents=True)
+        managed.write_bytes(BINARY_CONTENT)
+        managed.chmod(0o755)
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog.shutil.which",
+            lambda name: "/usr/local/bin/trufflehog",
+        )
+
+        assert trufflehog.resolve_binary() == str(managed)
+        assert trufflehog.is_available()
+
+    def test_falls_back_to_path_when_no_managed_binary(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / ".clawjournal")
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog.shutil.which",
+            lambda name: "/usr/local/bin/trufflehog",
+        )
+        assert trufflehog.resolve_binary() == "/usr/local/bin/trufflehog"
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX exec-bit semantics")
+    def test_non_executable_managed_file_is_skipped(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / ".clawjournal"
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+        managed = trufflehog.managed_binary_path()
+        managed.parent.mkdir(parents=True)
+        managed.write_bytes(BINARY_CONTENT)
+        managed.chmod(0o644)
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog.shutil.which", lambda name: None
+        )
+        assert trufflehog.resolve_binary() is None
+        assert not trufflehog.is_available()
+
+    def test_nothing_resolves(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / ".clawjournal")
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog.shutil.which", lambda name: None
+        )
+        assert trufflehog.resolve_binary() is None
+
+    def test_scan_file_invokes_managed_binary(self, tmp_path, monkeypatch):
+        import subprocess
+
+        monkeypatch.delenv("CLAWJOURNAL_SKIP_TRUFFLEHOG", raising=False)
+        config_dir = tmp_path / ".clawjournal"
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+        managed = trufflehog.managed_binary_path()
+        managed.parent.mkdir(parents=True)
+        managed.write_bytes(BINARY_CONTENT)
+        managed.chmod(0o755)
+
+        seen = {}
+
+        def fake_run(cmd, **kwargs):
+            seen["argv"] = cmd
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        scan_target = tmp_path / "sessions.jsonl"
+        scan_target.write_text("{}\n")
+
+        report = trufflehog.scan_file(scan_target)
+
+        assert not report.blocking
+        assert seen["argv"][0] == str(managed)
+
+    def test_install_hint_mentions_managed_install(self):
+        assert "clawjournal trufflehog install" in trufflehog.INSTALL_HINT
+
+
+class TestCliCommand:
+    def test_status_json_when_missing(self, tmp_path, monkeypatch, capsys):
+        import json as json_mod
+
+        from clawjournal.cli import _run_trufflehog_command
+
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / ".clawjournal")
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog.shutil.which", lambda name: None
+        )
+        args = Namespace(trufflehog_command="status", json=True)
+
+        _run_trufflehog_command(args)
+
+        payload = json_mod.loads(capsys.readouterr().out)
+        assert payload["available"] is False
+        assert payload["resolved_path"] is None
+        assert payload["pinned_version"] == trufflehog_install.PINNED_VERSION
+
+    def test_status_human_when_missing_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        from clawjournal.cli import _run_trufflehog_command
+
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / ".clawjournal")
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog.shutil.which", lambda name: None
+        )
+        args = Namespace(trufflehog_command="status", json=False)
+
+        with pytest.raises(SystemExit) as excinfo:
+            _run_trufflehog_command(args)
+
+        assert excinfo.value.code == 1
+        assert "clawjournal trufflehog install" in capsys.readouterr().out
+
+    def test_install_dispatch_passes_force_and_exits_zero(self, monkeypatch, capsys):
+        from clawjournal import cli
+
+        calls = {}
+
+        def fake_install(*, force=False):
+            calls["force"] = force
+            return {"status": "installed", "path": "/x/trufflehog", "version": "3.95.5"}
+
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog_install.install", fake_install
+        )
+        args = Namespace(trufflehog_command="install", force=True, json=False)
+
+        cli._run_trufflehog_command(args)
+
+        assert calls["force"] is True
+        assert "Installed TruffleHog 3.95.5" in capsys.readouterr().out
+
+    def test_install_failure_exits_nonzero(self, monkeypatch, capsys):
+        from clawjournal import cli
+
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog_install.install",
+            lambda *, force=False: {"status": "download-failed", "error": "offline"},
+        )
+        args = Namespace(trufflehog_command="install", force=False, json=False)
+
+        with pytest.raises(SystemExit) as excinfo:
+            cli._run_trufflehog_command(args)
+
+        assert excinfo.value.code == 1
+        assert "download-failed" in capsys.readouterr().out
+
+    def test_parser_roundtrip_via_main(self, tmp_path, monkeypatch, capsys):
+        import sys as sys_mod
+
+        from clawjournal.cli import main
+
+        monkeypatch.setenv("CLAWJOURNAL_NO_AUTO_UPDATE", "1")
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / ".clawjournal")
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog.shutil.which", lambda name: None
+        )
+        monkeypatch.setattr(
+            sys_mod, "argv", ["clawjournal", "trufflehog", "status", "--json"]
+        )
+
+        main()
+
+        out = capsys.readouterr().out
+        assert '"available": false' in out

--- a/tests/redaction/test_trufflehog_install.py
+++ b/tests/redaction/test_trufflehog_install.py
@@ -133,6 +133,8 @@ class TestInstall:
         result = trufflehog_install.install()
 
         assert result["status"] == "checksum-mismatch"
+        # Remediation guidance rides along for the CLI to print.
+        assert "proxy" in result["hint"]
         assert not install_env["target"].exists()
         # Nothing left behind in the bin dir either.
         bin_dir = install_env["target"].parent
@@ -142,12 +144,51 @@ class TestInstall:
         target = install_env["target"]
         target.parent.mkdir(parents=True)
         target.write_bytes(b"existing")
+        target.chmod(0o755)  # fixture's verify stub reports the pinned version
 
         result = trufflehog_install.install()
 
         assert result["status"] == "already-installed"
+        assert result["version"] == trufflehog_install.PINNED_VERSION
         assert target.read_bytes() == b"existing"
         assert install_env["urls"] == []  # no network touch
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX exec-bit semantics")
+    def test_non_executable_existing_file_is_reinstalled(self, install_env):
+        # A managed file the share gate would refuse (no exec bit) must not
+        # report already-installed — that combination previously claimed
+        # success while resolve_binary() ignored the file.
+        target = install_env["target"]
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"existing")
+        target.chmod(0o644)
+        install_env["serve"](_tar_gz({"trufflehog": BINARY_CONTENT}))
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "installed"
+        assert target.read_bytes() == BINARY_CONTENT
+        assert os.access(target, os.X_OK)
+
+    def test_off_pin_existing_binary_is_upgraded(self, install_env, monkeypatch):
+        # A managed binary from an older clawjournal pin is upgraded, not
+        # reported as already-installed.
+        target = install_env["target"]
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"old pinned version")
+        target.chmod(0o755)
+        monkeypatch.setattr(
+            trufflehog_install,
+            "_verify_installed_binary",
+            lambda path: "3.90.0" if Path(path) == target else "3.95.5",
+        )
+        install_env["serve"](_tar_gz({"trufflehog": BINARY_CONTENT}))
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "installed"
+        assert result["version"] == "3.95.5"
+        assert target.read_bytes() == BINARY_CONTENT
 
     def test_force_reinstalls(self, install_env):
         target = install_env["target"]
@@ -159,6 +200,15 @@ class TestInstall:
 
         assert result["status"] == "installed"
         assert target.read_bytes() == BINARY_CONTENT
+
+    def test_progress_callback_reports_download(self, install_env):
+        install_env["serve"](_tar_gz({"trufflehog": BINARY_CONTENT}))
+        messages: list[str] = []
+
+        result = trufflehog_install.install(progress=messages.append)
+
+        assert result["status"] == "installed"
+        assert messages and "Downloading TruffleHog" in messages[0]
 
     def test_unsupported_platform(self, install_env, monkeypatch):
         monkeypatch.setattr(trufflehog_install, "platform_key", lambda: None)
@@ -176,6 +226,7 @@ class TestInstall:
         result = trufflehog_install.install()
 
         assert result["status"] == "download-failed"
+        assert "proxy" in result["hint"]
         assert not install_env["target"].exists()
 
     def test_oversized_download_aborts(self, install_env, monkeypatch):
@@ -209,7 +260,7 @@ class TestInstall:
         assert result["status"] == "archive-invalid"
         assert not install_env["target"].exists()
 
-    def test_verify_failure_removes_binary(self, install_env, monkeypatch):
+    def test_verify_failure_never_publishes(self, install_env, monkeypatch):
         install_env["serve"](_tar_gz({"trufflehog": BINARY_CONTENT}))
         monkeypatch.setattr(
             trufflehog_install, "_verify_installed_binary", lambda path: None
@@ -219,6 +270,46 @@ class TestInstall:
 
         assert result["status"] == "verify-failed"
         assert not install_env["target"].exists()
+        # The staged temp and the downloaded archive are both cleaned up.
+        bin_dir = install_env["target"].parent
+        assert not bin_dir.exists() or list(bin_dir.iterdir()) == []
+
+    def test_verify_failure_leaves_existing_binary_untouched(self, install_env, monkeypatch):
+        # Verification happens BEFORE publish: a bad download (even under
+        # --force) must never displace a working managed binary.
+        target = install_env["target"]
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"known good binary")
+        target.chmod(0o755)
+        install_env["serve"](_tar_gz({"trufflehog": BINARY_CONTENT}))
+        monkeypatch.setattr(
+            trufflehog_install, "_verify_installed_binary", lambda path: None
+        )
+
+        result = trufflehog_install.install(force=True)
+
+        assert result["status"] == "verify-failed"
+        assert "left untouched" in result["error"]
+        assert target.read_bytes() == b"known good binary"
+
+    def test_replace_failure_is_install_failed_not_archive_invalid(self, install_env):
+        # A directory squatting on the target path fails at publish time —
+        # a LOCAL error. Reporting it as "archive-invalid" (with the GitHub
+        # URL) would misdirect the user at a re-download remediation right
+        # after the checksum proved the archive is byte-identical to
+        # upstream.
+        target = install_env["target"]
+        (target / "occupied").mkdir(parents=True)
+        install_env["serve"](_tar_gz({"trufflehog": BINARY_CONTENT}))
+
+        result = trufflehog_install.install(force=True)
+
+        assert result["status"] == "install-failed"
+        assert "into place" in result["error"]
+        assert target.is_dir()  # nothing destroyed
+        # Staged temp and archive cleaned; only the squatting dir remains.
+        leftovers = [p.name for p in target.parent.iterdir()]
+        assert leftovers == [target.name]
 
 
 class TestInstallNeverRaises:
@@ -340,7 +431,7 @@ class TestPlatformKey:
             ("linux", "posix", "x86_64", "linux_amd64"),
             ("linux", "posix", "aarch64", "linux_arm64"),
             ("win32", "nt", "AMD64", "windows_amd64"),
-            ("win32", "nt", "ARM64", None),  # no windows_arm64 release row
+            ("win32", "nt", "ARM64", "windows_arm64"),
             ("linux", "posix", "riscv64", None),
             ("sunos5", "posix", "x86_64", None),
         ],
@@ -360,7 +451,7 @@ class TestPlatformKey:
         assert set(trufflehog_install._ARCHIVE_SHA256) == {
             "darwin_amd64", "darwin_arm64",
             "linux_amd64", "linux_arm64",
-            "windows_amd64",
+            "windows_amd64", "windows_arm64",
         }
         for value in trufflehog_install._ARCHIVE_SHA256.values():
             assert len(value) == 64
@@ -453,7 +544,7 @@ class TestBinaryResolution:
 
 
 class TestCliCommand:
-    def test_status_json_when_missing(self, tmp_path, monkeypatch, capsys):
+    def test_status_json_when_missing_exits_nonzero(self, tmp_path, monkeypatch, capsys):
         import json as json_mod
 
         from clawjournal.cli import _run_trufflehog_command
@@ -464,11 +555,17 @@ class TestCliCommand:
         )
         args = Namespace(trufflehog_command="status", json=True)
 
-        _run_trufflehog_command(args)
+        # Exit code matches human mode — a script gets both the JSON on
+        # stdout and a non-zero exit when the gate binary is missing.
+        with pytest.raises(SystemExit) as excinfo:
+            _run_trufflehog_command(args)
 
+        assert excinfo.value.code == 1
         payload = json_mod.loads(capsys.readouterr().out)
         assert payload["available"] is False
         assert payload["resolved_path"] is None
+        assert payload["version"] is None
+        assert payload["fingerprint"] == "missing"
         assert payload["pinned_version"] == trufflehog_install.PINNED_VERSION
 
     def test_status_human_when_missing_exits_nonzero(self, tmp_path, monkeypatch, capsys):
@@ -491,8 +588,9 @@ class TestCliCommand:
 
         calls = {}
 
-        def fake_install(*, force=False):
+        def fake_install(*, force=False, progress=None):
             calls["force"] = force
+            calls["progress"] = progress
             return {"status": "installed", "path": "/x/trufflehog", "version": "3.95.5"}
 
         monkeypatch.setattr(
@@ -503,6 +601,7 @@ class TestCliCommand:
         cli._run_trufflehog_command(args)
 
         assert calls["force"] is True
+        assert calls["progress"] is not None  # human mode streams progress
         assert "Installed TruffleHog 3.95.5" in capsys.readouterr().out
 
     def test_install_failure_exits_nonzero(self, monkeypatch, capsys):
@@ -510,7 +609,12 @@ class TestCliCommand:
 
         monkeypatch.setattr(
             "clawjournal.redaction.trufflehog_install.install",
-            lambda *, force=False: {"status": "download-failed", "error": "offline"},
+            lambda *, force=False, progress=None: {
+                "status": "download-failed",
+                "error": "offline",
+                "url": "https://example.invalid/archive.tar.gz",
+                "hint": "Check your network.",
+            },
         )
         args = Namespace(trufflehog_command="install", force=False, json=False)
 
@@ -518,7 +622,11 @@ class TestCliCommand:
             cli._run_trufflehog_command(args)
 
         assert excinfo.value.code == 1
-        assert "download-failed" in capsys.readouterr().out
+        out = capsys.readouterr().out
+        assert "download-failed" in out
+        # Failure output carries the URL and the remediation hint.
+        assert "https://example.invalid/archive.tar.gz" in out
+        assert "Check your network." in out
 
     def test_parser_roundtrip_via_main(self, tmp_path, monkeypatch, capsys):
         import sys as sys_mod
@@ -534,7 +642,9 @@ class TestCliCommand:
             sys_mod, "argv", ["clawjournal", "trufflehog", "status", "--json"]
         )
 
-        main()
+        with pytest.raises(SystemExit) as excinfo:
+            main()
 
+        assert excinfo.value.code == 1
         out = capsys.readouterr().out
         assert '"available": false' in out

--- a/tests/redaction/test_trufflehog_install.py
+++ b/tests/redaction/test_trufflehog_install.py
@@ -479,6 +479,14 @@ class TestPlatformKey:
             assert len(value) == 64
             int(value, 16)  # valid hex
 
+    def test_checksum_values_are_pairwise_distinct(self):
+        # Each platform archive is a distinct artifact, so a repeated hash
+        # means a copy-paste slip during a pin bump (e.g. darwin_arm64's
+        # row left holding darwin_amd64's checksum) — which the key-set and
+        # hex-format checks above would not catch.
+        values = list(trufflehog_install._ARCHIVE_SHA256.values())
+        assert len(values) == len(set(values))
+
     def test_download_url_shape(self):
         url = trufflehog_install.download_url("linux_amd64")
         assert url == (

--- a/tests/redaction/test_trufflehog_install.py
+++ b/tests/redaction/test_trufflehog_install.py
@@ -170,6 +170,28 @@ class TestInstall:
         assert target.read_bytes() == BINARY_CONTENT
         assert os.access(target, os.X_OK)
 
+    def test_corrupt_executable_existing_file_is_reinstalled(self, install_env, monkeypatch):
+        # A truncated/corrupt managed binary that kept its exec bit fails
+        # the --version probe; already-installed must NOT be reported (that
+        # would exit 0 while the share gate keeps using a broken binary) —
+        # the install falls through and repairs it.
+        target = install_env["target"]
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"\x7fELF truncated garbage")
+        target.chmod(0o755)
+        monkeypatch.setattr(
+            trufflehog_install,
+            "_verify_installed_binary",
+            lambda path: None if Path(path) == target else "3.95.5",
+        )
+        install_env["serve"](_tar_gz({"trufflehog": BINARY_CONTENT}))
+
+        result = trufflehog_install.install()
+
+        assert result["status"] == "installed"
+        assert result["version"] == "3.95.5"
+        assert target.read_bytes() == BINARY_CONTENT
+
     def test_off_pin_existing_binary_is_upgraded(self, install_env, monkeypatch):
         # A managed binary from an older clawjournal pin is upgraded, not
         # reported as already-installed.
@@ -543,6 +565,57 @@ class TestBinaryResolution:
         assert "clawjournal trufflehog install" in trufflehog.INSTALL_HINT
 
 
+class TestManagedOffPin:
+    """managed_off_pin(): the drift signal between the installed managed
+    binary and the source pin (selfupdate moves the pin; nothing
+    re-installs the binary)."""
+
+    def _managed(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / ".clawjournal"
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+        managed = trufflehog.managed_binary_path()
+        managed.parent.mkdir(parents=True)
+        managed.write_bytes(BINARY_CONTENT)
+        managed.chmod(0o755)
+        return managed
+
+    def test_none_for_path_resolved_binary(self, tmp_path, monkeypatch):
+        # No managed copy; PATH provides the binary — its freshness is the
+        # package manager's business, never flagged.
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / ".clawjournal")
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog.shutil.which",
+            lambda name: "/usr/local/bin/trufflehog",
+        )
+        monkeypatch.setattr(
+            trufflehog, "engine_fingerprint", lambda: "trufflehog 1.0.0"
+        )
+        assert trufflehog.managed_off_pin() is None
+
+    def test_none_when_managed_matches_pin(self, tmp_path, monkeypatch):
+        self._managed(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            trufflehog,
+            "engine_fingerprint",
+            lambda: f"trufflehog {trufflehog_install.PINNED_VERSION}",
+        )
+        assert trufflehog.managed_off_pin() is None
+
+    def test_reports_drift_for_off_pin_managed_copy(self, tmp_path, monkeypatch):
+        self._managed(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            trufflehog, "engine_fingerprint", lambda: "trufflehog 3.90.0"
+        )
+        assert trufflehog.managed_off_pin() == (
+            "3.90.0", trufflehog_install.PINNED_VERSION
+        )
+
+    def test_none_when_fingerprint_unparseable(self, tmp_path, monkeypatch):
+        self._managed(tmp_path, monkeypatch)
+        monkeypatch.setattr(trufflehog, "engine_fingerprint", lambda: "unknown")
+        assert trufflehog.managed_off_pin() is None
+
+
 class TestCliCommand:
     def test_status_json_when_missing_exits_nonzero(self, tmp_path, monkeypatch, capsys):
         import json as json_mod
@@ -627,6 +700,72 @@ class TestCliCommand:
         # Failure output carries the URL and the remediation hint.
         assert "https://example.invalid/archive.tar.gz" in out
         assert "Check your network." in out
+
+    def _managed_setup(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / ".clawjournal"
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+        managed = trufflehog.managed_binary_path()
+        managed.parent.mkdir(parents=True)
+        managed.write_bytes(BINARY_CONTENT)
+        managed.chmod(0o755)
+        return managed
+
+    def test_status_warns_when_managed_copy_off_pin(self, tmp_path, monkeypatch, capsys):
+        from clawjournal.cli import _run_trufflehog_command
+
+        self._managed_setup(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog.engine_fingerprint",
+            lambda: "trufflehog 3.90.0",
+        )
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        args = Namespace(trufflehog_command="status", json=False)
+
+        # Warn, never block: off-pin status still exits 0.
+        _run_trufflehog_command(args)
+
+        out = capsys.readouterr().out
+        assert "Warning" in out
+        assert "v3.90.0" in out
+        assert f"pins v{trufflehog_install.PINNED_VERSION}" in out
+        assert "clawjournal trufflehog install" in out
+
+    def test_status_json_reports_off_pin_flag(self, tmp_path, monkeypatch, capsys):
+        import json as json_mod
+
+        from clawjournal.cli import _run_trufflehog_command
+
+        self._managed_setup(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog.engine_fingerprint",
+            lambda: "trufflehog 3.90.0",
+        )
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        args = Namespace(trufflehog_command="status", json=True)
+
+        _run_trufflehog_command(args)
+
+        payload = json_mod.loads(capsys.readouterr().out)
+        assert payload["managed_off_pin"] is True
+        assert payload["version"] == "3.90.0"
+
+    def test_status_notes_shadowed_path_binary(self, tmp_path, monkeypatch, capsys):
+        from clawjournal.cli import _run_trufflehog_command
+
+        self._managed_setup(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            "clawjournal.redaction.trufflehog.engine_fingerprint",
+            lambda: f"trufflehog {trufflehog_install.PINNED_VERSION}",
+        )
+        monkeypatch.setattr("shutil.which", lambda name: "/opt/homebrew/bin/trufflehog")
+        args = Namespace(trufflehog_command="status", json=False)
+
+        _run_trufflehog_command(args)
+
+        out = capsys.readouterr().out
+        assert "precedence over the PATH copy at /opt/homebrew/bin/trufflehog" in out
+        # Pin matched — no drift warning.
+        assert "Warning" not in out
 
     def test_parser_roundtrip_via_main(self, tmp_path, monkeypatch, capsys):
         import sys as sys_mod

--- a/tests/test_check_trufflehog_pin.py
+++ b/tests/test_check_trufflehog_pin.py
@@ -1,0 +1,87 @@
+"""Hermetic tests for scripts/check_trufflehog_pin.py.
+
+The script's network fetch lives in the CI workflow; the comparison
+logic is pure and tested here without touching the network. A synthetic
+"upstream" is built from the vendored table so the matching case can
+never silently rot, and corruption cases prove the mismatch paths.
+"""
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check_trufflehog_pin.py"
+_spec = importlib.util.spec_from_file_location("check_trufflehog_pin", _SCRIPT)
+pin = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pin)
+
+
+def _upstream_text_matching_table() -> str:
+    """A checksums.txt whose rows match the vendored table exactly, plus
+    extra unrelated rows (man pages, other artifacts) that must be ignored."""
+    lines = ["deadbeef" * 8 + "  trufflehog_extra_artifact.deb"]
+    for key, sha in pin._ARCHIVE_SHA256.items():
+        lines.append(f"{sha}  trufflehog_{pin.PINNED_VERSION}_{key}.tar.gz")
+    return "\n".join(lines) + "\n"
+
+
+def test_parse_checksums_ignores_malformed_lines():
+    text = (
+        "abc123  file_a.tar.gz\n"
+        "\n"
+        "# a comment with spaces\n"
+        "onlyonefield\n"
+        "DEAD  file_b.tar.gz\n"
+    )
+    parsed = pin.parse_checksums(text)
+    assert parsed == {"file_a.tar.gz": "abc123", "file_b.tar.gz": "dead"}
+
+
+def test_compare_passes_when_table_matches_upstream():
+    upstream = pin.parse_checksums(_upstream_text_matching_table())
+    assert pin.compare(upstream) == []
+
+
+def test_compare_flags_a_wrong_hash():
+    upstream = pin.parse_checksums(_upstream_text_matching_table())
+    # Corrupt one row's hash.
+    target = f"trufflehog_{pin.PINNED_VERSION}_linux_amd64.tar.gz"
+    upstream[target] = "0" * 64
+    errors = pin.compare(upstream)
+    assert len(errors) == 1
+    assert target in errors[0]
+    assert "vendored" in errors[0] and "upstream" in errors[0]
+
+
+def test_compare_flags_a_missing_row():
+    upstream = pin.parse_checksums(_upstream_text_matching_table())
+    target = f"trufflehog_{pin.PINNED_VERSION}_windows_arm64.tar.gz"
+    del upstream[target]
+    errors = pin.compare(upstream)
+    assert len(errors) == 1
+    assert "not present" in errors[0]
+
+
+def test_main_exit_codes(tmp_path, capsys):
+    good = tmp_path / "good.txt"
+    good.write_text(_upstream_text_matching_table())
+    assert pin.main(["prog", str(good)]) == 0
+    assert "match upstream" in capsys.readouterr().out
+
+    bad = tmp_path / "bad.txt"
+    bad.write_text("0000  trufflehog_0.0.0_linux_amd64.tar.gz\n")
+    assert pin.main(["prog", str(bad)]) == 1
+
+    assert pin.main(["prog"]) == 2  # wrong arg count
+    assert pin.main(["prog", str(tmp_path / "nope.txt")]) == 2  # unreadable
+
+
+def test_compare_is_case_insensitive_on_hashes():
+    upstream = pin.parse_checksums(
+        "\n".join(
+            f"{sha.upper()}  trufflehog_{pin.PINNED_VERSION}_{key}.tar.gz"
+            for key, sha in pin._ARCHIVE_SHA256.items()
+        )
+    )
+    assert pin.compare(upstream) == []


### PR DESCRIPTION
## Summary

TruffleHog install is the one genuine extra setup step for students — the share gate fails closed without it. This adds a managed install path so nobody has to find brew or the upstream release page:

- **`clawjournal trufflehog install [--force]`** — downloads the pinned **v3.95.5** from trufflesecurity's official GitHub release for macOS / Linux / Windows (x86-64 and ARM64), verifies the archive against **sha256 checksums vendored in the source** (never trusts what the network served), and installs into `~/.clawjournal/bin/` with a **stage → fsync → verify → atomic publish** flow: the binary is extracted to a temp file, sanity-checked with `--version`, and only then `os.replace()`d into place — a bad download can never displace a working managed binary. No root needed. Human mode streams download progress (size + a tick every 16 MB).
- **`clawjournal trufflehog status [--json]`** — shows which binary the share gate will use (bare `version` matching `install --json`, plus the raw engine `fingerprint`). Exit code 1 when no binary resolves, consistently across human and JSON modes.
- **`resolve_binary()`** in `redaction/trufflehog.py` prefers the managed copy over `PATH` (pinned + verified beats whatever brew last installed). The share gate, findings engine, and `engine_fingerprint` all resolve through it; the fingerprint cache keys on path+mtime+size, so a long-running daemon picks up the install without a restart.

### Correctness & hardening

- **`already-installed` means "the gate will use it AND it is the pin"**: the early exit requires `is_file` + executable + a `--version` match against `PINNED_VERSION`. Non-executable strays, directories, broken copies, and off-pin binaries from older clawjournals are repaired by a fresh install instead of reporting success while the gate stays blocked.
- **`install()` never raises**: every failure returns a status dict and fails closed — truncated chunked downloads (`IncompleteRead`), truncated gzip streams, a stray file blocking the bin dir, oversized payloads (200 MB download / 500 MB decompression caps).
- **Failure domains are reported distinctly**: archive parsing errors → `archive-invalid` (re-download might help); local file I/O and publish errors (disk full, directory squatting on the target, Windows refusing to replace a running `.exe`) → `install-failed` without the misleading GitHub URL. `download-failed` / `checksum-mismatch` results carry actionable `hint` text (TLS-intercepting campus/corporate proxies, `selfupdate`, manual fallback); the CLI prints error + URL + hint.
- **Exact-name tar member extraction** (no path traversal possible); the Windows archives were verified to contain a member named exactly `trufflehog.exe`, and every vendored checksum (including `windows_arm64`) was re-verified against upstream's release `checksums.txt`.
- **Windows-safe on Python 3.10+**: `os.chmod` on the temp path instead of `os.fchmod` (absent on Windows before 3.13).
- **AGPL posture unchanged**: fetched from upstream's own release artifacts at the user's explicit request, invoked subprocess-only with the existing scrubbed env.

### Remediation texts updated

`INSTALL_HINT`, events doctor, `install.sh` / `install.ps1` (which now also detect the managed copy instead of probing PATH only, and print the venv-qualified command since the venv isn't on `PATH` at that point), README, and PRIVACY.md all lead with the new command.

### Review process

Two multi-agent adversarial review rounds (findings only accepted on majority verdict from independent judges):
- **Round 1** (67 agents, during development): 10 confirmed findings fixed — `os.fchmod`-on-Windows crash, never-raises contract holes, stale brew-only remediation texts, missing test coverage.
- **Round 2** (56 agents, fresh lenses on the committed PR): 9 confirmed findings fixed in ca9a534 — the already-installed/X_OK/pin hole, verify-after-publish destroying good binaries, failure-domain misclassification, `status --json` exit-code asymmetry, missing `windows_arm64`, silent downloads, hint-less errors, version-shape inconsistency, bare-command script hints. Two findings were judged real-but-fine-as-is and deliberately left (benign double-resolution race in `scan_file`; bin-dir umask).

## Test plan

- 50 offline installer tests (fake urlopen + in-memory tarballs): happy path, checksum mismatch fails closed, pin-aware already-installed, reinstall-on-broken/off-pin, verify-failure-preserves-existing-binary, replace-failure classification, unsupported platform, download failures incl. truncation, size caps, missing/traversal/corrupt archive members, never-raises backstop, the real `_verify_installed_binary` contract, progress callback, hint plumbing, resolution precedence, CLI dispatch + exit codes + argparse round-trip, and an 8-case OS/arch matrix.
- Full suite: **2225 passed**; CI green on 3.10–3.13 + wheel smoke for both commits.
- Verified live end-to-end on macOS arm64: real download → checksum verification → install → status flip from brew 3.94.3 (PATH) to managed 3.95.5 → real `scan_file` through the managed binary → pin-aware `already-installed` re-running the real binary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
