### PR TITLE
feat: scrollable transcript viewer for the interactive share wizard

### DIFF
--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -58,12 +58,17 @@ from .share_flow import (
     gate_blockers,
     hosted_destination,
 )
+from .transcript_viewer import view_transcript
 
 # ---- tty helpers ------------------------------------------------------------
 
 BOLD = "\033[1m"; DIM = "\033[2m"; GRN = "\033[32m"; YEL = "\033[33m"; RED = "\033[31m"
 CYN = "\033[36m"; RST = "\033[0m"
 _ANSI_RE = re.compile(r"(\033\[[0-9;]*m)")
+# C0 control chars + DEL, excluding \t (0x09) and \n (0x0a). Stripped from
+# displayed message content so terminal escape sequences embedded in
+# (untrusted) agent logs can't manipulate the reviewer's terminal.
+_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b-\x1f\x7f]")
 NSTEPS = 6
 
 
@@ -582,7 +587,8 @@ def step_queue(conn, settings, args) -> list[dict]:
 
 # ---- step 2: redact ---------------------------------------------------------
 
-def render_transcript(redacted_session: dict, max_msgs: int | None = None, max_chars: int = 2000):
+def _transcript_lines(redacted_session: dict, max_msgs: int | None = None,
+                      max_chars: int = 2000) -> list[str]:
     all_msgs = redacted_session.get("messages") or []
     msgs, hidden = [], 0
     for m in all_msgs:
