### PR TITLE
[codex] Add OpenRefinery sharing hooks

### DIFF
--- a/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
+++ b/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
@@ -10,7 +10,8 @@ review and redaction workflow instead of uploading anything directly.
 
 The hook is intentionally narrow:
 
-- It prompts at most once per local day.
+- It prompts at most a few times per local day (default cap: 3) and never twice
+  within the same reminder-extended turn.
 - It can open the ClawJournal Share UI or point to the terminal Share wizard.
 - It never packages, submits, or uploads traces by itself.
 - It leaves ClawJournal's existing source/project confirmation, hold-state,
@@ -43,15 +44,20 @@ That command:
 5. Does not mark projects confirmed. The participant still reviews project
    scope before sharing.
 
-When the daily hook fires, it asks the agent to prompt:
+When the hook fires, it asks the agent to surface one concise question:
 
 ```text
-OpenRefinery Agent Failure Sharing is enabled for your research enrollment.
-ClawJournal can review and redact your recent agent failure traces locally, then
-submit them for OpenRefinery research.
+OpenRefinery Agent Failure Sharing reminder (opt-in research enrollment).
 
-Review now?  y: Review and submit  n: Later  d: Pause reminders
+Surface ONE concise question to the user, then wait for their choice:
+- y: Open local ClawJournal review
+- n: Later
+- d: Pause reminders for 30 days
 ```
+
+The agent is told to wait for an explicit choice and to never run a command on
+the participant's behalf. To preview the exact wording without consuming a daily
+slot, run `clawjournal hooks run openrefinery-failures --client claude --dry-run`.
 
 If the participant chooses `y`, the agent should run:
 
@@ -92,12 +98,13 @@ happens to be first on `PATH`.
 |---|---|
 | `clawjournal enroll openrefinery --agent all --ui auto` | Update if possible, install Claude+Codex hooks, enable the profile |
 | `clawjournal hooks install openrefinery-failures --agent all --ui auto` | Install or repair hooks without running selfupdate |
-| `clawjournal hooks status openrefinery-failures` | Show enabled state, installed agents, daily cap, prompt count, snooze date |
+| `clawjournal hooks status openrefinery-failures` | Show enabled state, installed agents, daily cap/count, next-prompt date, snooze state, and Share-scope readiness |
 | `clawjournal hooks launch openrefinery-failures` | Open Share UI or print terminal wizard fallback |
 | `clawjournal hooks snooze openrefinery-failures --days 30` | Pause daily reminders |
 | `clawjournal hooks disable openrefinery-failures` | Keep hook files but stop prompting |
 | `clawjournal hooks uninstall openrefinery-failures --agent all` | Remove hook definitions from agent config and disable if no agents remain |
 | `clawjournal hooks run openrefinery-failures --client codex --json` | Diagnostic hook invocation |
+| `clawjournal hooks run openrefinery-failures --client claude --dry-run` | Preview the reminder text without consuming a daily slot |
 
 ## Hook Runtime Behavior
 
@@ -108,14 +115,23 @@ Prompt eligibility:
 1. The profile must be enabled.
 2. `CLAWJOURNAL_DISABLE_SHARE_NUDGE=1` and
    `OPENREFINERY_SHARE_HOOK_DISABLE=1` must not be set.
-3. The profile must not be snoozed through today.
-4. The profile must not have reached `max_prompts_per_day` for today's local
+3. The Stop-hook input must not report `stop_hook_active` (this Stop already
+   followed a reminder), unless `--force` is used. This prevents a reminder from
+   re-firing within its own extended turn and draining the daily budget at once.
+4. The profile must not be snoozed through today.
+5. The profile must not have reached `max_prompts_per_day` for today's local
    date unless `--force` is used.
 
 When eligible, the hook increments `prompt_counts_by_date[today]` and records
-`last_prompt_date` before returning the prompt. The default cap is 10 prompts
+`last_prompt_date` before returning the prompt. The default cap is 3 prompts
 per day. This cap is shared across Claude Code and Codex: if both agents are
 used on the same day, they draw from the same daily prompt budget.
+
+`--dry-run` renders the prompt the hook *would* return without incrementing the
+counter, recording state, or honoring the loop guard — useful for verifying the
+wording without spending a daily slot. `clawjournal hooks status
+openrefinery-failures` reports the per-day count, the next eligible date, snooze
+state, and whether the Share scope (source + project confirmation) is ready.
 
 ## Agent-Specific Prompt Semantics
 
@@ -127,16 +143,21 @@ For Claude Code, the hook returns JSON with:
 - `hookSpecificOutput.hookEventName: "Stop"`
 - `hookSpecificOutput.additionalContext: <prompt text>`
 
