### PR TITLE
[codex] Fix OpenRefinery sharing follow-ups

### DIFF
--- a/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
+++ b/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
@@ -95,11 +95,14 @@ The hook installer writes only user-level agent config and ClawJournal state:
 | `~/.clawjournal/hooks/openrefinery-failures.json` | Local profile state, daily prompt cap, prompt counts, snooze status |
 | `~/.clawjournal/config.json` | Existing ClawJournal config; enrollment sets `source` to `both` |
 
-The hook command installed into both agents is:
+The POSIX hook command installed into both agents is:
 
 ```bash
 <python> -m clawjournal.cli hooks run openrefinery-failures --client <claude|codex>
 ```
+
+The hook entry also includes a Windows-specific `commandWindows` value with
+native Windows command-line quoting for the same argv.
 
 Using the current Python executable keeps the hook tied to the installed
 ClawJournal environment rather than relying on whatever `clawjournal` binary

--- a/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
+++ b/OPENREFINERY_AGENT_FAILURE_SHARING_HOOKS.md
@@ -101,8 +101,8 @@ The POSIX hook command installed into both agents is:
 <python> -m clawjournal.cli hooks run openrefinery-failures --client <claude|codex>
 ```
 
-The hook entry also includes a Windows-specific `commandWindows` value with
-native Windows command-line quoting for the same argv.
+The Codex hook entry also includes a Windows-specific `commandWindows` value
+with native Windows command-line quoting for the same argv.
 
 Using the current Python executable keeps the hook tied to the installed
 ClawJournal environment rather than relying on whatever `clawjournal` binary

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -8,6 +8,7 @@ ClawJournal is designed to be usable without uploading anything.
 - The browser workbench is local. If you install from source, `clawjournal serve` opens your own machine at `localhost:8384`.
 - `bundle-export` writes files to disk. It does not contact a server.
 - If you never use the workbench Submit step, and never configure `CLAWJOURNAL_INGEST_URL` or run `bundle-share`, nothing is uploaded.
+- If you are explicitly enrolled in OpenRefinery Agent Failure Sharing, the optional agent hook only shows a local reminder and can open the existing Share workflow. The hook does not read transcripts, package bundles, or upload data by itself.
 
 ## Automatic redaction
 

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -1386,24 +1386,45 @@ def _resolve_share_id(conn, prefix: str) -> str | None:
 
 def _run_bundle_create(args) -> None:
     """Create a bundle from session IDs or by review status."""
-    from .workbench.index import create_share, open_index, query_sessions
+    from .workbench.index import (
+        create_share,
+        get_effective_share_settings,
+        open_index,
+        query_sessions,
+        source_scope_blockers,
+    )
 
     conn = open_index()
     try:
+        settings = get_effective_share_settings(conn, load_config())
         session_ids = list(args.session_ids) if args.session_ids else []
 
         if args.status and not session_ids:
-            sessions = query_sessions(conn, status=args.status, limit=10000)
+            sessions = query_sessions(
+                conn,
+                status=args.status,
+                source=settings.get("source_filter"),
+                limit=10000,
+            )
             session_ids = [s["session_id"] for s in sessions]
 
         if not session_ids:
             print("No sessions to bundle. Provide session IDs or use --status approved.")
+            sys.exit(1)
+        source_blockers = source_scope_blockers(
+            conn,
+            session_ids,
+            settings.get("source_filter"),
+        )
+        if source_blockers:
+            print("Some selected sessions are outside the confirmed source scope.")
             sys.exit(1)
 
         share_id = create_share(
             conn, session_ids,
             attestation=args.attestation,
             note=args.note,
+            source_filter=settings.get("source_filter"),
         )
         # Get actual count from DB (create_share only links IDs that exist)
         from .workbench.index import get_share
@@ -1542,6 +1563,7 @@ def _run_bundle_export(args) -> None:
         get_effective_share_settings,
         get_share,
         open_index,
+        source_scope_blockers,
     )
 
     config = load_config()
@@ -1567,6 +1589,14 @@ def _run_bundle_export(args) -> None:
         share = get_share(conn, share_id)
         if share is None:
             print(f"Bundle not found: {share_id}")
+            sys.exit(1)
+        source_blockers = source_scope_blockers(
+            conn,
+            [s["session_id"] for s in share.get("sessions") or []],
+            settings.get("source_filter"),
+        )
+        if source_blockers:
+            print("Bundle contains sessions outside the confirmed source scope.")
             sys.exit(1)
 
         export_dir, manifest = export_share_to_disk(
@@ -1867,6 +1897,7 @@ def _run_bundle_share(args) -> None:
             excluded_projects=settings["excluded_projects"],
             blocked_domains=settings["blocked_domains"],
             allowlist_entries=settings["allowlist_entries"],
+            source_filter=settings.get("source_filter"),
             ai_pii_review_enabled=getattr(args, "ai_pii_review", False) is True,
         )
         if result.get("ok"):
@@ -1902,6 +1933,7 @@ def _run_share(args) -> None:
         open_index,
         query_sessions,
         session_matches_excluded_projects,
+        source_scope_blockers,
     )
 
     config = load_config()
@@ -1913,7 +1945,12 @@ def _run_share(args) -> None:
 
         # Query once, reuse for both ID collection and preview
         if args.status and not session_ids:
-            session_rows = query_sessions(conn, status=args.status, limit=10000)
+            session_rows = query_sessions(
+                conn,
+                status=args.status,
+                source=settings.get("source_filter"),
+                limit=10000,
+            )
             session_ids = [s["session_id"] for s in session_rows]
         elif session_ids:
             placeholders = ", ".join("?" for _ in session_ids)
@@ -1929,6 +1966,14 @@ def _run_share(args) -> None:
             session for session in session_rows
             if not session_matches_excluded_projects(session, settings["excluded_projects"])
         ]
+        source_blockers = source_scope_blockers(
+            conn,
+            [s["session_id"] for s in session_rows],
+            settings.get("source_filter"),
+        )
+        if source_blockers:
+            print("Some selected sessions are outside the confirmed source scope.")
+            sys.exit(1)
 
         if not session_ids or not session_rows:
             print("No sessions to share. Provide session IDs or use --status approved.")
@@ -1950,7 +1995,12 @@ def _run_share(args) -> None:
         from .workbench.daemon import _prepare_share_export_for_upload
 
         pii_status = _print_share_pii_warning(output_json=getattr(args, "json", False))
-        share_id = create_share(conn, session_ids, note=args.note)
+        share_id = create_share(
+            conn,
+            session_ids,
+            note=args.note,
+            source_filter=settings.get("source_filter"),
+        )
         share = get_share(conn, share_id)
         if share is None:
             print("Share failed: newly created share could not be loaded.")

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -52,6 +52,7 @@ DEFAULT_CONFIG: ClawJournalConfig = {
 
 
 _KNOWN_PREFIXES = ("claude:", "codex:", "gemini:", "opencode:", "openclaw:", "kimi:", "cline:", "custom:")
+_BOTH_SOURCES = ("claude", "codex")
 
 
 def load_config() -> ClawJournalConfig:
@@ -80,6 +81,21 @@ def set_source_scope(config: ClawJournalConfig, source: str) -> None:
     if config.get("source") != source:
         config["projects_confirmed"] = False
     config["source"] = source
+
+
+def source_scope_sources(source: str | None) -> tuple[str, ...] | None:
+    """Return allowed session sources for a confirmed source scope.
+
+    ``None`` means unrestricted/all sources. Legacy ``both`` means the
+    original Claude+Codex pair, while ``all`` intentionally means every
+    supported indexed source.
+    """
+    normalized = (source or "").strip().lower()
+    if normalized in ("", "auto", "all"):
+        return None
+    if normalized == "both":
+        return _BOTH_SOURCES
+    return (normalized,)
 
 
 def _normalize_excluded_project_name(name: str) -> str:

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -203,13 +203,15 @@ def _hook_command_windows(client: AgentName) -> str:
 
 
 def _handler_for(client: AgentName) -> dict[str, Any]:
-    return {
+    handler = {
         "type": "command",
         "command": _hook_command(client),
-        "commandWindows": _hook_command_windows(client),
         "timeout": 30,
         "statusMessage": "Checking OpenRefinery failure-sharing reminder",
     }
+    if client == "codex":
+        handler["commandWindows"] = _hook_command_windows(client)
+    return handler
 
 
 def _handler_is_ours(handler: Any) -> bool:

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -181,9 +181,9 @@ def _codex_hooks_path(home: Path | None = None) -> Path:
     return _home_dir(home) / ".codex" / "hooks.json"
 
 
-def _hook_command(client: AgentName) -> str:
-    pieces = [
-        shlex.quote(sys.executable),
+def _hook_argv(client: AgentName) -> list[str]:
+    return [
+        sys.executable,
         "-m",
         "clawjournal.cli",
         "hooks",
@@ -192,13 +192,21 @@ def _hook_command(client: AgentName) -> str:
         "--client",
         client,
     ]
-    return " ".join(pieces)
+
+
+def _hook_command(client: AgentName) -> str:
+    return shlex.join(_hook_argv(client))
+
+
+def _hook_command_windows(client: AgentName) -> str:
+    return subprocess.list2cmdline(_hook_argv(client))
 
 
 def _handler_for(client: AgentName) -> dict[str, Any]:
     return {
         "type": "command",
         "command": _hook_command(client),
+        "commandWindows": _hook_command_windows(client),
         "timeout": 30,
         "statusMessage": "Checking OpenRefinery failure-sharing reminder",
     }

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -487,10 +487,21 @@ def select_queue_rows(rows: list[dict], settings: dict, args, *, limit: bool = T
     return out[:args.limit] if limit else out
 
 
+def _effective_source_filter(settings: dict, requested_source: str | None):
+    allowed = settings.get("source_filter")
+    if not requested_source:
+        return allowed
+    if allowed is None:
+        return requested_source
+    allowed_values = set(allowed if isinstance(allowed, (list, tuple)) else [allowed])
+    return requested_source if requested_source in allowed_values else "__no_matching_source__"
+
+
 def step_queue(conn, settings, args) -> list[dict]:
     step(1, "Queue — select traces")
     # Fetch recent candidates (so time windows are accurate), then rank by value.
-    candidates = query_sessions(conn, status=args.status, source=args.source,
+    source_filter = _effective_source_filter(settings, args.source)
+    candidates = query_sessions(conn, status=args.status, source=source_filter,
                                 limit=5000, sort="end_time", order="desc")
 
     # By default (like the web), score the in-window unscored traces on open so
@@ -517,7 +528,7 @@ def step_queue(conn, settings, args) -> list[dict]:
                 r["session_id"] for r in query_unscored_sessions(
                     conn,
                     limit=5000,
-                    source=args.source,
+                    source=source_filter,
                     settle_seconds=SCORE_SETTLE_SECONDS,
                     include_stale_scored=True,
                 )

--- a/clawjournal/share_flow.py
+++ b/clawjournal/share_flow.py
@@ -20,6 +20,7 @@ from .workbench.index import (
     create_share,
     get_share,
     release_gate_blockers,
+    source_scope_blockers,
 )
 
 # Wrapped daemon helpers — imported here so callers depend on share_flow, not on
@@ -214,7 +215,19 @@ def package(conn, session_ids: list[str], settings: dict, *, ai_pii: bool,
         {ok, share_id, export_dir, manifest, blocked_sessions, error}
     blocked_sessions is the list of sessions TruffleHog/PII blocked (for recovery).
     """
-    share_id = create_share(conn, session_ids, note=note)
+    source_blockers = source_scope_blockers(conn, session_ids, settings.get("source_filter"))
+    if source_blockers:
+        return {
+            "ok": False,
+            "error": "Share contains sessions outside the confirmed source scope",
+            "blockers": source_blockers,
+        }
+    share_id = create_share(
+        conn,
+        session_ids,
+        note=note,
+        source_filter=settings.get("source_filter"),
+    )
     share = get_share(conn, share_id)
     if share is None:
         return {"ok": False, "error": "Share row could not be loaded after creation."}

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -72,6 +72,7 @@ from .index import (
     remove_policy,
     search_fts,
     SCORE_SETTLE_SECONDS,
+    source_scope_blockers,
     update_session,
     upsert_sessions,
 )
@@ -1392,14 +1393,14 @@ def finalize_share_export_for_upload(
 
 
 def _redaction_settings_fingerprint(settings: dict[str, Any]) -> str:
-    """Stable hash of the redaction inputs that shape an exported bundle.
+    """Stable hash of the settings that shape an exported bundle.
 
     A finalized export is a point-in-time artifact, but it must only be reused
     while these inputs are unchanged. Editing the allowlist, custom redaction
-    strings/usernames, excluded projects, or blocked domains must force a
-    rebuild so a later seal/submit/download can never ship content redacted
-    under stale settings. `ai_pii` is intentionally excluded — it is gated
-    separately by ``_manifest_is_finalized_for_upload``.
+    strings/usernames, excluded projects, blocked domains, or confirmed source
+    scope must force a rebuild so a later seal/submit/download can never ship
+    content prepared under stale settings. `ai_pii` is intentionally excluded —
+    it is gated separately by ``_manifest_is_finalized_for_upload``.
 
     Order-independent: each list is normalized (handles str and dict entries)
     and sorted, so config/policy ordering differences do not change the hash.
@@ -1421,6 +1422,7 @@ def _redaction_settings_fingerprint(settings: dict[str, Any]) -> str:
         "excluded_projects": _norm(settings.get("excluded_projects")),
         "blocked_domains": _norm(settings.get("blocked_domains")),
         "allowlist_entries": _norm(settings.get("allowlist_entries")),
+        "source_filter": _norm(settings.get("source_filter")),
     }
     return hashlib.sha256(
         json.dumps(payload, sort_keys=True).encode("utf-8")
@@ -1483,8 +1485,8 @@ def _load_finalized_share_export(
         expected_fingerprint is not None
         and manifest.get("redaction_settings_fingerprint") != expected_fingerprint
     ):
-        # Redaction settings (allowlist / custom strings / excluded projects /
-        # blocked domains) changed since this export was sealed. Force a
+        # Settings (allowlist / custom strings / excluded projects / blocked
+        # domains / source scope) changed since this export was sealed. Force a
         # rebuild rather than reuse a stale-redacted artifact. Exports sealed
         # before this field existed have no fingerprint and so also rebuild once.
         return None
@@ -1505,6 +1507,14 @@ def _prepare_share_export_for_upload(
         if ai_pii_review_enabled is None
         else ai_pii_review_enabled
     )
+    session_ids = [s["session_id"] for s in share.get("sessions") or []]
+    source_blockers = source_scope_blockers(conn, session_ids, settings.get("source_filter"))
+    if source_blockers:
+        return None, {}, {
+            "error": "Share contains sessions outside the confirmed source scope",
+            "blockers": source_blockers,
+            "status": 409,
+        }
     settings_fingerprint = _redaction_settings_fingerprint(settings)
     if reuse_finalized:
         # Pass the RAW override (not effective_ai_pii) on purpose: a finalized
@@ -1563,6 +1573,7 @@ def upload_share_to_self_hosted_ingest(
     excluded_projects: list[str] | None = None,
     blocked_domains: list[str] | None = None,
     allowlist_entries: list[dict[str, Any]] | None = None,
+    source_filter: str | list[str] | tuple[str, ...] | None = None,
     ai_pii_review_enabled: bool = False,
 ) -> dict[str, Any]:
     """Upload a share to the legacy self-hosted ingest service.
@@ -1600,6 +1611,13 @@ def upload_share_to_self_hosted_ingest(
         return {
             "error": "Share contains sessions that are not released",
             "blockers": blockers,
+            "status": 409,
+        }
+    source_blockers = source_scope_blockers(conn, session_ids, source_filter)
+    if source_blockers:
+        return {
+            "error": "Share contains sessions outside the confirmed source scope",
+            "blockers": source_blockers,
             "status": 409,
         }
 
@@ -3225,6 +3243,7 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             stats = get_share_ready_stats(
                 conn,
                 excluded_projects=settings["excluded_projects"],
+                source_filter=settings.get("source_filter"),
                 include_unapproved=include_unapproved,
             )
             _json_response(self, stats)
@@ -3268,7 +3287,19 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                     "blockers": blockers,
                 }, 409)
                 return
-            share_id = create_share(conn, session_ids, note=note)
+            source_blockers = source_scope_blockers(conn, session_ids, settings.get("source_filter"))
+            if source_blockers:
+                _json_response(self, {
+                    "error": "Some selected sessions are outside the confirmed source scope.",
+                    "blockers": source_blockers,
+                }, 409)
+                return
+            share_id = create_share(
+                conn,
+                session_ids,
+                note=note,
+                source_filter=settings.get("source_filter"),
+            )
             share = get_share(conn, share_id)
             if share is None:
                 _json_response(self, {"error": "Share not found"}, 404)
@@ -3344,10 +3375,19 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             return
         conn = open_index()
         try:
+            settings = get_effective_share_settings(conn, load_config())
+            source_blockers = source_scope_blockers(conn, session_ids, settings.get("source_filter"))
+            if source_blockers:
+                _json_response(self, {
+                    "error": "Some selected sessions are outside the confirmed source scope.",
+                    "blockers": source_blockers,
+                }, 409)
+                return
             share_id = create_share(
                 conn, session_ids,
                 attestation=body.get("attestation"),
                 note=body.get("note"),
+                source_filter=settings.get("source_filter"),
             )
             _json_response(self, {"share_id": share_id, "bundle_id": share_id}, 201)
         finally:
@@ -3464,6 +3504,17 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                 return
 
             settings = get_effective_share_settings(conn, load_config())
+            source_blockers = source_scope_blockers(
+                conn,
+                [s["session_id"] for s in share.get("sessions") or []],
+                settings.get("source_filter"),
+            )
+            if source_blockers:
+                _json_response(self, {
+                    "error": "Share contains sessions outside the confirmed source scope",
+                    "blockers": source_blockers,
+                }, 409)
+                return
             export_dir, manifest = export_share_to_disk(
                 conn,
                 share_id,

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 from ..redaction.secrets import redact_text
 from ..scoring.badges import compute_all_badges
-from ..config import CONFIG_DIR, load_config, normalize_excluded_project_names
+from ..config import CONFIG_DIR, load_config, normalize_excluded_project_names, source_scope_sources
 from ..paths import ensure_install_files
 from ..pricing import estimate_cost
 
@@ -1036,6 +1036,8 @@ def get_effective_share_settings(
         "excluded_projects": _dedupe_strings(excluded_projects),
         "blocked_domains": _dedupe_strings(blocked_domains),
         "ai_pii_review_enabled": bool(resolved.get("ai_pii_review_enabled", False)),
+        "source_scope": resolved.get("source"),
+        "source_filter": source_scope_sources(resolved.get("source")),
     }
 
 
@@ -3584,6 +3586,7 @@ def create_share(
     session_ids: list[str],
     attestation: str | None = None,
     note: str | None = None,
+    source_filter: str | list[str] | tuple[str, ...] | None = None,
 ) -> str:
     """Create a share linking the given sessions.
 
@@ -3596,9 +3599,20 @@ def create_share(
     found_ids: set[str] = set()
     if session_ids:
         placeholders = ", ".join("?" for _ in session_ids)
+        source_clause = ""
+        params: list[Any] = list(session_ids)
+        if source_filter is not None:
+            if isinstance(source_filter, (list, tuple)):
+                values = [s for s in source_filter if s]
+                if values:
+                    source_clause = f" AND source IN ({','.join('?' for _ in values)})"
+                    params.extend(values)
+            else:
+                source_clause = " AND source = ?"
+                params.append(source_filter)
         rows = conn.execute(
-            f"SELECT session_id FROM sessions WHERE session_id IN ({placeholders})",
-            session_ids,
+            f"SELECT session_id FROM sessions WHERE session_id IN ({placeholders}){source_clause}",
+            params,
         ).fetchall()
         found_ids = {row["session_id"] for row in rows}
 
@@ -3624,6 +3638,39 @@ def create_share(
     return share_id
 
 
+def source_scope_blockers(
+    conn: sqlite3.Connection,
+    session_ids: list[str],
+    source_filter: str | list[str] | tuple[str, ...] | None,
+) -> list[dict[str, Any]]:
+    """Return selected sessions outside the confirmed share source scope."""
+    if not session_ids or source_filter is None:
+        return []
+    placeholders = ", ".join("?" for _ in session_ids)
+    params: list[Any] = list(session_ids)
+    if isinstance(source_filter, (list, tuple)):
+        values = [s for s in source_filter if s]
+        if not values:
+            return []
+        source_clause = f"source NOT IN ({','.join('?' for _ in values)})"
+        params.extend(values)
+        allowed = ", ".join(values)
+    else:
+        source_clause = "source != ?"
+        params.append(source_filter)
+        allowed = str(source_filter)
+    rows = conn.execute(
+        "SELECT session_id, project, source, display_title "
+        f"FROM sessions WHERE session_id IN ({placeholders}) AND {source_clause} "
+        "ORDER BY source, project, session_id",
+        params,
+    ).fetchall()
+    blockers = [dict(row) for row in rows]
+    for blocker in blockers:
+        blocker["allowed_sources"] = allowed
+    return blockers
+
+
 def get_shares(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     """List all shares ordered by creation time (newest first)."""
     rows = conn.execute(
@@ -3636,6 +3683,7 @@ def get_share_ready_stats(
     conn: sqlite3.Connection,
     *,
     excluded_projects: list[str] | None = None,
+    source_filter: str | list[str] | tuple[str, ...] | None = None,
     include_unapproved: bool = False,
 ) -> dict[str, Any]:
     """Return sessions that have not been shared before.
@@ -3646,7 +3694,21 @@ def get_share_ready_stats(
     ranked by failure value first so the share wizard starts with the best
     failure examples.
     """
-    where_status = "" if include_unapproved else " WHERE review_status = 'approved'"
+    where_clauses: list[str] = []
+    params: list[Any] = []
+    if not include_unapproved:
+        where_clauses.append("review_status = 'approved'")
+    if source_filter is not None:
+        if isinstance(source_filter, (list, tuple)):
+            values = [s for s in source_filter if s]
+            if values:
+                where_clauses.append(f"source IN ({','.join('?' for _ in values)})")
+                params.extend(values)
+        else:
+            where_clauses.append("source = ?")
+            params.append(source_filter)
+    where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
+    and_sql = " AND" if where_clauses else " WHERE"
     rows = conn.execute(
         "SELECT session_id, project, model, source, display_title,"
         " ai_quality_score, ai_failure_value_score, ai_recovery_labels,"
@@ -3655,8 +3717,8 @@ def get_share_ready_stats(
         f" input_tokens, output_tokens, ({_OUTCOME_NORMALIZE_SQL}) as outcome_badge, client_origin,"
         " runtime_channel, start_time, review_status, hold_state, embargo_until"
         " FROM sessions"
-        f"{where_status}"
-        f"{' AND' if where_status else ' WHERE'} session_id NOT IN ("
+        f"{where_sql}"
+        f"{and_sql} session_id NOT IN ("
         "   SELECT DISTINCT session_id FROM ("
         "     SELECT s.session_id AS session_id"
         "     FROM sessions s"
@@ -3671,7 +3733,8 @@ def get_share_ready_stats(
         " )"
         " ORDER BY (ai_failure_value_score IS NULL),"
         " ai_failure_value_score DESC, start_time DESC,"
-        " (review_status = 'approved') DESC, ai_quality_score DESC"
+        " (review_status = 'approved') DESC, ai_quality_score DESC",
+        params,
     ).fetchall()
     cols = ["session_id", "project", "model", "source", "display_title",
             "ai_quality_score", "ai_failure_value_score", "ai_recovery_labels",

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -429,6 +429,168 @@ class TestConfigure:
         assert "scoring_warmup_declined" not in load_config()
 
 
+class TestOpenRefineryCliDispatch:
+    def _skip_auto_update(self, monkeypatch):
+        monkeypatch.setattr("clawjournal.cli._should_auto_update", lambda argv=None: False)
+
+    def test_enroll_openrefinery_dispatches_to_hook_installer(self, monkeypatch, capsys):
+        from clawjournal import openrefinery_hooks
+
+        self._skip_auto_update(monkeypatch)
+        seen = {}
+
+        def fake_enroll_openrefinery(**kwargs):
+            seen.update(kwargs)
+            return {
+                "profile": "openrefinery-failures",
+                "update": {"status": "skipped"},
+                "install": {
+                    "installed": [{"agent": "codex"}],
+                    "state_path": "/tmp/state.json",
+                    "projects_confirmed": False,
+                },
+                "next": {
+                    "review": "clawjournal hooks launch openrefinery-failures",
+                    "project_confirmation": "confirm projects",
+                },
+            }
+
+        monkeypatch.setattr(openrefinery_hooks, "enroll_openrefinery", fake_enroll_openrefinery)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "clawjournal",
+                "enroll",
+                "openrefinery",
+                "--agent",
+                "codex",
+                "--ui",
+                "cli",
+                "--skip-selfupdate",
+                "--json",
+            ],
+        )
+
+        main()
+
+        assert seen == {"agent": "codex", "ui": "cli", "skip_selfupdate": True}
+        payload = json.loads(capsys.readouterr().out)
+        assert payload["profile"] == "openrefinery-failures"
+
+    @pytest.mark.parametrize(
+        ("argv_tail", "function_name", "result", "expected_kwargs"),
+        [
+            (
+                ["install", "openrefinery-failures", "--agent", "claude", "--ui", "web"],
+                "install_profile",
+                {"installed": [], "state_path": "/tmp/state.json"},
+                {"profile": "openrefinery-failures", "agent": "claude", "ui": "web"},
+            ),
+            (
+                ["status", "openrefinery-failures"],
+                "status",
+                {"enabled": True},
+                {"profile": "openrefinery-failures"},
+            ),
+            (
+                ["disable", "openrefinery-failures"],
+                "disable_profile",
+                {"enabled": False},
+                {"profile": "openrefinery-failures"},
+            ),
+            (
+                ["uninstall", "openrefinery-failures", "--agent", "codex"],
+                "uninstall_profile",
+                {"removed": [{"agent": "codex"}]},
+                {"profile": "openrefinery-failures", "agent": "codex"},
+            ),
+            (
+                ["snooze", "openrefinery-failures", "--days", "7"],
+                "snooze_profile",
+                {"snooze_until": "2026-07-01"},
+                {"profile": "openrefinery-failures", "days": 7},
+            ),
+            (
+                ["launch", "openrefinery-failures", "--ui", "cli", "--port", "9999", "--no-browser"],
+                "launch_share_flow",
+                {"mode": "cli", "message": "Run share"},
+                {"profile": "openrefinery-failures", "ui": "cli", "open_browser": False, "port": 9999},
+            ),
+        ],
+    )
+    def test_hooks_subcommands_dispatch_json(
+        self,
+        monkeypatch,
+        capsys,
+        argv_tail,
+        function_name,
+        result,
+        expected_kwargs,
+    ):
+        from clawjournal import openrefinery_hooks
+
+        self._skip_auto_update(monkeypatch)
+        seen = {}
+
+        def fake_command(**kwargs):
+            seen.update(kwargs)
+            return result
+
+        monkeypatch.setattr(openrefinery_hooks, function_name, fake_command)
+        monkeypatch.setattr(sys, "argv", ["clawjournal", "hooks", *argv_tail, "--json"])
+
+        main()
+
+        assert seen == expected_kwargs
+        assert json.loads(capsys.readouterr().out) == result
+
+    def test_hooks_run_dispatches_and_renders(self, monkeypatch, capsys):
+        from clawjournal import openrefinery_hooks
+
+        self._skip_auto_update(monkeypatch)
+        seen = {}
+
+        def fake_run_hook(**kwargs):
+            seen.update(kwargs)
+            return openrefinery_hooks.HookRunResult(True, "dry-run", "message")
+
+        def fake_render_hook_response(result, *, client, output_json):
+            assert result.reason == "dry-run"
+            assert client == "codex"
+            assert output_json is True
+            return '{"rendered": true}'
+
+        monkeypatch.setattr(openrefinery_hooks, "run_hook", fake_run_hook)
+        monkeypatch.setattr(openrefinery_hooks, "render_hook_response", fake_render_hook_response)
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "clawjournal",
+                "hooks",
+                "run",
+                "openrefinery-failures",
+                "--client",
+                "codex",
+                "--force",
+                "--dry-run",
+                "--json",
+            ],
+        )
+
+        main()
+
+        assert seen == {
+            "profile": "openrefinery-failures",
+            "client": "codex",
+            "force": True,
+            "dry_run": True,
+            "stop_hook_active": False,
+        }
+        assert json.loads(capsys.readouterr().out) == {"rendered": True}
+
+
 # --- list_projects ---
 
 

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -169,6 +169,20 @@ def test_hook_handler_includes_windows_command_override(monkeypatch):
     assert " --client codex" in handler["commandWindows"]
 
 
+def test_claude_hook_handler_omits_codex_windows_override(monkeypatch):
+    monkeypatch.setattr(
+        hooks.sys,
+        "executable",
+        r"C:\Program Files\Python313\python.exe",
+    )
+
+    handler = hooks._handler_for("claude")
+
+    assert "commandWindows" not in handler
+    assert handler["command"].startswith("'C:\\Program Files\\Python313\\python.exe'")
+    assert " --client claude" in handler["command"]
+
+
 def test_daily_hook_prompts_until_daily_limit(isolated_hook_env, monkeypatch):
     hooks.install_profile(agent="codex", ui="cli", home=isolated_hook_env / "home")
     now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -155,6 +155,20 @@ def test_install_profile_updates_existing_openrefinery_hook(isolated_hook_env, m
     ]
 
 
+def test_hook_handler_includes_windows_command_override(monkeypatch):
+    monkeypatch.setattr(
+        hooks.sys,
+        "executable",
+        r"C:\Program Files\Python313\python.exe",
+    )
+
+    handler = hooks._handler_for("codex")
+
+    assert handler["command"].startswith("'C:\\Program Files\\Python313\\python.exe'")
+    assert handler["commandWindows"].startswith('"C:\\Program Files\\Python313\\python.exe"')
+    assert " --client codex" in handler["commandWindows"]
+
+
 def test_daily_hook_prompts_until_daily_limit(isolated_hook_env, monkeypatch):
     hooks.install_profile(agent="codex", ui="cli", home=isolated_hook_env / "home")
     now = datetime(2026, 6, 21, 12, 0, tzinfo=timezone.utc)

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -1078,6 +1078,41 @@ class TestSharesAPI:
         status, data = _post(server, "/api/shares", {"session_ids": []})
         assert status == 400
 
+    def test_create_rejects_sessions_outside_configured_source_scope(self, server, monkeypatch):
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: {"source": "both", "projects_confirmed": True},
+        )
+        conn = open_index()
+        try:
+            upsert_sessions(conn, [{
+                "session_id": "gemini-out",
+                "project": "gemini:private",
+                "source": "gemini",
+                "model": "gemini-cli",
+                "start_time": "2025-01-04T00:00:00+00:00",
+                "end_time": "2025-01-04T00:10:00+00:00",
+                "messages": [{"role": "user", "content": "private", "tool_uses": []}],
+                "stats": {
+                    "user_messages": 1,
+                    "assistant_messages": 0,
+                    "tool_uses": 0,
+                    "input_tokens": 10,
+                    "output_tokens": 0,
+                },
+            }])
+        finally:
+            conn.close()
+
+        status, data = _post(server, "/api/shares", {
+            "session_ids": ["sess-0", "gemini-out"],
+            "note": "Source scope test",
+        })
+
+        assert status == 409
+        assert "source scope" in data["error"]
+        assert [b["session_id"] for b in data["blockers"]] == ["gemini-out"]
+
 
 class TestPoliciesAPI:
     def test_add_and_list(self, server):

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -27,6 +27,7 @@ from clawjournal.workbench.index import (
     remove_policy,
     search_fts,
     session_matches_excluded_projects,
+    source_scope_blockers,
     set_hold_state,
     update_session,
     upsert_sessions,
@@ -1123,7 +1124,61 @@ class TestShares:
         )
 
         assert [s["session_id"] for s in stats["sessions"]] == ["public"]
-        assert stats["recommended_session_ids"] == ["public"]
+
+    def test_share_ready_respects_source_scope(self, index_conn):
+        from datetime import datetime, timedelta, timezone
+        now = datetime.now(timezone.utc)
+        upsert_sessions(index_conn, [
+            _make_session(
+                "claude-ok",
+                source="claude",
+                start_time=(now - timedelta(days=2)).isoformat(),
+            ),
+            _make_session(
+                "codex-ok",
+                source="codex",
+                start_time=(now - timedelta(days=1)).isoformat(),
+            ),
+            _make_session(
+                "gemini-out",
+                source="gemini",
+                start_time=now.isoformat(),
+            ),
+        ])
+        for sid in ("claude-ok", "codex-ok", "gemini-out"):
+            update_session(
+                index_conn,
+                sid,
+                status="approved",
+                ai_quality_score=5,
+                ai_failure_value_score=5,
+            )
+
+        stats = get_share_ready_stats(index_conn, source_filter=("claude", "codex"))
+
+        assert {s["session_id"] for s in stats["sessions"]} == {"claude-ok", "codex-ok"}
+        assert "gemini-out" not in stats["recommended_session_ids"]
+
+    def test_create_share_can_enforce_source_scope(self, index_conn):
+        upsert_sessions(index_conn, [
+            _make_session("claude-ok", source="claude"),
+            _make_session("gemini-out", source="gemini"),
+        ])
+
+        blockers = source_scope_blockers(
+            index_conn,
+            ["claude-ok", "gemini-out"],
+            ("claude", "codex"),
+        )
+        share_id = create_share(
+            index_conn,
+            ["claude-ok", "gemini-out"],
+            source_filter=("claude", "codex"),
+        )
+
+        assert [b["session_id"] for b in blockers] == ["gemini-out"]
+        share = get_share(index_conn, share_id)
+        assert [s["session_id"] for s in share["sessions"]] == ["claude-ok"]
 
     def test_exclusion_matches_legacy_claude_hyphenated_name(self):
         session = {


### PR DESCRIPTION
## Summary
- enforce confirmed source scope in share queues, share creation, export, and upload preparation
- add Windows-safe commandWindows hook commands while preserving POSIX command output
- add CLI dispatch smoke tests for OpenRefinery enroll/hooks subcommands
- disclose OpenRefinery enrollment reminders in PRIVACY.md and update hook docs

## Validation
- python -m py_compile clawjournal/config.py clawjournal/workbench/index.py clawjournal/workbench/daemon.py clawjournal/share_flow.py clawjournal/share_cli.py clawjournal/openrefinery_hooks.py clawjournal/cli.py tests/test_cli.py tests/test_openrefinery_hooks.py tests/workbench/test_index.py tests/workbench/test_daemon.py
- python -m pytest tests/test_openrefinery_hooks.py tests/test_cli.py::TestOpenRefineryCliDispatch tests/workbench/test_index.py::TestShares tests/workbench/test_daemon.py::TestSharesAPI -q
- python -m pytest tests/test_openrefinery_hooks.py tests/test_cli.py tests/workbench/test_index.py tests/workbench/test_daemon.py -q
- python -m pytest tests/events/export tests/workbench/test_share_gates.py tests/test_openrefinery_hooks.py tests/test_cli.py -q
- python -m pytest -q