@@ -597,20 +603,30 @@ def render_transcript(redacted_session: dict, max_msgs: int | None = None, max_c
     if hidden:
         note += f", {hidden} empty/thinking hidden"
     note += " — already scrubbed)"
-    print(f"  {DIM}{note}{RST}")
+    out = [f"  {DIM}{note}{RST}"]
     for m in shown:
         role = m.get("role", "?")
-        content = m["content"]
+        # Neutralize terminal escapes embedded in agent-log content before display.
+        content = _CONTROL_CHARS_RE.sub("", m["content"])
         color = CYN if role == "user" else (YEL if role == "assistant" else DIM)
         body = content
         if len(body) > max_chars:
             body = body[:max_chars] + f"  …(+{len(content) - max_chars} more chars)"
         lines = body.split("\n")
-        print(f"  {color}{role:>9}{RST}  {lines[0] if lines else ''}")
+        # NOTE: the "  {role:>9}  " layout here is parsed by
+        # transcript_viewer._role_line_fragments to recolor role labels — keep in sync.
+        out.append(f"  {color}{role:>9}{RST}  {lines[0] if lines else ''}")
         for ln in lines[1:]:
-            print(f"             {ln}")
+            out.append(f"             {ln}")
     if max_msgs is not None and len(msgs) > max_msgs:
-        print(f"  {DIM}… {len(msgs) - max_msgs} more — press [v] for the full transcript{RST}")
+        out.append(f"  {DIM}… {len(msgs) - max_msgs} more — press [v] for the full transcript{RST}")
+    return out
+
+
+def render_transcript(redacted_session: dict, max_msgs: int | None = None,
+                      max_chars: int = 2000):
+    for line in _transcript_lines(redacted_session, max_msgs, max_chars):
+        print(line)
 
 
 def _build_records(conn, settings, chosen, ai_pii):
@@ -683,7 +699,8 @@ def step_redact(conn, settings, chosen, assume_yes, ai_pii_requested) -> tuple[l
                 print(f"{YEL}Enter a # between 1 and {len(scrubbed)}, or blank to skip.{RST}")
                 continue
             print()
-            render_transcript(scrubbed[n - 1]["redacted"])
+            view_transcript(scrubbed[n - 1]["redacted"],
+                            title=trace_title(scrubbed[n - 1]["row"]))
     print(f"{GRN}✓ scrubbed {len(scrubbed)} trace(s){RST}")
     return scrubbed, package_ai
 
@@ -750,7 +767,7 @@ def step_review(conn, scrubbed: list[dict], assume_yes: bool,
                                  f"{BOLD}[i]{RST}nclude  {BOLD}[r]{RST}emove: ").lower()
                     if choice in ("v", "view"):
                         print()
-                        render_transcript(s["redacted"])
+                        view_transcript(s["redacted"], title=trace_title(s["row"]))
                         continue
                     if choice in ("i", "include", "y", "yes"):
                         included_ids.add(s["row"]["session_id"])

--- a/clawjournal/transcript_viewer.py
+++ b/clawjournal/transcript_viewer.py
@@ -1,0 +1,167 @@
+"""Scrollable, mouse-wheel-capable modal viewer for redacted transcripts.
+
+Used by the interactive share wizard in :mod:`clawjournal.share_cli` to let a
+user read a full transcript without dumping it into the terminal scrollback.
+prompt_toolkit (a hard dependency) is imported lazily; the viewer still falls
+back to the plain ``render_transcript`` dump whenever a TUI cannot run (stdin
+or stdout is not a tty, prompt_toolkit is unavailable/broken, dumb ``$TERM``,
+or any runtime error), so the share flow is never broken by the viewer.
+"""
+from __future__ import annotations
+
+import re
+import sys
+
+# Strips SGR color escapes so the prepared lines can go into a plain-text,
+# buffer-backed viewer (which is what makes it actually scroll — see _run_pager).
+_ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+_ROLE_STYLES = {"user": "fg:ansicyan", "assistant": "fg:ansiyellow"}
+
+
+def _role_line_fragments(line: str) -> list[tuple[str, str]]:
+    """Color just the role label word in a transcript line.
+
+    ``_transcript_lines`` lays each message line out as ``"  {role:>9}  {text}"``
+    (two leading spaces, a 9-wide right-justified role field, two spaces, text).
+    Re-apply the original per-role color to the ``user``/``assistant`` word only,
+    leaving padding and message text in the default style. Returns prompt_toolkit
+    ``(style, text)`` fragments. Pure: no prompt_toolkit import needed.
+    """
+    if len(line) >= 13 and line[:2] == "  " and line[11:13] == "  ":
+        role = line[2:11].strip()
+        style = _ROLE_STYLES.get(role)
+        if style is not None:
+            start = 11 - len(role)  # role word begins after its right-justify pad
+            return [("", line[:start]), (style, line[start:11]), ("", line[11:])]
+    return [("", line)]
+
+
+def _stdout_isatty() -> bool:
+    try:
+        return sys.stdout.isatty()
+    except (AttributeError, OSError):
+        return False
+
+
+def _stdin_isatty() -> bool:
+    try:
+        return sys.stdin.isatty()
+    except (AttributeError, OSError):
+        return False
+
+
+def view_transcript(redacted_session: dict, *, title: str = "") -> None:
+    # Imported lazily to avoid an import cycle with share_cli.
+    from .share_cli import _transcript_lines, render_transcript
+
+    try:
+        # The pager renders to stdout AND reads keys/mouse from stdin. If either
+        # is not an interactive terminal (piped, heredoc, captured by an agent),
+        # the TUI would render but be frozen — fall back to the plain dump.
+        if not (_stdin_isatty() and _stdout_isatty()):
+            render_transcript(redacted_session)
+            return
+        lines = _transcript_lines(redacted_session)
+        _run_pager(lines, title=title)
+    except Exception as exc:
+        # Missing prompt_toolkit, dumb $TERM, malformed session, or any runtime
+        # TUI failure: degrade rather than abort the share flow, but leave a
+        # one-line breadcrumb on stderr so the cause is diagnosable in the field.
+        print(f"  (transcript viewer fell back: {type(exc).__name__}: {exc})",
+              file=sys.stderr)
+        try:
+            render_transcript(redacted_session)
+        except Exception as dump_exc:
+            # Even the plain dump failed — never raise into the wizard.
+            print(f"  (could not render transcript: {type(dump_exc).__name__})",
+                  file=sys.stderr)
+            print("  (could not render transcript)")
+
+
+def _build_pager_app(lines: list[str], *, title: str):
+    """Build the full-screen pager Application over ``lines``.
+
+    The body is a read-only, buffer-backed ``TextArea``. A buffer is essential:
+    a ``FormattedTextControl``'s cursor is fixed at ``(0, 0)``, so the ``Window``
+    snaps ``vertical_scroll`` back to the top every render to keep that cursor in
+    view — making it impossible to scroll. With a real ``Buffer`` the cursor
+    position moves as you navigate, so the ``Window`` scrolls to follow it.
+    Arrow keys (default bindings) and the mouse wheel both move that cursor.
+
+    Returns ``(app, body)`` so tests can drive the app and inspect scroll state.
+    """
+    from prompt_toolkit.application import Application
+    from prompt_toolkit.formatted_text import ANSI
+    from prompt_toolkit.key_binding import KeyBindings
+    from prompt_toolkit.key_binding.bindings.scroll import (
+        scroll_page_down,
+        scroll_page_up,
+    )
+    from prompt_toolkit.layout import Layout
+    from prompt_toolkit.layout.containers import HSplit, Window
+    from prompt_toolkit.layout.controls import FormattedTextControl
+    from prompt_toolkit.lexers import Lexer
+    from prompt_toolkit.widgets import TextArea
+
+    class _RoleLexer(Lexer):
+        # Re-color the role label words on top of the plain-text buffer.
+        def lex_document(self, document):
+            doc_lines = document.lines
+
+            def get_line(lineno):
+                return list(_role_line_fragments(doc_lines[lineno]))
+
+            return get_line
+
+    # TextArea holds plain text; drop the SGR color escapes from the lines.
+    text = _ANSI_ESCAPE_RE.sub("", "\n".join(lines))
+    body = TextArea(
+        text=text,
+        read_only=True,
+        scrollbar=True,
+        focusable=True,
+        wrap_lines=True,
+        lexer=_RoleLexer(),
+    )
+
+    safe_title = re.sub(r"[\x00-\x1f\x7f]", " ", title).strip()
+    header = f" {safe_title} " if safe_title else " transcript "
+    hint = "↑/↓ PgUp/PgDn Home/End · wheel to scroll · q to close"
+    status = Window(
+        content=FormattedTextControl(ANSI(f"\033[7m{header}— {hint} \033[0m")),
+        height=1,
+    )
+
+    kb = KeyBindings()
+    # Arrow keys + Home/End-of-line come from prompt_toolkit's default bindings
+    # (they move the buffer cursor). Add page scrolling and document Home/End.
+    kb.add("pageup")(scroll_page_up)
+    kb.add("pagedown")(scroll_page_down)
+
+    @kb.add("home")
+    def _(event):
+        event.app.current_buffer.cursor_position = 0
+
+    @kb.add("end")
+    def _(event):
+        buf = event.app.current_buffer
+        buf.cursor_position = len(buf.text)
+
+    @kb.add("q")
+    @kb.add("c-c")
+    def _(event):
+        event.app.exit()
+
+    app = Application(
+        layout=Layout(HSplit([body, status]), focused_element=body),
+        key_bindings=kb,
+        mouse_support=True,   # buffer-backed Window scrolls on the wheel
+        full_screen=True,
+    )
+    return app, body
+
+
+def _run_pager(lines: list[str], *, title: str) -> None:
+    app, _ = _build_pager_app(lines, title=title)
+    app.run()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 ]
 dependencies = [
     "pyyaml>=6.0",
+    "prompt_toolkit>=3.0",
 ]
 
 [project.urls]

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -644,3 +644,75 @@ def test_no_score_is_interactive_only():
                         certify_ownership=False, download=False, no_refresh=False,
                         include_needs_review=False, status="approved")
     assert any("--no-score" in x for x in share_cli.noninteractive_share_rejections(a))