-This asks Claude Code to continue the turn with the participant-facing prompt
-without labeling the response as a Stop-hook error.
+This is the non-blocking path: the current turn completes normally (the
+participant still sees the agent's real answer) and the reminder is delivered to
+Claude Code as a system reminder on its next model request. We deliberately avoid
+`decision: "block"` here because, on a Stop hook, `block` *suppresses* the
+agent's response and shows `reason` in its place — too disruptive for a nudge.
 
 For Codex, the hook returns:
 
 - `decision: "block"`
 - `reason: <prompt text>`
 
-Codex may also require the participant to review and trust the newly installed
-hook through `/hooks` before non-managed user hooks run.
+Codex's Stop hook does not surface `additionalContext`, so `decision: "block"` +
+`reason` is the supported way to deliver the reminder there. Codex may also
+require the participant to review and trust the newly installed hook through
+`/hooks` before non-managed user hooks run.
 
 ## Launch Behavior
 
@@ -184,8 +205,11 @@ The implementation is covered by `tests/test_openrefinery_hooks.py`:
 
 - Claude and Codex hook JSON installation.
 - Existing hook update without clobbering unrelated hooks.
-- Shared daily prompt cap.
+- Shared daily prompt cap (cadence-agnostic, keyed off the default).
 - Snooze suppression.
+- `--dry-run` previews without consuming a slot.
+- `stop_hook_active` loop guard suppresses (and `--force` overrides it).
+- `status` reports next-prompt date, snooze days left, and Share-scope readiness.
 - Claude-specific `additionalContext` response.
 - Web launch, CLI fallback, and missing-frontend fallback.
 - Uninstall removes only the OpenRefinery hook.

--- a/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
+++ b/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
@@ -1,0 +1,197 @@
+# OpenRefinery Agent Failure Sharing Hooks
+
+## Purpose
+
+OpenRefinery Agent Failure Sharing is an enrollment-only reminder workflow for
+participants who have already agreed to share agent failure traces for research.
+It gives Claude Code and Codex a daily nudge similar to the built-in Claude Code
+session-quality prompt, but routes the participant through ClawJournal's local
+review and redaction workflow instead of uploading anything directly.
+
+The hook is intentionally narrow:
+
+- It prompts at most once per local day.
+- It can open the ClawJournal Share UI or point to the terminal Share wizard.
+- It never packages, submits, or uploads traces by itself.
+- It leaves ClawJournal's existing source/project confirmation, hold-state,
+  redaction, AI-PII opt-in, and TruffleHog gates as the only share path.
+
+## Participant Workflow
+
+For a new participant, the enrollment instructions should first install or
+update ClawJournal from the public GitHub source:
+
+```bash
+git clone https://github.com/rayward-external/clawjournal.git ~/clawjournal
+cd ~/clawjournal
+./scripts/install.sh --with-frontend
+```
+
+Once `clawjournal` is available, enroll the participant:
+
+```bash
+clawjournal enroll openrefinery --agent all --ui auto
+```
+
+That command:
+
+1. Runs the safe synchronous updater (`clawjournal selfupdate`) when the install
+   is an editable Git checkout.
+2. Installs Stop hooks for Claude Code and Codex.
+3. Enables the local `openrefinery-failures` state profile.
+4. Sets the source scope to `both` so Claude Code and Codex traces are in scope.
+5. Does not mark projects confirmed. The participant still reviews project
+   scope before sharing.
+
+When the daily hook fires, it asks the agent to prompt:
+
+```text
+OpenRefinery Agent Failure Sharing is enabled for your research enrollment.
+ClawJournal can review and redact your recent agent failure traces locally, then
+submit them for OpenRefinery research.
+
+Review now?  y: Review and submit  n: Later  d: Pause reminders
+```
+
+If the participant chooses `y`, the agent should run:
+
+```bash
+clawjournal hooks launch openrefinery-failures
+```
+
+If the participant chooses `d`, the agent should run:
+
+```bash
+clawjournal hooks snooze openrefinery-failures --days 30
+```
+
+## Installed Files
+
+The hook installer writes only user-level agent config and ClawJournal state:
+
+| Path | Purpose |
+|---|---|
+| `~/.claude/settings.json` | Claude Code Stop hook definition |
+| `~/.codex/hooks.json` | Codex Stop hook definition |
+| `~/.clawjournal/hooks/openrefinery-failures.json` | Local profile state, daily cadence, snooze status |
+| `~/.clawjournal/config.json` | Existing ClawJournal config; enrollment sets `source` to `both` |
+
+The hook command installed into both agents is:
+
+```bash
+<python> -m clawjournal.cli hooks run openrefinery-failures --client <claude|codex>
+```
+
+Using the current Python executable keeps the hook tied to the installed
+ClawJournal environment rather than relying on whatever `clawjournal` binary
+happens to be first on `PATH`.
+
+## Commands
+
+| Command | Use |
+|---|---|
+| `clawjournal enroll openrefinery --agent all --ui auto` | Update if possible, install Claude+Codex hooks, enable the profile |
+| `clawjournal hooks install openrefinery-failures --agent all --ui auto` | Install or repair hooks without running selfupdate |
+| `clawjournal hooks status openrefinery-failures` | Show enabled state, installed agents, last prompt date, snooze date |
+| `clawjournal hooks launch openrefinery-failures` | Open Share UI or print terminal wizard fallback |
+| `clawjournal hooks snooze openrefinery-failures --days 30` | Pause daily reminders |
+| `clawjournal hooks disable openrefinery-failures` | Keep hook files but stop prompting |
+| `clawjournal hooks uninstall openrefinery-failures --agent all` | Remove hook definitions from agent config and disable if no agents remain |
+| `clawjournal hooks run openrefinery-failures --client codex --json` | Diagnostic hook invocation |
+
+## Hook Runtime Behavior
+
+The hook reads only local state and emits a response for the running agent.
+
+Prompt eligibility:
+
+1. The profile must be enabled.
+2. `CLAWJOURNAL_DISABLE_SHARE_NUDGE=1` and
+   `OPENREFINERY_SHARE_HOOK_DISABLE=1` must not be set.
+3. The profile must not be snoozed through today.
+4. `last_prompt_date` must not equal today's local date unless `--force` is used.
+
+When eligible, the hook records `last_prompt_date` before returning the prompt.
+This makes the daily cadence shared across Claude Code and Codex: if both agents
+are used on the same day, only the first eligible Stop hook prompts.
+
+## Agent-Specific Prompt Semantics
+
+Claude Code and Codex both support Stop hooks, but they present hook output
+differently.
+
+For Claude Code, the hook returns JSON with:
+
+- `decision: "block"`
+- `reason: <prompt text>`
+- `hookSpecificOutput.hookEventName: "Stop"`
+- `hookSpecificOutput.additionalContext: <prompt text>`
+
+This asks Claude Code to continue the turn with the participant-facing prompt.
+
+For Codex, the hook returns:
+
+- `decision: "block"`
+- `reason: <prompt text>`
+
+Codex may also require the participant to review and trust the newly installed
+hook through `/hooks` before non-managed user hooks run.
+
+## Launch Behavior
+
+`clawjournal hooks launch openrefinery-failures` uses the enrolled UI preference:
+
+- `web`: require the browser workbench, start `clawjournal serve --no-browser`
+  detached when needed, then open `http://localhost:8384/share`.
+- `cli`: print `clawjournal share --interactive --weekly`.
+- `auto`: prefer the web path, but fall back to the CLI wizard if the frontend is
+  not built, the daemon cannot start, or the port does not become reachable.
+
+The detached server launcher intentionally starts only the existing
+ClawJournal daemon. It does not create a special upload path or bypass any
+Share workflow step.
+
+## Privacy and Safety Invariants
+
+The hook design preserves the existing local-first privacy model:
+
+- Source and project confirmation remain required before export/share.
+- `pending_review` and active `embargoed` sessions remain blocked from upload.
+- Only `auto_redacted` and `released` sessions can leave the machine.
+- Regex redaction runs at share time even if findings were already computed.
+- AI-assisted PII review remains optional and explicit.
+- TruffleHog remains mandatory after redaction and blocks missing-binary or
+  detected-secret cases.
+- The hook itself does not read session transcripts, package bundles, submit
+  HTTP requests, or call any AI backend.
+
+## Failure Modes
+
+| Failure | Behavior |
+|---|---|
+| ClawJournal is not installed yet | Enrollment cannot run; use the GitHub install path first |
+| Editable checkout is dirty, ahead, diverged, or not on `main` | `enroll openrefinery` reports the `selfupdate` status but still installs hooks |
+| Existing hook JSON is malformed | Installer fails with a user-actionable parse error |
+| Browser workbench frontend is missing | `--ui auto` falls back to CLI; `--ui web` errors with rebuild guidance |
+| Workbench port does not become reachable | `--ui auto` falls back to CLI; `--ui web` errors |
+| Participant wants quiet | `hooks snooze ... --days 30`, `hooks disable ...`, or env opt-out |
+| Codex hook is untrusted | Codex prompts for `/hooks` review before running the hook |
+
+## Tests
+
+The implementation is covered by `tests/test_openrefinery_hooks.py`:
+
+- Claude and Codex hook JSON installation.
+- Existing hook update without clobbering unrelated hooks.
+- Shared daily prompt suppression.
+- Snooze suppression.
+- Claude-specific `additionalContext` response.
+- Web launch, CLI fallback, and missing-frontend fallback.
+- Uninstall removes only the OpenRefinery hook.
+
+The PR also keeps existing CLI and self-update coverage passing:
+
+```bash
+python -m pytest tests/test_cli.py tests/test_selfupdate.py tests/test_openrefinery_hooks.py -q
+python -m py_compile clawjournal/openrefinery_hooks.py clawjournal/cli.py tests/test_openrefinery_hooks.py
+```

--- a/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
+++ b/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
@@ -47,26 +47,16 @@ That command:
 5. Does not mark projects confirmed. The participant still reviews project
    scope before sharing.
 
-When the hook fires, it injects a short briefing for the agent followed by the
-plain-language question to relay. The briefing explains what OpenRefinery is and
-what each choice does, so the user can understand the ask without seeing any
-internal scaffolding:
+When the hook fires, it injects a **terse directive** for the agent — not a
+script for the user. Claude Code prints a Stop hook's `additionalContext`
+verbatim in the transcript as "Stop hook feedback", so the injected text is kept
+short and reads like a tidy reminder; the agent expands it into a friendly
+question (and adds the privacy reassurance) when it actually asks the user:
 
 ```text
-[OpenRefinery Agent Failure Sharing] You're enrolled in OpenRefinery, a research
-program that improves coding agents by learning from sessions where they got
-stuck or failed. About once a day, ClawJournal reminds you to look over recent
-failed sessions and decide whether to contribute a redacted copy.
-
-Ask the user this, then wait for their answer — don't run anything yet:
-
-    Review recent agent-failure sessions to share with OpenRefinery?
-    This opens a review screen on your own machine where you pick what to
-    share — nothing leaves your computer until you look it over and approve it.
-      y — open the local review now
-      n — not now (I'll remind you tomorrow)
-
-If they say yes, run `clawjournal hooks launch openrefinery-failures` ...
+OpenRefinery daily reminder — ask the user (y/n) whether to open the local
+review of recent agent-failure sessions to consider sharing. On yes, run
+`clawjournal hooks launch openrefinery-failures`. On no, drop it.
 ```
 
 The agent is told to wait for an explicit choice before running anything. To
@@ -79,10 +69,12 @@ If the participant chooses `y`, the agent runs the launch command:
 clawjournal hooks launch openrefinery-failures
 ```
 
-The reminder also notes that this is a local-only command and that, if a
-permission/auto-mode classifier blocks it as unrelated to the current task, the
-agent should stop retrying and tell the user they can run it themselves in a
-terminal — so an out-of-scope session never dead-ends the reminder.
+The launch command only opens the local review UI and uploads nothing. To keep
+the injected line short, the directive no longer spells out a blocked-launch
+fallback; if a permission/auto-mode classifier denies the command as unrelated to
+the current task, the agent reports that to the user as it would any blocked
+command, and the user can run `clawjournal hooks launch openrefinery-failures`
+themselves in a terminal.
 
 The reminder no longer offers a pause/snooze choice — participants are already
 enrolled. `clawjournal hooks snooze` and `clawjournal hooks disable` remain

--- a/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
+++ b/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
@@ -47,25 +47,42 @@ That command:
 5. Does not mark projects confirmed. The participant still reviews project
    scope before sharing.
 
-When the hook fires, it asks the agent to surface one concise question:
+When the hook fires, it injects a short briefing for the agent followed by the
+plain-language question to relay. The briefing explains what OpenRefinery is and
+what each choice does, so the user can understand the ask without seeing any
+internal scaffolding:
 
 ```text
-OpenRefinery Agent Failure Sharing reminder (research enrollment).
+[OpenRefinery Agent Failure Sharing] You're enrolled in OpenRefinery, a research
+program that improves coding agents by learning from sessions where they got
+stuck or failed. About once a day, ClawJournal reminds you to look over recent
+failed sessions and decide whether to contribute a redacted copy.
 
-Surface ONE concise question to the user, then wait for their choice:
-- y: Open local ClawJournal review
-- n: Later
+Ask the user this, then wait for their answer — don't run anything yet:
+
+    Review recent agent-failure sessions to share with OpenRefinery?
+    This opens a review screen on your own machine where you pick what to
+    share — nothing leaves your computer until you look it over and approve it.
+      y — open the local review now
+      n — not now (I'll remind you tomorrow)
+
+If they say yes, run `clawjournal hooks launch openrefinery-failures` ...
 ```
 
-The agent is told to wait for an explicit choice and to never run a command on
-the participant's behalf. To preview the exact wording without consuming a daily
-slot, run `clawjournal hooks run openrefinery-failures --client claude --dry-run`.
+The agent is told to wait for an explicit choice before running anything. To
+preview the exact wording without consuming a daily slot, run
+`clawjournal hooks run openrefinery-failures --client claude --dry-run`.
 
-If the participant chooses `y`, the agent should run:
+If the participant chooses `y`, the agent runs the launch command:
 
 ```bash
 clawjournal hooks launch openrefinery-failures
 ```
+
+The reminder also notes that this is a local-only command and that, if a
+permission/auto-mode classifier blocks it as unrelated to the current task, the
+agent should stop retrying and tell the user they can run it themselves in a
+terminal — so an out-of-scope session never dead-ends the reminder.
 
 The reminder no longer offers a pause/snooze choice — participants are already
 enrolled. `clawjournal hooks snooze` and `clawjournal hooks disable` remain

--- a/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
+++ b/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
@@ -49,14 +49,16 @@ That command:
 
 When the hook fires, it injects a **terse directive** for the agent — not a
 script for the user. Claude Code prints a Stop hook's `additionalContext`
-verbatim in the transcript as "Stop hook feedback", so the injected text is kept
-short and reads like a tidy reminder; the agent expands it into a friendly
-question (and adds the privacy reassurance) when it actually asks the user:
+verbatim as "Stop hook feedback" (and Codex relays it as a blocked-stop reason),
+so the injected text is kept short and reads like a tidy reminder; the agent
+expands it into a friendly question when it actually asks the user. The privacy
+reassurance is baked into the directive so the agent surfaces it every time:
 
 ```text
 OpenRefinery daily reminder — ask the user (y/n) whether to open the local
-review of recent agent-failure sessions to consider sharing. On yes, run
-`clawjournal hooks launch openrefinery-failures`. On no, drop it.
+review of recent agent-failure sessions to consider sharing (nothing's uploaded
+until they approve). On yes, run `clawjournal hooks launch openrefinery-failures`.
+On no, drop it.
 ```
 
 The agent is told to wait for an explicit choice before running anything. To

--- a/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
+++ b/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
@@ -10,8 +10,11 @@ review and redaction workflow instead of uploading anything directly.
 
 The hook is intentionally narrow:
 
-- It prompts at most a few times per local day (default cap: 3) and never twice
-  within the same reminder-extended turn.
+- It prompts at most once per local day (production cap: 1) and never twice
+  within the same reminder-extended turn. Developers can set
+  `OPENREFINERY_SHARE_HOOK_TEST=1` to raise the cap to 10/day for testing.
+- Because participants are already enrolled, the nudge offers only "review now"
+  or "later" — it does not advertise pausing or disabling reminders.
 - It can open the ClawJournal Share UI or point to the terminal Share wizard.
 - It never packages, submits, or uploads traces by itself.
 - It leaves ClawJournal's existing source/project confirmation, hold-state,
@@ -47,12 +50,11 @@ That command:
 When the hook fires, it asks the agent to surface one concise question:
 
 ```text
-OpenRefinery Agent Failure Sharing reminder (opt-in research enrollment).
+OpenRefinery Agent Failure Sharing reminder (research enrollment).
 
 Surface ONE concise question to the user, then wait for their choice:
 - y: Open local ClawJournal review
 - n: Later
-- d: Pause reminders for 30 days
 ```
 
 The agent is told to wait for an explicit choice and to never run a command on
@@ -65,11 +67,11 @@ If the participant chooses `y`, the agent should run:
 clawjournal hooks launch openrefinery-failures
 ```
 
-If the participant chooses `d`, the agent should run:
-
-```bash
-clawjournal hooks snooze openrefinery-failures --days 30
-```
+The reminder no longer offers a pause/snooze choice — participants are already
+enrolled. `clawjournal hooks snooze` and `clawjournal hooks disable` remain
+available as administrative escape hatches (and `OPENREFINERY_SHARE_HOOK_DISABLE=1`
+/ `CLAWJOURNAL_DISABLE_SHARE_NUDGE=1` as env opt-outs), but the nudge itself does
+not advertise them.
 
 ## Installed Files
 
@@ -123,9 +125,12 @@ Prompt eligibility:
    date unless `--force` is used.
 
 When eligible, the hook increments `prompt_counts_by_date[today]` and records
-`last_prompt_date` before returning the prompt. The default cap is 3 prompts
-per day. This cap is shared across Claude Code and Codex: if both agents are
-used on the same day, they draw from the same daily prompt budget.
+`last_prompt_date` before returning the prompt. The production cap is 1 prompt
+per day; setting `OPENREFINERY_SHARE_HOOK_TEST=1` raises it to 10 for local
+testing. This cap is shared across Claude Code and Codex: if both agents are
+used on the same day, they draw from the same daily prompt budget. Re-running
+`clawjournal hooks install` (or `enroll`) rewrites the stored cap to the current
+default, so an upgraded participant is not left frozen at an old cadence.
 
 `--dry-run` renders the prompt the hook *would* return without incrementing the
 counter, recording state, or honoring the loop guard — useful for verifying the

--- a/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
+++ b/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
@@ -73,7 +73,7 @@ The hook installer writes only user-level agent config and ClawJournal state:
 |---|---|
 | `~/.claude/settings.json` | Claude Code Stop hook definition |
 | `~/.codex/hooks.json` | Codex Stop hook definition |
-| `~/.clawjournal/hooks/openrefinery-failures.json` | Local profile state, daily cadence, snooze status |
+| `~/.clawjournal/hooks/openrefinery-failures.json` | Local profile state, daily prompt cap, prompt counts, snooze status |
 | `~/.clawjournal/config.json` | Existing ClawJournal config; enrollment sets `source` to `both` |
 
 The hook command installed into both agents is:
@@ -92,7 +92,7 @@ happens to be first on `PATH`.
 |---|---|
 | `clawjournal enroll openrefinery --agent all --ui auto` | Update if possible, install Claude+Codex hooks, enable the profile |
 | `clawjournal hooks install openrefinery-failures --agent all --ui auto` | Install or repair hooks without running selfupdate |
-| `clawjournal hooks status openrefinery-failures` | Show enabled state, installed agents, last prompt date, snooze date |
+| `clawjournal hooks status openrefinery-failures` | Show enabled state, installed agents, daily cap, prompt count, snooze date |
 | `clawjournal hooks launch openrefinery-failures` | Open Share UI or print terminal wizard fallback |
 | `clawjournal hooks snooze openrefinery-failures --days 30` | Pause daily reminders |
 | `clawjournal hooks disable openrefinery-failures` | Keep hook files but stop prompting |
@@ -109,11 +109,13 @@ Prompt eligibility:
 2. `CLAWJOURNAL_DISABLE_SHARE_NUDGE=1` and
    `OPENREFINERY_SHARE_HOOK_DISABLE=1` must not be set.
 3. The profile must not be snoozed through today.
-4. `last_prompt_date` must not equal today's local date unless `--force` is used.
+4. The profile must not have reached `max_prompts_per_day` for today's local
+   date unless `--force` is used.
 
-When eligible, the hook records `last_prompt_date` before returning the prompt.
-This makes the daily cadence shared across Claude Code and Codex: if both agents
-are used on the same day, only the first eligible Stop hook prompts.
+When eligible, the hook increments `prompt_counts_by_date[today]` and records
+`last_prompt_date` before returning the prompt. The default cap is 10 prompts
+per day. This cap is shared across Claude Code and Codex: if both agents are
+used on the same day, they draw from the same daily prompt budget.
 
 ## Agent-Specific Prompt Semantics
 
@@ -183,7 +185,7 @@ The implementation is covered by `tests/test_openrefinery_hooks.py`:
 
 - Claude and Codex hook JSON installation.
 - Existing hook update without clobbering unrelated hooks.
-- Shared daily prompt suppression.
+- Shared daily prompt cap.
 - Snooze suppression.
 - Claude-specific `additionalContext` response.
 - Web launch, CLI fallback, and missing-frontend fallback.

--- a/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
+++ b/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
@@ -124,12 +124,11 @@ differently.
 
 For Claude Code, the hook returns JSON with:
 
-- `decision: "block"`
-- `reason: <prompt text>`
 - `hookSpecificOutput.hookEventName: "Stop"`
 - `hookSpecificOutput.additionalContext: <prompt text>`
 
-This asks Claude Code to continue the turn with the participant-facing prompt.
+This asks Claude Code to continue the turn with the participant-facing prompt
+without labeling the response as a Stop-hook error.
 
 For Codex, the hook returns:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Research participants who are explicitly enrolled in OpenRefinery Agent Failure 
 clawjournal enroll openrefinery --agent all --ui auto
 ```
 
-The enrollment command first tries a safe `clawjournal selfupdate`, then writes a Stop hook into `~/.claude/settings.json` and `~/.codex/hooks.json`. The hook shows up to 10 nudges per day asking whether to review recent agent failures with ClawJournal. If the participant accepts, run:
+The enrollment command first tries a safe `clawjournal selfupdate`, then writes a Stop hook into `~/.claude/settings.json` and `~/.codex/hooks.json`. The hook shows up to 3 gentle nudges per day asking whether to review recent agent failures with ClawJournal (preview the exact text any time with `clawjournal hooks run openrefinery-failures --client claude --dry-run`). If the participant accepts, run:
 
 ```bash
 clawjournal hooks launch openrefinery-failures

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Research participants who are explicitly enrolled in OpenRefinery Agent Failure 
 clawjournal enroll openrefinery --agent all --ui auto
 ```
 
-The enrollment command first tries a safe `clawjournal selfupdate`, then writes a Stop hook into `~/.claude/settings.json` and `~/.codex/hooks.json`. The hook shows up to 3 gentle nudges per day asking whether to review recent agent failures with ClawJournal (preview the exact text any time with `clawjournal hooks run openrefinery-failures --client claude --dry-run`). If the participant accepts, run:
+The enrollment command first tries a safe `clawjournal selfupdate`, then writes a Stop hook into `~/.claude/settings.json` and `~/.codex/hooks.json`. The hook shows at most one gentle nudge per day asking whether to review recent agent failures with ClawJournal — answer **y** to open local review or **n** for later (preview the exact text any time with `clawjournal hooks run openrefinery-failures --client claude --dry-run`). Developers testing the hook can set `OPENREFINERY_SHARE_HOOK_TEST=1` to raise the cap to 10/day. If the participant accepts, run:
 
 ```bash
 clawjournal hooks launch openrefinery-failures

--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ The AI detects your OS, installs what it needs (git, Python, Node.js), runs the 
 
 When it's done, your AI gives you a web address like `http://localhost:8384`. Copy it into your browser's address bar and press Enter — the workbench opens locally on your own computer; nothing is uploaded.
 
+## OpenRefinery enrollment hooks
+
+Research participants who are explicitly enrolled in OpenRefinery Agent Failure Sharing can install a daily reminder hook for Claude Code and Codex:
+
+```bash
+clawjournal enroll openrefinery --agent all --ui auto
+```
+
+The enrollment command first tries a safe `clawjournal selfupdate`, then writes a Stop hook into `~/.claude/settings.json` and `~/.codex/hooks.json`. The hook shows at most one nudge per day asking whether to review recent agent failures with ClawJournal. If the participant accepts, run:
+
+```bash
+clawjournal hooks launch openrefinery-failures
+```
+
+`launch` prefers the browser Share workflow at `http://localhost:8384/share`; if it cannot start or reach the local workbench in auto mode, it falls back to `clawjournal share --interactive --weekly`. The hook never uploads by itself. The Share flow still requires source/project confirmation, local redaction review, and the mandatory TruffleHog gate before anything leaves the machine. Codex may ask you to review/trust the newly installed hook with `/hooks` before it runs.
+
+Design details: [OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md](OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md).
+
 ## Your data stays local
 
 - `scan`, `serve`, `inbox`, `search`, `score`, `export`, and `bundle-export` all run on your own computer. The review UI opens on `localhost:8384` — no account, no cloud service.
@@ -361,6 +379,10 @@ clawjournal bundle-share <bundle_id>
 | `clawjournal config --scoring-warmup` / `--no-scoring-warmup` | Enable or decline the background AI auto-scorer |
 | `clawjournal list` / `clawjournal status` | List projects with exclusion status / show current stage (JSON) |
 | `clawjournal update-skill <agent>` | Install/update the clawjournal skill for an agent |
+| `clawjournal enroll openrefinery --agent all` | Install/update OpenRefinery Agent Failure Sharing hooks for enrolled participants |
+| `clawjournal hooks status openrefinery-failures` | Show enrollment hook state, daily cadence, and installed agents |
+| `clawjournal hooks launch openrefinery-failures` | Open the Share workflow or print the CLI fallback command |
+| `clawjournal hooks snooze openrefinery-failures --days 30` / `disable` | Pause or disable the daily enrollment reminder |
 | `clawjournal selfupdate [--check] [--force]` | Fast-forward to latest from `rayward-external/clawjournal` |
 | `clawjournal trufflehog install [--force]` | Download the pinned, checksum-verified TruffleHog (share-gate dependency) into `~/.clawjournal/bin` |
 | `clawjournal trufflehog status [--json]` | Show which TruffleHog binary the share gate will use |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Research participants who are explicitly enrolled in OpenRefinery Agent Failure 
 clawjournal enroll openrefinery --agent all --ui auto
 ```
 
-The enrollment command first tries a safe `clawjournal selfupdate`, then writes a Stop hook into `~/.claude/settings.json` and `~/.codex/hooks.json`. The hook shows at most one nudge per day asking whether to review recent agent failures with ClawJournal. If the participant accepts, run:
+The enrollment command first tries a safe `clawjournal selfupdate`, then writes a Stop hook into `~/.claude/settings.json` and `~/.codex/hooks.json`. The hook shows up to 10 nudges per day asking whether to review recent agent failures with ClawJournal. If the participant accepts, run:
 
 ```bash
 clawjournal hooks launch openrefinery-failures
@@ -380,7 +380,7 @@ clawjournal bundle-share <bundle_id>
 | `clawjournal list` / `clawjournal status` | List projects with exclusion status / show current stage (JSON) |
 | `clawjournal update-skill <agent>` | Install/update the clawjournal skill for an agent |
 | `clawjournal enroll openrefinery --agent all` | Install/update OpenRefinery Agent Failure Sharing hooks for enrolled participants |
-| `clawjournal hooks status openrefinery-failures` | Show enrollment hook state, daily cadence, and installed agents |
+| `clawjournal hooks status openrefinery-failures` | Show enrollment hook state, daily cap, and installed agents |
 | `clawjournal hooks launch openrefinery-failures` | Open the Share workflow or print the CLI fallback command |
 | `clawjournal hooks snooze openrefinery-failures --days 30` / `disable` | Pause or disable the daily enrollment reminder |
 | `clawjournal selfupdate [--check] [--force]` | Fast-forward to latest from `rayward-external/clawjournal` |

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -61,7 +61,7 @@ SETUP_TO_PUBLISH_STEPS = [
 ]
 
 EXPLICIT_SOURCE_CHOICES = {"claude", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "all", "both"}
-SOURCE_CHOICES = ["auto", "claude", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "all"]
+SOURCE_CHOICES = ["auto", "claude", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "all", "both"]
 WORKBENCH_SOURCE_CHOICES = ["claude", "codex", "opencode", "openclaw", "cursor", "copilot", "aider", "gemini", "kimi"]
 EVENT_SOURCE_CHOICES = ["auto", "claude", "codex", "openclaw", "all"]
 PII_PROVIDER_CHOICES = ("rules", "ai", "hybrid")
@@ -3652,6 +3652,90 @@ def main() -> None:
     us.add_argument("target", choices=["claude", "openclaw", "codex", "cline"],
                     help="Agent to install skill for")
 
+    enroll = sub.add_parser("enroll", help="Install research-enrollment workflows")
+    enroll_sub = enroll.add_subparsers(dest="enroll_command")
+    enroll_openrefinery = enroll_sub.add_parser(
+        "openrefinery",
+        help="Install OpenRefinery Agent Failure Sharing hooks",
+    )
+    enroll_openrefinery.add_argument(
+        "--agent",
+        choices=["claude", "codex", "all"],
+        default="all",
+        help="Agent hook(s) to install (default: all)",
+    )
+    enroll_openrefinery.add_argument(
+        "--ui",
+        choices=["auto", "web", "cli"],
+        default="auto",
+        help="Preferred review surface when the participant accepts the prompt",
+    )
+    enroll_openrefinery.add_argument(
+        "--skip-selfupdate",
+        action="store_true",
+        help="Do not try to fast-forward the editable ClawJournal checkout first",
+    )
+    enroll_openrefinery.add_argument("--json", action="store_true", help="Output result as JSON")
+
+    hooks = sub.add_parser("hooks", help="Manage ClawJournal agent hooks")
+    hooks_sub = hooks.add_subparsers(dest="hooks_command")
+    hooks_install = hooks_sub.add_parser(
+        "install",
+        help="Install a ClawJournal hook profile",
+    )
+    hooks_install.add_argument("profile", choices=["openrefinery-failures"])
+    hooks_install.add_argument(
+        "--agent",
+        choices=["claude", "codex", "all"],
+        default="all",
+        help="Agent hook(s) to install (default: all)",
+    )
+    hooks_install.add_argument(
+        "--ui",
+        choices=["auto", "web", "cli"],
+        default="auto",
+        help="Preferred review surface when the participant accepts the prompt",
+    )
+    hooks_install.add_argument("--json", action="store_true", help="Output result as JSON")
+    hooks_status = hooks_sub.add_parser("status", help="Show hook profile status")
+    hooks_status.add_argument("profile", choices=["openrefinery-failures"])
+    hooks_status.add_argument("--json", action="store_true", help="Output result as JSON")
+    hooks_disable = hooks_sub.add_parser("disable", help="Disable a hook profile locally")
+    hooks_disable.add_argument("profile", choices=["openrefinery-failures"])
+    hooks_disable.add_argument("--json", action="store_true", help="Output result as JSON")
+    hooks_uninstall = hooks_sub.add_parser("uninstall", help="Remove a hook profile from agent config")
+    hooks_uninstall.add_argument("profile", choices=["openrefinery-failures"])
+    hooks_uninstall.add_argument(
+        "--agent",
+        choices=["claude", "codex", "all"],
+        default="all",
+        help="Agent hook(s) to remove (default: all)",
+    )
+    hooks_uninstall.add_argument("--json", action="store_true", help="Output result as JSON")
+    hooks_snooze = hooks_sub.add_parser("snooze", help="Pause hook reminders for a number of days")
+    hooks_snooze.add_argument("profile", choices=["openrefinery-failures"])
+    hooks_snooze.add_argument("--days", type=int, default=30, help="Snooze duration (default: 30)")
+    hooks_snooze.add_argument("--json", action="store_true", help="Output result as JSON")
+    hooks_run = hooks_sub.add_parser("run", help="Run a hook handler from agent config")
+    hooks_run.add_argument("profile", choices=["openrefinery-failures"])
+    hooks_run.add_argument("--client", choices=["claude", "codex"], required=True)
+    hooks_run.add_argument("--force", action="store_true", help="Prompt even if already shown today")
+    hooks_run.add_argument("--json", action="store_true", help="Output diagnostic JSON")
+    hooks_launch = hooks_sub.add_parser(
+        "launch",
+        help="Open the review surface for a hook profile",
+    )
+    hooks_launch.add_argument("profile", choices=["openrefinery-failures"])
+    hooks_launch.add_argument(
+        "--ui",
+        choices=["auto", "web", "cli"],
+        default=None,
+        help="Override the enrolled review surface",
+    )
+    hooks_launch.add_argument("--port", type=int, default=None, help="Workbench port override")
+    hooks_launch.add_argument("--no-browser", action="store_true", help="Do not open a browser")
+    hooks_launch.add_argument("--json", action="store_true", help="Output result as JSON")
+
     su = sub.add_parser("selfupdate",
                         help="Pull the latest clawjournal from the public repo (manual sync update)")
     su.add_argument("--check", action="store_true",
@@ -4609,6 +4693,123 @@ def main() -> None:
     if command == "update-skill":
         update_skill(args.target)
         return
+
+    if command == "enroll":
+        if args.enroll_command != "openrefinery":
+            print("error: enroll requires a subcommand (openrefinery)", file=sys.stderr)
+            sys.exit(2)
+        from .openrefinery_hooks import HookError, enroll_openrefinery
+        try:
+            result = enroll_openrefinery(
+                agent=args.agent,
+                ui=args.ui,
+                skip_selfupdate=args.skip_selfupdate,
+            )
+        except HookError as exc:
+            print(f"Enrollment failed: {exc}", file=sys.stderr)
+            sys.exit(1)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            update = result.get("update") or {}
+            update_status = update.get("status") if isinstance(update, dict) else None
+            if update_status:
+                print(f"ClawJournal update status: {update_status}")
+            install = result["install"]
+            installed = install.get("installed", [])
+            agents = ", ".join(item.get("agent", "?") for item in installed)
+            print(f"Installed OpenRefinery Agent Failure Sharing hook for: {agents}.")
+            print(f"Daily reminders are enabled; state: {install.get('state_path')}")
+            print(f"Review command: {result['next']['review']}")
+            if not install.get("projects_confirmed"):
+                print(f"Project confirmation still required: {result['next']['project_confirmation']}")
+        return
+
+    if command == "hooks":
+        from .openrefinery_hooks import (
+            HookError,
+            disable_profile,
+            install_profile,
+            launch_share_flow,
+            render_hook_response,
+            run_hook,
+            snooze_profile,
+            status as hook_status,
+            uninstall_profile,
+        )
+        try:
+            if args.hooks_command == "install":
+                result = install_profile(profile=args.profile, agent=args.agent, ui=args.ui)
+                if args.json:
+                    print(json.dumps(result, indent=2))
+                else:
+                    installed = ", ".join(item.get("agent", "?") for item in result.get("installed", []))
+                    print(f"Installed {args.profile} for: {installed}.")
+                    print(f"Daily reminders are enabled; state: {result.get('state_path')}")
+                return
+            if args.hooks_command == "status":
+                result = hook_status(profile=args.profile)
+                if args.json:
+                    print(json.dumps(result, indent=2))
+                else:
+                    enabled = "enabled" if result.get("enabled") else "disabled"
+                    agents = ", ".join(result.get("installed_agents") or []) or "none"
+                    print(f"{result['display_name']}: {enabled}")
+                    print(f"Agents: {agents}")
+                    print(f"UI: {result.get('ui')}  Cadence: {result.get('cadence')}")
+                    print(f"Last prompt: {result.get('last_prompt_date') or 'never'}")
+                    if result.get("snooze_until"):
+                        print(f"Snoozed until: {result['snooze_until']}")
+                    print(f"State: {result['state_path']}")
+                return
+            if args.hooks_command == "disable":
+                result = disable_profile(profile=args.profile)
+                if args.json:
+                    print(json.dumps(result, indent=2))
+                else:
+                    print(f"Disabled {args.profile}.")
+                return
+            if args.hooks_command == "uninstall":
+                result = uninstall_profile(profile=args.profile, agent=args.agent)
+                if args.json:
+                    print(json.dumps(result, indent=2))
+                else:
+                    removed = ", ".join(item.get("agent", "?") for item in result.get("removed", []))
+                    print(f"Removed {args.profile} from: {removed}.")
+                return
+            if args.hooks_command == "snooze":
+                result = snooze_profile(profile=args.profile, days=args.days)
+                if args.json:
+                    print(json.dumps(result, indent=2))
+                else:
+                    print(f"Snoozed {args.profile} until {result['snooze_until']}.")
+                return
+            if args.hooks_command == "run":
+                result = run_hook(profile=args.profile, client=args.client, force=args.force)
+                rendered = render_hook_response(result, client=args.client, output_json=args.json)
+                if rendered:
+                    print(rendered)
+                return
+            if args.hooks_command == "launch":
+                result = launch_share_flow(
+                    profile=args.profile,
+                    ui=args.ui,
+                    open_browser=not args.no_browser,
+                    port=args.port,
+                )
+                if args.json:
+                    print(json.dumps(result, indent=2))
+                else:
+                    if result.get("mode") == "web":
+                        print(f"Opened ClawJournal Share: {result['url']}")
+                    else:
+                        print(result["message"])
+                return
+        except HookError as exc:
+            print(f"Hook command failed: {exc}", file=sys.stderr)
+            sys.exit(1)
+        print("error: hooks requires a subcommand", file=sys.stderr)
+        sys.exit(2)
 
     if command == "selfupdate":
         from .selfupdate import selfupdate_sync

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -13,7 +13,14 @@ from pathlib import Path
 from typing import Any, Mapping, cast
 
 from .redaction.anonymizer import Anonymizer
-from .config import CONFIG_FILE, ClawJournalConfig, load_config, normalize_excluded_project_names, save_config
+from .config import (
+    CONFIG_FILE,
+    ClawJournalConfig,
+    load_config,
+    normalize_excluded_project_names,
+    save_config,
+    set_source_scope,
+)
 from .parsing.parser import CLAUDE_DIR, CODEX_DIR, COPILOT_DIR, CURSOR_DIR, CUSTOM_DIR, GEMINI_DIR, KIMI_DIR, LOCAL_AGENT_DIR, OPENCODE_DIR, OPENCLAW_DIR, discover_projects, parse_project_sessions
 from .scoring.backends import BACKEND_CHOICES, DEFAULT_CLAUDE_MODEL, DEFAULT_CODEX_MODEL
 from .redaction.pii import apply_findings_to_session, load_findings, load_jsonl_sessions, review_session_pii, review_session_pii_hybrid, review_session_pii_with_agent, write_findings, write_jsonl_sessions
@@ -383,7 +390,7 @@ def configure(
     if repo is not None:
         config["repo"] = repo
     if source is not None:
-        config["source"] = source
+        set_source_scope(config, source)
     if scorer_backend is not None:
         if scorer_backend == "none":
             config.pop("scorer_backend", None)

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3720,6 +3720,11 @@ def main() -> None:
     hooks_run.add_argument("profile", choices=["openrefinery-failures"])
     hooks_run.add_argument("--client", choices=["claude", "codex"], required=True)
     hooks_run.add_argument("--force", action="store_true", help="Prompt even if already shown today")
+    hooks_run.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Preview the reminder without consuming a daily slot or changing state",
+    )
     hooks_run.add_argument("--json", action="store_true", help="Output diagnostic JSON")
     hooks_launch = hooks_sub.add_parser(
         "launch",
@@ -4733,6 +4738,7 @@ def main() -> None:
             launch_share_flow,
             render_hook_response,
             run_hook,
+            share_readiness,
             snooze_profile,
             status as hook_status,
             uninstall_profile,
@@ -4763,8 +4769,28 @@ def main() -> None:
                         f"({prompts_today}/{max_prompts} prompts today)"
                     )
                     print(f"Last prompt: {result.get('last_prompt_date') or 'never'}")
-                    if result.get("snooze_until"):
-                        print(f"Snoozed until: {result['snooze_until']}")
+                    if result.get("snoozed"):
+                        days = result.get("snooze_days_remaining")
+                        print(f"Snoozed until: {result['snooze_until']} ({days} day(s) left)")
+                    next_prompt = result.get("next_prompt")
+                    if not result.get("enabled"):
+                        print("Next reminder: never (disabled)")
+                    elif result.get("eligible_now"):
+                        print("Next reminder: eligible now (this session)")
+                    elif next_prompt:
+                        print(f"Next reminder: {next_prompt}")
+                    if result.get("share_ready"):
+                        print("Share scope: confirmed (source + projects)")
+                    else:
+                        missing = []
+                        if not result.get("source_confirmed"):
+                            missing.append("source")
+                        if not result.get("projects_confirmed"):
+                            missing.append("projects")
+                        print(
+                            f"Share scope: NOT confirmed ({', '.join(missing)} pending) — "
+                            "the upload step will block until you confirm."
+                        )
                     print(f"State: {result['state_path']}")
                 return
             if args.hooks_command == "disable":
@@ -4790,8 +4816,35 @@ def main() -> None:
                     print(f"Snoozed {args.profile} until {result['snooze_until']}.")
                 return
             if args.hooks_command == "run":
-                result = run_hook(profile=args.profile, client=args.client, force=args.force)
-                rendered = render_hook_response(result, client=args.client, output_json=args.json)
+                # Honor the Stop-hook input's `stop_hook_active` flag to avoid
+                # re-prompting inside a reminder-extended turn. Only read piped
+                # input so an interactive `hooks run` never blocks on a TTY.
+                stop_hook_active = False
+                if not args.dry_run and not sys.stdin.isatty():
+                    try:
+                        raw = sys.stdin.read()
+                        if raw.strip():
+                            stop_hook_active = bool(json.loads(raw).get("stop_hook_active"))
+                    except (json.JSONDecodeError, ValueError, OSError):
+                        stop_hook_active = False
+                result = run_hook(
+                    profile=args.profile,
+                    client=args.client,
+                    force=args.force,
+                    dry_run=args.dry_run,
+                    stop_hook_active=stop_hook_active,
+                )
+                if args.json:
+                    print(render_hook_response(result, client=args.client, output_json=True))
+                    return
+                if args.dry_run:
+                    if result.should_prompt and result.message:
+                        print("[dry-run] Reminder preview (no state changed):\n")
+                        print(result.message)
+                    else:
+                        print(f"[dry-run] No reminder would be shown now (reason: {result.reason}).")
+                    return
+                rendered = render_hook_response(result, client=args.client, output_json=False)
                 if rendered:
                     print(rendered)
                 return
@@ -4809,6 +4862,21 @@ def main() -> None:
                         print(f"Opened ClawJournal Share: {result['url']}")
                     else:
                         print(result["message"])
+                    readiness = share_readiness()
+                    if not readiness["ready"]:
+                        missing = []
+                        if not readiness["source_confirmed"]:
+                            missing.append("source scope (`clawjournal config --source both`)")
+                        if not readiness["projects_confirmed"]:
+                            missing.append(
+                                "project list (`clawjournal list --source both` then "
+                                "`clawjournal config --confirm-projects`)"
+                            )
+                        print(
+                            "Heads up: the upload step will block until you confirm "
+                            + " and ".join(missing)
+                            + "."
+                        )
                 return
         except HookError as exc:
             print(f"Hook command failed: {exc}", file=sys.stderr)

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -4756,7 +4756,12 @@ def main() -> None:
                     agents = ", ".join(result.get("installed_agents") or []) or "none"
                     print(f"{result['display_name']}: {enabled}")
                     print(f"Agents: {agents}")
-                    print(f"UI: {result.get('ui')}  Cadence: {result.get('cadence')}")
+                    max_prompts = result.get("max_prompts_per_day")
+                    prompts_today = result.get("prompts_today")
+                    print(
+                        f"UI: {result.get('ui')}  Cadence: {result.get('cadence')} "
+                        f"({prompts_today}/{max_prompts} prompts today)"
+                    )
                     print(f"Last prompt: {result.get('last_prompt_date') or 'never'}")
                     if result.get("snooze_until"):
                         print(f"Snoozed until: {result['snooze_until']}")

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -75,6 +75,13 @@ def normalize_excluded_project_names(names: list[str]) -> list[str]:
     return [_normalize_excluded_project_name(name) for name in names]
 
 
+def set_source_scope(config: ClawJournalConfig, source: str) -> None:
+    """Set export source and invalidate project confirmation when scope changes."""
+    if config.get("source") != source:
+        config["projects_confirmed"] = False
+    config["source"] = source
+
+
 def _normalize_excluded_project_name(name: str) -> str:
     if name.startswith(_KNOWN_PREFIXES):
         return name

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -710,7 +710,14 @@ def launch_share_flow(
             except OSError as exc:
                 if ui_mode == "web":
                     raise HookError(f"Could not start the ClawJournal workbench: {exc}") from exc
-        if already_running or _wait_for_port(resolved_port):
+        # A freshly started server can need more than a few seconds to bind on a
+        # cold boot (imports + SQLite/FTS init). Only the first launch pays this,
+        # since later ones short-circuit on `already_running`; without the longer
+        # wait a slow boot silently downgrades to the CLI (the bug that made the
+        # first "y" in a session land on the CLI while a later one opened the UI).
+        if already_running or _wait_for_port(
+            resolved_port, timeout_seconds=10.0 if started else 3.0
+        ):
             opened = _open_browser(url) if open_browser else False
             return {
                 "mode": "web",

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -200,7 +200,7 @@ def _handler_for(client: AgentName) -> dict[str, Any]:
         "type": "command",
         "command": _hook_command(client),
         "timeout": 30,
-        "statusMessage": "Checking OpenRefinery sharing reminder",
+        "statusMessage": "Checking OpenRefinery failure-sharing reminder",
     }
 
 
@@ -540,16 +540,29 @@ def _next_prompt_date(
 
 def _prompt_message(client: str, launch_command: str) -> str:
     agent = "Claude Code" if client == "claude" else "Codex"
+    # This text is injected as agent context, so it does double duty: a short
+    # briefing for the agent followed by the exact question to relay. Keeping the
+    # question self-contained — and free of agent-only scaffolding like "surface a
+    # question to the user" — stops the internal instructions from leaking into
+    # what the user sees, and makes the ask understandable on its own.
     return (
-        f"{PROFILE_DISPLAY_NAME} reminder (research enrollment).\n\n"
-        "Surface ONE concise question to the user, then wait for their choice:\n"
-        "- y: Open local ClawJournal review\n"
-        "- n: Later\n\n"
-        f"If they choose y, run `{launch_command}`. Do not run any command until "
-        "the user chooses. The launch command only opens the local ClawJournal "
-        "review UI on this machine — nothing is uploaded or submitted until the "
-        "user has reviewed and approved the redacted bundle themselves. "
-        f"Current agent: {agent}."
+        f"[{PROFILE_DISPLAY_NAME}] You're enrolled in OpenRefinery, a research "
+        "program that improves coding agents by learning from sessions where they "
+        "got stuck or failed. About once a day, ClawJournal reminds you to look "
+        "over recent failed sessions and decide whether to contribute a redacted "
+        "copy.\n\n"
+        "Ask the user this, then wait for their answer — don't run anything yet:\n\n"
+        "    Review recent agent-failure sessions to share with OpenRefinery?\n"
+        "    This opens a review screen on your own machine where you pick what to "
+        "share — nothing leaves your computer until you look it over and approve it.\n"
+        "      y — open the local review now\n"
+        "      n — not now (I'll remind you tomorrow)\n\n"
+        f"If they say yes, run `{launch_command}`: a local ClawJournal command that "
+        "only opens that review UI and uploads nothing. If a permission or "
+        "auto-mode check blocks it as unrelated to the current task, don't keep "
+        f"retrying — tell the user they can run `{launch_command}` themselves in a "
+        "terminal. If they say no, acknowledge it and carry on. "
+        f"(Delivered via {agent}.)"
     )
 
 

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -29,7 +29,7 @@ SUPPORTED_AGENTS = ("claude", "codex")
 SUPPORTED_UI_MODES = ("auto", "web", "cli")
 DEFAULT_PORT = 8384
 DEFAULT_SNOOZE_DAYS = 30
-DEFAULT_MAX_PROMPTS_PER_DAY = 10
+DEFAULT_MAX_PROMPTS_PER_DAY = 3
 STATE_VERSION = 1
 
 AgentName = Literal["claude", "codex"]
@@ -385,24 +385,37 @@ def uninstall_profile(
     }
 
 
-def status(*, profile: str = PROFILE_NAME) -> dict[str, Any]:
+def status(*, profile: str = PROFILE_NAME, now: datetime | None = None) -> dict[str, Any]:
     _normalize_profile(profile)
     state = load_state()
-    today = _today().isoformat()
+    today = _today(now)
+    today_key = today.isoformat()
     prompt_counts = _prompt_counts_by_date(state)
+    max_prompts = _max_prompts_per_day(state)
+    prompts_today = prompt_counts.get(today_key, 0)
+    next_prompt = _next_prompt_date(state, today, prompts_today, max_prompts)
+    readiness = share_readiness()
     return {
         "profile": PROFILE_NAME,
         "display_name": PROFILE_DISPLAY_NAME,
         "enabled": bool(state.get("enabled", False)),
         "ui": state.get("ui", "auto"),
         "cadence": state.get("cadence", "daily"),
-        "max_prompts_per_day": _max_prompts_per_day(state),
-        "prompts_today": prompt_counts.get(today, 0),
+        "max_prompts_per_day": max_prompts,
+        "prompts_today": prompts_today,
+        "prompts_remaining_today": max(0, max_prompts - prompts_today),
         "installed_agents": list(state.get("installed_agents") or []),
         "last_prompt_date": state.get("last_prompt_date"),
         "snooze_until": state.get("snooze_until"),
+        "snoozed": _is_snoozed(state, today),
+        "snooze_days_remaining": _snooze_days_remaining(state, today),
+        "next_prompt": next_prompt,
+        "eligible_now": next_prompt == today_key,
         "state_path": str(_state_path()),
         "source_scope": state.get("source_scope"),
+        "source_confirmed": readiness["source_confirmed"],
+        "projects_confirmed": readiness["projects_confirmed"],
+        "share_ready": readiness["ready"],
     }
 
 
@@ -460,18 +473,76 @@ def _trim_prompt_counts(counts: dict[str, int], today: date) -> dict[str, int]:
     return trimmed
 
 
-def _prompt_message(client: str, launch_command: str, snooze_command: str) -> str:
+def share_readiness(config: dict[str, Any] | None = None) -> dict[str, Any]:
+    """Report whether the existing Share gates are satisfied.
+
+    The hook only nudges; the actual upload still requires an explicit source
+    scope and a confirmed project list. Surfacing this lets `status`/`launch`
+    tell the participant what is still missing instead of sending them into a
+    Share flow that will block.
+    """
+    cfg = config if config is not None else config_module.load_config()
+    source = cfg.get("source")
+    source_confirmed = bool(source) and str(source).strip().lower() != "auto"
+    projects_confirmed = bool(cfg.get("projects_confirmed", False))
+    return {
+        "source": source,
+        "source_confirmed": source_confirmed,
+        "projects_confirmed": projects_confirmed,
+        "ready": source_confirmed and projects_confirmed,
+    }
+
+
+def _snooze_days_remaining(state: dict[str, Any], today: date) -> int:
+    raw = state.get("snooze_until")
+    if not raw:
+        return 0
+    try:
+        until = date.fromisoformat(str(raw))
+    except ValueError:
+        return 0
+    return (until - today).days + 1 if until >= today else 0
+
+
+def _next_prompt_date(
+    state: dict[str, Any], today: date, prompts_today: int, max_prompts: int
+) -> str | None:
+    """ISO date the next reminder is eligible, or None if reminders are off."""
+    if not state.get("enabled", False):
+        return None
+    raw = state.get("snooze_until")
+    if raw:
+        try:
+            until = date.fromisoformat(str(raw))
+            if until >= today:
+                return (until + timedelta(days=1)).isoformat()
+        except ValueError:
+            pass
+    if prompts_today >= max_prompts:
+        return (today + timedelta(days=1)).isoformat()
+    return today.isoformat()
+
+
+def _prompt_message(
+    client: str,
+    launch_command: str,
+    snooze_command: str,
+    disable_command: str,
+    snooze_days: int = DEFAULT_SNOOZE_DAYS,
+) -> str:
     agent = "Claude Code" if client == "claude" else "Codex"
     return (
-        f"{PROFILE_DISPLAY_NAME} reminder.\n\n"
-        "Ask the user one concise question with three choices:\n"
+        f"{PROFILE_DISPLAY_NAME} reminder (opt-in research enrollment).\n\n"
+        "Surface ONE concise question to the user, then wait for their choice:\n"
         "- y: Open local ClawJournal review\n"
         "- n: Later\n"
-        "- d: Pause reminders for 30 days\n\n"
+        f"- d: Pause reminders for {snooze_days} days\n\n"
         f"If they choose y, run `{launch_command}`. If they choose d, run "
-        f"`{snooze_command}`. Do not run either command until the user chooses. "
-        "The launch command only opens local ClawJournal review; it does not "
-        f"upload or submit anything. Current agent: {agent}."
+        f"`{snooze_command}`. To stop reminders entirely they can run "
+        f"`{disable_command}`. Do not run any command until the user chooses. "
+        "The launch command only opens the local ClawJournal review UI on this "
+        "machine — nothing is uploaded or submitted until the user has reviewed "
+        f"and approved the redacted bundle themselves. Current agent: {agent}."
     )
 
 
@@ -480,6 +551,8 @@ def run_hook(
     profile: str = PROFILE_NAME,
     client: str = "codex",
     force: bool = False,
+    dry_run: bool = False,
+    stop_hook_active: bool = False,
     now: datetime | None = None,
 ) -> HookRunResult:
     _normalize_profile(profile)
@@ -489,6 +562,10 @@ def run_hook(
         return HookRunResult(False, "disabled-by-env", state_path=_state_path())
     if not state.get("enabled", False):
         return HookRunResult(False, "disabled", state_path=_state_path())
+    # `stop_hook_active` means this Stop fired because a previous reminder kept the
+    # turn going; re-prompting now would loop and burn the daily budget at once.
+    if stop_hook_active and not force:
+        return HookRunResult(False, "stop-hook-active", state_path=_state_path())
     if not force and _is_snoozed(state, today):
         return HookRunResult(False, "snoozed", state_path=_state_path())
     today_key = today.isoformat()
@@ -498,19 +575,22 @@ def run_hook(
     if not force and prompt_count >= max_prompts:
         return HookRunResult(False, "daily-prompt-limit-reached", state_path=_state_path())
 
+    launch_command = f"clawjournal hooks launch {PROFILE_NAME}"
+    snooze_command = f"clawjournal hooks snooze {PROFILE_NAME} --days {DEFAULT_SNOOZE_DAYS}"
+    disable_command = f"clawjournal hooks disable {PROFILE_NAME}"
+    message = _prompt_message(
+        client, launch_command, snooze_command, disable_command, DEFAULT_SNOOZE_DAYS
+    )
+    # A preview must never consume a daily slot or mutate state.
+    if dry_run:
+        return HookRunResult(True, "dry-run", message, state_path=_state_path())
+
     prompt_counts[today_key] = prompt_count + 1
     state["prompt_counts_by_date"] = _trim_prompt_counts(prompt_counts, today)
     state["last_prompt_date"] = today_key
     state["last_prompt_client"] = client
     path = save_state(state)
-    launch_command = f"clawjournal hooks launch {PROFILE_NAME}"
-    snooze_command = f"clawjournal hooks snooze {PROFILE_NAME} --days {DEFAULT_SNOOZE_DAYS}"
-    return HookRunResult(
-        True,
-        "prompt",
-        _prompt_message(client, launch_command, snooze_command),
-        state_path=path,
-    )
+    return HookRunResult(True, "prompt", message, state_path=path)
 
 
 def render_hook_response(result: HookRunResult, *, client: str, output_json: bool = False) -> str:

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -310,6 +310,10 @@ def install_profile(
             "enabled": True,
             "ui": ui_mode,
             "cadence": "daily",
+            # Refresh the cap to the current default so an explicit re-install
+            # adopts a changed cadence instead of keeping a value frozen in the
+            # state file from an earlier version.
+            "max_prompts_per_day": DEFAULT_MAX_PROMPTS_PER_DAY,
             "installed_agents": sorted(known_agents),
             "source_scope": source_scope or "both",
         }

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -29,7 +29,11 @@ SUPPORTED_AGENTS = ("claude", "codex")
 SUPPORTED_UI_MODES = ("auto", "web", "cli")
 DEFAULT_PORT = 8384
 DEFAULT_SNOOZE_DAYS = 30
-DEFAULT_MAX_PROMPTS_PER_DAY = 3
+# Production cadence: a single daily nudge for an already-enrolled participant.
+DEFAULT_MAX_PROMPTS_PER_DAY = 1
+# Test cadence: opt-in via OPENREFINERY_SHARE_HOOK_TEST=1 so it can never ship as
+# the default. Lets a developer see the reminder fire repeatedly in one day.
+TEST_MAX_PROMPTS_PER_DAY = 10
 STATE_VERSION = 1
 
 AgentName = Literal["claude", "codex"]
@@ -440,7 +444,14 @@ def _hook_disabled_by_env() -> bool:
     )
 
 
+def _test_mode() -> bool:
+    """Opt-in testing cadence so the reminder can fire repeatedly in one day."""
+    return os.environ.get("OPENREFINERY_SHARE_HOOK_TEST") == "1"
+
+
 def _max_prompts_per_day(state: dict[str, Any]) -> int:
+    if _test_mode():
+        return TEST_MAX_PROMPTS_PER_DAY
     try:
         value = int(state.get("max_prompts_per_day", DEFAULT_MAX_PROMPTS_PER_DAY))
     except (TypeError, ValueError):
@@ -527,26 +538,18 @@ def _next_prompt_date(
     return today.isoformat()
 
 
-def _prompt_message(
-    client: str,
-    launch_command: str,
-    snooze_command: str,
-    disable_command: str,
-    snooze_days: int = DEFAULT_SNOOZE_DAYS,
-) -> str:
+def _prompt_message(client: str, launch_command: str) -> str:
     agent = "Claude Code" if client == "claude" else "Codex"
     return (
-        f"{PROFILE_DISPLAY_NAME} reminder (opt-in research enrollment).\n\n"
+        f"{PROFILE_DISPLAY_NAME} reminder (research enrollment).\n\n"
         "Surface ONE concise question to the user, then wait for their choice:\n"
         "- y: Open local ClawJournal review\n"
-        "- n: Later\n"
-        f"- d: Pause reminders for {snooze_days} days\n\n"
-        f"If they choose y, run `{launch_command}`. If they choose d, run "
-        f"`{snooze_command}`. To stop reminders entirely they can run "
-        f"`{disable_command}`. Do not run any command until the user chooses. "
-        "The launch command only opens the local ClawJournal review UI on this "
-        "machine — nothing is uploaded or submitted until the user has reviewed "
-        f"and approved the redacted bundle themselves. Current agent: {agent}."
+        "- n: Later\n\n"
+        f"If they choose y, run `{launch_command}`. Do not run any command until "
+        "the user chooses. The launch command only opens the local ClawJournal "
+        "review UI on this machine — nothing is uploaded or submitted until the "
+        "user has reviewed and approved the redacted bundle themselves. "
+        f"Current agent: {agent}."
     )
 
 
@@ -580,11 +583,7 @@ def run_hook(
         return HookRunResult(False, "daily-prompt-limit-reached", state_path=_state_path())
 
     launch_command = f"clawjournal hooks launch {PROFILE_NAME}"
-    snooze_command = f"clawjournal hooks snooze {PROFILE_NAME} --days {DEFAULT_SNOOZE_DAYS}"
-    disable_command = f"clawjournal hooks disable {PROFILE_NAME}"
-    message = _prompt_message(
-        client, launch_command, snooze_command, disable_command, DEFAULT_SNOOZE_DAYS
-    )
+    message = _prompt_message(client, launch_command)
     # A preview must never consume a daily slot or mutate state.
     if dry_run:
         return HookRunResult(True, "dry-run", message, state_path=_state_path())

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -538,31 +538,15 @@ def _next_prompt_date(
     return today.isoformat()
 
 
-def _prompt_message(client: str, launch_command: str) -> str:
-    agent = "Claude Code" if client == "claude" else "Codex"
-    # This text is injected as agent context, so it does double duty: a short
-    # briefing for the agent followed by the exact question to relay. Keeping the
-    # question self-contained — and free of agent-only scaffolding like "surface a
-    # question to the user" — stops the internal instructions from leaking into
-    # what the user sees, and makes the ask understandable on its own.
+def _prompt_message(launch_command: str) -> str:
+    # Claude Code prints this string verbatim in the transcript as "Stop hook
+    # feedback", so it must stay short and read like a tidy reminder, not a wall
+    # of agent-only instructions. Keep it to a terse directive: the agent expands
+    # it into a friendly question (and adds the privacy reassurance) when it asks.
     return (
-        f"[{PROFILE_DISPLAY_NAME}] You're enrolled in OpenRefinery, a research "
-        "program that improves coding agents by learning from sessions where they "
-        "got stuck or failed. About once a day, ClawJournal reminds you to look "
-        "over recent failed sessions and decide whether to contribute a redacted "
-        "copy.\n\n"
-        "Ask the user this, then wait for their answer — don't run anything yet:\n\n"
-        "    Review recent agent-failure sessions to share with OpenRefinery?\n"
-        "    This opens a review screen on your own machine where you pick what to "
-        "share — nothing leaves your computer until you look it over and approve it.\n"
-        "      y — open the local review now\n"
-        "      n — not now (I'll remind you tomorrow)\n\n"
-        f"If they say yes, run `{launch_command}`: a local ClawJournal command that "
-        "only opens that review UI and uploads nothing. If a permission or "
-        "auto-mode check blocks it as unrelated to the current task, don't keep "
-        f"retrying — tell the user they can run `{launch_command}` themselves in a "
-        "terminal. If they say no, acknowledge it and carry on. "
-        f"(Delivered via {agent}.)"
+        "OpenRefinery daily reminder — ask the user (y/n) whether to open the "
+        "local review of recent agent-failure sessions to consider sharing. "
+        f"On yes, run `{launch_command}`. On no, drop it."
     )
 
 
@@ -596,7 +580,7 @@ def run_hook(
         return HookRunResult(False, "daily-prompt-limit-reached", state_path=_state_path())
 
     launch_command = f"clawjournal hooks launch {PROFILE_NAME}"
-    message = _prompt_message(client, launch_command)
+    message = _prompt_message(launch_command)
     # A preview must never consume a daily slot or mutate state.
     if dry_run:
         return HookRunResult(True, "dry-run", message, state_path=_state_path())

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -326,7 +326,7 @@ def install_profile(
 
     if source_scope:
         config = config_module.load_config()
-        config["source"] = source_scope
+        config_module.set_source_scope(config, source_scope)
         config_module.save_config(config)
 
     return {
@@ -619,14 +619,29 @@ def render_hook_response(result: HookRunResult, *, client: str, output_json: boo
     return json.dumps(payload)
 
 
-def _port_is_open(port: int) -> bool:
-    import socket
+def _workbench_responding(port: int, *, timeout: float = 1.0) -> bool:
+    """True only if *our* ClawJournal workbench answers on the port.
+
+    A bare TCP connect can't tell our daemon apart from an unrelated process
+    holding the same port. Trusting it would let us open the wrong
+    ``localhost:<port>`` page, or treat a foreign listener as "already running"
+    and then spawn a daemon that silently rebinds to an ephemeral port (a leaked,
+    unreachable process). So fetch the SPA shell and look for a ClawJournal
+    signature: the ``clawjournal_token`` cookie the daemon sets on HTML
+    responses, or the ``<title>ClawJournal</title>`` marker in the served index.
+    """
+    import urllib.error
+    import urllib.request
 
     try:
-        with socket.create_connection(("127.0.0.1", port), timeout=0.25):
-            return True
-    except OSError:
+        with urllib.request.urlopen(f"http://127.0.0.1:{port}/", timeout=timeout) as resp:
+            if resp.status != 200:
+                return False
+            cookie = resp.headers.get("Set-Cookie", "") or ""
+            body = resp.read(4096).decode("utf-8", "replace")
+    except (urllib.error.URLError, OSError, ValueError):
         return False
+    return "clawjournal_token" in cookie or "ClawJournal" in body
 
 
 def _open_browser(url: str) -> bool:
@@ -668,13 +683,23 @@ def _start_detached_server(port: int) -> subprocess.Popen[Any]:
     )
 
 
-def _wait_for_port(port: int, *, timeout_seconds: float = 3.0) -> bool:
+def _terminate_proc(proc: subprocess.Popen[Any] | None) -> None:
+    """Best-effort reap of a server we started but can no longer reach."""
+    if proc is None:
+        return
+    try:
+        proc.terminate()
+    except Exception:
+        pass
+
+
+def _wait_for_workbench(port: int, *, timeout_seconds: float = 3.0) -> bool:
     deadline = time.monotonic() + timeout_seconds
     while time.monotonic() < deadline:
-        if _port_is_open(port):
+        if _workbench_responding(port, timeout=0.5):
             return True
-        time.sleep(0.1)
-    return _port_is_open(port)
+        time.sleep(0.25)
+    return _workbench_responding(port, timeout=0.5)
 
 
 def launch_share_flow(
@@ -699,9 +724,12 @@ def launch_share_flow(
                     "`./scripts/install.sh --with-frontend` or use `--ui cli`."
                 )
             return _cli_launch_result()
-        already_running = _port_is_open(resolved_port)
+        # Only treat the port as serving if *our* workbench actually answers — a
+        # foreign listener must not be opened or counted as already running.
+        already_running = _workbench_responding(resolved_port)
         started = False
         pid: int | None = None
+        proc: subprocess.Popen[Any] | None = None
         if not already_running:
             try:
                 proc = _start_detached_server(resolved_port)
@@ -715,7 +743,7 @@ def launch_share_flow(
         # since later ones short-circuit on `already_running`; without the longer
         # wait a slow boot silently downgrades to the CLI (the bug that made the
         # first "y" in a session land on the CLI while a later one opened the UI).
-        if already_running or _wait_for_port(
+        if already_running or _wait_for_workbench(
             resolved_port, timeout_seconds=10.0 if started else 3.0
         ):
             opened = _open_browser(url) if open_browser else False
@@ -728,6 +756,11 @@ def launch_share_flow(
                 "pid": pid,
                 "browser_opened": opened,
             }
+        # We started a server but our workbench never answered on resolved_port —
+        # e.g. the port was taken by something else and the daemon rebound to an
+        # ephemeral port. Reap the orphan rather than leaking it, and never open
+        # the foreign service that's holding the port.
+        _terminate_proc(proc)
         if ui_mode == "web":
             raise HookError("Started the ClawJournal workbench, but it did not become reachable.")
 

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -539,13 +539,14 @@ def _next_prompt_date(
 
 
 def _prompt_message(launch_command: str) -> str:
-    # Claude Code prints this string verbatim in the transcript as "Stop hook
-    # feedback", so it must stay short and read like a tidy reminder, not a wall
-    # of agent-only instructions. Keep it to a terse directive: the agent expands
-    # it into a friendly question (and adds the privacy reassurance) when it asks.
+    # Claude Code prints this verbatim as "Stop hook feedback" and Codex as a
+    # blocked-stop reason, so keep it a tight directive — not a wall of agent-only
+    # instructions. The privacy reassurance is baked in so the agent surfaces it
+    # every time, not only when it happens to.
     return (
         "OpenRefinery daily reminder — ask the user (y/n) whether to open the "
-        "local review of recent agent-failure sessions to consider sharing. "
+        "local review of recent agent-failure sessions to consider sharing "
+        "(nothing's uploaded until they approve). "
         f"On yes, run `{launch_command}`. On no, drop it."
     )
 

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -463,13 +463,15 @@ def _trim_prompt_counts(counts: dict[str, int], today: date) -> dict[str, int]:
 def _prompt_message(client: str, launch_command: str, snooze_command: str) -> str:
     agent = "Claude Code" if client == "claude" else "Codex"
     return (
-        f"{PROFILE_DISPLAY_NAME} is enabled for your research enrollment.\n"
-        "ClawJournal can review and redact your recent agent failure traces locally, "
-        "then submit them for OpenRefinery research.\n\n"
-        f"Ask the participant: Review now?  y: Review and submit  n: Later  d: Pause reminders\n\n"
+        f"{PROFILE_DISPLAY_NAME} reminder.\n\n"
+        "Ask the user one concise question with three choices:\n"
+        "- y: Open local ClawJournal review\n"
+        "- n: Later\n"
+        "- d: Pause reminders for 30 days\n\n"
         f"If they choose y, run `{launch_command}`. If they choose d, run "
-        f"`{snooze_command}`. Do not submit anything until they have reviewed the "
-        f"redacted bundle in ClawJournal. Current agent: {agent}."
+        f"`{snooze_command}`. Do not run either command until the user chooses. "
+        "The launch command only opens local ClawJournal review; it does not "
+        f"upload or submit anything. Current agent: {agent}."
     )
 
 
@@ -526,8 +528,6 @@ def render_hook_response(result: HookRunResult, *, client: str, output_json: boo
         return ""
     if client == "claude":
         payload = {
-            "decision": "block",
-            "reason": result.message,
             "hookSpecificOutput": {
                 "hookEventName": "Stop",
                 "additionalContext": result.message,

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -1,0 +1,631 @@
+"""OpenRefinery enrollment hooks for Claude Code and Codex.
+
+The hook itself does not package or upload traces. It only nudges an enrolled
+participant once per day and launches the existing local Share workflow on
+request, so the normal source/project confirmation, redaction, hold-state, and
+TruffleHog gates remain authoritative.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import time
+import webbrowser
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Literal
+
+from . import config as config_module
+
+PROFILE_NAME = "openrefinery-failures"
+PROFILE_DISPLAY_NAME = "OpenRefinery Agent Failure Sharing"
+SUPPORTED_AGENTS = ("claude", "codex")
+SUPPORTED_UI_MODES = ("auto", "web", "cli")
+DEFAULT_PORT = 8384
+DEFAULT_SNOOZE_DAYS = 30
+STATE_VERSION = 1
+
+AgentName = Literal["claude", "codex"]
+UiMode = Literal["auto", "web", "cli"]
+
+
+class HookError(RuntimeError):
+    """Raised for user-actionable hook setup problems."""
+
+
+@dataclass(frozen=True)
+class HookRunResult:
+    should_prompt: bool
+    reason: str
+    message: str | None = None
+    state_path: Path | None = None
+
+
+def _now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _today(now: datetime | None = None) -> date:
+    return (now or _now()).astimezone().date()
+
+
+def _state_path() -> Path:
+    return config_module.CONFIG_DIR / "hooks" / f"{PROFILE_NAME}.json"
+
+
+def _read_json_file(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+    try:
+        with path.open(encoding="utf-8") as f:
+            data = json.load(f)
+    except json.JSONDecodeError as exc:
+        raise HookError(f"Could not parse {path}: {exc}") from exc
+    except OSError as exc:
+        raise HookError(f"Could not read {path}: {exc}") from exc
+    if not isinstance(data, dict):
+        raise HookError(f"{path} must contain a JSON object.")
+    return data
+
+
+def _write_json_file(path: Path, data: dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as f:
+            json.dump(data, f, indent=2)
+            f.write("\n")
+        os.replace(tmp_path, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def load_state() -> dict[str, Any]:
+    state = _read_json_file(_state_path())
+    if not state:
+        state = {
+            "version": STATE_VERSION,
+            "profile": PROFILE_NAME,
+            "display_name": PROFILE_DISPLAY_NAME,
+            "enabled": False,
+            "ui": "auto",
+            "cadence": "daily",
+            "installed_agents": [],
+            "created_at": _now().isoformat(),
+        }
+    state.setdefault("version", STATE_VERSION)
+    state.setdefault("profile", PROFILE_NAME)
+    state.setdefault("display_name", PROFILE_DISPLAY_NAME)
+    state.setdefault("enabled", False)
+    state.setdefault("ui", "auto")
+    state.setdefault("cadence", "daily")
+    state.setdefault("installed_agents", [])
+    return state
+
+
+def save_state(state: dict[str, Any]) -> Path:
+    state["version"] = STATE_VERSION
+    state["profile"] = PROFILE_NAME
+    state["display_name"] = PROFILE_DISPLAY_NAME
+    state["updated_at"] = _now().isoformat()
+    path = _state_path()
+    _write_json_file(path, state)
+    return path
+
+
+def _normalize_profile(profile: str) -> str:
+    if profile != PROFILE_NAME:
+        raise HookError(f"Unknown hook profile: {profile}. Expected {PROFILE_NAME}.")
+    return profile
+
+
+def _normalize_agents(agent: str | None) -> list[AgentName]:
+    value = (agent or "all").strip().lower()
+    if value in ("all", "both"):
+        return ["claude", "codex"]
+    if value not in SUPPORTED_AGENTS:
+        allowed = ", ".join((*SUPPORTED_AGENTS, "all"))
+        raise HookError(f"Unsupported agent: {agent}. Expected one of: {allowed}.")
+    return [value]  # type: ignore[list-item]
+
+
+def _normalize_ui(ui: str | None) -> UiMode:
+    value = (ui or "auto").strip().lower()
+    if value not in SUPPORTED_UI_MODES:
+        raise HookError(
+            f"Unsupported UI mode: {ui}. Expected one of: {', '.join(SUPPORTED_UI_MODES)}."
+        )
+    return value  # type: ignore[return-value]
+
+
+def _home_dir(home: Path | None = None) -> Path:
+    return (home or Path.home()).expanduser()
+
+
+def _claude_settings_path(home: Path | None = None) -> Path:
+    override = os.environ.get("CLAUDE_CONFIG_DIR")
+    if override:
+        return Path(override).expanduser() / "settings.json"
+    return _home_dir(home) / ".claude" / "settings.json"
+
+
+def _codex_hooks_path(home: Path | None = None) -> Path:
+    override = os.environ.get("CODEX_HOME")
+    if override:
+        return Path(override).expanduser() / "hooks.json"
+    return _home_dir(home) / ".codex" / "hooks.json"
+
+
+def _hook_command(client: AgentName) -> str:
+    pieces = [
+        shlex.quote(sys.executable),
+        "-m",
+        "clawjournal.cli",
+        "hooks",
+        "run",
+        PROFILE_NAME,
+        "--client",
+        client,
+    ]
+    return " ".join(pieces)
+
+
+def _handler_for(client: AgentName) -> dict[str, Any]:
+    return {
+        "type": "command",
+        "command": _hook_command(client),
+        "timeout": 30,
+        "statusMessage": "Checking OpenRefinery sharing reminder",
+    }
+
+
+def _handler_is_ours(handler: Any) -> bool:
+    return (
+        isinstance(handler, dict)
+        and handler.get("type") == "command"
+        and PROFILE_NAME in str(handler.get("command", ""))
+        and "hooks run" in str(handler.get("command", ""))
+    )
+
+
+def _upsert_stop_hook(document: dict[str, Any], client: AgentName) -> bool:
+    hooks = document.setdefault("hooks", {})
+    if not isinstance(hooks, dict):
+        raise HookError("The existing hooks field must be a JSON object.")
+    groups = hooks.setdefault("Stop", [])
+    if not isinstance(groups, list):
+        raise HookError("The existing Stop hooks field must be a JSON array.")
+
+    desired = _handler_for(client)
+    for group in groups:
+        if not isinstance(group, dict):
+            continue
+        handlers = group.setdefault("hooks", [])
+        if not isinstance(handlers, list):
+            continue
+        for idx, handler in enumerate(handlers):
+            if _handler_is_ours(handler):
+                if handler == desired:
+                    return False
+                handlers[idx] = desired
+                return True
+
+    groups.append({"hooks": [desired]})
+    return True
+
+
+def _remove_stop_hook(document: dict[str, Any]) -> bool:
+    hooks = document.get("hooks")
+    if not isinstance(hooks, dict):
+        return False
+    groups = hooks.get("Stop")
+    if not isinstance(groups, list):
+        return False
+    changed = False
+    kept_groups = []
+    for group in groups:
+        if not isinstance(group, dict):
+            kept_groups.append(group)
+            continue
+        handlers = group.get("hooks")
+        if not isinstance(handlers, list):
+            kept_groups.append(group)
+            continue
+        kept_handlers = [handler for handler in handlers if not _handler_is_ours(handler)]
+        if len(kept_handlers) != len(handlers):
+            changed = True
+        if kept_handlers:
+            group = dict(group)
+            group["hooks"] = kept_handlers
+            kept_groups.append(group)
+    if changed:
+        hooks["Stop"] = kept_groups
+    return changed
+
+
+def install_agent_hook(agent: AgentName, *, home: Path | None = None) -> dict[str, Any]:
+    path = _claude_settings_path(home) if agent == "claude" else _codex_hooks_path(home)
+    document = _read_json_file(path)
+    changed = _upsert_stop_hook(document, agent)
+    if changed or not path.exists():
+        _write_json_file(path, document)
+    return {
+        "agent": agent,
+        "path": str(path),
+        "changed": changed,
+        "command": _hook_command(agent),
+    }
+
+
+def uninstall_agent_hook(agent: AgentName, *, home: Path | None = None) -> dict[str, Any]:
+    path = _claude_settings_path(home) if agent == "claude" else _codex_hooks_path(home)
+    if not path.exists():
+        return {"agent": agent, "path": str(path), "changed": False}
+    document = _read_json_file(path)
+    changed = _remove_stop_hook(document)
+    if changed:
+        _write_json_file(path, document)
+    return {"agent": agent, "path": str(path), "changed": changed}
+
+
+def install_profile(
+    *,
+    profile: str = PROFILE_NAME,
+    agent: str | None = "all",
+    ui: str | None = "auto",
+    source_scope: str | None = "both",
+    home: Path | None = None,
+) -> dict[str, Any]:
+    _normalize_profile(profile)
+    agents = _normalize_agents(agent)
+    ui_mode = _normalize_ui(ui)
+
+    installed = [install_agent_hook(agent_name, home=home) for agent_name in agents]
+    state = load_state()
+    known_agents = set(state.get("installed_agents") or [])
+    known_agents.update(agents)
+    state.update(
+        {
+            "enabled": True,
+            "ui": ui_mode,
+            "cadence": "daily",
+            "installed_agents": sorted(known_agents),
+            "source_scope": source_scope or "both",
+        }
+    )
+    state_path = save_state(state)
+
+    if source_scope:
+        config = config_module.load_config()
+        config["source"] = source_scope
+        config_module.save_config(config)
+
+    return {
+        "profile": PROFILE_NAME,
+        "enabled": True,
+        "ui": ui_mode,
+        "cadence": "daily",
+        "state_path": str(state_path),
+        "installed": installed,
+        "source_scope": source_scope,
+        "projects_confirmed": bool(config_module.load_config().get("projects_confirmed", False)),
+    }
+
+
+def disable_profile(*, profile: str = PROFILE_NAME) -> dict[str, Any]:
+    _normalize_profile(profile)
+    state = load_state()
+    state["enabled"] = False
+    path = save_state(state)
+    return {"profile": PROFILE_NAME, "enabled": False, "state_path": str(path)}
+
+
+def snooze_profile(
+    *,
+    profile: str = PROFILE_NAME,
+    days: int = DEFAULT_SNOOZE_DAYS,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    _normalize_profile(profile)
+    if days < 1:
+        raise HookError("--days must be at least 1.")
+    state = load_state()
+    until = _today(now) + timedelta(days=days)
+    state["snooze_until"] = until.isoformat()
+    path = save_state(state)
+    return {
+        "profile": PROFILE_NAME,
+        "snooze_until": state["snooze_until"],
+        "state_path": str(path),
+    }
+
+
+def uninstall_profile(
+    *,
+    profile: str = PROFILE_NAME,
+    agent: str | None = "all",
+    home: Path | None = None,
+) -> dict[str, Any]:
+    _normalize_profile(profile)
+    agents = _normalize_agents(agent)
+    removed = [uninstall_agent_hook(agent_name, home=home) for agent_name in agents]
+    state = load_state()
+    installed = set(state.get("installed_agents") or [])
+    installed.difference_update(agents)
+    state["installed_agents"] = sorted(installed)
+    if not installed:
+        state["enabled"] = False
+    path = save_state(state)
+    return {
+        "profile": PROFILE_NAME,
+        "enabled": bool(state.get("enabled")),
+        "state_path": str(path),
+        "removed": removed,
+    }
+
+
+def status(*, profile: str = PROFILE_NAME) -> dict[str, Any]:
+    _normalize_profile(profile)
+    state = load_state()
+    return {
+        "profile": PROFILE_NAME,
+        "display_name": PROFILE_DISPLAY_NAME,
+        "enabled": bool(state.get("enabled", False)),
+        "ui": state.get("ui", "auto"),
+        "cadence": state.get("cadence", "daily"),
+        "installed_agents": list(state.get("installed_agents") or []),
+        "last_prompt_date": state.get("last_prompt_date"),
+        "snooze_until": state.get("snooze_until"),
+        "state_path": str(_state_path()),
+        "source_scope": state.get("source_scope"),
+    }
+
+
+def _is_snoozed(state: dict[str, Any], today: date) -> bool:
+    raw = state.get("snooze_until")
+    if not raw:
+        return False
+    try:
+        return date.fromisoformat(str(raw)) >= today
+    except ValueError:
+        return False
+
+
+def _hook_disabled_by_env() -> bool:
+    return (
+        os.environ.get("CLAWJOURNAL_DISABLE_SHARE_NUDGE") == "1"
+        or os.environ.get("OPENREFINERY_SHARE_HOOK_DISABLE") == "1"
+    )
+
+
+def _prompt_message(client: str, launch_command: str, snooze_command: str) -> str:
+    agent = "Claude Code" if client == "claude" else "Codex"
+    return (
+        f"{PROFILE_DISPLAY_NAME} is enabled for your research enrollment.\n"
+        "ClawJournal can review and redact your recent agent failure traces locally, "
+        "then submit them for OpenRefinery research.\n\n"
+        f"Ask the participant: Review now?  y: Review and submit  n: Later  d: Pause reminders\n\n"
+        f"If they choose y, run `{launch_command}`. If they choose d, run "
+        f"`{snooze_command}`. Do not submit anything until they have reviewed the "
+        f"redacted bundle in ClawJournal. Current agent: {agent}."
+    )
+
+
+def run_hook(
+    *,
+    profile: str = PROFILE_NAME,
+    client: str = "codex",
+    force: bool = False,
+    now: datetime | None = None,
+) -> HookRunResult:
+    _normalize_profile(profile)
+    today = _today(now)
+    state = load_state()
+    if _hook_disabled_by_env():
+        return HookRunResult(False, "disabled-by-env", state_path=_state_path())
+    if not state.get("enabled", False):
+        return HookRunResult(False, "disabled", state_path=_state_path())
+    if not force and _is_snoozed(state, today):
+        return HookRunResult(False, "snoozed", state_path=_state_path())
+    if not force and state.get("last_prompt_date") == today.isoformat():
+        return HookRunResult(False, "already-prompted-today", state_path=_state_path())
+
+    state["last_prompt_date"] = today.isoformat()
+    state["last_prompt_client"] = client
+    path = save_state(state)
+    launch_command = f"clawjournal hooks launch {PROFILE_NAME}"
+    snooze_command = f"clawjournal hooks snooze {PROFILE_NAME} --days {DEFAULT_SNOOZE_DAYS}"
+    return HookRunResult(
+        True,
+        "prompt",
+        _prompt_message(client, launch_command, snooze_command),
+        state_path=path,
+    )
+
+
+def render_hook_response(result: HookRunResult, *, client: str, output_json: bool = False) -> str:
+    if output_json:
+        return json.dumps(
+            {
+                "should_prompt": result.should_prompt,
+                "reason": result.reason,
+                "message": result.message,
+                "state_path": str(result.state_path) if result.state_path else None,
+            },
+            indent=2,
+        )
+    if not result.should_prompt or not result.message:
+        return ""
+    if client == "claude":
+        payload = {
+            "decision": "block",
+            "reason": result.message,
+            "hookSpecificOutput": {
+                "hookEventName": "Stop",
+                "additionalContext": result.message,
+            },
+        }
+    else:
+        payload = {"decision": "block", "reason": result.message}
+    return json.dumps(payload)
+
+
+def _port_is_open(port: int) -> bool:
+    import socket
+
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=0.25):
+            return True
+    except OSError:
+        return False
+
+
+def _open_browser(url: str) -> bool:
+    try:
+        return bool(webbrowser.open(url))
+    except Exception:
+        return False
+
+
+def _frontend_available() -> bool:
+    try:
+        from .workbench.daemon import FRONTEND_DIST
+    except Exception:
+        return False
+    return (FRONTEND_DIST / "index.html").exists()
+
+
+def _start_detached_server(port: int) -> subprocess.Popen[Any]:
+    kwargs: dict[str, Any] = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.DEVNULL,
+        "stderr": subprocess.DEVNULL,
+    }
+    if os.name != "nt":
+        kwargs["start_new_session"] = True
+    else:
+        kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP  # type: ignore[attr-defined]
+    return subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "clawjournal.cli",
+            "serve",
+            "--port",
+            str(port),
+            "--no-browser",
+        ],
+        **kwargs,
+    )
+
+
+def _wait_for_port(port: int, *, timeout_seconds: float = 3.0) -> bool:
+    deadline = time.monotonic() + timeout_seconds
+    while time.monotonic() < deadline:
+        if _port_is_open(port):
+            return True
+        time.sleep(0.1)
+    return _port_is_open(port)
+
+
+def launch_share_flow(
+    *,
+    profile: str = PROFILE_NAME,
+    ui: str | None = None,
+    open_browser: bool = True,
+    port: int | None = None,
+) -> dict[str, Any]:
+    _normalize_profile(profile)
+    state = load_state()
+    ui_mode = _normalize_ui(ui or str(state.get("ui") or "auto"))
+    config = config_module.load_config()
+    resolved_port = int(port or config.get("daemon_port") or DEFAULT_PORT)
+    url = f"http://localhost:{resolved_port}/share"
+
+    if ui_mode in ("auto", "web"):
+        if not _frontend_available():
+            if ui_mode == "web":
+                raise HookError(
+                    "The ClawJournal browser workbench is not built. Re-run "
+                    "`./scripts/install.sh --with-frontend` or use `--ui cli`."
+                )
+            return _cli_launch_result()
+        already_running = _port_is_open(resolved_port)
+        started = False
+        pid: int | None = None
+        if not already_running:
+            try:
+                proc = _start_detached_server(resolved_port)
+                started = True
+                pid = proc.pid
+            except OSError as exc:
+                if ui_mode == "web":
+                    raise HookError(f"Could not start the ClawJournal workbench: {exc}") from exc
+        if already_running or _wait_for_port(resolved_port):
+            opened = _open_browser(url) if open_browser else False
+            return {
+                "mode": "web",
+                "url": url,
+                "port": resolved_port,
+                "already_running": already_running,
+                "started": started,
+                "pid": pid,
+                "browser_opened": opened,
+            }
+        if ui_mode == "web":
+            raise HookError("Started the ClawJournal workbench, but it did not become reachable.")
+
+    return _cli_launch_result()
+
+
+def _cli_launch_result() -> dict[str, Any]:
+    command = "clawjournal share --interactive --weekly"
+    return {
+        "mode": "cli",
+        "command": command,
+        "message": f"Run `{command}` to review, redact, package, and submit recent traces.",
+    }
+
+
+def enroll_openrefinery(
+    *,
+    agent: str | None = "all",
+    ui: str | None = "auto",
+    skip_selfupdate: bool = False,
+    home: Path | None = None,
+) -> dict[str, Any]:
+    update_result: dict[str, Any] | None = None
+    if not skip_selfupdate:
+        from .selfupdate import selfupdate_sync
+
+        update_result = dict(selfupdate_sync())
+    install_result = install_profile(
+        profile=PROFILE_NAME,
+        agent=agent,
+        ui=ui,
+        source_scope="both",
+        home=home,
+    )
+    return {
+        "profile": PROFILE_NAME,
+        "update": update_result,
+        "install": install_result,
+        "next": {
+            "review": f"clawjournal hooks launch {PROFILE_NAME}",
+            "status": f"clawjournal hooks status {PROFILE_NAME}",
+            "project_confirmation": (
+                "Open the Share workflow or run `clawjournal list --source both`, "
+                "then `clawjournal config --confirm-projects` after review."
+            ),
+        },
+    }

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -1,9 +1,9 @@
 """OpenRefinery enrollment hooks for Claude Code and Codex.
 
 The hook itself does not package or upload traces. It only nudges an enrolled
-participant once per day and launches the existing local Share workflow on
-request, so the normal source/project confirmation, redaction, hold-state, and
-TruffleHog gates remain authoritative.
+participant up to a small daily cap and launches the existing local Share
+workflow on request, so the normal source/project confirmation, redaction,
+hold-state, and TruffleHog gates remain authoritative.
 """
 
 from __future__ import annotations
@@ -29,6 +29,7 @@ SUPPORTED_AGENTS = ("claude", "codex")
 SUPPORTED_UI_MODES = ("auto", "web", "cli")
 DEFAULT_PORT = 8384
 DEFAULT_SNOOZE_DAYS = 30
+DEFAULT_MAX_PROMPTS_PER_DAY = 10
 STATE_VERSION = 1
 
 AgentName = Literal["claude", "codex"]
@@ -100,6 +101,8 @@ def load_state() -> dict[str, Any]:
             "enabled": False,
             "ui": "auto",
             "cadence": "daily",
+            "max_prompts_per_day": DEFAULT_MAX_PROMPTS_PER_DAY,
+            "prompt_counts_by_date": {},
             "installed_agents": [],
             "created_at": _now().isoformat(),
         }
@@ -109,7 +112,15 @@ def load_state() -> dict[str, Any]:
     state.setdefault("enabled", False)
     state.setdefault("ui", "auto")
     state.setdefault("cadence", "daily")
+    state.setdefault("max_prompts_per_day", DEFAULT_MAX_PROMPTS_PER_DAY)
     state.setdefault("installed_agents", [])
+    counts = state.get("prompt_counts_by_date")
+    if not isinstance(counts, dict):
+        counts = {}
+    legacy_last_prompt = state.get("last_prompt_date")
+    if legacy_last_prompt and str(legacy_last_prompt) not in counts:
+        counts[str(legacy_last_prompt)] = 1
+    state["prompt_counts_by_date"] = counts
     return state
 
 
@@ -377,12 +388,16 @@ def uninstall_profile(
 def status(*, profile: str = PROFILE_NAME) -> dict[str, Any]:
     _normalize_profile(profile)
     state = load_state()
+    today = _today().isoformat()
+    prompt_counts = _prompt_counts_by_date(state)
     return {
         "profile": PROFILE_NAME,
         "display_name": PROFILE_DISPLAY_NAME,
         "enabled": bool(state.get("enabled", False)),
         "ui": state.get("ui", "auto"),
         "cadence": state.get("cadence", "daily"),
+        "max_prompts_per_day": _max_prompts_per_day(state),
+        "prompts_today": prompt_counts.get(today, 0),
         "installed_agents": list(state.get("installed_agents") or []),
         "last_prompt_date": state.get("last_prompt_date"),
         "snooze_until": state.get("snooze_until"),
@@ -406,6 +421,43 @@ def _hook_disabled_by_env() -> bool:
         os.environ.get("CLAWJOURNAL_DISABLE_SHARE_NUDGE") == "1"
         or os.environ.get("OPENREFINERY_SHARE_HOOK_DISABLE") == "1"
     )
+
+
+def _max_prompts_per_day(state: dict[str, Any]) -> int:
+    try:
+        value = int(state.get("max_prompts_per_day", DEFAULT_MAX_PROMPTS_PER_DAY))
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_PROMPTS_PER_DAY
+    return value if value > 0 else DEFAULT_MAX_PROMPTS_PER_DAY
+
+
+def _prompt_counts_by_date(state: dict[str, Any]) -> dict[str, int]:
+    raw_counts = state.get("prompt_counts_by_date")
+    if not isinstance(raw_counts, dict):
+        return {}
+    counts: dict[str, int] = {}
+    for raw_day, raw_count in raw_counts.items():
+        try:
+            day = date.fromisoformat(str(raw_day)).isoformat()
+            count = int(raw_count)
+        except (TypeError, ValueError):
+            continue
+        if count > 0:
+            counts[day] = count
+    return counts
+
+
+def _trim_prompt_counts(counts: dict[str, int], today: date) -> dict[str, int]:
+    earliest = today - timedelta(days=31)
+    trimmed: dict[str, int] = {}
+    for raw_day, count in counts.items():
+        try:
+            day = date.fromisoformat(raw_day)
+        except ValueError:
+            continue
+        if day >= earliest:
+            trimmed[day.isoformat()] = count
+    return trimmed
 
 
 def _prompt_message(client: str, launch_command: str, snooze_command: str) -> str:
@@ -437,10 +489,16 @@ def run_hook(
         return HookRunResult(False, "disabled", state_path=_state_path())
     if not force and _is_snoozed(state, today):
         return HookRunResult(False, "snoozed", state_path=_state_path())
-    if not force and state.get("last_prompt_date") == today.isoformat():
-        return HookRunResult(False, "already-prompted-today", state_path=_state_path())
+    today_key = today.isoformat()
+    prompt_counts = _prompt_counts_by_date(state)
+    prompt_count = prompt_counts.get(today_key, 0)
+    max_prompts = _max_prompts_per_day(state)
+    if not force and prompt_count >= max_prompts:
+        return HookRunResult(False, "daily-prompt-limit-reached", state_path=_state_path())
 
-    state["last_prompt_date"] = today.isoformat()
+    prompt_counts[today_key] = prompt_count + 1
+    state["prompt_counts_by_date"] = _trim_prompt_counts(prompt_counts, today)
+    state["last_prompt_date"] = today_key
     state["last_prompt_client"] = client
     path = save_state(state)
     launch_command = f"clawjournal hooks launch {PROFILE_NAME}"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -324,6 +324,32 @@ class TestConfigure:
         configure(source="codex")
         assert saved["source"] == "codex"
 
+    def test_changing_source_resets_project_confirmation(self, tmp_config, monkeypatch, capsys):
+        monkeypatch.setattr("clawjournal.cli.CONFIG_FILE", tmp_config)
+        monkeypatch.setattr(
+            "clawjournal.cli.load_config",
+            lambda: {"repo": None, "source": "codex", "projects_confirmed": True},
+        )
+        saved = {}
+        monkeypatch.setattr("clawjournal.cli.save_config", lambda c: saved.update(c))
+
+        configure(source="both")
+        assert saved["source"] == "both"
+        assert saved["projects_confirmed"] is False
+
+    def test_same_source_preserves_project_confirmation(self, tmp_config, monkeypatch, capsys):
+        monkeypatch.setattr("clawjournal.cli.CONFIG_FILE", tmp_config)
+        monkeypatch.setattr(
+            "clawjournal.cli.load_config",
+            lambda: {"repo": None, "source": "codex", "projects_confirmed": True},
+        )
+        saved = {}
+        monkeypatch.setattr("clawjournal.cli.save_config", lambda c: saved.update(c))
+
+        configure(source="codex")
+        assert saved["source"] == "codex"
+        assert saved["projects_confirmed"] is True
+
     def test_sets_ai_pii_review_flag(self, tmp_config, monkeypatch, capsys):
         monkeypatch.setattr("clawjournal.cli.CONFIG_FILE", tmp_config)
         monkeypatch.setattr("clawjournal.cli.load_config", lambda: {"repo": None})

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -153,6 +153,20 @@ def test_daily_hook_prompts_until_daily_limit(isolated_hook_env, monkeypatch):
     assert status["prompts_today"] == cap
 
 
+def test_reinstall_refreshes_stale_prompt_cap(isolated_hook_env):
+    home = isolated_hook_env / "home"
+    hooks.install_profile(agent="claude", home=home)
+    # Simulate a state file written by an older version with a higher cap.
+    state = hooks.load_state()
+    state["max_prompts_per_day"] = 10
+    hooks.save_state(state)
+    assert hooks.status()["max_prompts_per_day"] == 10
+
+    hooks.install_profile(agent="claude", home=home)
+
+    assert hooks.status()["max_prompts_per_day"] == hooks.DEFAULT_MAX_PROMPTS_PER_DAY
+
+
 def test_dry_run_previews_without_consuming(isolated_hook_env):
     hooks.install_profile(agent="claude", ui="cli", home=isolated_hook_env / "home")
     now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -124,12 +124,13 @@ def test_install_profile_updates_existing_openrefinery_hook(isolated_hook_env, m
     ]
 
 
-def test_daily_hook_prompts_once_then_suppresses(isolated_hook_env):
+def test_daily_hook_prompts_until_daily_limit(isolated_hook_env, monkeypatch):
     hooks.install_profile(agent="codex", ui="cli", home=isolated_hook_env / "home")
     now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
 
-    first = hooks.run_hook(client="codex", now=now)
-    second = hooks.run_hook(client="codex", now=now)
+    results = [hooks.run_hook(client="codex", now=now) for _ in range(11)]
+    first = results[0]
+    over_limit = results[-1]
 
     assert first.should_prompt is True
     assert first.reason == "prompt"
@@ -137,8 +138,18 @@ def test_daily_hook_prompts_once_then_suppresses(isolated_hook_env):
     payload = json.loads(rendered)
     assert payload["decision"] == "block"
     assert "Review now?" in payload["reason"]
-    assert second.should_prompt is False
-    assert second.reason == "already-prompted-today"
+    assert [result.should_prompt for result in results[:10]] == [True] * 10
+    assert over_limit.should_prompt is False
+    assert over_limit.reason == "daily-prompt-limit-reached"
+
+    monkeypatch.setattr(
+        hooks,
+        "_today",
+        lambda now=None: datetime(2026, 6, 21, tzinfo=timezone.utc).date(),
+    )
+    status = hooks.status()
+    assert status["max_prompts_per_day"] == 10
+    assert status["prompts_today"] == 10
 
 
 def test_snooze_suppresses_daily_hook(isolated_hook_env):

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -262,6 +262,8 @@ def test_prompt_message_omits_pause_for_enrolled_participant(isolated_hook_env):
     assert "open the local review" in message
     assert "agent-failure sessions" in message
     assert "clawjournal hooks launch openrefinery-failures" in message
+    # Privacy reassurance is baked in so the agent surfaces it every time.
+    assert "uploaded" in message
     assert len(message) < 280
     # No admin escape-hatch wording for an already-enrolled participant, and none
     # of the old "surface a question to the user" scaffolding.

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -326,7 +326,7 @@ def test_launch_share_flow_starts_server_and_opens_browser(isolated_hook_env, mo
     monkeypatch.setattr(hooks, "_frontend_available", lambda: True)
     monkeypatch.setattr(hooks, "_port_is_open", lambda port: False)
     monkeypatch.setattr(hooks, "_start_detached_server", lambda port: Proc())
-    monkeypatch.setattr(hooks, "_wait_for_port", lambda port: True)
+    monkeypatch.setattr(hooks, "_wait_for_port", lambda port, timeout_seconds=3.0: True)
     monkeypatch.setattr(hooks, "_open_browser", lambda url: calls.append(url) or True)
 
     result = hooks.launch_share_flow(open_browser=True, port=8484)
@@ -336,6 +336,32 @@ def test_launch_share_flow_starts_server_and_opens_browser(isolated_hook_env, mo
     assert result["pid"] == 1234
     assert result["url"] == "http://localhost:8484/share"
     assert calls == ["http://localhost:8484/share"]
+
+
+def test_launch_share_flow_waits_longer_for_cold_started_server(isolated_hook_env, monkeypatch):
+    # A freshly started server gets a longer grace period than the default so a
+    # slow cold boot does not silently downgrade to the CLI (the first-"y" bug).
+    hooks.install_profile(agent="codex", ui="web", home=isolated_hook_env / "home")
+
+    class Proc:
+        pid = 1234
+
+    waited: dict = {}
+    monkeypatch.setattr(hooks, "_frontend_available", lambda: True)
+    monkeypatch.setattr(hooks, "_port_is_open", lambda port: False)
+    monkeypatch.setattr(hooks, "_start_detached_server", lambda port: Proc())
+    monkeypatch.setattr(hooks, "_open_browser", lambda url: True)
+
+    def fake_wait(port, timeout_seconds=3.0):
+        waited["timeout"] = timeout_seconds
+        return True
+
+    monkeypatch.setattr(hooks, "_wait_for_port", fake_wait)
+
+    result = hooks.launch_share_flow(open_browser=False, port=8484)
+
+    assert result["mode"] == "web"
+    assert waited["timeout"] >= 10.0
 
 
 def test_launch_share_flow_falls_back_when_frontend_missing(isolated_hook_env, monkeypatch):

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -82,6 +82,36 @@ def test_install_profile_writes_claude_and_codex_hooks(isolated_hook_env):
     )
 
 
+def test_install_profile_resets_project_confirmation_when_source_scope_changes(isolated_hook_env):
+    config_module.save_config({"source": "codex", "projects_confirmed": True})
+
+    result = hooks.install_profile(
+        agent="claude",
+        source_scope="both",
+        home=isolated_hook_env / "home",
+    )
+
+    config = config_module.load_config()
+    assert config["source"] == "both"
+    assert config["projects_confirmed"] is False
+    assert result["projects_confirmed"] is False
+
+
+def test_install_profile_preserves_project_confirmation_for_same_source_scope(isolated_hook_env):
+    config_module.save_config({"source": "both", "projects_confirmed": True})
+
+    result = hooks.install_profile(
+        agent="claude",
+        source_scope="both",
+        home=isolated_hook_env / "home",
+    )
+
+    config = config_module.load_config()
+    assert config["source"] == "both"
+    assert config["projects_confirmed"] is True
+    assert result["projects_confirmed"] is True
+
+
 def test_install_profile_updates_existing_openrefinery_hook(isolated_hook_env, monkeypatch):
     home = isolated_hook_env / "home"
     codex_hooks = home / ".codex" / "hooks.json"
@@ -303,7 +333,8 @@ def test_launch_share_flow_falls_back_to_cli_when_auto_web_unavailable(
 ):
     hooks.install_profile(agent="codex", ui="auto", home=isolated_hook_env / "home")
     monkeypatch.setattr(hooks, "_frontend_available", lambda: True)
-    monkeypatch.setattr(hooks, "_port_is_open", lambda port: False)
+    monkeypatch.setattr(hooks, "_workbench_responding", lambda port, timeout=1.0: False)
+    monkeypatch.setattr(hooks, "_wait_for_workbench", lambda port, timeout_seconds=3.0: False)
     monkeypatch.setattr(
         hooks,
         "_start_detached_server",
@@ -324,9 +355,9 @@ def test_launch_share_flow_starts_server_and_opens_browser(isolated_hook_env, mo
 
     calls: list[str] = []
     monkeypatch.setattr(hooks, "_frontend_available", lambda: True)
-    monkeypatch.setattr(hooks, "_port_is_open", lambda port: False)
+    monkeypatch.setattr(hooks, "_workbench_responding", lambda port, timeout=1.0: False)
     monkeypatch.setattr(hooks, "_start_detached_server", lambda port: Proc())
-    monkeypatch.setattr(hooks, "_wait_for_port", lambda port, timeout_seconds=3.0: True)
+    monkeypatch.setattr(hooks, "_wait_for_workbench", lambda port, timeout_seconds=3.0: True)
     monkeypatch.setattr(hooks, "_open_browser", lambda url: calls.append(url) or True)
 
     result = hooks.launch_share_flow(open_browser=True, port=8484)
@@ -348,7 +379,7 @@ def test_launch_share_flow_waits_longer_for_cold_started_server(isolated_hook_en
 
     waited: dict = {}
     monkeypatch.setattr(hooks, "_frontend_available", lambda: True)
-    monkeypatch.setattr(hooks, "_port_is_open", lambda port: False)
+    monkeypatch.setattr(hooks, "_workbench_responding", lambda port, timeout=1.0: False)
     monkeypatch.setattr(hooks, "_start_detached_server", lambda port: Proc())
     monkeypatch.setattr(hooks, "_open_browser", lambda url: True)
 
@@ -356,12 +387,43 @@ def test_launch_share_flow_waits_longer_for_cold_started_server(isolated_hook_en
         waited["timeout"] = timeout_seconds
         return True
 
-    monkeypatch.setattr(hooks, "_wait_for_port", fake_wait)
+    monkeypatch.setattr(hooks, "_wait_for_workbench", fake_wait)
 
     result = hooks.launch_share_flow(open_browser=False, port=8484)
 
     assert result["mode"] == "web"
     assert waited["timeout"] >= 10.0
+
+
+def test_launch_share_flow_reaps_server_when_workbench_never_answers(
+    isolated_hook_env, monkeypatch
+):
+    # If we start a server but our workbench never answers on the port (e.g. the
+    # port was held by something else and the daemon rebound to an ephemeral
+    # port), don't open the foreign service and don't leak the spawned process —
+    # reap it and fall back to the CLI.
+    hooks.install_profile(agent="codex", ui="auto", home=isolated_hook_env / "home")
+
+    terminated: dict = {"count": 0}
+
+    class Proc:
+        pid = 4321
+
+        def terminate(self):
+            terminated["count"] += 1
+
+    opened: list[str] = []
+    monkeypatch.setattr(hooks, "_frontend_available", lambda: True)
+    monkeypatch.setattr(hooks, "_workbench_responding", lambda port, timeout=1.0: False)
+    monkeypatch.setattr(hooks, "_start_detached_server", lambda port: Proc())
+    monkeypatch.setattr(hooks, "_wait_for_workbench", lambda port, timeout_seconds=3.0: False)
+    monkeypatch.setattr(hooks, "_open_browser", lambda url: opened.append(url) or True)
+
+    result = hooks.launch_share_flow(open_browser=True)
+
+    assert result["mode"] == "cli"
+    assert terminated["count"] == 1  # the orphaned server was reaped
+    assert opened == []  # never opened the foreign service holding the port
 
 
 def test_launch_share_flow_falls_back_when_frontend_missing(isolated_hook_env, monkeypatch):

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -127,8 +127,9 @@ def test_install_profile_updates_existing_openrefinery_hook(isolated_hook_env, m
 def test_daily_hook_prompts_until_daily_limit(isolated_hook_env, monkeypatch):
     hooks.install_profile(agent="codex", ui="cli", home=isolated_hook_env / "home")
     now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
+    cap = hooks.DEFAULT_MAX_PROMPTS_PER_DAY
 
-    results = [hooks.run_hook(client="codex", now=now) for _ in range(11)]
+    results = [hooks.run_hook(client="codex", now=now) for _ in range(cap + 1)]
     first = results[0]
     over_limit = results[-1]
 
@@ -138,7 +139,7 @@ def test_daily_hook_prompts_until_daily_limit(isolated_hook_env, monkeypatch):
     payload = json.loads(rendered)
     assert payload["decision"] == "block"
     assert "Open local ClawJournal review" in payload["reason"]
-    assert [result.should_prompt for result in results[:10]] == [True] * 10
+    assert [result.should_prompt for result in results[:cap]] == [True] * cap
     assert over_limit.should_prompt is False
     assert over_limit.reason == "daily-prompt-limit-reached"
 
@@ -148,8 +149,65 @@ def test_daily_hook_prompts_until_daily_limit(isolated_hook_env, monkeypatch):
         lambda now=None: datetime(2026, 6, 21, tzinfo=timezone.utc).date(),
     )
     status = hooks.status()
-    assert status["max_prompts_per_day"] == 10
-    assert status["prompts_today"] == 10
+    assert status["max_prompts_per_day"] == cap
+    assert status["prompts_today"] == cap
+
+
+def test_dry_run_previews_without_consuming(isolated_hook_env):
+    hooks.install_profile(agent="claude", ui="cli", home=isolated_hook_env / "home")
+    now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
+
+    preview = hooks.run_hook(client="claude", dry_run=True, now=now)
+
+    assert preview.should_prompt is True
+    assert preview.reason == "dry-run"
+    assert "OpenRefinery Agent Failure Sharing" in (preview.message or "")
+    # A preview must not consume a slot: a real run still treats today as fresh.
+    assert hooks.status(now=now)["prompts_today"] == 0
+    follow = hooks.run_hook(client="claude", now=now)
+    assert follow.should_prompt is True
+    assert follow.reason == "prompt"
+
+
+def test_stop_hook_active_suppresses_without_consuming(isolated_hook_env):
+    hooks.install_profile(agent="claude", ui="cli", home=isolated_hook_env / "home")
+    now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
+
+    guarded = hooks.run_hook(client="claude", stop_hook_active=True, now=now)
+    assert guarded.should_prompt is False
+    assert guarded.reason == "stop-hook-active"
+    assert hooks.status(now=now)["prompts_today"] == 0
+
+    # --force overrides the loop guard.
+    forced = hooks.run_hook(client="claude", stop_hook_active=True, force=True, now=now)
+    assert forced.should_prompt is True
+
+
+def test_status_reports_readiness_and_next_prompt(isolated_hook_env):
+    hooks.install_profile(agent="claude", ui="cli", home=isolated_hook_env / "home")
+    now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
+
+    st = hooks.status(now=now)
+    assert st["eligible_now"] is True
+    assert st["next_prompt"] == "2026-06-21"
+    assert st["source_confirmed"] is True  # install set source=both
+    assert st["projects_confirmed"] is False
+    assert st["share_ready"] is False
+
+    hooks.snooze_profile(days=3, now=now)
+    st2 = hooks.status(now=now)
+    assert st2["snoozed"] is True
+    assert st2["snooze_days_remaining"] == 4  # today + 3 days, inclusive of today
+    assert st2["next_prompt"] == "2026-06-25"  # snooze_until (06-24) + 1 day
+    assert st2["eligible_now"] is False
+
+
+def test_share_readiness_tracks_config():
+    assert hooks.share_readiness({"source": "auto"})["source_confirmed"] is False
+    assert hooks.share_readiness({"source": "both"})["source_confirmed"] is True
+    ready = hooks.share_readiness({"source": "both", "projects_confirmed": True})
+    assert ready["ready"] is True
+    assert hooks.share_readiness({})["ready"] is False
 
 
 def test_snooze_suppresses_daily_hook(isolated_hook_env):

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -139,7 +139,7 @@ def test_daily_hook_prompts_until_daily_limit(isolated_hook_env, monkeypatch):
     rendered = hooks.render_hook_response(first, client="codex")
     payload = json.loads(rendered)
     assert payload["decision"] == "block"
-    assert "Open local ClawJournal review" in payload["reason"]
+    assert "share with OpenRefinery" in payload["reason"]
     assert [result.should_prompt for result in results[:cap]] == [True] * cap
     assert over_limit.should_prompt is False
     assert over_limit.reason == "daily-prompt-limit-reached"
@@ -256,11 +256,16 @@ def test_prompt_message_omits_pause_for_enrolled_participant(isolated_hook_env):
     )
 
     message = result.message or ""
-    assert "Open local ClawJournal review" in message
-    assert "Later" in message
+    assert "open the local review" in message
+    assert "not now" in message
     assert "Pause" not in message
     assert "snooze" not in message.lower()
     assert "disable" not in message.lower()
+    # The reminder must explain what it is and reassure on privacy, not leak the
+    # agent-only scaffolding that used to surface verbatim to the user.
+    assert "OpenRefinery" in message
+    assert "nothing leaves your computer until you" in message
+    assert "Surface ONE" not in message
 
 
 def test_snooze_suppresses_daily_hook(isolated_hook_env):

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -137,7 +137,7 @@ def test_daily_hook_prompts_until_daily_limit(isolated_hook_env, monkeypatch):
     rendered = hooks.render_hook_response(first, client="codex")
     payload = json.loads(rendered)
     assert payload["decision"] == "block"
-    assert "Review now?" in payload["reason"]
+    assert "Open local ClawJournal review" in payload["reason"]
     assert [result.should_prompt for result in results[:10]] == [True] * 10
     assert over_limit.should_prompt is False
     assert over_limit.reason == "daily-prompt-limit-reached"
@@ -172,7 +172,7 @@ def test_claude_hook_response_includes_additional_context(isolated_hook_env):
 
     payload = json.loads(hooks.render_hook_response(result, client="claude"))
 
-    assert payload["decision"] == "block"
+    assert "decision" not in payload
     assert payload["hookSpecificOutput"]["hookEventName"] == "Stop"
     assert "OpenRefinery Agent Failure Sharing" in payload["hookSpecificOutput"]["additionalContext"]
 

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -19,6 +19,7 @@ def isolated_hook_env(tmp_path, monkeypatch):
     monkeypatch.delenv("CODEX_HOME", raising=False)
     monkeypatch.delenv("CLAWJOURNAL_DISABLE_SHARE_NUDGE", raising=False)
     monkeypatch.delenv("OPENREFINERY_SHARE_HOOK_DISABLE", raising=False)
+    monkeypatch.delenv("OPENREFINERY_SHARE_HOOK_TEST", raising=False)
     return tmp_path
 
 
@@ -222,6 +223,44 @@ def test_share_readiness_tracks_config():
     ready = hooks.share_readiness({"source": "both", "projects_confirmed": True})
     assert ready["ready"] is True
     assert hooks.share_readiness({})["ready"] is False
+
+
+def test_prod_cadence_is_one_per_day(isolated_hook_env):
+    hooks.install_profile(agent="claude", home=isolated_hook_env / "home")
+    now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
+
+    assert hooks.DEFAULT_MAX_PROMPTS_PER_DAY == 1
+    first = hooks.run_hook(client="claude", now=now)
+    second = hooks.run_hook(client="claude", now=now)
+
+    assert first.should_prompt is True
+    assert second.should_prompt is False
+    assert second.reason == "daily-prompt-limit-reached"
+
+
+def test_test_mode_env_raises_cap(isolated_hook_env, monkeypatch):
+    hooks.install_profile(agent="claude", home=isolated_hook_env / "home")
+    now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
+    monkeypatch.setenv("OPENREFINERY_SHARE_HOOK_TEST", "1")
+
+    results = [hooks.run_hook(client="claude", now=now) for _ in range(10)]
+
+    assert all(r.should_prompt for r in results)
+    assert hooks.status(now=now)["max_prompts_per_day"] == hooks.TEST_MAX_PROMPTS_PER_DAY
+
+
+def test_prompt_message_omits_pause_for_enrolled_participant(isolated_hook_env):
+    hooks.install_profile(agent="claude", home=isolated_hook_env / "home")
+    result = hooks.run_hook(
+        client="claude", dry_run=True, now=datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
+    )
+
+    message = result.message or ""
+    assert "Open local ClawJournal review" in message
+    assert "Later" in message
+    assert "Pause" not in message
+    assert "snooze" not in message.lower()
+    assert "disable" not in message.lower()
 
 
 def test_snooze_suppresses_daily_hook(isolated_hook_env):

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -139,7 +139,7 @@ def test_daily_hook_prompts_until_daily_limit(isolated_hook_env, monkeypatch):
     rendered = hooks.render_hook_response(first, client="codex")
     payload = json.loads(rendered)
     assert payload["decision"] == "block"
-    assert "share with OpenRefinery" in payload["reason"]
+    assert "clawjournal hooks launch openrefinery-failures" in payload["reason"]
     assert [result.should_prompt for result in results[:cap]] == [True] * cap
     assert over_limit.should_prompt is False
     assert over_limit.reason == "daily-prompt-limit-reached"
@@ -176,7 +176,7 @@ def test_dry_run_previews_without_consuming(isolated_hook_env):
 
     assert preview.should_prompt is True
     assert preview.reason == "dry-run"
-    assert "OpenRefinery Agent Failure Sharing" in (preview.message or "")
+    assert "OpenRefinery" in (preview.message or "")
     # A preview must not consume a slot: a real run still treats today as fresh.
     assert hooks.status(now=now)["prompts_today"] == 0
     follow = hooks.run_hook(client="claude", now=now)
@@ -256,15 +256,18 @@ def test_prompt_message_omits_pause_for_enrolled_participant(isolated_hook_env):
     )
 
     message = result.message or ""
+    # The injected text is printed verbatim in the Stop-hook trace, so it must be
+    # a short directive — not a multi-paragraph blurb or leaked agent scaffolding.
+    assert "OpenRefinery" in message
     assert "open the local review" in message
-    assert "not now" in message
+    assert "agent-failure sessions" in message
+    assert "clawjournal hooks launch openrefinery-failures" in message
+    assert len(message) < 280
+    # No admin escape-hatch wording for an already-enrolled participant, and none
+    # of the old "surface a question to the user" scaffolding.
     assert "Pause" not in message
     assert "snooze" not in message.lower()
     assert "disable" not in message.lower()
-    # The reminder must explain what it is and reassure on privacy, not leak the
-    # agent-only scaffolding that used to surface verbatim to the user.
-    assert "OpenRefinery" in message
-    assert "nothing leaves your computer until you" in message
     assert "Surface ONE" not in message
 
 
@@ -290,7 +293,7 @@ def test_claude_hook_response_includes_additional_context(isolated_hook_env):
 
     assert "decision" not in payload
     assert payload["hookSpecificOutput"]["hookEventName"] == "Stop"
-    assert "OpenRefinery Agent Failure Sharing" in payload["hookSpecificOutput"]["additionalContext"]
+    assert "OpenRefinery" in payload["hookSpecificOutput"]["additionalContext"]
 
 
 def test_launch_share_flow_falls_back_to_cli_when_auto_web_unavailable(

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -1,0 +1,237 @@
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from clawjournal import config as config_module
+from clawjournal import openrefinery_hooks as hooks
+
+
+@pytest.fixture
+def isolated_hook_env(tmp_path, monkeypatch):
+    cfg_dir = tmp_path / ".clawjournal"
+    monkeypatch.setattr(config_module, "CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(config_module, "CONFIG_FILE", cfg_dir / "config.json")
+    monkeypatch.delenv("CLAUDE_CONFIG_DIR", raising=False)
+    monkeypatch.delenv("CODEX_HOME", raising=False)
+    monkeypatch.delenv("CLAWJOURNAL_DISABLE_SHARE_NUDGE", raising=False)
+    monkeypatch.delenv("OPENREFINERY_SHARE_HOOK_DISABLE", raising=False)
+    return tmp_path
+
+
+def _read(path: Path) -> dict:
+    return json.loads(path.read_text())
+
+
+def test_install_profile_writes_claude_and_codex_hooks(isolated_hook_env):
+    home = isolated_hook_env / "home"
+    claude_settings = home / ".claude" / "settings.json"
+    codex_hooks = home / ".codex" / "hooks.json"
+    claude_settings.parent.mkdir(parents=True)
+    claude_settings.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "echo existing",
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        )
+    )
+
+    result = hooks.install_profile(agent="all", ui="web", home=home)
+
+    assert result["enabled"] is True
+    assert result["source_scope"] == "both"
+    assert result["projects_confirmed"] is False
+    assert config_module.load_config()["source"] == "both"
+
+    claude_doc = _read(claude_settings)
+    claude_handlers = [
+        handler
+        for group in claude_doc["hooks"]["Stop"]
+        for handler in group.get("hooks", [])
+    ]
+    assert any(handler["command"] == "echo existing" for handler in claude_handlers)
+    assert any(
+        "hooks run openrefinery-failures --client claude" in handler["command"]
+        for handler in claude_handlers
+    )
+
+    codex_doc = _read(codex_hooks)
+    codex_handlers = [
+        handler
+        for group in codex_doc["hooks"]["Stop"]
+        for handler in group.get("hooks", [])
+    ]
+    assert any(
+        "hooks run openrefinery-failures --client codex" in handler["command"]
+        for handler in codex_handlers
+    )
+
+
+def test_install_profile_updates_existing_openrefinery_hook(isolated_hook_env, monkeypatch):
+    home = isolated_hook_env / "home"
+    codex_hooks = home / ".codex" / "hooks.json"
+    codex_hooks.parent.mkdir(parents=True)
+    codex_hooks.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "Stop": [
+                        {
+                            "hooks": [
+                                {
+                                    "type": "command",
+                                    "command": "old-python -m clawjournal.cli hooks run openrefinery-failures --client codex",
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(hooks.sys, "executable", "/tmp/new-python")
+
+    result = hooks.install_profile(agent="codex", ui="auto", home=home)
+
+    assert result["installed"][0]["changed"] is True
+    doc = _read(codex_hooks)
+    handlers = [
+        handler
+        for group in doc["hooks"]["Stop"]
+        for handler in group.get("hooks", [])
+    ]
+    commands = [
+        handler["command"]
+        for handler in handlers
+        if "openrefinery-failures" in handler["command"]
+    ]
+    assert commands == [
+        "/tmp/new-python -m clawjournal.cli hooks run openrefinery-failures --client codex"
+    ]
+
+
+def test_daily_hook_prompts_once_then_suppresses(isolated_hook_env):
+    hooks.install_profile(agent="codex", ui="cli", home=isolated_hook_env / "home")
+    now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
+
+    first = hooks.run_hook(client="codex", now=now)
+    second = hooks.run_hook(client="codex", now=now)
+
+    assert first.should_prompt is True
+    assert first.reason == "prompt"
+    rendered = hooks.render_hook_response(first, client="codex")
+    payload = json.loads(rendered)
+    assert payload["decision"] == "block"
+    assert "Review now?" in payload["reason"]
+    assert second.should_prompt is False
+    assert second.reason == "already-prompted-today"
+
+
+def test_snooze_suppresses_daily_hook(isolated_hook_env):
+    hooks.install_profile(agent="claude", ui="cli", home=isolated_hook_env / "home")
+    now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)
+    hooks.snooze_profile(days=3, now=now)
+
+    result = hooks.run_hook(client="claude", now=now)
+
+    assert result.should_prompt is False
+    assert result.reason == "snoozed"
+
+
+def test_claude_hook_response_includes_additional_context(isolated_hook_env):
+    hooks.install_profile(agent="claude", ui="cli", home=isolated_hook_env / "home")
+    result = hooks.run_hook(
+        client="claude",
+        now=datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc),
+    )
+
+    payload = json.loads(hooks.render_hook_response(result, client="claude"))
+
+    assert payload["decision"] == "block"
+    assert payload["hookSpecificOutput"]["hookEventName"] == "Stop"
+    assert "OpenRefinery Agent Failure Sharing" in payload["hookSpecificOutput"]["additionalContext"]
+
+
+def test_launch_share_flow_falls_back_to_cli_when_auto_web_unavailable(
+    isolated_hook_env, monkeypatch
+):
+    hooks.install_profile(agent="codex", ui="auto", home=isolated_hook_env / "home")
+    monkeypatch.setattr(hooks, "_frontend_available", lambda: True)
+    monkeypatch.setattr(hooks, "_port_is_open", lambda port: False)
+    monkeypatch.setattr(
+        hooks,
+        "_start_detached_server",
+        lambda port: (_ for _ in ()).throw(OSError("no server")),
+    )
+
+    result = hooks.launch_share_flow(open_browser=False)
+
+    assert result["mode"] == "cli"
+    assert result["command"] == "clawjournal share --interactive --weekly"
+
+
+def test_launch_share_flow_starts_server_and_opens_browser(isolated_hook_env, monkeypatch):
+    hooks.install_profile(agent="codex", ui="web", home=isolated_hook_env / "home")
+
+    class Proc:
+        pid = 1234
+
+    calls: list[str] = []
+    monkeypatch.setattr(hooks, "_frontend_available", lambda: True)
+    monkeypatch.setattr(hooks, "_port_is_open", lambda port: False)
+    monkeypatch.setattr(hooks, "_start_detached_server", lambda port: Proc())
+    monkeypatch.setattr(hooks, "_wait_for_port", lambda port: True)
+    monkeypatch.setattr(hooks, "_open_browser", lambda url: calls.append(url) or True)
+
+    result = hooks.launch_share_flow(open_browser=True, port=8484)
+
+    assert result["mode"] == "web"
+    assert result["started"] is True
+    assert result["pid"] == 1234
+    assert result["url"] == "http://localhost:8484/share"
+    assert calls == ["http://localhost:8484/share"]
+
+
+def test_launch_share_flow_falls_back_when_frontend_missing(isolated_hook_env, monkeypatch):
+    hooks.install_profile(agent="codex", ui="auto", home=isolated_hook_env / "home")
+    monkeypatch.setattr(hooks, "_frontend_available", lambda: False)
+
+    result = hooks.launch_share_flow(open_browser=False)
+
+    assert result["mode"] == "cli"
+
+
+def test_uninstall_profile_removes_only_openrefinery_hook(isolated_hook_env):
+    home = isolated_hook_env / "home"
+    hooks.install_profile(agent="codex", ui="auto", home=home)
+    codex_hooks = home / ".codex" / "hooks.json"
+    doc = _read(codex_hooks)
+    doc["hooks"]["Stop"].append(
+        {"hooks": [{"type": "command", "command": "echo keep-me"}]}
+    )
+    codex_hooks.write_text(json.dumps(doc))
+
+    hooks.uninstall_profile(agent="codex", home=home)
+
+    doc = _read(codex_hooks)
+    handlers = [
+        handler
+        for group in doc["hooks"]["Stop"]
+        for handler in group.get("hooks", [])
+    ]
+    assert any(handler["command"] == "echo keep-me" for handler in handlers)
+    assert not any("openrefinery-failures" in handler["command"] for handler in handlers)


### PR DESCRIPTION
## Summary

Adds an enrollment-only OpenRefinery Agent Failure Sharing hook workflow for Claude Code and Codex.

- Adds `clawjournal enroll openrefinery` and `clawjournal hooks ... openrefinery-failures` commands.
- Installs user-level Stop hooks into Claude Code and Codex config.
- Stores local daily cadence/snooze state under `~/.clawjournal/hooks/openrefinery-failures.json`.
- Launches the existing ClawJournal Share flow, preferring the browser workbench and falling back to `clawjournal share --interactive --weekly`.
- Documents the design in `OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md` and links it from the README.

## Safety / Privacy

The hook never reads transcripts, packages bundles, uploads data, or calls an AI backend. It only nudges an enrolled participant and launches the existing local Share workflow. Existing ClawJournal gates remain authoritative: source/project confirmation, hold-state restrictions, share-time redaction, optional AI-PII review, and mandatory TruffleHog post-redaction scanning.

## Validation

- `python -m pytest tests/test_cli.py tests/test_selfupdate.py tests/test_openrefinery_hooks.py -q`
- `python -m py_compile clawjournal/openrefinery_hooks.py clawjournal/cli.py tests/test_openrefinery_hooks.py`
- `git diff --check --cached`