### PR TITLE
Fix TruffleHog subprocess env on Windows

### DIFF
--- a/clawjournal/redaction/trufflehog.py
+++ b/clawjournal/redaction/trufflehog.py
@@ -46,6 +46,9 @@ def _scrubbed_subprocess_env() -> dict[str, str]:
 
     - ``PATH`` to exec helpers
     - ``HOME`` / ``TMPDIR`` for config + workspace
+    - Windows' ``SystemRoot`` / temp / profile vars; without
+      ``SystemRoot`` Go-built TruffleHog can exit before producing
+      JSON on Windows even for a clean scan
     - locale vars for UTF-8 decoding
     - **Network trust**: ``SSL_CERT_FILE`` / ``SSL_CERT_DIR`` so
       verification against provider APIs works on distros that rely
@@ -56,6 +59,8 @@ def _scrubbed_subprocess_env() -> dict[str, str]:
     """
     keep = (
         "PATH", "HOME", "TMPDIR",
+        "SystemRoot", "WINDIR", "TEMP", "TMP",
+        "USERPROFILE", "LOCALAPPDATA", "APPDATA",
         "LANG", "LC_ALL", "LC_CTYPE",
         "SSL_CERT_FILE", "SSL_CERT_DIR",
         "HTTP_PROXY", "HTTPS_PROXY", "NO_PROXY",

--- a/tests/redaction/test_trufflehog.py
+++ b/tests/redaction/test_trufflehog.py
@@ -851,11 +851,17 @@ class TestSubprocessHardening:
         monkeypatch.setenv("OPENAI_API_KEY", "sk-mustnotleak")
         monkeypatch.setenv("PATH", "/usr/bin:/bin")
         monkeypatch.setenv("HOME", "/home/u")
+        monkeypatch.setenv("SystemRoot", r"C:\Windows")
+        monkeypatch.setenv("TEMP", r"C:\Users\u\AppData\Local\Temp")
         env = trufflehog._scrubbed_subprocess_env()
         assert "ANTHROPIC_API_KEY" not in env
         assert "OPENAI_API_KEY" not in env
         assert env.get("PATH") == "/usr/bin:/bin"
         assert env.get("HOME") == "/home/u"
+        # Windows needs SystemRoot in a replaced subprocess environment;
+        # without it TruffleHog can exit 1 before producing JSON.
+        assert env.get("SystemRoot") == r"C:\Windows"
+        assert env.get("TEMP") == r"C:\Users\u\AppData\Local\Temp"
 
     def test_payload_streams_via_stdin_not_tempfile(self, tmp_path, monkeypatch):
         monkeypatch.delenv(trufflehog.SKIP_ENV_VAR, raising=False)


### PR DESCRIPTION
Under windows: Unexpected Packaging failed error 1 at the end. 
Fix:
Added Windows-safe runtime vars to the TruffleHog subprocess allowlist in trufflehog.py
Added regression coverage in test_trufflehog.py
<img width="646" height="450" alt="image" src="https://github.com/user-attachments/assets/7deaa049-f82e-4353-8824-f03ff39ebd6d" />
