### PR TITLE
feat(workbench): add sessions-per-page selector to Inbox

### DIFF
--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -188,6 +188,7 @@ export function Inbox() {
   expandedIdRef.current = expandedId;
   const expandedMsgsRef = useRef(expandedMessages);
   expandedMsgsRef.current = expandedMessages;
+  const loadRequestSeqRef = useRef(0);
   // Session ids with an in-flight redacted-content fetch (single-flight guard).
   const loadingIdsRef = useRef<Set<string>>(new Set());
 
@@ -202,6 +203,8 @@ export function Inbox() {
   }, []);
 
   const loadSessions = useCallback(async (currentOffset: number, append: boolean) => {
+    const requestSeq = loadRequestSeqRef.current + 1;
+    loadRequestSeqRef.current = requestSeq;
     setLoading(true);
     const [sortField, sortOrder] = sort.split(':');
     try {
@@ -215,20 +218,29 @@ export function Inbox() {
         failure_mode: modeFilter,
         sort: sortField,
         order: sortOrder,
-        limit: pageSize,
+        limit: pageSize + 1,
         offset: currentOffset,
       });
-      setSessions(prev => append ? [...prev, ...data] : data);
-      // A full batch means there may be more; a short/empty batch is the end.
-      setHasMore(data.length === pageSize);
+      if (requestSeq !== loadRequestSeqRef.current) return;
+      const visibleRows = data.slice(0, pageSize);
+      setSessions(prev => append ? [...prev, ...visibleRows] : visibleRows);
+      setOffset(currentOffset);
+      setHasMore(data.length > pageSize);
     } catch (e) {
+      if (requestSeq !== loadRequestSeqRef.current) return;
       toast(e instanceof Error ? e.message : 'Failed to load sessions', 'error');
     }
-    finally { setLoading(false); setLoaded(true); }
+    finally {
+      if (requestSeq === loadRequestSeqRef.current) {
+        setLoading(false);
+        setLoaded(true);
+      }
+    }
   }, [sort, sourceFilter, projectFilter, typeFilter, recoveryFilter, attributionFilter, modeFilter, pageSize, toast]);
 
   useEffect(() => {
     setOffset(0);
+    setHasMore(false);
     setSelectedIds(new Set());
     setFocusIndex(-1);
     loadSessions(0, false);
@@ -805,7 +817,7 @@ export function Inbox() {
       {hasMore && sessions.length > 0 && (
         <div style={{ textAlign: 'center', marginTop: '8px' }}>
           <button
-            onClick={() => { const n = offset + pageSize; setOffset(n); loadSessions(n, true); }}
+            onClick={() => { void loadSessions(offset + pageSize, true); }}
             disabled={loading}
             style={{
               padding: '5px 18px', background: colors.gray100, color: colors.gray700, border: `1px solid ${colors.gray300}`,

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -10,7 +10,6 @@ import { GettingStartedGuide } from '../components/GettingStartedGuide.tsx';
 import { ZeroState } from '../components/ZeroState.tsx';
 import { colors, selectStyle, btnPrimary, btnDanger, btnSecondary } from '../theme.ts';
 
-const PAGE_SIZE = 10;
 // Show only the top few task-type chips by default; the long tail collapses
 // behind a "More (N)" toggle. Keeps the toolbar to one calm row instead of ~17
 // chips wrapping across the viewport.
@@ -157,6 +156,8 @@ export function Inbox() {
   // empty-state don't flash for a frame before the first fetch resolves.
   const [loaded, setLoaded] = useState(false);
   const [offset, setOffset] = useState(0);
+  const [pageSize, setPageSize] = useState(10);
+  const [hasMore, setHasMore] = useState(false);
   const [expandedId, setExpandedId] = useState<string | null>(null);
   const [expandedMessages, setExpandedMessages] = useState<Record<string, Array<{ role: string; content: string; tool_uses?: Array<{ tool: string }> }>>>({});
   const [sort, setSort] = useState('ai_failure_value_score:desc');
@@ -214,15 +215,17 @@ export function Inbox() {
         failure_mode: modeFilter,
         sort: sortField,
         order: sortOrder,
-        limit: PAGE_SIZE,
+        limit: pageSize,
         offset: currentOffset,
       });
       setSessions(prev => append ? [...prev, ...data] : data);
+      // A full batch means there may be more; a short/empty batch is the end.
+      setHasMore(data.length === pageSize);
     } catch (e) {
       toast(e instanceof Error ? e.message : 'Failed to load sessions', 'error');
     }
     finally { setLoading(false); setLoaded(true); }
-  }, [sort, sourceFilter, projectFilter, typeFilter, recoveryFilter, attributionFilter, modeFilter, toast]);
+  }, [sort, sourceFilter, projectFilter, typeFilter, recoveryFilter, attributionFilter, modeFilter, pageSize, toast]);
 
   useEffect(() => {
     setOffset(0);
@@ -230,7 +233,7 @@ export function Inbox() {
     setFocusIndex(-1);
     loadSessions(0, false);
     loadStats();
-  }, [sort, sourceFilter, projectFilter, typeFilter, recoveryFilter, attributionFilter, modeFilter, loadSessions, loadStats]);
+  }, [sort, sourceFilter, projectFilter, typeFilter, recoveryFilter, attributionFilter, modeFilter, pageSize, loadSessions, loadStats]);
 
   // Keyboard navigation — uses refs to avoid stale closures
   useEffect(() => {
@@ -410,6 +413,17 @@ export function Inbox() {
             <option value="ai_quality_score:desc">Highest productivity</option>
             <option value="start_time:desc">Newest first</option>
             <option value="start_time:asc">Oldest first</option>
+          </select>
+          <select
+            value={pageSize}
+            onChange={e => setPageSize(Number(e.target.value))}
+            aria-label="Sessions per page"
+            style={selectStyle}
+          >
+            <option value={10}>10 / page</option>
+            <option value={20}>20 / page</option>
+            <option value={50}>50 / page</option>
+            <option value={100}>100 / page</option>
           </select>
           <button
             onClick={() => setShowFilters(!showFilters)}
@@ -788,10 +802,10 @@ export function Inbox() {
       </div>
 
       {/* Load more */}
-      {sessions.length >= PAGE_SIZE && sessions.length > 0 && (
+      {hasMore && sessions.length > 0 && (
         <div style={{ textAlign: 'center', marginTop: '8px' }}>
           <button
-            onClick={() => { const n = offset + PAGE_SIZE; setOffset(n); loadSessions(n, true); }}
+            onClick={() => { const n = offset + pageSize; setOffset(n); loadSessions(n, true); }}
             disabled={loading}
             style={{
               padding: '5px 18px', background: colors.gray100, color: colors.gray700, border: `1px solid ${colors.gray300}`,


### PR DESCRIPTION
Fixes #85.

## Summary

The workbench Inbox listed sessions in fixed batches of 10 with no way to change the page size; the only way to see more was to repeatedly click **Load more**. This adds a **sessions-per-page selector** (10 / 20 / 50 / 100) next to the Sort dropdown.

- Replaces the hard-coded `const PAGE_SIZE = 10` with `pageSize` state (default 10, session-only; not persisted).
- Adds a `<select>` (10/20/50/100) in the toolbar, styled to match the existing Sort select.
- Changing the page size resets the offset and reloads from the top, reusing the existing filter/sort reload pattern.
- Fixes **Load more** pagination with an explicit `hasMore` flag based on a one-row over-fetch (`limit = pageSize + 1`, render only `pageSize`). This hides **Load more** exactly at the end, including exact page-size multiples.
- Guards session-list requests with a latest-request sequence so stale responses from earlier page-size/filter/load-more requests cannot overwrite or append into the current list.
- Advances `offset` only after a successful latest load, so a failed Load more request cannot skip a page.

Frontend-only: `clawjournal/web/frontend/src/views/Inbox.tsx`. The daemon's session-list endpoint passes `limit` through to SQLite, so no backend change is needed. Built `dist/` is gitignored and produced at package time, so it is not committed.

## Test Plan

- [x] `npm run build` (`tsc -b && vite build`) passes; type-checks and bundles.
- [x] `npm run lint` run; fails only on pre-existing repo lint debt unrelated to this PR (`BadgeChip.tsx`, `RedactionReportPanel.tsx`, `SessionDrawer.tsx`, `Toast.tsx`, `Dashboard.tsx`, existing unused vars in `Inbox.tsx`, `SessionDetail.tsx`).
- [x] `git diff --check` passes.
- [x] Daemon smoke: `python -m clawjournal.cli serve --no-browser`; `/`, `/api/features`, `/api/stats`, and `/api/sessions?limit=11&offset=0` respond.
- [x] Manual browser smoke: open Inbox, switch selector to 20 and confirm 20 rows; click **Load more** and confirm 40 rows; switch selector to 50 and confirm it reloads to 50 rows.