+
+
+# ---- _transcript_lines helper and render_transcript refactor ----------------
+
+def test_transcript_lines_counts_and_hides():
+    session = {"messages": [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+        {"role": "assistant", "content": "   "},   # blank -> hidden
+        {"role": "assistant", "content": "None"},  # literal None -> hidden
+    ]}
+    lines = share_cli._transcript_lines(session)
+    body = "\n".join(lines)
+    assert "all 2 content messages" in lines[0]
+    assert "2 empty/thinking hidden" in lines[0]
+    assert "hello" in body
+    assert "hi there" in body
+
+
+def test_transcript_lines_truncates_long_content():
+    session = {"messages": [{"role": "user", "content": "x" * 50}]}
+    body = "\n".join(share_cli._transcript_lines(session, max_chars=10))
+    assert "more chars)" in body
+
+
+def test_transcript_lines_max_msgs_adds_more_hint():
+    session = {"messages": [{"role": "user", "content": f"m{i}"} for i in range(5)]}
+    body = "\n".join(share_cli._transcript_lines(session, max_msgs=2))
+    assert "first 2 of 5" in body
+    assert "press [v] for the full transcript" in body
+
+
+def test_render_transcript_prints_the_lines(capsys):
+    session = {"messages": [{"role": "user", "content": "hello world"}]}
+    share_cli.render_transcript(session)
+    out = capsys.readouterr().out
+    expected = "\n".join(share_cli._transcript_lines(session)) + "\n"
+    assert out == expected
+
+
+def test_transcript_lines_strip_terminal_escapes_from_content():
+    # Agent-log content can carry raw terminal control sequences; they must be
+    # neutralized so they can't manipulate the reviewer's terminal on display.
+    session = {"messages": [
+        {"role": "user", "content": "hi \x1b]0;PWNED\x07 there \x1b[2J"},
+    ]}
+    body = "\n".join(share_cli._transcript_lines(session))
+    clean = share_cli._ANSI_RE.sub("", body)  # drop our own SGR color codes
+    assert "\x1b" not in clean and "\x07" not in clean  # content escapes removed
+    assert "hi" in clean and "there" in clean and "PWNED" in clean  # text kept inert
+
+
+def test_transcript_lines_handles_zero_messages():
+    for messages in ([], None):
+        lines = share_cli._transcript_lines({"messages": messages})
+        assert len(lines) == 1
+        assert "all 0 content messages" in lines[0]
+    assert "all 0 content messages" in share_cli._transcript_lines({})[0]
+
+
+def test_view_transcript_is_wired_into_share_cli():
+    import inspect
+    from clawjournal import transcript_viewer
+    assert share_cli.view_transcript is transcript_viewer.view_transcript
+    redact_src = inspect.getsource(share_cli.step_redact)
+    review_src = inspect.getsource(share_cli.step_review)
+    # Full-transcript views now go through the scrollable viewer.
+    assert "view_transcript(" in redact_src
+    assert "view_transcript(" in review_src
+    # And no longer dump the full transcript inline.
+    assert "render_transcript(scrubbed[n - 1]" not in redact_src
+    assert "render_transcript(s[\"redacted\"])" not in review_src

