### PR TITLE
fix(skill): objective support count reaches the installed rule badge

### DIFF
--- a/clawjournal/skill/distill.py
+++ b/clawjournal/skill/distill.py
@@ -323,7 +323,18 @@ def distill_skills(
             return []
     rules = parse_rules(data)
     allowed_aliases = set(aliases.values())
-    # backfill support from recurrence where the rule named a mode
+    # A candidate's real support keyed by its rendered alias, so a rule inherits the
+    # recurrence of whatever it cites as evidence. This is the ONLY path that carries a
+    # synthetic env/rejection candidate's OBJECTIVE session count (e.g. 12 sessions of
+    # "file not read yet", 8 sessions of rejected actions) onto the emitted rule — those
+    # candidates carry no taxonomy, so the mode-recurrence backfill below can't see them,
+    # and the rule would otherwise display a coincidental judge count (or ~0). Max over
+    # colliding aliases: a synthetic candidate may reuse a real pool session id.
+    support_by_alias: dict[str, int] = {}
+    for c in corpus.candidates:
+        alias = aliases.get(c.session_id)
+        if alias is not None:
+            support_by_alias[alias] = max(support_by_alias.get(alias, 0), int(c.support_count or 0))
     for r in rules:
         evidence: list[str] = []
         for sid in r.evidence_session_ids:
@@ -332,6 +343,11 @@ def distill_skills(
             elif sid in allowed_aliases:
                 evidence.append(sid)
         r.evidence_session_ids = list(dict.fromkeys(evidence))
+        # backfill support from recurrence where the rule named a mode...
         if r.taxonomy and r.taxonomy in corpus.mode_recurrence:
             r.support = max(r.support, corpus.mode_recurrence[r.taxonomy])
+        # ...and from the real support of any candidate the rule cites as evidence.
+        cited = [support_by_alias[a] for a in r.evidence_session_ids if a in support_by_alias]
+        if cited:
+            r.support = max(r.support, max(cited))
     return rules

--- a/clawjournal/skill/turns.py
+++ b/clawjournal/skill/turns.py
@@ -365,13 +365,16 @@ def add_env_candidates(
         (item for item in hits.items() if len(item[1]["sessions"]) >= min_sessions),
         key=lambda item: -len(item[1]["sessions"]),
     )[:max_candidates]
-    for sig, info in recurring:
+    for idx, (sig, info) in enumerate(recurring):
         n = len(info["sessions"])
         recency = _recency_weight(info.get("start_time"), now=clock)
         excerpt = EnvExcerpt(action=info["action"], error=info["error"],
                              recovery=info["recovery"])
         corpus.failures.append(SkillCandidate(
-            session_id=info["sessions"][-1],
+            # a SYNTHETIC id (not a real session): these clusters summarize many
+            # sessions, and reusing a member's real id would collide with that session's
+            # own pool candidate in _candidate_aliases — bleeding support across the alias.
+            session_id=f"env-signature-{idx}",
             project=info.get("project", ""), source=info.get("source", ""),
             kind="avoid",
             learning_summary=(
@@ -466,7 +469,7 @@ def add_rejection_candidate(
     recency = _recency_weight(last_detail.get("start_time"), now=clock)
     top = ", ".join(f"{r}×{k}" for r, k in reasons.most_common(4))
     corpus.failures.append(SkillCandidate(
-        session_id=sessions[-1],
+        session_id="human-rejection",   # synthetic id: summarizes many sessions (see add_env_candidates)
         project=last_detail.get("project") or "", source=last_detail.get("source") or "",
         kind="avoid",
         learning_summary=(

--- a/tests/skill/test_distill.py
+++ b/tests/skill/test_distill.py
@@ -47,6 +47,31 @@ def test_evidence_ids_are_limited_to_selected_sessions():
     assert rules[0].evidence_session_ids == ["case-01"]
 
 
+def test_rule_inherits_cited_candidate_support():
+    # a synthetic env/rejection candidate carries its OBJECTIVE session count in
+    # support_count and NO taxonomy; a rule that cites it must inherit that count
+    # (the taxonomy backfill can't, so the badge would otherwise be ~0 / coincidental).
+    env = SkillCandidate("s_env", "proj", "claude", "avoid",
+                         title="Recurring Edit error", support_count=12)   # 12 sessions, no taxonomy
+    corpus = SkillCorpus(window_start="a", window_end="b", failures=[env])  # -> case-01
+    fake = FakeCaller({"rules": [
+        {"kind": "avoid", "trigger": "before editing", "guidance": "read the file first",
+         "why": "recurring tool error", "taxonomy": "", "evidence_session_ids": ["case-01"]},
+    ]})
+    (rule,) = distill_skills(corpus, caller=fake)
+    assert rule.support == 12                          # objective count reached the rule
+
+
+def test_uncited_rule_keeps_taxonomy_support():
+    # the evidence path must not regress the mode-recurrence backfill for rules that
+    # name a taxonomy but cite no case.
+    fake = FakeCaller({"rules": [
+        {"kind": "avoid", "trigger": "before done", "guidance": "run tests first",
+         "why": "premature", "taxonomy": "verification_skipped"},   # no evidence_session_ids
+    ]})
+    assert distill_skills(_corpus(), caller=fake)[0].support == 4   # still backfilled from mode
+
+
 def test_empty_corpus_no_call():
     fake = FakeCaller({"rules": []})
     empty = SkillCorpus(window_start="a", window_end="b")

--- a/tests/skill/test_turns.py
+++ b/tests/skill/test_turns.py
@@ -305,3 +305,29 @@ def test_add_rejection_candidate_requires_min_recurrence():
 
     add_rejection_candidate(None, corpus, loader=loader)   # 2 sessions < min 3
     assert corpus.failures == []
+
+
+def test_synthetic_candidates_get_noncolliding_ids():
+    # synthetic env/rejection candidates must NOT reuse a real session id, or they
+    # collide with that session's own pool candidate in _candidate_aliases and bleed
+    # support across the shared alias.
+    from clawjournal.skill.turns import add_env_candidates, add_rejection_candidate
+    corpus = SkillCorpus(window_start="a", window_end="b",
+                         eligible_session_ids=["s1", "s2", "s3"])
+
+    def loader(conn, sid):
+        return {"project": "p", "source": "claude", "start_time": "2026-07-01T00:00:00+00:00",
+                "messages": [
+                    _at(_tu("Edit", "x", status="error",
+                            output="String to replace not found in file.")),
+                    _at(_tu("Write", "y", status="error",
+                            output="File has not been read yet. Read it first before writing to it.")),
+                    _at(_tu("Bash", "git push", status="error",
+                            output="The user doesn't want to take this action right now.")),
+                ]}
+
+    add_env_candidates(None, corpus, loader=loader)
+    add_rejection_candidate(None, corpus, loader=loader)
+    ids = [c.session_id for c in corpus.failures]
+    assert len(ids) == len(set(ids))                    # all distinct
+    assert not any(i in {"s1", "s2", "s3"} for i in ids)  # none is a real session id


### PR DESCRIPTION
Fixes gap #1 in the merged Mode A objective-feedback logic (follow-up to #95/#96).

## The bug
The env/rejection candidates carry the **real** session count in `support_count` — 12 sessions of "file not read yet", 8 sessions of rejected actions — but `distill.py` only backfilled a rule's `support` from `mode_recurrence` keyed by `taxonomy`, and those synthetic candidates carry no taxonomy. So an objective-feedback rule's `seen ~N×` badge showed:
- a **coincidental** judge count — "Read Before Editing" read `~15×` only because the LLM happened to tag it `execution_error`; or
- **~0 / misleadingly low** — a rejection rule tagged `safety_security` (~1% window rate) would read `~1×` despite being grounded in 8 sessions of rejections.

The "ground truth, not judge-inferred" value degraded at the very last step.

## The fix (two parts)
1. **distill** — a rule now inherits the real support of any candidate it **cites as evidence** (max over cited). This is the only path that carries a synthetic candidate's objective count onto the emitted rule. The taxonomy backfill still applies for rules that name a mode but cite no case (regression-tested).
2. **turns** — give synthetic env/rejection candidates **synthetic** session ids (`env-signature-N`, `human-rejection`) instead of a representative real id. Reusing a real id collided with that session's own pool candidate in `_candidate_aliases`, sharing one alias and **bleeding** support across it — a rejection rule inherited `15` from a colliding candidate instead of its true `7`.

## Verified on the real 30-day corpus
Synthetic candidates get distinct aliases (`case-02`…`case-05`), and a rejection rule citing its candidate inherits `support=7` — its true session count — with no bleed.

Full suite green (2459).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnzqCuYZudab6cSjAgZvfE