### PR TITLE
[codex] Add Claude Science trace ingest

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ClawJournal
 
-Review and curate your coding-agent session traces — 100% locally. ClawJournal scans session logs from Claude Code, Claude Desktop, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline, anonymizes secrets and personal information, and gives you a browser workbench to review everything before it ever leaves your machine.
+Review and curate your coding-agent session traces — 100% locally. ClawJournal scans session logs from Claude Code, Claude Desktop, Claude Science, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline, anonymizes secrets and personal information, and gives you a browser workbench to review everything before it ever leaves your machine.
 
 ## Copy-paste prompts
 
@@ -173,7 +173,7 @@ Tell ClawJournal which agents to scan and what to exclude or redact.
 <summary><b>Show shell commands</b></summary>
 
 ```bash
-clawjournal config --source all                   # claude | codex | gemini | opencode | openclaw | kimi | custom | all
+clawjournal config --source all                   # claude | claude-science | codex | gemini | opencode | openclaw | kimi | custom | all
 clawjournal list                                  # see discovered projects
 clawjournal config --exclude "project1,project2"  # optional (appends)
 clawjournal config --redact "string1,string2"     # optional custom redactions (appends)
@@ -416,7 +416,7 @@ Each line of the exported JSONL is one session: `session_id`, `project`, `model`
 
 ## Supported agents
 
-Claude Code, Claude Desktop, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline.
+Claude Code, Claude Desktop, Claude Science, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline.
 
 ## Project docs
 

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -21,7 +21,22 @@ from .config import (
     save_config,
     set_source_scope,
 )
-from .parsing.parser import CLAUDE_DIR, CODEX_DIR, COPILOT_DIR, CURSOR_DIR, CUSTOM_DIR, GEMINI_DIR, KIMI_DIR, LOCAL_AGENT_DIR, OPENCODE_DIR, OPENCLAW_DIR, discover_projects, parse_project_sessions
+from .parsing.parser import (
+    CLAUDE_DIR,
+    CLAUDE_SCIENCE_DIR,
+    CLAUDE_SCIENCE_SOURCE,
+    CODEX_DIR,
+    COPILOT_DIR,
+    CURSOR_DIR,
+    CUSTOM_DIR,
+    GEMINI_DIR,
+    KIMI_DIR,
+    LOCAL_AGENT_DIR,
+    OPENCODE_DIR,
+    OPENCLAW_DIR,
+    discover_projects,
+    parse_project_sessions,
+)
 from .scoring.backends import BACKEND_CHOICES, DEFAULT_CLAUDE_MODEL, DEFAULT_CODEX_MODEL
 from .redaction.pii import apply_findings_to_session, load_findings, load_jsonl_sessions, review_session_pii, review_session_pii_hybrid, review_session_pii_with_agent, write_findings, write_jsonl_sessions
 from .scoring.scoring import SCORING_BACKEND_CHOICES
@@ -61,18 +76,18 @@ EXPORT_REVIEW_PUBLISH_STEPS = [
 
 SETUP_TO_PUBLISH_STEPS = [
     "Step 1/5: Run prep/list to review project scope: clawjournal prep && clawjournal list",
-    "Step 2/5: Explicitly choose source scope: clawjournal config --source <claude|codex|gemini|all>",
+    "Step 2/5: Explicitly choose source scope: clawjournal config --source <claude|claude-science|codex|gemini|all>",
     "Step 3/5: Configure exclusions/redactions and confirm projects: clawjournal config ...",
     "Step 4/5: Export locally: clawjournal export --output /tmp/clawjournal_export.jsonl",
     "Step 5/5: Review and confirm: clawjournal confirm ...",
 ]
 
-EXPLICIT_SOURCE_CHOICES = {"claude", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "all", "both"}
-SOURCE_CHOICES = ["auto", "claude", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "all", "both"]
-WORKBENCH_SOURCE_CHOICES = ["claude", "codex", "opencode", "openclaw", "cursor", "copilot", "aider", "gemini", "kimi"]
+EXPLICIT_SOURCE_CHOICES = {"claude", "claude-science", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "all", "both"}
+SOURCE_CHOICES = ["auto", "claude", "claude-science", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "all", "both"]
+WORKBENCH_SOURCE_CHOICES = ["claude", "claude-science", "codex", "opencode", "openclaw", "cursor", "copilot", "aider", "gemini", "kimi"]
 EVENT_SOURCE_CHOICES = ["auto", "claude", "codex", "openclaw", "all"]
 PII_PROVIDER_CHOICES = ("rules", "ai", "hybrid")
-FAILURE_VALUE_SOURCE_SCOPE = ("claude", "codex", "opencode", "openclaw")
+FAILURE_VALUE_SOURCE_SCOPE = ("claude", "claude-science", "codex", "opencode", "openclaw")
 SCORE_SOURCE_CHOICES = set(WORKBENCH_SOURCE_CHOICES) | {"failure-corpus", "failure-v1", "all", "auto", "both"}
 
 
@@ -144,6 +159,8 @@ def _source_label(source_filter: str) -> str:
         return "Claude Code and Codex"
     if source_filter == "claude":
         return "Claude Code"
+    if source_filter == CLAUDE_SCIENCE_SOURCE:
+        return "Claude Science"
     if source_filter == "codex":
         return "Codex"
     if source_filter == "gemini":
@@ -162,7 +179,7 @@ def _source_label(source_filter: str) -> str:
         return "Aider"
     if source_filter == "custom":
         return "Custom"
-    return "Claude Code, Codex, Cursor, Copilot CLI, Aider, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, or Custom"
+    return "Claude Code, Claude Science, Codex, Cursor, Copilot CLI, Aider, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, or Custom"
 
 
 def _normalize_source_filter(source_filter: str) -> str:
@@ -198,6 +215,8 @@ def _has_session_sources(source_filter: str = "auto") -> bool:
     source_filter = _normalize_source_filter(source_filter)
     if source_filter == "claude":
         return CLAUDE_DIR.exists() or LOCAL_AGENT_DIR.exists()
+    if source_filter == CLAUDE_SCIENCE_SOURCE:
+        return CLAUDE_SCIENCE_DIR.exists()
     if source_filter == "codex":
         return CODEX_DIR.exists()
     if source_filter == "both":
@@ -219,7 +238,7 @@ def _has_session_sources(source_filter: str = "auto") -> bool:
     if source_filter == "aider":
         from .parsing.parser import _get_aider_project_index
         return bool(_get_aider_project_index())
-    return CLAUDE_DIR.exists() or LOCAL_AGENT_DIR.exists() or CODEX_DIR.exists() or CUSTOM_DIR.exists() or GEMINI_DIR.exists() or KIMI_DIR.exists() or OPENCODE_DIR.exists() or OPENCLAW_DIR.exists() or CURSOR_DIR.exists() or COPILOT_DIR.exists()
+    return CLAUDE_DIR.exists() or LOCAL_AGENT_DIR.exists() or CLAUDE_SCIENCE_DIR.exists() or CODEX_DIR.exists() or CUSTOM_DIR.exists() or GEMINI_DIR.exists() or KIMI_DIR.exists() or OPENCODE_DIR.exists() or OPENCLAW_DIR.exists() or CURSOR_DIR.exists() or COPILOT_DIR.exists()
 
 
 def _filter_projects_by_source(projects: list[dict], source_filter: str) -> list[dict]:
@@ -280,14 +299,14 @@ def _build_status_next_steps(
         steps = []
         if not source_confirmed:
             steps.append(
-                "Ask the user to explicitly choose export source scope: Claude Code, Codex, Gemini, or all. "
-                "Then set it: clawjournal config --source <claude|codex|gemini|all>. "
+                "Ask the user to explicitly choose export source scope: Claude Code, Claude Science, Codex, Gemini, or all. "
+                "Then set it: clawjournal config --source <claude|claude-science|codex|gemini|all>. "
                 "Do not run export until source scope is explicitly confirmed."
             )
         else:
             steps.append(
                 f"Source scope is currently set to '{configured_source}'. "
-                "If the user wants a different scope, run: clawjournal config --source <claude|codex|gemini|all>."
+                "If the user wants a different scope, run: clawjournal config --source <claude|claude-science|codex|gemini|all>."
             )
         if not projects_confirmed:
             steps.append(
@@ -1140,13 +1159,15 @@ def prep(source_filter: str = "auto") -> None:
     if not _has_session_sources(effective_source_filter):
         if effective_source_filter == "claude":
             err = "~/.claude was not found."
+        elif effective_source_filter == CLAUDE_SCIENCE_SOURCE:
+            err = "~/.claude-science was not found."
         elif effective_source_filter == "codex":
             err = "~/.codex was not found."
         elif effective_source_filter == "gemini":
             from .parsing.parser import GEMINI_DIR
             err = f"{GEMINI_DIR} was not found."
         else:
-            err = "None of ~/.claude, ~/.codex, or ~/.gemini/tmp were found."
+            err = "None of ~/.claude, ~/.claude-science, ~/.codex, or ~/.gemini/tmp were found."
         print(json.dumps({"error": err}))
         sys.exit(1)
 
@@ -3826,7 +3847,7 @@ def main() -> None:
     cfg = sub.add_parser("config", help="View or set config")
     cfg.add_argument("--repo", type=str, help=argparse.SUPPRESS)
     cfg.add_argument("--source", choices=sorted(EXPLICIT_SOURCE_CHOICES),
-                     help="Set export source scope explicitly: claude, codex, gemini, or all")
+                     help="Set export source scope explicitly: claude, claude-science, codex, gemini, or all")
     cfg.add_argument("--scorer-backend", choices=[b for b in SCORING_BACKEND_CHOICES if b != "auto"] + ["none"],
                      help="Confirm the AI scoring backend for automatic workbench scoring")
     cfg.add_argument("--exclude", type=str, help="Comma-separated projects to exclude")
@@ -6525,12 +6546,12 @@ def _run_export(args) -> None:
             "error": "Source scope is not confirmed yet.",
             "hint": (
                 "Explicitly choose one source scope before exporting: "
-                "`claude`, `codex`, `gemini`, or `all`."
+                "`claude`, `claude-science`, `codex`, `gemini`, or `all`."
             ),
             "required_action": (
-                "Ask the user whether to export Claude Code, Codex, Gemini, or all. "
-                "Then run `clawjournal config --source <claude|codex|gemini|all>` "
-                "or pass `--source <claude|codex|gemini|all>` on the export command."
+                "Ask the user whether to export Claude Code, Claude Science, Codex, Gemini, or all. "
+                "Then run `clawjournal config --source <claude|claude-science|codex|gemini|all>` "
+                "or pass `--source <claude|claude-science|codex|gemini|all>` on the export command."
             ),
             "allowed_sources": sorted(EXPLICIT_SOURCE_CHOICES),
             "blocked_on_step": "Step 2/5",
@@ -6546,13 +6567,15 @@ def _run_export(args) -> None:
     if not _has_session_sources(source_filter):
         if source_filter == "claude":
             print(f"Error: {CLAUDE_DIR} not found.", file=sys.stderr)
+        elif source_filter == CLAUDE_SCIENCE_SOURCE:
+            print(f"Error: {CLAUDE_SCIENCE_DIR} not found.", file=sys.stderr)
         elif source_filter == "codex":
             print(f"Error: {CODEX_DIR} not found.", file=sys.stderr)
         elif source_filter == "gemini":
             from .parsing.parser import GEMINI_DIR
             print(f"Error: {GEMINI_DIR} not found.", file=sys.stderr)
         else:
-            print("Error: none of ~/.claude, ~/.codex, or ~/.gemini/tmp were found.", file=sys.stderr)
+            print("Error: none of ~/.claude, ~/.claude-science, ~/.codex, or ~/.gemini/tmp were found.", file=sys.stderr)
         sys.exit(1)
 
     projects = discover_projects(source_filter=source_filter)

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -51,7 +51,7 @@ DEFAULT_CONFIG: ClawJournalConfig = {
 }
 
 
-_KNOWN_PREFIXES = ("claude:", "codex:", "gemini:", "opencode:", "openclaw:", "kimi:", "cline:", "custom:")
+_KNOWN_PREFIXES = ("claude:", "claude-science:", "codex:", "gemini:", "opencode:", "openclaw:", "kimi:", "cline:", "custom:")
 _BOTH_SOURCES = ("claude", "codex")
 
 

--- a/clawjournal/events/doctor/probes.py
+++ b/clawjournal/events/doctor/probes.py
@@ -47,6 +47,7 @@ VERDICT_UNKNOWN_SCHEMA = "unknown-schema"
 # probing makes no sense.
 _FS_PROBES: tuple[tuple[str, str], ...] = (
     ("claude", "CLAUDE_DIR"),
+    ("claude-science", "CLAUDE_SCIENCE_DIR"),
     ("codex", "CODEX_DIR"),
     ("openclaw", "OPENCLAW_DIR"),
     ("gemini", "GEMINI_DIR"),

--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -1,4 +1,4 @@
-"""Parse Claude Code, Codex, Gemini CLI, OpenCode, and OpenClaw session data into conversations."""
+"""Parse Claude Code, Claude Science, Codex, Gemini CLI, OpenCode, and OpenClaw session data into conversations."""
 
 import dataclasses
 import hashlib
@@ -17,6 +17,7 @@ from ..redaction.secrets import redact_text
 logger = logging.getLogger(__name__)
 
 CLAUDE_SOURCE = "claude"
+CLAUDE_SCIENCE_SOURCE = "claude-science"
 CODEX_SOURCE = "codex"
 GEMINI_SOURCE = "gemini"
 OPENCODE_SOURCE = "opencode"
@@ -29,6 +30,8 @@ CUSTOM_SOURCE = "custom"
 
 CLAUDE_DIR = Path.home() / ".claude"
 PROJECTS_DIR = CLAUDE_DIR / "projects"
+CLAUDE_SCIENCE_DIR = Path.home() / ".claude-science"
+CLAUDE_SCIENCE_DB_NAME = "operon-cli.db"
 
 CODEX_DIR = Path.home() / ".codex"
 CODEX_SESSIONS_DIR = CODEX_DIR / "sessions"
@@ -68,7 +71,7 @@ _UUID_RE = re.compile(r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f
 # --- Field classification for tool input anonymization ---
 # Fields containing filesystem paths -> anonymizer.path()
 _PATH_FIELDS = frozenset({
-    "file_path", "path", "workdir", "dir_path",
+    "file_path", "path", "workdir", "working_dir", "dir_path",
 })
 # Fields containing shell commands or search patterns -> redact_text() + anonymizer.text()
 _COMMAND_FIELDS = frozenset({
@@ -81,7 +84,7 @@ _TEXT_FIELDS = frozenset({
 })
 # Fields containing lists of paths -> anonymizer.path() per element
 _PATH_LIST_FIELDS = frozenset({
-    "paths",
+    "paths", "files",
 })
 # Fields containing lists of text strings -> anonymizer.text() per element
 _TEXT_LIST_FIELDS = frozenset({
@@ -89,6 +92,7 @@ _TEXT_LIST_FIELDS = frozenset({
 })
 
 _CODEX_PROJECT_INDEX: dict[str, list[Path]] = {}
+_CLAUDE_SCIENCE_PROJECT_INDEX: dict[str, list[dict[str, Any]]] = {}
 _GEMINI_HASH_MAP: dict[str, str] = {}
 _OPENCODE_PROJECT_INDEX: dict[str, list[str]] = {}
 _OPENCLAW_PROJECT_INDEX: dict[str, list[Path]] = {}
@@ -368,6 +372,7 @@ def discover_projects(source_filter: str | None = None) -> list[dict]:
     """Discover supported source projects with optional source filtering."""
     discovery_by_source = {
         CLAUDE_SOURCE: _discover_claude_projects,
+        CLAUDE_SCIENCE_SOURCE: _discover_claude_science_projects,
         CODEX_SOURCE: _discover_codex_projects,
         GEMINI_SOURCE: _discover_gemini_projects,
         OPENCODE_SOURCE: _discover_opencode_projects,
@@ -466,6 +471,140 @@ def _discover_claude_projects() -> list[dict]:
             }
 
     return [p for p in canonical.values() if p["session_count"] > 0]
+
+
+def _connect_sqlite_readonly(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _iter_claude_science_dbs() -> list[tuple[str, Path]]:
+    orgs_dir = CLAUDE_SCIENCE_DIR / "orgs"
+    if not orgs_dir.exists():
+        return []
+    dbs: list[tuple[str, Path]] = []
+    try:
+        for org_dir in sorted(orgs_dir.iterdir()):
+            if not org_dir.is_dir():
+                continue
+            db_path = org_dir / CLAUDE_SCIENCE_DB_NAME
+            if db_path.exists():
+                dbs.append((org_dir.name, db_path))
+    except OSError:
+        return []
+    return dbs
+
+
+def _claude_science_project_key(org_id: str, project_id: Any) -> str:
+    project = project_id if isinstance(project_id, str) and project_id.strip() else "unknown"
+    return f"{org_id}:{project}"
+
+
+def _split_claude_science_project_key(project_key: str) -> tuple[str, str]:
+    org_id, sep, project_id = project_key.partition(":")
+    return org_id, project_id if sep else "unknown"
+
+
+def _claude_science_session_id(org_id: str, frame_id: str) -> str:
+    return f"{CLAUDE_SCIENCE_SOURCE}:{org_id}:{frame_id}"
+
+
+def _get_claude_science_project_index(refresh: bool = False) -> dict[str, list[dict[str, Any]]]:
+    global _CLAUDE_SCIENCE_PROJECT_INDEX
+    if refresh or not _CLAUDE_SCIENCE_PROJECT_INDEX:
+        _CLAUDE_SCIENCE_PROJECT_INDEX = _build_claude_science_project_index()
+    return _CLAUDE_SCIENCE_PROJECT_INDEX
+
+
+def _build_claude_science_project_index() -> dict[str, list[dict[str, Any]]]:
+    index: dict[str, list[dict[str, Any]]] = {}
+    for org_id, db_path in _iter_claude_science_dbs():
+        try:
+            db_size = db_path.stat().st_size
+        except OSError:
+            db_size = 0
+        try:
+            with _connect_sqlite_readonly(db_path) as conn:
+                rows = conn.execute(
+                    """
+                    SELECT
+                        f.id, f.parent_frame_id, f.root_frame_id,
+                        f.agent_name, f.status, f.model, f.effort,
+                        f.input_tokens, f.output_tokens,
+                        f.cache_read_tokens, f.cache_write_tokens,
+                        f.aux_input_tokens, f.aux_output_tokens,
+                        f.aux_cache_read_tokens, f.aux_cache_write_tokens,
+                        f.created_at, f.updated_at, f.completed_at,
+                        f.project_id, f.name, f.conversation_type,
+                        f.task_summary, f.status_description, f.is_hidden,
+                        p.name AS project_name,
+                        (SELECT COUNT(*) FROM frame_messages fm WHERE fm.frame_id = f.id) AS message_count,
+                        (SELECT COALESCE(SUM(LENGTH(fm.msg_json)), 0) FROM frame_messages fm WHERE fm.frame_id = f.id) AS message_bytes,
+                        (SELECT COUNT(*) FROM execution_log el WHERE el.frame_id = f.id) AS execution_count
+                      FROM frames f
+                      LEFT JOIN projects p ON p.id = f.project_id
+                     ORDER BY COALESCE(f.completed_at, f.updated_at, f.created_at) DESC, f.id DESC
+                    """
+                ).fetchall()
+        except sqlite3.Error:
+            logger.warning("Failed to scan Claude Science database %s", db_path)
+            continue
+
+        for row in rows:
+            message_count = _safe_int(row["message_count"])
+            execution_count = _safe_int(row["execution_count"])
+            if message_count == 0 and execution_count == 0:
+                continue
+            project_key = _claude_science_project_key(org_id, row["project_id"])
+            frame = dict(row)
+            frame["org_id"] = org_id
+            frame["db_path"] = db_path
+            frame["message_count"] = message_count
+            frame["execution_count"] = execution_count
+            message_bytes = _safe_int(row["message_bytes"])
+            frame["size_bytes"] = message_bytes if message_bytes > 0 else db_size // max(len(rows), 1)
+            index.setdefault(project_key, []).append(frame)
+    return index
+
+
+def _build_claude_science_project_name(project_key: str, frames: list[dict[str, Any]]) -> str:
+    for frame in frames:
+        project_name = frame.get("project_name")
+        if isinstance(project_name, str) and project_name.strip():
+            return f"{CLAUDE_SCIENCE_SOURCE}:{project_name.strip()}"
+    _org_id, project_id = _split_claude_science_project_key(project_key)
+    label = project_id[:12] if project_id and project_id != "unknown" else "unknown"
+    return f"{CLAUDE_SCIENCE_SOURCE}:{label}"
+
+
+def _claude_science_frame_title(frame: dict[str, Any], anonymizer: Anonymizer) -> str | None:
+    for key in ("name", "status_description", "task_summary"):
+        value = frame.get(key)
+        if not isinstance(value, str):
+            continue
+        title = re.sub(r"\s+", " ", value).strip()
+        if title:
+            return anonymizer.text(title)
+    return None
+
+
+def _discover_claude_science_projects() -> list[dict]:
+    index = _get_claude_science_project_index(refresh=True)
+    projects = []
+    for project_key, frames in sorted(index.items()):
+        if not frames:
+            continue
+        projects.append(
+            {
+                "dir_name": project_key,
+                "display_name": _build_claude_science_project_name(project_key, frames),
+                "session_count": len(frames),
+                "total_size_bytes": sum(_safe_int(frame.get("size_bytes")) for frame in frames),
+                "source": CLAUDE_SCIENCE_SOURCE,
+            }
+        )
+    return projects
 
 
 def _discover_codex_projects() -> list[dict]:
@@ -719,6 +858,326 @@ def _parse_custom_sessions(
     return sessions
 
 
+def _parse_claude_science_project_sessions(
+    project_dir_name: str,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> list[dict]:
+    index = _get_claude_science_project_index()
+    frames = index.get(project_dir_name, [])
+    if not frames:
+        return []
+    project_name = _build_claude_science_project_name(project_dir_name, frames)
+    sessions = []
+    for frame in frames:
+        parsed = _parse_claude_science_frame(frame, anonymizer, include_thinking)
+        if not parsed or not parsed["messages"]:
+            continue
+        org_id = frame.get("org_id")
+        frame_id = frame.get("id")
+        if not isinstance(org_id, str) or not isinstance(frame_id, str):
+            continue
+        parsed["project"] = project_name
+        parsed["source"] = CLAUDE_SCIENCE_SOURCE
+        parsed["raw_source_path"] = f"{frame.get('db_path')}#frame={frame_id}"
+        parsed["client_origin"] = "desktop"
+        parsed["runtime_channel"] = "claude-science"
+        parent_frame_id = frame.get("parent_frame_id")
+        if isinstance(parent_frame_id, str) and parent_frame_id:
+            parsed["parent_session_id"] = _claude_science_session_id(org_id, parent_frame_id)
+        root_frame_id = frame.get("root_frame_id")
+        if isinstance(root_frame_id, str) and root_frame_id and root_frame_id != frame_id:
+            parsed["outer_session_id"] = _claude_science_session_id(org_id, root_frame_id)
+        sessions.append(parsed)
+    return sessions
+
+
+def _parse_claude_science_frame(
+    frame: dict[str, Any],
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> dict | None:
+    db_path = frame.get("db_path")
+    frame_id = frame.get("id")
+    org_id = frame.get("org_id")
+    if not isinstance(db_path, Path) or not isinstance(frame_id, str) or not isinstance(org_id, str):
+        return None
+
+    metadata: dict[str, Any] = {
+        "session_id": _claude_science_session_id(org_id, frame_id),
+        "cwd": None,
+        "git_branch": None,
+        "model": frame.get("model") or "claude-science",
+        "model_effort": frame.get("effort") if isinstance(frame.get("effort"), str) else None,
+        "start_time": _normalize_timestamp(frame.get("created_at")),
+        "end_time": _normalize_timestamp(frame.get("completed_at") or frame.get("updated_at")),
+        "segment_title": _claude_science_frame_title(frame, anonymizer),
+    }
+    stats = _make_stats()
+    stats["input_tokens"] = _safe_int(frame.get("input_tokens")) + _safe_int(frame.get("aux_input_tokens"))
+    stats["output_tokens"] = _safe_int(frame.get("output_tokens")) + _safe_int(frame.get("aux_output_tokens"))
+    stats["cache_read_tokens"] = (
+        _safe_int(frame.get("cache_read_tokens")) + _safe_int(frame.get("aux_cache_read_tokens"))
+    )
+    stats["cache_creation_tokens"] = (
+        _safe_int(frame.get("cache_write_tokens")) + _safe_int(frame.get("aux_cache_write_tokens"))
+    )
+
+    messages: list[dict[str, Any]] = []
+    try:
+        with _connect_sqlite_readonly(db_path) as conn:
+            rows = conn.execute(
+                "SELECT idx, msg_json FROM frame_messages WHERE frame_id = ? ORDER BY idx",
+                (frame_id,),
+            ).fetchall()
+            entries = _load_claude_science_message_entries(rows)
+            tool_result_map = _build_tool_result_map(entries, anonymizer)
+            for entry in entries:
+                _process_claude_science_entry(
+                    entry, messages, metadata, stats, anonymizer, include_thinking, tool_result_map,
+                )
+            _append_claude_science_execution_messages(conn, frame_id, messages, metadata, stats, anonymizer)
+    except sqlite3.Error:
+        logger.warning("Failed to parse Claude Science frame %s in %s", frame_id, db_path)
+        return None
+
+    result = _make_session_result(metadata, messages, stats)
+    if result is None:
+        return None
+    for key in ("agent_name", "conversation_type", "status"):
+        value = frame.get(key)
+        if isinstance(value, str) and value:
+            result[key] = value
+    return result
+
+
+def _load_claude_science_message_entries(rows: list[sqlite3.Row]) -> list[dict[str, Any]]:
+    entries: list[dict[str, Any]] = []
+    for row in rows:
+        try:
+            msg_data = json.loads(row["msg_json"])
+        except (TypeError, json.JSONDecodeError):
+            continue
+        if not isinstance(msg_data, dict):
+            continue
+        role = msg_data.get("role")
+        if role not in ("user", "assistant"):
+            continue
+        entries.append({"type": role, "message": msg_data, "idx": row["idx"]})
+    return entries
+
+
+def _process_claude_science_entry(
+    entry: dict[str, Any],
+    messages: list[dict[str, Any]],
+    metadata: dict[str, Any],
+    stats: dict[str, int],
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+    tool_result_map: dict[str, dict],
+) -> None:
+    role = entry.get("type")
+    msg_data = entry.get("message", {})
+    if not isinstance(msg_data, dict):
+        return
+
+    if role == "user":
+        content = _extract_claude_science_user_content(msg_data, anonymizer)
+        if content is not None:
+            messages.append({"role": "user", "content": content, "timestamp": None})
+            stats["user_messages"] += 1
+        return
+
+    if role != "assistant":
+        return
+
+    if metadata["model"] in (None, "claude-science"):
+        model = msg_data.get("model")
+        if isinstance(model, str) and model.strip():
+            metadata["model"] = model
+    if metadata.get("model_effort") is None:
+        metadata["model_effort"] = _extract_model_effort(msg_data)
+
+    msg = _extract_assistant_content(
+        {"message": msg_data}, anonymizer, include_thinking, tool_result_map,
+    )
+    if msg:
+        msg["timestamp"] = None
+        messages.append(msg)
+        stats["assistant_messages"] += 1
+        stats["tool_uses"] += len(msg.get("tool_uses", []))
+
+
+def _extract_claude_science_user_content(msg_data: dict[str, Any], anonymizer: Anonymizer) -> str | None:
+    content = msg_data.get("content")
+    if isinstance(content, str):
+        text = content.strip()
+        return anonymizer.text(text) if text else None
+    if not isinstance(content, list):
+        return None
+
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = block.get("type")
+        if block_type == "text":
+            text = block.get("text")
+            if isinstance(text, str) and text.strip():
+                parts.append(anonymizer.text(text.strip()))
+        elif block_type in ("image", "document"):
+            label = _claude_science_attachment_label(block_type, block, anonymizer)
+            if label:
+                parts.append(label)
+    if not parts:
+        return None
+    return "\n\n".join(parts)
+
+
+def _claude_science_attachment_label(
+    block_type: str, block: dict[str, Any], anonymizer: Anonymizer,
+) -> str | None:
+    filename = block.get("_filename")
+    if isinstance(filename, str) and filename.strip():
+        return f"[{block_type}: {anonymizer.path(filename.strip())}]"
+    return f"[{block_type}]"
+
+
+def _append_claude_science_execution_messages(
+    conn: sqlite3.Connection,
+    frame_id: str,
+    messages: list[dict[str, Any]],
+    metadata: dict[str, Any],
+    stats: dict[str, int],
+    anonymizer: Anonymizer,
+) -> None:
+    rows = conn.execute(
+        """
+        SELECT id, cell_index, conda_env, language, source, stdout, stderr,
+               exit_status, created_at, files_written, files_read, error_lineno,
+               kernel_kind, origin, detection
+          FROM execution_log
+         WHERE frame_id = ?
+         ORDER BY created_at, cell_index, id
+        """,
+        (frame_id,),
+    ).fetchall()
+    for row in rows:
+        tool_use = _parse_claude_science_execution_tool(conn, row, anonymizer)
+        timestamp = _normalize_timestamp(row["created_at"])
+        messages.append({"role": "assistant", "tool_uses": [tool_use], "timestamp": timestamp})
+        stats["assistant_messages"] += 1
+        stats["tool_uses"] += 1
+
+
+def _parse_claude_science_execution_tool(
+    conn: sqlite3.Connection,
+    row: sqlite3.Row,
+    anonymizer: Anonymizer,
+) -> dict[str, Any]:
+    language = row["language"] if isinstance(row["language"], str) and row["language"] else "execution"
+    tool_name = "bash" if language in ("bash", "shell", "sh", "zsh") else language
+    source = row["source"] if isinstance(row["source"], str) else ""
+    if tool_name == "bash":
+        input_data: dict[str, Any] = {"command": source}
+    else:
+        input_data = {"code": source, "language": language}
+    input_data["cell_index"] = row["cell_index"]
+    if isinstance(row["conda_env"], str) and row["conda_env"]:
+        input_data["environment"] = row["conda_env"]
+    if isinstance(row["kernel_kind"], str) and row["kernel_kind"]:
+        input_data["kernel_kind"] = row["kernel_kind"]
+
+    output: dict[str, Any] = {"exit_status": row["exit_status"]}
+    if isinstance(row["stdout"], str) and row["stdout"]:
+        output["stdout"] = anonymizer.text(row["stdout"])
+    if isinstance(row["stderr"], str) and row["stderr"]:
+        output["stderr"] = anonymizer.text(row["stderr"])
+    for key in ("files_written", "files_read", "detection"):
+        parsed = _json_loads_maybe(row[key])
+        if parsed:
+            output[key] = _anonymize_claude_science_value(parsed, anonymizer, key)
+    if row["error_lineno"] is not None:
+        output["error_lineno"] = row["error_lineno"]
+
+    host_calls = _load_claude_science_host_calls(conn, row["id"], anonymizer)
+    if host_calls:
+        output["host_calls"] = host_calls
+
+    status = "success" if row["exit_status"] in ("ok", "success", "0", 0, None) else "error"
+    return {
+        "tool": tool_name,
+        "input": _parse_tool_input(tool_name, input_data, anonymizer),
+        "output": output,
+        "status": status,
+    }
+
+
+def _load_claude_science_host_calls(
+    conn: sqlite3.Connection,
+    execution_log_id: str,
+    anonymizer: Anonymizer,
+) -> list[dict[str, Any]]:
+    rows = conn.execute(
+        """
+        SELECT seq, method, args_json, derivable, data_ref, error, bytes, created_at
+          FROM host_call_log
+         WHERE execution_log_id = ?
+         ORDER BY seq, id
+        """,
+        (execution_log_id,),
+    ).fetchall()
+    calls: list[dict[str, Any]] = []
+    for row in rows:
+        method = row["method"] if isinstance(row["method"], str) and row["method"] else "host_call"
+        args = _json_loads_maybe(row["args_json"])
+        call: dict[str, Any] = {
+            "seq": row["seq"],
+            "method": method,
+            "args": _parse_tool_input(method, args if isinstance(args, dict) else {}, anonymizer),
+            "bytes": row["bytes"],
+            "derivable": bool(row["derivable"]),
+        }
+        if isinstance(row["data_ref"], str) and row["data_ref"]:
+            call["data_ref"] = anonymizer.path(row["data_ref"])
+        if isinstance(row["error"], str) and row["error"]:
+            call["error"] = anonymizer.text(row["error"])
+        timestamp = _normalize_timestamp(row["created_at"])
+        if timestamp:
+            call["timestamp"] = timestamp
+        calls.append(call)
+    return calls
+
+
+def _json_loads_maybe(value: Any) -> Any:
+    if value is None:
+        return None
+    if not isinstance(value, str):
+        return value
+    if not value.strip():
+        return None
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        return value
+
+
+def _anonymize_claude_science_value(value: Any, anonymizer: Anonymizer, key: str = "") -> Any:
+    if isinstance(value, dict):
+        return {
+            k: _anonymize_claude_science_value(v, anonymizer, str(k))
+            for k, v in value.items()
+        }
+    if isinstance(value, list):
+        return [_anonymize_claude_science_value(item, anonymizer, key) for item in value]
+    if isinstance(value, str):
+        key_l = key.lower()
+        if "path" in key_l or "file" in key_l or key_l in {"cwd", "working_dir", "data_ref"}:
+            return anonymizer.path(value)
+        return anonymizer.text(value)
+    return value
+
+
 def parse_project_sessions(
     project_dir_name: str,
     anonymizer: Anonymizer,
@@ -727,6 +1186,11 @@ def parse_project_sessions(
     locator: dict | None = None,
 ) -> list[dict]:
     """Parse all sessions for a project into structured dicts."""
+    if source == CLAUDE_SCIENCE_SOURCE:
+        return _parse_claude_science_project_sessions(
+            project_dir_name, anonymizer, include_thinking,
+        )
+
     if source == CUSTOM_SOURCE:
         return _parse_custom_sessions(project_dir_name, anonymizer)
 
@@ -1104,7 +1568,7 @@ def _make_session_result(
         "stats": stats,
     }
     # Pass through optional provenance fields from metadata
-    for key in ("entrypoint", "originator", "codex_source", "model_effort"):
+    for key in ("entrypoint", "originator", "codex_source", "model_effort", "segment_title"):
         val = metadata.get(key)
         if val is not None:
             result[key] = val

--- a/clawjournal/web/frontend/src/components/FilterBar.tsx
+++ b/clawjournal/web/frontend/src/components/FilterBar.tsx
@@ -48,6 +48,7 @@ export function FilterBar({ filters, onChange }: FilterBarProps) {
       >
         <option value="">All sources</option>
         <option value="claude">Claude Code</option>
+        <option value="claude-science">Claude Science</option>
         <option value="codex">Codex</option>
         <option value="openclaw">OpenClaw</option>
       </select>

--- a/clawjournal/web/frontend/src/components/TraceCard.tsx
+++ b/clawjournal/web/frontend/src/components/TraceCard.tsx
@@ -6,6 +6,7 @@ import { api } from '../api.ts';
 
 const SOURCE_ICONS: Record<string, string> = {
   claude: 'CC',
+  'claude-science': 'CS',
   codex: 'CX',
   openclaw: 'OC',
 };

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -125,6 +125,8 @@ function sourceInfo(s: Session): { label: string; color: string } {
       return { label: 'Claude Desktop', color: '#7c3aed' };
     return { label: 'Claude Code', color: '#d97706' };
   }
+  if (s.source === 'claude-science')
+    return { label: 'Claude Science', color: '#9333ea' };
   if (s.source === 'openclaw')
     return { label: 'OpenClaw', color: '#6b7280' };
   return { label: s.source, color: '#6b7280' };

--- a/clawjournal/web/frontend/src/views/Insights.tsx
+++ b/clawjournal/web/frontend/src/views/Insights.tsx
@@ -221,6 +221,7 @@ function shortDuration(seconds: number | null | undefined): string {
 
 function sourceLabel(source: string | null | undefined): string {
   if (!source) return '';
+  if (source === 'claude-science') return 'Claude Science';
   return source.charAt(0).toUpperCase() + source.slice(1);
 }
 

--- a/clawjournal/web/frontend/src/views/SessionDetail.tsx
+++ b/clawjournal/web/frontend/src/views/SessionDetail.tsx
@@ -31,6 +31,8 @@ function sourceLabel(s: { source: string; client_origin?: string | null; runtime
       return { label: 'Claude Desktop', color: '#7c3aed' };
     return { label: 'Claude Code', color: '#d97706' };
   }
+  if (s.source === 'claude-science')
+    return { label: 'Claude Science', color: '#9333ea' };
   if (s.source === 'openclaw')
     return { label: 'OpenClaw', color: '#6b7280' };
   return { label: s.source, color: '#6b7280' };

--- a/clawjournal/web/frontend/src/views/Settings.tsx
+++ b/clawjournal/web/frontend/src/views/Settings.tsx
@@ -93,7 +93,7 @@ export function Settings() {
         >
           <option value="" disabled>Select a source…</option>
           {cfg.source_choices.map(s => (
-            <option key={s} value={s}>{s === 'all' ? 'All agents' : s}</option>
+            <option key={s} value={s}>{s === 'all' ? 'All agents' : s === 'claude-science' ? 'Claude Science' : s}</option>
           ))}
         </select>
       </div>

--- a/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
@@ -6,7 +6,7 @@ import { colors } from '../../theme.ts';
 import { SessionDrawer } from '../../components/SessionDrawer.tsx';
 import { TraceCard } from '../../components/TraceCard.tsx';
 import type { ReadySession, ShareReadyStats } from './types.ts';
-import { autoDescription, formatDate, formatTokens, outcomeBadge, outcomeTooltip, sessionTotalTokens } from './helpers.ts';
+import { autoDescription, formatDate, formatTokens, outcomeBadge, outcomeTooltip, sessionTotalTokens, sourceFullLabel } from './helpers.ts';
 import { SHARE_SHELL_WIDTH, btnGhost, btnPrimary, btnSecondary } from './styles.tsx';
 import { CheckboxRow, HelpModal, Icon, SourceBadge, UsageDisclosure } from './shared.tsx';
 
@@ -107,7 +107,7 @@ export function QueueStep(p: QueueStepProps) {
           <select value={p.sourceFilter} onChange={e => p.setSourceFilter(e.target.value)} aria-label="Filter by source"
             style={{ padding: '6px 8px', fontSize: 12, border: `1px solid ${colors.gray300}`, borderRadius: 6, background: colors.white }}>
             <option value="">All sources</option>
-            {sources.map(src => <option key={src} value={src}>{src}</option>)}
+            {sources.map(src => <option key={src} value={src}>{sourceFullLabel({ source: src }).label}</option>)}
           </select>
         )}
         {projects.length > 1 && (

--- a/clawjournal/web/frontend/src/views/Share/helpers.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.ts
@@ -37,6 +37,7 @@ export function sourceFullLabel(s: { source: string; client_origin?: string | nu
     if (s.client_origin === 'desktop' || s.runtime_channel === 'local-agent') return { label: 'Claude Desktop', color: '#7c3aed' };
     return { label: 'Claude Code', color: '#d97706' };
   }
+  if (s.source === 'claude-science') return { label: 'Claude Science', color: '#9333ea' };
   if (s.source === 'openclaw') return { label: 'OpenClaw', color: '#6b7280' };
   return { label: s.source, color: '#6b7280' };
 }

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -85,6 +85,7 @@ from .timeline import (
 from ..parsing.parser import (
     AIDER_SOURCE,
     CLAUDE_SOURCE,
+    CLAUDE_SCIENCE_SOURCE,
     CODEX_SOURCE,
     COPILOT_SOURCE,
     CURSOR_SOURCE,
@@ -130,7 +131,7 @@ _hosted_capabilities_cache: tuple[str, float, dict[str, Any]] | None = None
 
 # Sources supported in the workbench (scientist-facing subset)
 WORKBENCH_SOURCES = {
-    CLAUDE_SOURCE, CODEX_SOURCE, OPENCLAW_SOURCE,
+    CLAUDE_SOURCE, CLAUDE_SCIENCE_SOURCE, CODEX_SOURCE, OPENCLAW_SOURCE,
     CURSOR_SOURCE, COPILOT_SOURCE, AIDER_SOURCE,
     GEMINI_SOURCE, OPENCODE_SOURCE, KIMI_SOURCE,
 }
@@ -563,6 +564,14 @@ def _parse_cookie_token(cookie_header: str | None) -> str | None:
     if morsel is None:
         return None
     return morsel.value or None
+
+
+def _api_session_id(path: str, *, suffix: str = "") -> str:
+    """Extract and decode a session id from a `/api/sessions/<id>` route."""
+    session_id = path[len("/api/sessions/"):]
+    if suffix:
+        session_id = session_id[:-len(suffix)]
+    return unquote(session_id)
 
 
 def _api_token_cookie_header(token: str) -> str:
@@ -2077,20 +2086,20 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         if path == "/api/sessions":
             self._handle_list_sessions(params)
         elif path.startswith("/api/sessions/") and path.endswith("/redaction-report"):
-            session_id = path[len("/api/sessions/"):-len("/redaction-report")]
+            session_id = _api_session_id(path, suffix="/redaction-report")
             ai_pii = params.get("ai_pii", [""])[0] == "1"
             self._handle_redaction_report(session_id, ai_pii=ai_pii)
         elif path.startswith("/api/sessions/") and path.endswith("/findings"):
-            session_id = path[len("/api/sessions/"):-len("/findings")]
+            session_id = _api_session_id(path, suffix="/findings")
             self._handle_list_session_findings(session_id, params)
         elif path.startswith("/api/sessions/") and path.endswith("/hold-history"):
-            session_id = path[len("/api/sessions/"):-len("/hold-history")]
+            session_id = _api_session_id(path, suffix="/hold-history")
             self._handle_hold_history(session_id)
         elif path.startswith("/api/sessions/") and path.endswith("/redacted"):
-            session_id = path[len("/api/sessions/"):-len("/redacted")]
+            session_id = _api_session_id(path, suffix="/redacted")
             self._handle_session_redacted(session_id)
         elif path.startswith("/api/sessions/"):
-            session_id = path[len("/api/sessions/"):]
+            session_id = _api_session_id(path)
             self._handle_get_session(session_id)
         elif path == "/api/search":
             self._handle_search(params)
@@ -2175,13 +2184,13 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         path = parsed.path.rstrip("/")
 
         if path.startswith("/api/sessions/") and path.endswith("/score"):
-            session_id = path[len("/api/sessions/"):-len("/score")]
+            session_id = _api_session_id(path, suffix="/score")
             self._handle_score_session(session_id)
         elif path.startswith("/api/sessions/") and path.endswith("/scan"):
-            session_id = path[len("/api/sessions/"):-len("/scan")]
+            session_id = _api_session_id(path, suffix="/scan")
             self._handle_force_scan_session(session_id)
         elif path.startswith("/api/sessions/"):
-            session_id = path[len("/api/sessions/"):]
+            session_id = _api_session_id(path)
             self._handle_update_session(session_id)
         elif path == "/api/quick-share":
             self._handle_quick_share()

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -34,7 +34,7 @@ WIDENED_MESSAGE_SCHEMA_VERSION = 4
 HOSTED_SUBMISSION_SCHEMA_VERSION = 5
 WORKBENCH_SCHEMA_VERSION = HOSTED_SUBMISSION_SCHEMA_VERSION
 BACKFILL_WINDOW = 100
-FAILURE_VALUE_SOURCE_SCOPE = ("claude", "codex", "opencode", "openclaw")
+FAILURE_VALUE_SOURCE_SCOPE = ("claude", "claude-science", "codex", "opencode", "openclaw")
 SHARE_RECOMMENDATION_LIMIT = 10
 
 # Display-only normalization from the mixed AI/heuristic outcome vocabulary
@@ -3126,6 +3126,7 @@ def get_dashboard_analytics(
         "SELECT CASE "
         "  WHEN source = 'claude' AND (client_origin = 'desktop' OR runtime_channel = 'local-agent') THEN 'Claude Desktop' "
         "  WHEN source = 'claude' THEN 'Claude Code' "
+        "  WHEN source = 'claude-science' THEN 'Claude Science' "
         "  WHEN source = 'codex' AND client_origin = 'desktop' THEN 'Codex Desktop' "
         "  WHEN source = 'codex' THEN 'Codex' "
         "  WHEN source = 'openclaw' THEN 'OpenClaw' "

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 authors = [
     {name = "rayward-external"},
 ]
-keywords = ["claude-code", "codex", "gemini-cli", "opencode", "openclaw", "dataset", "conversations"]
+keywords = ["claude-code", "claude-science", "codex", "gemini-cli", "opencode", "openclaw", "dataset", "conversations"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/tests/parsing/test_parser.py
+++ b/tests/parsing/test_parser.py
@@ -565,6 +565,8 @@ class TestDiscoverProjects:
     def _disable_codex(self, tmp_path, monkeypatch):
         monkeypatch.setattr("clawjournal.parsing.parser.PROJECTS_DIR", tmp_path / "no-claude-projects")
         monkeypatch.setattr("clawjournal.parsing.parser.LOCAL_AGENT_DIR", tmp_path / "no-local-agent")
+        monkeypatch.setattr("clawjournal.parsing.parser.CLAUDE_SCIENCE_DIR", tmp_path / "no-claude-science")
+        monkeypatch.setattr("clawjournal.parsing.parser._CLAUDE_SCIENCE_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser.CODEX_SESSIONS_DIR", tmp_path / "no-codex-sessions")
         monkeypatch.setattr("clawjournal.parsing.parser.CODEX_ARCHIVED_DIR", tmp_path / "no-codex-archived")
         monkeypatch.setattr("clawjournal.parsing.parser._CODEX_PROJECT_INDEX", {})
@@ -1255,6 +1257,8 @@ class TestDiscoverSubagentProjects:
 
     def _disable_codex(self, tmp_path, monkeypatch):
         monkeypatch.setattr("clawjournal.parsing.parser.LOCAL_AGENT_DIR", tmp_path / "no-local-agent")
+        monkeypatch.setattr("clawjournal.parsing.parser.CLAUDE_SCIENCE_DIR", tmp_path / "no-claude-science")
+        monkeypatch.setattr("clawjournal.parsing.parser._CLAUDE_SCIENCE_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser.CODEX_SESSIONS_DIR", tmp_path / "no-codex-sessions")
         monkeypatch.setattr("clawjournal.parsing.parser.CODEX_ARCHIVED_DIR", tmp_path / "no-codex-archived")
         monkeypatch.setattr("clawjournal.parsing.parser._CODEX_PROJECT_INDEX", {})
@@ -1958,6 +1962,8 @@ class TestDiscoverOpenclawProjects:
     def _disable_others(self, tmp_path, monkeypatch):
         monkeypatch.setattr("clawjournal.parsing.parser.PROJECTS_DIR", tmp_path / "no-claude")
         monkeypatch.setattr("clawjournal.parsing.parser.LOCAL_AGENT_DIR", tmp_path / "no-local-agent")
+        monkeypatch.setattr("clawjournal.parsing.parser.CLAUDE_SCIENCE_DIR", tmp_path / "no-claude-science")
+        monkeypatch.setattr("clawjournal.parsing.parser._CLAUDE_SCIENCE_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser.CODEX_SESSIONS_DIR", tmp_path / "no-codex-sessions")
         monkeypatch.setattr("clawjournal.parsing.parser.CODEX_ARCHIVED_DIR", tmp_path / "no-codex-archived")
         monkeypatch.setattr("clawjournal.parsing.parser._CODEX_PROJECT_INDEX", {})
@@ -2047,10 +2053,237 @@ class TestDiscoverOpenclawProjects:
         assert projects[0]["session_count"] == 2
 
 
+class TestDiscoverClaudeScienceProjects:
+    def _disable_others(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.parsing.parser.PROJECTS_DIR", tmp_path / "no-claude")
+        monkeypatch.setattr("clawjournal.parsing.parser.LOCAL_AGENT_DIR", tmp_path / "no-local-agent")
+        monkeypatch.setattr("clawjournal.parsing.parser.CODEX_SESSIONS_DIR", tmp_path / "no-codex-sessions")
+        monkeypatch.setattr("clawjournal.parsing.parser.CODEX_ARCHIVED_DIR", tmp_path / "no-codex-archived")
+        monkeypatch.setattr("clawjournal.parsing.parser._CODEX_PROJECT_INDEX", {})
+        monkeypatch.setattr("clawjournal.parsing.parser.GEMINI_DIR", tmp_path / "no-gemini")
+        monkeypatch.setattr("clawjournal.parsing.parser.OPENCODE_DB_PATH", tmp_path / "no-opencode.db")
+        monkeypatch.setattr("clawjournal.parsing.parser._OPENCODE_PROJECT_INDEX", {})
+        monkeypatch.setattr("clawjournal.parsing.parser.OPENCLAW_AGENTS_DIR", tmp_path / "no-openclaw-agents")
+        monkeypatch.setattr("clawjournal.parsing.parser._OPENCLAW_PROJECT_INDEX", {})
+        monkeypatch.setattr("clawjournal.parsing.parser.KIMI_SESSIONS_DIR", tmp_path / "no-kimi-sessions")
+        monkeypatch.setattr("clawjournal.parsing.parser.CUSTOM_DIR", tmp_path / "no-custom")
+        monkeypatch.setattr("clawjournal.parsing.parser.CURSOR_DIR", tmp_path / "no-cursor")
+        monkeypatch.setattr("clawjournal.parsing.parser._CURSOR_PROJECT_INDEX", {})
+        monkeypatch.setattr("clawjournal.parsing.parser.COPILOT_DIR", tmp_path / "no-copilot")
+        monkeypatch.setattr("clawjournal.parsing.parser._AIDER_PROJECT_INDEX", {})
+        monkeypatch.setattr("clawjournal.parsing.parser._get_aider_project_index", lambda refresh=False: {})
+
+    def _write_db(self, db_path, *, with_execution=False, hidden_frame=False):
+        db_path.parent.mkdir(parents=True)
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            "CREATE TABLE projects ("
+            "id TEXT PRIMARY KEY, name TEXT, description TEXT, context TEXT, "
+            "created_at INTEGER, updated_at INTEGER, user_id TEXT, "
+            "uploads_frame_id TEXT, memory_enabled INTEGER)"
+        )
+        conn.execute(
+            "CREATE TABLE frames ("
+            "id TEXT PRIMARY KEY, parent_frame_id TEXT, root_frame_id TEXT, "
+            "agent_name TEXT, status TEXT, input_data TEXT, output_data TEXT, "
+            "context_data TEXT, model TEXT, effort TEXT, input_tokens INTEGER, "
+            "output_tokens INTEGER, total_cost REAL, created_at INTEGER, "
+            "updated_at INTEGER, completed_at INTEGER, project_id TEXT, name TEXT, "
+            "conversation_type TEXT, artifact_id TEXT, task_summary TEXT, "
+            "mentioned_artifact_ids TEXT, specialists_used TEXT, is_hidden INTEGER, "
+            "status_description TEXT, compute_enabled TEXT, delegate_name TEXT, "
+            "cache_read_tokens INTEGER, cache_write_tokens INTEGER, "
+            "last_user_message_at INTEGER, last_extract_msg_idx INTEGER, root_seq INTEGER, "
+            "aux_input_tokens INTEGER, aux_output_tokens INTEGER, "
+            "aux_cache_read_tokens INTEGER, aux_cache_write_tokens INTEGER, "
+            "aux_cost REAL, token_class_usage TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE frame_messages (frame_id TEXT, idx INTEGER, msg_json TEXT, PRIMARY KEY(frame_id, idx))"
+        )
+        conn.execute(
+            "CREATE TABLE execution_log ("
+            "id TEXT PRIMARY KEY, frame_id TEXT, cell_index INTEGER, kernel_id TEXT, "
+            "conda_env TEXT, language TEXT, source TEXT, stdout TEXT, stderr TEXT, "
+            "exit_status TEXT, created_at INTEGER, files_written TEXT, error_lineno INTEGER, "
+            "kernel_kind TEXT, origin TEXT, detection TEXT, files_read TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE host_call_log ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, execution_log_id TEXT, seq INTEGER, "
+            "method TEXT, args_json TEXT, derivable INTEGER, data_inline TEXT, data_ref TEXT, "
+            "error TEXT, bytes INTEGER, created_at INTEGER)"
+        )
+        conn.execute(
+            "INSERT INTO projects (id, name, created_at, updated_at) VALUES (?, ?, ?, ?)",
+            ("proj-1", "Physics Lab", 1782883193508, 1782883193508),
+        )
+        conn.execute(
+            "INSERT INTO frames ("
+            "id, parent_frame_id, root_frame_id, agent_name, status, model, effort, "
+            "input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, "
+            "created_at, updated_at, completed_at, project_id, name, conversation_type, "
+            "is_hidden, aux_input_tokens, aux_output_tokens, aux_cache_read_tokens, "
+            "aux_cache_write_tokens) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                "frame-1", None, "frame-1", "Claude Science", "completed",
+                "claude-sonnet-4", "high", 100, 50, 10, 5,
+                1782883193508, 1782883200000, 1782883205000,
+                "proj-1", "Density task", "agent", 0, 3, 2, 1, 1,
+            ),
+        )
+        messages = [
+            {"role": "user", "content": [{"type": "text", "text": "Measure density"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "text", "text": "I will run the calculation."},
+                    {
+                        "type": "tool_use",
+                        "id": "tool-1",
+                        "name": "python",
+                        "input": {"code": "print('ok')", "working_dir": "/Users/testuser/project"},
+                    },
+                ],
+            },
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": "tool-1",
+                        "content": "ok",
+                    }
+                ],
+            },
+            {"role": "assistant", "content": [{"type": "text", "text": "Done."}]},
+        ]
+        for idx, msg in enumerate(messages):
+            conn.execute(
+                "INSERT INTO frame_messages (frame_id, idx, msg_json) VALUES (?, ?, ?)",
+                ("frame-1", idx, json.dumps(msg)),
+            )
+        if hidden_frame:
+            conn.execute(
+                "INSERT INTO frames ("
+                "id, parent_frame_id, root_frame_id, agent_name, status, model, effort, "
+                "input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, "
+                "created_at, updated_at, completed_at, project_id, name, conversation_type, "
+                "is_hidden, aux_input_tokens, aux_output_tokens, aux_cache_read_tokens, "
+                "aux_cache_write_tokens) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "frame-2", "frame-1", "frame-1", "Claude Science", "completed",
+                    "claude-sonnet-4", "high", 20, 10, 0, 0,
+                    1782883210000, 1782883215000, 1782883216000,
+                    "proj-1", "Hidden specialist", "agent", 1, 0, 0, 0, 0,
+                ),
+            )
+            conn.execute(
+                "INSERT INTO frame_messages (frame_id, idx, msg_json) VALUES (?, ?, ?)",
+                (
+                    "frame-2", 0,
+                    json.dumps({"role": "assistant", "content": [{"type": "text", "text": "Specialist note"}]}),
+                ),
+            )
+        if with_execution:
+            conn.execute(
+                "INSERT INTO execution_log ("
+                "id, frame_id, cell_index, kernel_id, conda_env, language, source, "
+                "stdout, stderr, exit_status, created_at, files_written, files_read, "
+                "kernel_kind, origin) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "exec-1", "frame-1", 0, "kernel-1", "science-env", "python",
+                    "print('ok')", "ok\n", "", "ok", 1782883201000,
+                    json.dumps(["/Users/testuser/project/result.csv"]),
+                    json.dumps(["/Users/testuser/project/input.csv"]),
+                    "python", "agent",
+                ),
+            )
+            conn.execute(
+                "INSERT INTO host_call_log (execution_log_id, seq, method, args_json, derivable, bytes, created_at) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?)",
+                (
+                    "exec-1", 0, "artifact_path",
+                    json.dumps({"path": "/Users/testuser/project/result.csv"}),
+                    1, 128, 1782883201500,
+                ),
+            )
+        conn.commit()
+        conn.close()
+
+    def test_discover_claude_science_projects(self, tmp_path, monkeypatch):
+        self._disable_others(tmp_path, monkeypatch)
+        root = tmp_path / "claude-science"
+        self._write_db(root / "orgs" / "org-1" / "operon-cli.db")
+        monkeypatch.setattr("clawjournal.parsing.parser.CLAUDE_SCIENCE_DIR", root)
+        monkeypatch.setattr("clawjournal.parsing.parser._CLAUDE_SCIENCE_PROJECT_INDEX", {})
+
+        projects = discover_projects(source_filter="claude-science")
+
+        assert len(projects) == 1
+        assert projects[0]["source"] == "claude-science"
+        assert projects[0]["dir_name"] == "org-1:proj-1"
+        assert projects[0]["display_name"] == "claude-science:Physics Lab"
+        assert projects[0]["session_count"] == 1
+
+    def test_discover_claude_science_includes_hidden_message_frames(self, tmp_path, monkeypatch):
+        self._disable_others(tmp_path, monkeypatch)
+        root = tmp_path / "claude-science"
+        self._write_db(root / "orgs" / "org-1" / "operon-cli.db", hidden_frame=True)
+        monkeypatch.setattr("clawjournal.parsing.parser.CLAUDE_SCIENCE_DIR", root)
+        monkeypatch.setattr("clawjournal.parsing.parser._CLAUDE_SCIENCE_PROJECT_INDEX", {})
+
+        projects = discover_projects(source_filter="claude-science")
+
+        assert len(projects) == 1
+        assert projects[0]["session_count"] == 2
+
+    def test_parse_claude_science_project_sessions(self, tmp_path, monkeypatch, mock_anonymizer):
+        self._disable_others(tmp_path, monkeypatch)
+        root = tmp_path / "claude-science"
+        self._write_db(root / "orgs" / "org-1" / "operon-cli.db", with_execution=True)
+        monkeypatch.setattr("clawjournal.parsing.parser.CLAUDE_SCIENCE_DIR", root)
+        monkeypatch.setattr("clawjournal.parsing.parser._CLAUDE_SCIENCE_PROJECT_INDEX", {})
+
+        sessions = parse_project_sessions(
+            "org-1:proj-1", mock_anonymizer, source="claude-science"
+        )
+
+        assert len(sessions) == 1
+        session = sessions[0]
+        assert session["session_id"] == "claude-science:org-1:frame-1"
+        assert session["project"] == "claude-science:Physics Lab"
+        assert session["source"] == "claude-science"
+        assert session["model"] == "claude-sonnet-4"
+        assert session["model_effort"] == "high"
+        assert session["segment_title"] == "Density task"
+        assert session["end_time"] == "2026-07-01T05:20:05+00:00"
+        assert session["stats"]["input_tokens"] == 103
+        assert session["stats"]["output_tokens"] == 52
+        assert session["stats"]["cache_read_tokens"] == 11
+        assert session["stats"]["cache_creation_tokens"] == 6
+        assert session["messages"][0]["content"] == "Measure density"
+        tool_use = session["messages"][1]["tool_uses"][0]
+        assert tool_use["tool"] == "python"
+        assert tool_use["output"]["text"] == "ok"
+        execution_tool = session["messages"][-1]["tool_uses"][0]
+        assert execution_tool["tool"] == "python"
+        assert execution_tool["output"]["stdout"] == "ok\n"
+        assert execution_tool["output"]["host_calls"][0]["method"] == "artifact_path"
+        assert session["client_origin"] == "desktop"
+        assert session["runtime_channel"] == "claude-science"
+        assert session["raw_source_path"].endswith("operon-cli.db#frame=frame-1")
+
+
 class TestDiscoverKimiProjects:
     def _disable_others(self, tmp_path, monkeypatch):
         monkeypatch.setattr("clawjournal.parsing.parser.PROJECTS_DIR", tmp_path / "no-claude")
         monkeypatch.setattr("clawjournal.parsing.parser.LOCAL_AGENT_DIR", tmp_path / "no-local-agent")
+        monkeypatch.setattr("clawjournal.parsing.parser.CLAUDE_SCIENCE_DIR", tmp_path / "no-claude-science")
+        monkeypatch.setattr("clawjournal.parsing.parser._CLAUDE_SCIENCE_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser.CODEX_SESSIONS_DIR", tmp_path / "no-codex-sessions")
         monkeypatch.setattr("clawjournal.parsing.parser.CODEX_ARCHIVED_DIR", tmp_path / "no-codex-archived")
         monkeypatch.setattr("clawjournal.parsing.parser._CODEX_PROJECT_INDEX", {})
@@ -2141,6 +2374,8 @@ class TestDiscoverCustomProjects:
     def _disable_others(self, tmp_path, monkeypatch):
         monkeypatch.setattr("clawjournal.parsing.parser.PROJECTS_DIR", tmp_path / "no-claude")
         monkeypatch.setattr("clawjournal.parsing.parser.LOCAL_AGENT_DIR", tmp_path / "no-local-agent")
+        monkeypatch.setattr("clawjournal.parsing.parser.CLAUDE_SCIENCE_DIR", tmp_path / "no-claude-science")
+        monkeypatch.setattr("clawjournal.parsing.parser._CLAUDE_SCIENCE_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser.CODEX_SESSIONS_DIR", tmp_path / "no-codex-sessions")
         monkeypatch.setattr("clawjournal.parsing.parser.CODEX_ARCHIVED_DIR", tmp_path / "no-codex-archived")
         monkeypatch.setattr("clawjournal.parsing.parser._CODEX_PROJECT_INDEX", {})
@@ -2410,6 +2645,8 @@ class TestScanLocalAgentSessions:
 
 class TestDiscoverClaudeProjectsWithLocalAgent:
     def _disable_other_sources(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.parsing.parser.CLAUDE_SCIENCE_DIR", tmp_path / "no-claude-science")
+        monkeypatch.setattr("clawjournal.parsing.parser._CLAUDE_SCIENCE_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser.CODEX_SESSIONS_DIR", tmp_path / "no-codex-sessions")
         monkeypatch.setattr("clawjournal.parsing.parser.CODEX_ARCHIVED_DIR", tmp_path / "no-codex-archived")
         monkeypatch.setattr("clawjournal.parsing.parser._CODEX_PROJECT_INDEX", {})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -614,7 +614,7 @@ class TestListProjects:
         monkeypatch.setattr("clawjournal.cli.discover_projects", lambda source_filter=None: [])
         list_projects()
         captured = capsys.readouterr()
-        assert "No Claude Code, Codex, Cursor, Copilot CLI, Aider, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, or Custom sessions" in captured.out
+        assert "No Claude Code, Claude Science, Codex, Cursor, Copilot CLI, Aider, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, or Custom sessions" in captured.out
 
     def test_source_filter_codex(self, monkeypatch, capsys):
         monkeypatch.setattr(
@@ -794,7 +794,7 @@ class TestWorkflowGateMessages:
         assert payload["error"] == "Source scope is not confirmed yet."
         assert payload["blocked_on_step"] == "Step 2/5"
         assert len(payload["process_steps"]) == 5
-        assert payload["allowed_sources"] == ["aider", "all", "both", "claude", "codex", "copilot", "cursor", "custom", "gemini", "kimi", "openclaw", "opencode"]
+        assert payload["allowed_sources"] == ["aider", "all", "both", "claude", "claude-science", "codex", "copilot", "cursor", "custom", "gemini", "kimi", "openclaw", "opencode"]
         assert payload["next_command"] == "clawjournal config --source all"
 
     def test_configure_next_steps_require_full_folder_presentation(self):

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -394,6 +394,64 @@ class TestSessionsAPI:
         assert data["session_id"] == "sess-0"
         assert "messages" in data
 
+    def test_encoded_session_id_routes(self, server, monkeypatch):
+        from urllib.parse import quote
+
+        session_id = "claude-science:org-1:frame-1"
+        conn = open_index()
+        try:
+            upsert_sessions(conn, [{
+                "session_id": session_id,
+                "project": "claude-science:lab",
+                "source": "claude-science",
+                "model": "claude-science",
+                "messages": [
+                    {"role": "user", "content": "Inspect the trace", "tool_uses": []},
+                ],
+                "stats": {
+                    "user_messages": 1,
+                    "assistant_messages": 0,
+                    "tool_uses": 0,
+                    "input_tokens": 1,
+                    "output_tokens": 0,
+                },
+            }])
+        finally:
+            conn.close()
+
+        encoded = quote(session_id, safe="")
+        status, data = _get(server, f"/api/sessions/{encoded}")
+        assert status == 200
+        assert data["session_id"] == session_id
+
+        status, data = _post(server, f"/api/sessions/{encoded}", {"status": "approved"})
+        assert status == 200
+        assert data["ok"] is True
+
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.score_session",
+            lambda conn, sid, model=None, backend="auto": SimpleNamespace(
+                quality=4,
+                reason=f"scored {sid}",
+                detail_json='{"substance": 4}',
+                task_type="analysis",
+                outcome_label="completed",
+                value_labels=[],
+                risk_level=[],
+                display_title="Encoded route scored",
+                effort_estimate=1.0,
+                summary="Scored through encoded API route",
+            ),
+        )
+        status, data = _post(server, f"/api/sessions/{encoded}/score")
+        assert status == 200
+        assert data["ok"] is True
+
+        status, detail = _get(server, f"/api/sessions/{encoded}")
+        assert status == 200
+        assert detail["review_status"] == "approved"
+        assert detail["ai_summary"] == "Scored through encoded API route"
+
     def test_get_session_not_found(self, server):
         status, data = _get(server, "/api/sessions/nonexistent")
         assert status == 404


### PR DESCRIPTION
## Summary

Adds Claude Science as a first-class ClawJournal source.

- discovers Claude Science SQLite traces at `~/.claude-science/orgs/*/operon-cli.db`
- parses frames, messages, tool calls, execution logs, host calls, token stats, model metadata, and frame hierarchy into the shared session shape
- uses Claude Science frame metadata for useful trace titles instead of internal system/reviewer prompts
- wires `claude-science` into CLI source choices, config prefix handling, doctor probes, daemon scanning, workbench analytics labels, frontend filters/cards/settings/share labels, docs, and package keywords
- adds parser and CLI tests for discovery, hidden frames, execution logs, host calls, source filtering, and user-facing source lists

## Validation

- `pytest tests/parsing/test_parser.py tests/test_cli.py -q`
- `pytest tests/workbench/test_daemon.py::TestSessionsAPI tests/parsing/test_parser.py tests/test_cli.py -q`
- `npm run build` in `clawjournal/web/frontend`
- `git diff --check`
- live parser smoke against local Claude Science data: 3 projects, 28 sessions, 849 messages, 695 tool uses
- `python -m clawjournal.cli list --source claude-science`