--- a/tests/test_transcript_viewer.py
+++ b/tests/test_transcript_viewer.py
@@ -1,0 +1,187 @@
+from clawjournal import transcript_viewer
+
+
+SESSION = {"messages": [
+    {"role": "user", "content": "hello"},
+    {"role": "assistant", "content": "world"},
+]}
+
+
+def test_falls_back_to_dump_when_not_a_tty(monkeypatch, capsys):
+    monkeypatch.setattr(transcript_viewer, "_stdout_isatty", lambda: False)
+    called = {"pager": False}
+    monkeypatch.setattr(transcript_viewer, "_run_pager",
+                        lambda *a, **k: called.__setitem__("pager", True))
+    transcript_viewer.view_transcript(SESSION, title="t")
+    out = capsys.readouterr().out
+    assert "hello" in out and "world" in out
+    assert called["pager"] is False  # never tried the TUI without a tty
+
+
+def test_falls_back_to_dump_when_stdin_not_a_tty(monkeypatch, capsys):
+    # stdout is a tty but stdin is not (e.g. a heredoc / piped invocation).
+    # prompt_toolkit reads keys from stdin, so the pager would render but be
+    # frozen — fall back to the dump instead of launching a dead TUI.
+    monkeypatch.setattr(transcript_viewer, "_stdout_isatty", lambda: True)
+    monkeypatch.setattr(transcript_viewer, "_stdin_isatty", lambda: False)
+    called = {"pager": False}
+    monkeypatch.setattr(transcript_viewer, "_run_pager",
+                        lambda *a, **k: called.__setitem__("pager", True))
+    transcript_viewer.view_transcript(SESSION, title="t")
+    out = capsys.readouterr().out
+    assert "hello" in out and "world" in out
+    assert called["pager"] is False  # no TUI when stdin can't deliver input
+
+
+def test_falls_back_to_dump_when_pager_raises(monkeypatch, capsys):
+    monkeypatch.setattr(transcript_viewer, "_stdout_isatty", lambda: True)
+    monkeypatch.setattr(transcript_viewer, "_stdin_isatty", lambda: True)
+
+    def _boom(*a, **k):
+        raise ImportError("no prompt_toolkit")
+
+    monkeypatch.setattr(transcript_viewer, "_run_pager", _boom)
+    transcript_viewer.view_transcript(SESSION, title="t")
+    captured = capsys.readouterr()
+    assert "hello" in captured.out and "world" in captured.out
+    assert "fell back" in captured.err  # diagnostic breadcrumb, not silent
+
+
+def test_module_does_not_import_prompt_toolkit_at_top_level():
+    import inspect
+    import re
+
+    src = inspect.getsource(transcript_viewer)
+    top = src.split("def ", 1)[0]  # module preamble, before the first function
+    # The name may appear in the docstring; what must NOT appear is a top-level
+    # import (prompt_toolkit must be imported lazily inside functions).
+    assert not re.search(r"^\s*(import prompt_toolkit|from prompt_toolkit)", top, re.M), \
+        "prompt_toolkit must be imported lazily, not at module top level"
+
+
+def test_pager_scrolls_and_holds_then_exits_on_q():
+    # Regression: the original FormattedTextControl viewer had no cursor, so the
+    # Window snapped vertical_scroll back to 0 every render and could not scroll.
+    # The buffer-backed TextArea moves a real cursor, so Down advances and HOLDS.
+    import pytest
+    pytest.importorskip("prompt_toolkit")
+    from prompt_toolkit.application import create_app_session
+    from prompt_toolkit.input import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+
+    lines = [f"line {i}" for i in range(200)]
+    with create_pipe_input() as inp:
+        inp.send_text("\x1b[B\x1b[B\x1b[B\x1b[B\x1b[B")  # five Down arrows
+        inp.send_text("q")                                # then quit
+        with create_app_session(input=inp, output=DummyOutput()):
+            # Build inside the session so the app uses the pipe input / dummy output.
+            app, body = transcript_viewer._build_pager_app(lines, title="t")
+            app.run()
+    # Cursor advanced 5 rows and held — not stuck/oscillating at 0.
+    assert body.buffer.document.cursor_position_row == 5
+
+
+def test_never_raises_on_malformed_session_tty(monkeypatch, capsys):
+    # Regression: a non-dict message entry used to escape on the TTY path,
+    # aborting the share wizard. It must degrade instead.
+    monkeypatch.setattr(transcript_viewer, "_stdout_isatty", lambda: True)
+    monkeypatch.setattr(transcript_viewer, "_stdin_isatty", lambda: True)
+    transcript_viewer.view_transcript({"messages": [123]}, title="t")  # must not raise
+    assert "could not render transcript" in capsys.readouterr().out
+
+
+def test_never_raises_on_malformed_session_non_tty(monkeypatch, capsys):
+    monkeypatch.setattr(transcript_viewer, "_stdout_isatty", lambda: False)
+    transcript_viewer.view_transcript({"messages": [123]}, title="t")  # must not raise
+    assert "could not render transcript" in capsys.readouterr().out
+
+
+def test_role_line_fragments_colors_only_the_role_word():
+    from clawjournal import share_cli
+
+    session = {"messages": [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there\nsecond line"},
+    ]}
+    raw = transcript_viewer._ANSI_ESCAPE_RE.sub(
+        "", "\n".join(share_cli._transcript_lines(session)))
+    doc_lines = raw.split("\n")
+
+    # The note line (index 0) carries no role color.
+    assert transcript_viewer._role_line_fragments(doc_lines[0]) == [("", doc_lines[0])]
+
+    def colored(line):
+        return [(style, word) for style, word in
+                transcript_viewer._role_line_fragments(line) if style]
+
+    user_line = next(l for l in doc_lines if l[2:11].strip() == "user")
+    asst_line = next(l for l in doc_lines if l[2:11].strip() == "assistant")
+    cont_line = next(l for l in doc_lines if l.startswith("             second line"))
+
+    assert colored(user_line) == [("fg:ansicyan", "user")]
+    assert colored(asst_line) == [("fg:ansiyellow", "assistant")]
+    # Continuation/wrapped message lines keep the default style.
+    assert colored(cont_line) == []
+
+
+def _vt100_app(lines):
+    # Build the pager with a real fixed-size Vt100 output so render_info exists
+    # (DummyOutput leaves it None, which makes wheel/scroll math no-op).
+    import io
+    from prompt_toolkit.output.vt100 import Vt100_Output
+    from prompt_toolkit.data_structures import Size
+
+    out = Vt100_Output(io.StringIO(), lambda: Size(rows=24, columns=80))
+    app, body = transcript_viewer._build_pager_app(lines, title="t")
+    app.output = out
+    return app, body
+
+
+def test_pager_mouse_wheel_scrolls():
+    import pytest
+    pytest.importorskip("prompt_toolkit")
+    from prompt_toolkit.input import create_pipe_input
+
+    lines = [f"line {i}" for i in range(200)]
+    with create_pipe_input() as inp:
+        inp.send_text("\x1b[<65;1;1M" * 5)  # SGR mouse wheel-down x5
+        inp.send_text("q")
+        app, body = _vt100_app(lines)
+        app.input = inp
+        app.run()
+    assert body.buffer.document.cursor_position_row == 5  # wheel scrolled 5 lines
+
+
+def test_pager_end_jumps_to_document_bottom():
+    import pytest
+    pytest.importorskip("prompt_toolkit")
+    from prompt_toolkit.input import create_pipe_input
+
+    lines = [f"line {i}" for i in range(200)]
+    with create_pipe_input() as inp:
+        inp.send_text("\x1b[F")  # End -> document bottom
+        inp.send_text("q")
+        app, body = _vt100_app(lines)
+        app.input = inp
+        app.run()
+    assert body.buffer.document.cursor_position_row == 199
+
+
+def test_role_lexer_is_wired_into_the_textarea():
+    import pytest
+    pytest.importorskip("prompt_toolkit")
+    from prompt_toolkit.application import create_app_session
+    from prompt_toolkit.input import create_pipe_input
+    from prompt_toolkit.output import DummyOutput
+    from clawjournal import share_cli
+
+    lines = share_cli._transcript_lines({"messages": [{"role": "user", "content": "hi"}]})
+    with create_pipe_input() as inp:
+        inp.send_text("q")
+        with create_app_session(input=inp, output=DummyOutput()):
+            app, body = transcript_viewer._build_pager_app(lines, title="t")
+            # The lexer must be the one attached to the body, and it must color
+            # the user role on the actual buffer content (line 0 is the note).
+            frags = body.lexer.lex_document(body.buffer.document)(1)
+            app.run()
+    assert any(style == "fg:ansicyan" for style, _ in frags)


