### PR TITLE
feat(skill): widen the installed lesson set to 10 rules (distill still proposes 5)

### DIFF
--- a/clawjournal/cli_skill.py
+++ b/clawjournal/cli_skill.py
@@ -21,7 +21,7 @@ from .skill import render as _render
 from .skill import select as _select
 from .skill import store as _store
 from .skill import turns as _turns
-from .skill.schema import MAX_RULES, SkillRule
+from .skill.schema import MAX_INSTALLED_RULES, SkillRule
 from .workbench.index import FAILURE_VALUE_SOURCE_SCOPE
 
 # A wide window approximates "all history" for the first run.
@@ -31,7 +31,7 @@ DEFAULT_SCORE_LIMIT = 25
 
 @dataclass
 class SkillResult:
-    rules: list[SkillRule]          # the merged top-<=5 to install
+    rules: list[SkillRule]          # the merged top-<=MAX_INSTALLED_RULES to install
     skill_md: str
     region: str
     blocked: list[tuple[SkillRule, list[str]]]
@@ -177,7 +177,7 @@ def _semantic_dedup(ranked: list[SkillRule], new_fps: set[str]) -> list[SkillRul
 
 def merge_rules(existing: list[SkillRule], new: list[SkillRule], rejected: set[str],
                 *, now: datetime | None = None) -> list[SkillRule]:
-    """Merge existing + newly-distilled rules -> top-<=5 (replace the weakest).
+    """Merge existing + newly-distilled rules -> top-<=10 installed (replace the weakest).
 
     Deduped by fingerprint; rejected fingerprints dropped; ranked by RECENCY-WEIGHTED
     support (so stale peaks decay) then recurred-this-run. **Interleaved across kinds**
@@ -216,10 +216,10 @@ def merge_rules(existing: list[SkillRule], new: list[SkillRule], rejected: set[s
     do = [r for r in deduped if r.kind == "do"]
     out: list[SkillRule] = []
     ai = di = 0
-    while len(out) < MAX_RULES and (ai < len(avoid) or di < len(do)):
+    while len(out) < MAX_INSTALLED_RULES and (ai < len(avoid) or di < len(do)):
         if ai < len(avoid):
             out.append(avoid[ai]); ai += 1
-        if len(out) < MAX_RULES and di < len(do):
+        if len(out) < MAX_INSTALLED_RULES and di < len(do):
             out.append(do[di]); di += 1
     return out
 

--- a/clawjournal/skill/__init__.py
+++ b/clawjournal/skill/__init__.py
@@ -10,6 +10,6 @@ distill call -> render <=5 rules -> deterministic gate -> preview -> install a
 See ``docs/self-improving-skills/plan.md`` (Mode A) for the design.
 """
 
-from .schema import MAX_RULES, SkillRule
+from .schema import MAX_INSTALLED_RULES, MAX_RULES, SkillRule
 
-__all__ = ["MAX_RULES", "SkillRule"]
+__all__ = ["MAX_INSTALLED_RULES", "MAX_RULES", "SkillRule"]

--- a/clawjournal/skill/schema.py
+++ b/clawjournal/skill/schema.py
@@ -17,8 +17,15 @@ import re
 from dataclasses import dataclass, field
 from typing import Any
 
-# Hard cap. Too many skills are unmanageable; 5 keeps review/use/maintenance sane.
+# Per-DISTILL cap: each run's single LLM call proposes at most this many fresh
+# rules — a small ask keeps the distiller focused on the window's strongest lessons.
 MAX_RULES = 5
+
+# INSTALLED-set cap: the durable merged set the user's agents load. Wider than the
+# per-run cap so lessons accumulate across weekly runs instead of churning — a rule
+# only leaves when decayed support ranks it below a newer lesson, not because one
+# run's 5 slots filled up. 10 rules ≈ a screen of text; still reviewable.
+MAX_INSTALLED_RULES = 10
 
 VALID_KINDS = ("avoid", "do")
 

--- a/tests/skill/test_merge.py
+++ b/tests/skill/test_merge.py
@@ -1,8 +1,8 @@
-"""Merge loop (§9): cap-5, dedupe, replace-weakest, skip-rejected."""
+"""Merge loop (§9): installed cap, dedupe, replace-weakest, skip-rejected."""
 
 from clawjournal.cli_skill import merge_rules
 from clawjournal.skill import store
-from clawjournal.skill.schema import MAX_RULES, SkillRule
+from clawjournal.skill.schema import MAX_INSTALLED_RULES, SkillRule
 
 
 def _tr(g, *, taxonomy="", support=0, kind="avoid"):
@@ -88,11 +88,11 @@ def _r(g, support=0, kind="avoid"):
     return SkillRule(kind=kind, trigger="t", guidance=g, why="w", support=support)
 
 
-def test_caps_at_five_by_support():
+def test_caps_installed_set_by_support():
     # distinct wording per rule so the paraphrase dedup doesn't collapse them
-    merged = merge_rules([], [_r(f"topic{i} action{i} lesson", support=i) for i in range(8)], set())
-    assert len(merged) == MAX_RULES
-    assert [r.support for r in merged] == [7, 6, 5, 4, 3]
+    merged = merge_rules([], [_r(f"topic{i} action{i} lesson", support=i) for i in range(13)], set())
+    assert len(merged) == MAX_INSTALLED_RULES
+    assert [r.support for r in merged] == list(range(12, 2, -1))   # top 10 by support
 
 
 def test_dedupe_prefers_higher_support():
@@ -106,12 +106,12 @@ def test_rejected_excluded():
 
 
 def test_replace_weakest():
-    existing = [_r(f"weak{i} old{i} habit", support=1) for i in range(5)]   # 5 distinct weak
+    existing = [_r(f"weak{i} old{i} habit", support=1) for i in range(MAX_INSTALLED_RULES)]
     merged = merge_rules(existing, [_r("strong brandnew distinct lesson", support=10)], set())
-    assert len(merged) == MAX_RULES
+    assert len(merged) == MAX_INSTALLED_RULES
     guides = {r.guidance for r in merged}
     assert "strong brandnew distinct lesson" in guides
-    assert sum(g.startswith("weak") for g in guides) == 4        # one weak one displaced
+    assert sum(g.startswith("weak") for g in guides) == MAX_INSTALLED_RULES - 1  # one displaced
 
 
 def test_recency_decays_stale_support_below_fresh():
@@ -137,13 +137,13 @@ def test_merge_rules_tolerates_naive_now():
 def test_preserves_good_bad_mix():
     # 'avoid' rules carry high mode-recurrence support; 'do' rules get support=0.
     # A support-only merge would drop every 'do'; the interleave must keep both (D2).
-    avoid = [_r(f"badhabit{i} mistake{i} pitfall", support=50, kind="avoid") for i in range(5)]
+    avoid = [_r(f"badhabit{i} mistake{i} pitfall", support=50, kind="avoid") for i in range(9)]
     do = [_r("alpha task workflow", support=0, kind="do"), _r("bravo chore routine", support=0, kind="do")]
     merged = merge_rules([], avoid + do, set())
     kinds = [r.kind for r in merged]
-    assert len(merged) == MAX_RULES
-    assert kinds.count("do") >= 1 and kinds.count("avoid") >= 1   # both kinds survive
-    assert kinds == ["avoid", "do", "avoid", "do", "avoid"]       # interleaved
+    assert len(merged) == MAX_INSTALLED_RULES                     # 9 avoid + 2 do -> capped
+    assert kinds.count("do") == 2 and kinds.count("avoid") == 8   # both kinds survive
+    assert kinds[:4] == ["avoid", "do", "avoid", "do"]            # interleaved head
 
 
 def test_cross_kind_title_extension_collapses():


### PR DESCRIPTION
Follow-up to #95. Splits the single MAX_RULES cap into its two real jobs:

- `MAX_RULES = 5` stays the per-distill cap — each run's one LLM call proposes at most 5 fresh rules, keeping it focused on the window's strongest lessons.
- `MAX_INSTALLED_RULES = 10` is the durable merged set the agents load.

The 5-slot install cap was the churn engine: every run's strongest lessons displaced still-valid ones, and mid-support candidates (e.g. the human-rejection lesson, support 10) could never win a slot. With 10 slots, lessons accumulate across weekly runs and leave only when decayed support ranks them out; the good/bad interleave keeps the avoid/do mix at any size.

First regeneration on the new cap installed 7 rules — including "Ask Before Risky Actions" (grounded in 25 auto-rejected attempts across 8 sessions) and the previously-churned adversarial-review lesson — with zero duplicates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnzqCuYZudab6cSjAgZvfE