### PR TITLE
[codex] fix parser utf8 decoding

### DIFF
--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -122,7 +122,7 @@ def _extract_project_path_from_sessions(project_hash: str) -> str | None:
         return None
     for session_file in sorted(chats_dir.glob("session-*.json"), reverse=True):
         try:
-            data = json.loads(session_file.read_text())
+            data = json.loads(session_file.read_text(encoding="utf-8", errors="replace"))
         except (json.JSONDecodeError, OSError):
             continue
         for msg in data.get("messages", []):
@@ -164,7 +164,7 @@ def _resolve_gemini_hash(project_hash: str) -> str:
 
 def _iter_jsonl(filepath: Path):
     """Yield parsed JSON objects from a JSONL file, skipping blank/malformed lines."""
-    with open(filepath) as f:
+    with open(filepath, encoding="utf-8", errors="replace") as f:
         for line in f:
             line = line.strip()
             if not line:
@@ -218,7 +218,7 @@ def _scan_workspace_dir(workspace_dir: Path, groups: dict[str, list[dict]]) -> N
             continue
 
         try:
-            wrapper = json.loads(entry.read_text())
+            wrapper = json.loads(entry.read_text(encoding="utf-8", errors="replace"))
         except (json.JSONDecodeError, OSError):
             continue
         if not isinstance(wrapper, dict):
@@ -558,7 +558,7 @@ def _load_kimi_work_dirs() -> dict[str, str]:
     if not KIMI_CONFIG_PATH.exists():
         return {}
     try:
-        data = json.loads(KIMI_CONFIG_PATH.read_text())
+        data = json.loads(KIMI_CONFIG_PATH.read_text(encoding="utf-8", errors="replace"))
         work_dirs = data.get("work_dirs", [])
         return {
             entry.get("path", ""): entry.get("path", "")
@@ -645,7 +645,11 @@ def _discover_custom_projects() -> list[dict]:
         for f in jsonl_files:
             total_size += f.stat().st_size
             try:
-                session_count += sum(1 for line in f.open() if line.strip())
+                session_count += sum(
+                    1
+                    for line in f.open(encoding="utf-8", errors="replace")
+                    if line.strip()
+                )
             except OSError:
                 pass
         if session_count == 0:
@@ -674,7 +678,10 @@ def _parse_custom_sessions(
     sessions = []
     for jsonl_file in sorted(project_path.glob("*.jsonl")):
         try:
-            for line_num, line in enumerate(jsonl_file.open(), 1):
+            for line_num, line in enumerate(
+                jsonl_file.open(encoding="utf-8", errors="replace"),
+                1,
+            ):
                 line = line.strip()
                 if not line:
                     continue
@@ -1324,7 +1331,7 @@ def _parse_gemini_session_file(
     filepath: Path, anonymizer: Anonymizer, include_thinking: bool = True
 ) -> dict | None:
     try:
-        with open(filepath) as f:
+        with open(filepath, encoding="utf-8", errors="replace") as f:
             data = json.load(f)
     except (OSError, json.JSONDecodeError):
         return None
@@ -2391,7 +2398,7 @@ def _build_openclaw_project_index() -> dict[str, list[Path]]:
 def _extract_openclaw_cwd(session_file: Path) -> str | None:
     """Read the first line (session header) of an OpenClaw JSONL file to extract cwd."""
     try:
-        with open(session_file) as f:
+        with open(session_file, encoding="utf-8", errors="replace") as f:
             first_line = f.readline().strip()
             if not first_line:
                 return None
@@ -2972,7 +2979,7 @@ def _discover_aider_projects() -> list[dict]:
             continue
         # Estimate session count from markdown headers
         try:
-            content = history_file.read_text(errors="replace")
+            content = history_file.read_text(encoding="utf-8", errors="replace")
             session_count = max(
                 1,
                 len(re.findall(r"^# aider chat started at .+$", content, flags=re.MULTILINE)),
@@ -3005,7 +3012,7 @@ def _parse_aider_history_file(
     are plain text.
     """
     try:
-        content = filepath.read_text(errors="replace")
+        content = filepath.read_text(encoding="utf-8", errors="replace")
     except OSError:
         return []
 

--- a/tests/parsing/test_parser.py
+++ b/tests/parsing/test_parser.py
@@ -16,6 +16,7 @@ from clawjournal.parsing.parser import (
     _extract_model_effort,
     _extract_user_content,
     _find_subagent_only_sessions,
+    _iter_jsonl,
     _normalize_timestamp,
     _parse_session_file,
     _parse_subagent_session,
@@ -28,6 +29,27 @@ from clawjournal.parsing.parser import (
     _parse_codex_session_file,
     _parse_openclaw_session_file,
 )
+
+
+def test_iter_jsonl_reads_utf8_explicitly(tmp_path, monkeypatch):
+    path = tmp_path / "session.jsonl"
+    payload = {"message": "research note with Cyrillic: с"}
+    path.write_bytes((json.dumps(payload, ensure_ascii=False) + "\n").encode("utf-8"))
+
+    import builtins
+
+    real_open = builtins.open
+    seen_encodings = []
+
+    def open_spy(file, *args, **kwargs):
+        if file == path:
+            seen_encodings.append(kwargs.get("encoding"))
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", open_spy)
+
+    assert list(_iter_jsonl(path)) == [payload]
+    assert seen_encodings == ["utf-8"]
 
 
 class TestExtractModelEffort:


### PR DESCRIPTION
## Summary

Fix parser file reads so ClawJournal consistently decodes session logs as UTF-8 instead of falling back to the platform locale.

## Why

On Windows, Python can default text reads to cp1252 when UTF-8 mode is not enabled. That can cause scan/serve paths to skip or under-index traces containing UTF-8 characters, while commands run with `PYTHONUTF8=1` see the expected trace count.

## Changes

- Add explicit `encoding="utf-8"` plus replacement handling to parser JSON, JSONL, and markdown session reads.
- Add a parser regression test that asserts the JSONL iterator opens files with UTF-8 and preserves non-ASCII content.

## Validation

- `PYTHONPATH=. /opt/miniconda3/bin/pytest tests/parsing/test_parser.py -q`
- `PYTHONPATH=. /opt/miniconda3/bin/pytest tests/test_selfupdate.py -q`
- `PYTHONPATH=. /opt/miniconda3/bin/pytest tests/events/test_invariants.py -q`
- `git diff --check`
- Synthetic end-to-end smoke with disposable `HOME`: seeded a fake Claude trace containing `café 測試 с عربى 😀`, ran `clawjournal scan --source claude`, started `clawjournal serve --no-browser --source claude`, queried `/api/stats` and `/api/sessions`, and verified one indexed Claude session with one user and one assistant message.
- Real-data end-to-end run on the local machine, without `PYTHONUTF8`: `clawjournal list --source all` discovered 413 real source sessions; `clawjournal scan` indexed 32 new real sessions and reported 653 total indexed sessions; `clawjournal serve --no-browser` on the real index returned `/api/stats` total 653 and `/api/sessions?limit=10000` returned 653 rows with matching source counts (`claude: 422`, `codex: 231`). A non-ASCII source-file cross-check found 340 real source logs containing non-ASCII bytes; 293 were present in the serve API, and the remainder were accounted for as intentional non-session exclusions (slash-command-only Claude logs such as `/login`/`/exit`) or older Codex logs that parse as unsupported/no-session under the current parser.