### PR DESCRIPTION
Closes #89

## Problem
`clawjournal share --interactive` dumped full transcripts straight to stdout, overflowing terminal scrollback so long transcripts couldn't be reviewed.

## Change
Adds a modal, scrollable transcript viewer and routes the two full-transcript views through it.

- **`transcript_viewer.view_transcript()`** — a full-screen pager on a read-only, **buffer-backed** prompt_toolkit `TextArea`. (A buffer is required to scroll: a cursorless control snaps the scroll position back every render.) **Mouse wheel**, arrows, PgUp/PgDn, and Home/End all work; `q` / `Ctrl-C` exit. The `user`/`assistant` role labels keep their colors via a small lexer.
- **Never aborts the share flow** — falls back to the plain dump whenever a TUI can't run (stdin or stdout not a tty, prompt_toolkit unavailable, dumb `$TERM`, or a malformed session), leaving a one-line `stderr` breadcrumb instead of failing silently.
- **Terminal-escape hardening** — strips C0/DEL control characters from displayed message content so escape sequences in (untrusted) agent logs can't manipulate the reviewer's terminal; applied in `_transcript_lines`, covering both the pager and the plain dump.
- Extracts a pure `_transcript_lines()` helper from `render_transcript`; adds `prompt_toolkit>=3.0` (imported lazily); wires the step-2 redact preview and step-3 `[v]iew` calls (the short inline previews are unchanged).

## Testing
Full suite green (2275 passed). New tests cover the scroll-and-hold regression (real Down keys, cursor advances & holds), mouse-wheel scrolling, Home/End, the lexer wiring, escape stripping, zero-message sessions, and the non-tty / missing-dep / malformed-session fallback paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)