### PR TITLE
clawshare: parallelize on-open failure-value scoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,7 +220,7 @@ clawjournal set-score <id> --failure-value 4 --failure-evidence "User corrected 
 clawjournal set-score <id> --quality 4               # legacy productivity override
 ```
 
-Scoring uses the current agent's automation CLI by default (`codex exec` in Codex, the Claude CLI in Claude Code); backends are `claude`, `codex`, `hermes`, `openclaw` (override with `--backend`). Claude Code-backed AI features default to `claude-sonnet-4-6`, Codex-backed AI features default to `gpt-5.4-mini`, and the other backends use their own agent defaults unless you pass `--model`. For Codex specifically, run `codex login` or set `CODEX_API_KEY` for headless scoring. The workbench can also auto-score share-ready traces in the background, but only after you confirm a backend once; confirm it headlessly with `clawjournal config --scorer-backend <backend>` (`none` clears it).
+Scoring uses the current agent's automation CLI by default (`codex exec` in Codex, the Claude CLI in Claude Code); backends are `claude`, `codex`, `hermes`, `openclaw` (override with `--backend`). Claude Code-backed AI features default to `claude-haiku-4-5`, Codex-backed AI features default to `gpt-5.4-mini`, and the other backends use their own agent defaults unless you pass `--model`. For Codex specifically, run `codex login` or set `CODEX_API_KEY` for headless scoring. The workbench can also auto-score share-ready traces in the background, but only after you confirm a backend once; confirm it headlessly with `clawjournal config --scorer-backend <backend>` (`none` clears it).
 
 </details>
 

--- a/clawjournal/scoring/backends.py
+++ b/clawjournal/scoring/backends.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 SUPPORTED_BACKENDS = ("claude", "codex", "hermes", "openclaw")
 BACKEND_CHOICES = ("auto", *SUPPORTED_BACKENDS)
 AUTO_BACKEND_FALLBACK_ORDER = ("codex", "claude", "hermes", "openclaw")
-DEFAULT_CLAUDE_MODEL = "claude-sonnet-4-6"
+DEFAULT_CLAUDE_MODEL = "claude-haiku-4-5"
 DEFAULT_CODEX_MODEL = "gpt-5.4-mini"
 DEFAULT_BACKEND_MODELS: dict[str, str] = {
     "claude": DEFAULT_CLAUDE_MODEL,

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -411,6 +411,9 @@ def step_queue(conn, settings, args) -> list[dict]:
         except Exception:  # noqa: BLE001
             backend_ok = False
         if backend_ok:
+            # Scoring uses the backend's fast default model (Claude → haiku,
+            # Codex → gpt-5.4-mini) via score_session; --score-model overrides.
+            score_model = getattr(args, "score_model", None)
             from types import SimpleNamespace
             pool_args = SimpleNamespace(**{**vars(args), "min_failure_value": None})
             pool = select_queue_rows(candidates, settings, pool_args, limit=False)
@@ -423,7 +426,7 @@ def step_queue(conn, settings, args) -> list[dict]:
                 )
             }
             pool = [r for r in pool if r["session_id"] in ready_ids]
-            score_traces(conn, pool, model=getattr(args, "score_model", None), cap=args.limit)
+            score_traces(conn, pool, model=score_model, cap=args.limit)
 
     rows = select_queue_rows(candidates, settings, args)
     if not rows:

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -321,28 +321,39 @@ def _rank_key(r: dict):
 
 
 def score_traces(conn, rows: list[dict], *, backend: str = "auto",
-                 model: str | None = None, cap: int | None = None) -> int:
-    """Score unscored rows for failure value, one at a time.
+                 model: str | None = None, cap: int | None = None, workers: int = 6) -> int:
+    """Score unscored rows for failure value, IN PARALLEL.
 
-    Runs before queue display, mutates rows in place, and persists each finished
-    score. Ctrl-C stops before launching the next AI judge call, so it does not
-    start extra background work after the user chooses to skip.
+    The slow AI-judge step runs in worker threads (each with its own read
+    connection via share_flow.score_compute), while DB writes happen serially on
+    `conn` (single writer; WAL handles the readers) — so N traces take about one
+    judge call, not N. At most `workers` judge calls are in flight at once; on
+    Ctrl-C, pending (not-yet-started) calls are cancelled and we return what's
+    done (in-flight calls may still finish). Mutates rows in place and persists.
     """
+    from concurrent.futures import as_completed
+
     unscored = [r for r in rows if r.get("ai_failure_value_score") is None]
     if cap is not None:
         unscored = unscored[:cap]
     if not unscored:
         return 0
     total = len(unscored)
+    by_sid = {r["session_id"]: r for r in unscored}
+    n_workers = max(1, min(workers, total))
     print(f"  {DIM}Scoring {total} unscored trace(s) for failure value "
-          f"(AI judge — Ctrl-C to skip the rest)…{RST}")
+          f"({n_workers} in parallel, AI judge — Ctrl-C to skip the rest)…{RST}")
     done = 0
+    pool = ThreadPoolExecutor(max_workers=n_workers)
+    futures = {pool.submit(share_flow.score_compute, sid, backend=backend, model=model): sid
+               for sid in by_sid}
     try:
-        for r in unscored:
-            sid = r["session_id"]
-            res = share_flow.score_compute(sid, backend=backend, model=model)
+        for fut in as_completed(futures):
+            res = fut.result()
             if res.get("ok"):
+                sid = futures[fut]
                 share_flow.persist_score(conn, sid, res["fields"])  # serial write on main conn
+                r = by_sid[sid]
                 r["ai_failure_value_score"] = res.get("failure_value")
                 if res.get("display_title"):
                     r["ai_display_title"] = res["display_title"]
@@ -352,6 +363,8 @@ def score_traces(conn, rows: list[dict], *, backend: str = "auto",
     except KeyboardInterrupt:
         print(f"\n  {YEL}Skipped remaining scoring ({done}/{total} done).{RST}")
         return done
+    finally:
+        pool.shutdown(wait=False, cancel_futures=True)
     return done
 
 

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -327,11 +327,12 @@ def score_traces(conn, rows: list[dict], *, backend: str = "auto",
     The slow AI-judge step runs in worker threads (each with its own read
     connection via share_flow.score_compute), while DB writes happen serially on
     `conn` (single writer; WAL handles the readers) — so N traces take about one
-    judge call, not N. At most `workers` judge calls are in flight at once; on
-    Ctrl-C, pending (not-yet-started) calls are cancelled and we return what's
-    done (in-flight calls may still finish). Mutates rows in place and persists.
+    judge call, not N. Only `workers` judge calls are submitted at a time; on
+    Ctrl-C we stop queueing new calls, cancel any submitted calls that have not
+    started, and return what's done (in-flight calls may still finish). Mutates
+    rows in place and persists.
     """
-    from concurrent.futures import as_completed
+    from concurrent.futures import FIRST_COMPLETED, wait
 
     unscored = [r for r in rows if r.get("ai_failure_value_score") is None]
     if cap is not None:
@@ -339,28 +340,50 @@ def score_traces(conn, rows: list[dict], *, backend: str = "auto",
     if not unscored:
         return 0
     total = len(unscored)
-    by_sid = {r["session_id"]: r for r in unscored}
     n_workers = max(1, min(workers, total))
     print(f"  {DIM}Scoring {total} unscored trace(s) for failure value "
           f"({n_workers} in parallel, AI judge — Ctrl-C to skip the rest)…{RST}")
     done = 0
     pool = ThreadPoolExecutor(max_workers=n_workers)
-    futures = {pool.submit(share_flow.score_compute, sid, backend=backend, model=model): sid
-               for sid in by_sid}
+    rows_iter = iter(unscored)
+    futures = {}
+
+    def submit_next() -> bool:
+        try:
+            r = next(rows_iter)
+        except StopIteration:
+            return False
+        sid = r["session_id"]
+        futures[pool.submit(share_flow.score_compute, sid, backend=backend, model=model)] = r
+        return True
+
+    for _ in range(n_workers):
+        submit_next()
+
     try:
-        for fut in as_completed(futures):
-            res = fut.result()
-            if res.get("ok"):
-                sid = futures[fut]
+        while futures:
+            completed, _pending = wait(futures, timeout=0.1, return_when=FIRST_COMPLETED)
+            if not completed:
+                continue
+            for fut in completed:
+                r = futures.pop(fut)
+                sid = r["session_id"]
+                res = fut.result()
+                if not res.get("ok"):
+                    print(f"\r  {DIM}scored {done}/{total}…{RST}", end="", flush=True)
+                    submit_next()
+                    continue
                 share_flow.persist_score(conn, sid, res["fields"])  # serial write on main conn
-                r = by_sid[sid]
                 r["ai_failure_value_score"] = res.get("failure_value")
                 if res.get("display_title"):
                     r["ai_display_title"] = res["display_title"]
                 done += 1
-            print(f"\r  {DIM}scored {done}/{total}…{RST}", end="", flush=True)
+                print(f"\r  {DIM}scored {done}/{total}…{RST}", end="", flush=True)
+                submit_next()
         print()
     except KeyboardInterrupt:
+        for fut in futures:
+            fut.cancel()
         print(f"\n  {YEL}Skipped remaining scoring ({done}/{total} done).{RST}")
         return done
     finally:

--- a/tests/scoring/test_backends.py
+++ b/tests/scoring/test_backends.py
@@ -42,7 +42,7 @@ class TestConstants:
         assert set(SUPPORTED_BACKENDS) == {"claude", "codex", "hermes", "openclaw"}
 
     def test_default_backend_models(self):
-        assert DEFAULT_CLAUDE_MODEL == "claude-sonnet-4-6"
+        assert DEFAULT_CLAUDE_MODEL == "claude-haiku-4-5"
         assert DEFAULT_CODEX_MODEL == "gpt-5.4-mini"
         assert default_model_for_backend("claude") == DEFAULT_CLAUDE_MODEL
         assert default_model_for_backend("codex") == DEFAULT_CODEX_MODEL

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -1,5 +1,6 @@
 """Tests for the interactive share wizard CLI surface."""
 import argparse
+import threading
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from types import SimpleNamespace
@@ -525,6 +526,34 @@ def test_score_traces_keyboard_interrupt_is_graceful(monkeypatch):
     result = share_cli.score_traces(None, rows, workers=2)
     assert result == 0                                    # nothing completed; no crash
     assert all(r.get("ai_failure_value_score") is None for r in rows)
+
+
+def test_score_traces_keyboard_interrupt_does_not_submit_beyond_workers(monkeypatch):
+    started = []
+    release = threading.Event()
+    u2_started = threading.Event()
+
+    def fake_compute(sid, *, backend="auto", model=None):
+        started.append(sid)
+        if sid == "u1":
+            u2_started.wait(timeout=1)
+            raise KeyboardInterrupt
+        if sid == "u2":
+            u2_started.set()
+        release.wait(timeout=1)
+        return {"ok": True, "fields": {}, "failure_value": 5, "display_title": None}
+
+    monkeypatch.setattr(share_cli.share_flow, "score_compute", fake_compute)
+    monkeypatch.setattr(share_cli.share_flow, "persist_score", lambda conn, sid, fields: None)
+
+    rows = [_row(fv=None, session_id=f"u{i}") for i in range(1, 5)]
+    try:
+        result = share_cli.score_traces(None, rows, workers=2)
+    finally:
+        release.set()
+
+    assert result == 0
+    assert set(started) == {"u1", "u2"}
 
 
 def test_score_traces_respects_cap(monkeypatch):

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -503,32 +503,28 @@ def test_score_traces_scores_unscored_and_updates(monkeypatch):
             _row(fv=None, session_id="u2")]
     n = share_cli.score_traces(None, rows, backend="auto")
     assert n == 2
-    assert scored_ids == ["u1", "u2"]                     # only the unscored ones
+    assert set(scored_ids) == {"u1", "u2"}                # only the unscored ones (parallel; any order)
     assert rows[1]["ai_failure_value_score"] == 5          # mutated in place
     assert rows[1]["ai_display_title"] == "scored u1"
     assert rows[0]["ai_failure_value_score"] == 3          # already-scored untouched
 
 
-def test_score_traces_keyboard_interrupt_stops_before_next(monkeypatch):
-    calls = []
+def test_score_traces_keyboard_interrupt_is_graceful(monkeypatch):
+    # Parallel: Ctrl-C (here, raised from a worker) must be handled gracefully —
+    # score_traces returns a count and does not propagate, cancelling pending work.
+    def boom(sid, *, backend="auto", model=None):
+        raise KeyboardInterrupt
 
-    def fake_compute(sid, *, backend="auto", model=None):
-        calls.append(sid)
-        if sid == "u2":
-            raise KeyboardInterrupt
-        return {"ok": True, "fields": {}, "failure_value": 5, "display_title": None}
-
-    monkeypatch.setattr(share_cli.share_flow, "score_compute", fake_compute)
+    monkeypatch.setattr(share_cli.share_flow, "score_compute", boom)
     monkeypatch.setattr(share_cli.share_flow, "persist_score", lambda conn, sid, fields: None)
 
     rows = [_row(fv=None, session_id="u1"),
             _row(fv=None, session_id="u2"),
             _row(fv=None, session_id="u3")]
 
-    assert share_cli.score_traces(None, rows) == 1
-    assert calls == ["u1", "u2"]
-    assert rows[0]["ai_failure_value_score"] == 5
-    assert rows[2]["ai_failure_value_score"] is None
+    result = share_cli.score_traces(None, rows, workers=2)
+    assert result == 0                                    # nothing completed; no crash
+    assert all(r.get("ai_failure_value_score") is None for r in rows)
 
 
 def test_score_traces_respects_cap(monkeypatch):


### PR DESCRIPTION
Follow-up to #78, bringing back parallel on-open scoring so we can compare the speedup while keeping the settle gate and Ctrl-C behavior honest.

## What

Re-parallelizes the on-open failure-value scoring that #78 reverted to sequential:
- The slow AI judge step runs in worker threads, each with its own read connection via `share_flow.score_compute`.
- DB writes stay serial on the main connection through `share_flow.persist_score`, so the index still has one writer while SQLite WAL handles concurrent readers.
- Only settled, unscored traces are scored on open. Active or recent traces remain deferred through `query_unscored_sessions(..., settle_seconds=SCORE_SETTLE_SECONDS)`.
- `workers` defaults to 6 and bounds concurrency by lazily submitting only the active worker window. `--no-score` still skips scoring entirely.

## Haiku is now the default Claude scoring model

Per discussion with Kai, Claude-backed AI features now default to `claude-haiku-4-5`, while Codex continues to default to `gpt-5.4-mini`. This is the shared backend default, so the web daemon, `clawjournal score`, and CLI on-open scoring resolve consistently. `--score-model` and `--model` still override per run.

## Ctrl-C tradeoff

The sequential version in #78 guaranteed that Ctrl-C launched no further judge calls. Parallel keeps at most `workers` calls in flight; on Ctrl-C we stop queueing new work and cancel submitted calls that have not started. In-flight calls may still finish. If strict no-in-flight-work matters more than speed, that remains the tradeoff.

## Local workflow validation

Kai tested this PR branch locally through the ClawJournal workbench and successfully uploaded a package to `https://data.rayward.ai/`.

## Tests

- Local: `python -m pytest tests/ -q` -> 2177 passed
- CI run `27455492513`: smoke + Python 3.10, 3.11, 3.12, and 3.13 all passed

Generated with Claude Code