### PR TITLE
feat(skill): persist objective-feedback recurrence + surface its run-over-run trend

### DIFF
--- a/clawjournal/cli_skill.py
+++ b/clawjournal/cli_skill.py
@@ -42,6 +42,8 @@ class SkillResult:
     dropped: list[SkillRule] = field(default_factory=list)
     # run-over-run: {failure_mode: (prev_rate_or_None, current_rate)} for targeted modes
     trend: dict[str, tuple[float | None, float]] = field(default_factory=dict)
+    # run-over-run for OBJECTIVE signals: {signal: (prev_rate_or_None, current_rate)}
+    objective_trend: dict[str, tuple[float | None, float]] = field(default_factory=dict)
 
 
 _SUPPORT_HALFLIFE_DAYS = 30.0  # a rule's effective support halves every 30 idle days
@@ -375,8 +377,17 @@ def generate_skill(conn, *, window_days: int, backend: str = "auto",
     targeted = {r.taxonomy for r in rules if r.kind == "avoid" and r.taxonomy}
     trend = {m: (prev_rates.get(m), cur_rates.get(m, 0.0)) for m in sorted(targeted)}
 
+    # OBJECTIVE-signal trend: judge-free ground truth (tool-error signatures, rejections).
+    # Union of what recurs now with what was tracked last run, so a signal that fell
+    # below the teach bar still shows as improved rather than silently vanishing.
+    cur_obj = corpus.objective_rates()
+    last_obj = _store.last_objective_snapshot(conn)
+    prev_obj = last_obj[2] if last_obj else {}
+    obj_keys = set(cur_obj) | set(prev_obj)
+    objective_trend = {k: (prev_obj.get(k), cur_obj.get(k, 0.0)) for k in sorted(obj_keys)}
+
     return SkillResult(rules, skill_md, region, blocked, gate_issues, corpus, meta,
-                       added_fps, dropped, trend)
+                       added_fps, dropped, trend, objective_trend)
 
 
 # --- scan + score (§7.1, §7.2) ---------------------------------------------
@@ -533,6 +544,21 @@ def _print_preview(res: SkillResult) -> None:
             else:
                 arrow = "↓ improving" if cur < prev - 1e-9 else ("↑ worsening" if cur > prev + 1e-9 else "→ flat")
                 print(_ascii_safe(f"    - {mode}: {prev:.0%} → {cur:.0%}  ({arrow})"))
+    if res.objective_trend:
+        n = res.corpus.eligible_scored
+        print(_ascii_safe("\n  Objective feedback recurrence vs your last run "
+                          "(tool errors + rejections per scored session — verifiable, not judge-inferred):"))
+        # most-recurrent first; cap so a long tail of rare signatures doesn't flood output
+        ordered = sorted(res.objective_trend.items(),
+                         key=lambda kv: -max(kv[1][0] or 0.0, kv[1][1]))[:6]
+        for sig, (prev, cur) in ordered:
+            if n < 10:
+                print(_ascii_safe(f"    - {sig}: {cur:.0%}  (insufficient data — n={n})"))
+            elif prev is None:
+                print(_ascii_safe(f"    - {sig}: {cur:.0%}  (baseline; re-run later to see the trend)"))
+            else:
+                arrow = "↓ improving" if cur < prev - 1e-9 else ("↑ worsening" if cur > prev + 1e-9 else "→ flat")
+                print(_ascii_safe(f"    - {sig}: {prev:.0%} → {cur:.0%}  ({arrow})"))
     if res.blocked:
         print(f"\n  {len(res.blocked)} rule(s) dropped by the safety gate:")
         for r, reasons in res.blocked:
@@ -670,6 +696,8 @@ def run_skill(args) -> None:
                 # last real snapshot with an empty one (would reset the run-over-run trend).
                 if res.corpus.eligible_scored > 0:
                     _store.save_mode_snapshot(conn, res.corpus.mode_rates(), res.corpus.eligible_scored)
+                    _store.save_objective_snapshot(conn, res.corpus.objective_rates(),
+                                                   res.corpus.eligible_scored)
             except Exception as exc:
                 print(f"note: installed to disk, but failed to record state "
                       f"({exc.__class__.__name__}); the next run may re-propose these rules.")

--- a/clawjournal/skill/select.py
+++ b/clawjournal/skill/select.py
@@ -75,12 +75,22 @@ class SkillCorpus:
     # every gated (hold-state + exclusion checked) scored session in the window —
     # the scan universe for cross-session env-signature candidates (skill.turns)
     eligible_session_ids: list[str] = field(default_factory=list)
+    # OBJECTIVE feedback recurrence: {readable signal key -> distinct-session count}
+    # for tool-error signatures + human rejections (skill.turns populates it). Judge-
+    # free ground truth; snapshotted run-over-run for a verifiable improvement trend.
+    objective_recurrence: dict[str, int] = field(default_factory=dict)
 
     def mode_rates(self) -> dict[str, float]:
         """Per-failure-mode incidence rate over eligible scored sessions."""
         if self.eligible_scored <= 0:
             return {}
         return {m: n / self.eligible_scored for m, n in self.mode_recurrence.items()}
+
+    def objective_rates(self) -> dict[str, float]:
+        """Per-objective-signal incidence rate over eligible scored sessions."""
+        if self.eligible_scored <= 0:
+            return {}
+        return {k: n / self.eligible_scored for k, n in self.objective_recurrence.items()}
 
     @property
     def candidates(self) -> list[SkillCandidate]:

--- a/clawjournal/skill/store.py
+++ b/clawjournal/skill/store.py
@@ -169,6 +169,12 @@ def _ensure_snapshots(conn: sqlite3.Connection) -> None:
         "CREATE TABLE IF NOT EXISTS skill_mode_snapshots ("
         "recorded_at TEXT, n INTEGER, rates_json TEXT)"
     )
+    # Separate table (not an ALTER) so an older DB with no objective column can't break;
+    # same shape as the mode snapshot, holding objective-signal rates instead.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS skill_objective_snapshots ("
+        "recorded_at TEXT, n INTEGER, rates_json TEXT)"
+    )
     conn.commit()
 
 
@@ -183,11 +189,10 @@ def save_mode_snapshot(conn: sqlite3.Connection, rates: dict[str, float], n: int
     conn.commit()
 
 
-def last_mode_snapshot(conn: sqlite3.Connection) -> tuple[str, int, dict[str, float]] | None:
-    """Return the most recent (recorded_at, n, rates) snapshot, or None."""
+def _read_last_snapshot(conn: sqlite3.Connection, table: str) -> tuple[str, int, dict[str, float]] | None:
     _ensure_snapshots(conn)
     row = conn.execute(
-        "SELECT recorded_at, n, rates_json FROM skill_mode_snapshots ORDER BY recorded_at DESC LIMIT 1"
+        f"SELECT recorded_at, n, rates_json FROM {table} ORDER BY recorded_at DESC LIMIT 1"
     ).fetchone()
     if not row:
         return None
@@ -198,6 +203,27 @@ def last_mode_snapshot(conn: sqlite3.Connection) -> tuple[str, int, dict[str, fl
     except (TypeError, ValueError, AttributeError, json.JSONDecodeError):
         rates = {}
     return (row[0], int(row[1] or 0), rates)
+
+
+def last_mode_snapshot(conn: sqlite3.Connection) -> tuple[str, int, dict[str, float]] | None:
+    """Return the most recent (recorded_at, n, rates) mode snapshot, or None."""
+    return _read_last_snapshot(conn, "skill_mode_snapshots")
+
+
+def save_objective_snapshot(conn: sqlite3.Connection, rates: dict[str, float], n: int,
+                            *, now: str | None = None) -> None:
+    """Record the window's objective-signal incidence rates (run-over-run trend)."""
+    _ensure_snapshots(conn)
+    conn.execute(
+        "INSERT INTO skill_objective_snapshots (recorded_at, n, rates_json) VALUES (?,?,?)",
+        (now or now_iso(), int(n), json.dumps(rates)),
+    )
+    conn.commit()
+
+
+def last_objective_snapshot(conn: sqlite3.Connection) -> tuple[str, int, dict[str, float]] | None:
+    """Return the most recent (recorded_at, n, rates) objective snapshot, or None."""
+    return _read_last_snapshot(conn, "skill_objective_snapshots")
 
 
 def reject(conn: sqlite3.Connection, fp: str, *, now: str | None = None) -> bool:

--- a/clawjournal/skill/turns.py
+++ b/clawjournal/skill/turns.py
@@ -301,8 +301,16 @@ def excerpts_for_session(
 
 # --- cross-session error-signature candidates (objective support) ------------
 
-MIN_SIGNATURE_SESSIONS = 3   # a signature must hit this many sessions to teach
+MIN_SIGNATURE_SESSIONS = 3   # a signature must hit this many sessions to TEACH a rule
+MIN_SIGNATURE_RECORD = 2     # ...but record recurrence >=2 so a signal falling below the
+                             # teach bar (e.g. 4 -> 2 sessions) still shows an improving trend
 MAX_ENV_CANDIDATES = 3       # appended on top of the ranked pool
+
+
+def _signal_label(sig: str) -> str:
+    """A short, stable, readable key for an error signature (drops the wrapper tags)."""
+    text = re.sub(r"</?tool_use_error>", "", sig).strip(" .:")
+    return (text[:60] + "…") if len(text) > 60 else text
 
 
 def add_env_candidates(
@@ -361,6 +369,11 @@ def add_env_candidates(
                         entry["recovery"] = _head(_action_desc(tu), _ACTION_CHARS)
 
     clock = now or datetime.now(timezone.utc)
+    # record recurrence for the run-over-run objective trend (broader than the teach bar)
+    for sig, info in hits.items():
+        c = len(info["sessions"])
+        if c >= MIN_SIGNATURE_RECORD:
+            corpus.objective_recurrence[_signal_label(sig)] = c
     recurring = sorted(
         (item for item in hits.items() if len(item[1]["sessions"]) >= min_sessions),
         key=lambda item: -len(item[1]["sessions"]),
@@ -463,6 +476,8 @@ def add_rejection_candidate(
                             after="",
                         ))
     n = len(sessions)
+    if n >= MIN_SIGNATURE_RECORD:   # record for the trend even below the teach bar
+        corpus.objective_recurrence["user-rejected actions"] = n
     if n < min_sessions:
         return
     clock = now or datetime.now(timezone.utc)

--- a/tests/skill/test_cli_skill.py
+++ b/tests/skill/test_cli_skill.py
@@ -68,6 +68,7 @@ def test_gate_issues_exit_nonzero(monkeypatch):
         added_fps = set()
         dropped = []
         trend = {}
+        objective_trend = {}
 
     monkeypatch.setattr("clawjournal.cli_skill._ensure_corpus", lambda *a, **k: None)
     monkeypatch.setattr("clawjournal.cli_skill._config_excluded_projects", lambda *a, **k: [])
@@ -101,6 +102,7 @@ def test_preview_persists_proposed_rules_for_rejection(monkeypatch, index_conn):
         added_fps = {store.fingerprint(rule)}
         dropped = []
         trend = {}
+        objective_trend = {}
 
     monkeypatch.setattr("clawjournal.cli_skill._ensure_corpus", lambda *a, **k: None)
     monkeypatch.setattr("clawjournal.workbench.index.open_index", lambda: ConnProxy())

--- a/tests/skill/test_telemetry.py
+++ b/tests/skill/test_telemetry.py
@@ -49,3 +49,28 @@ def test_generate_reports_week_over_week_trend(index_conn, ins):
     prev, cur = res.trend["verification_skipped"]
     assert prev == 0.90                       # from last week's snapshot
     assert abs(cur - 3 / 12) < 1e-9           # this window: 3 of 12 scored
+
+
+def test_objective_snapshot_round_trip(index_conn):
+    store.save_objective_snapshot(index_conn, {"user-rejected actions": 0.2}, 15)
+    last = store.last_objective_snapshot(index_conn)
+    assert last is not None
+    _, n, rates = last
+    assert n == 15 and abs(rates["user-rejected actions"] - 0.2) < 1e-9
+
+
+def test_generate_reports_objective_trend(index_conn, ins, monkeypatch):
+    store.save_objective_snapshot(index_conn, {"user-rejected actions": 0.40}, 20)   # prior run
+    for i in range(12):
+        ins(index_conn, f"ok{i}", quality=5, outcome="resolved", learning="y")
+    # `ins` seeds no message blobs, so inject a known objective signal directly
+    def fake_env(conn, corpus, **kw):
+        corpus.objective_recurrence["user-rejected actions"] = 3   # 3 of 12 scored = 25%
+    monkeypatch.setattr("clawjournal.cli_skill._turns.add_env_candidates", fake_env)
+    monkeypatch.setattr("clawjournal.cli_skill._turns.add_rejection_candidate", lambda *a, **k: None)
+    fake = FakeCaller({"rules": [
+        {"kind": "do", "trigger": "t", "guidance": "read source first", "why": "w"}]})
+    res = generate_skill(index_conn, window_days=3650, caller=fake, now=NOW)
+    assert "user-rejected actions" in res.objective_trend
+    prev, cur = res.objective_trend["user-rejected actions"]
+    assert prev == 0.40 and abs(cur - 3 / 12) < 1e-9

--- a/tests/skill/test_turns.py
+++ b/tests/skill/test_turns.py
@@ -331,3 +331,40 @@ def test_synthetic_candidates_get_noncolliding_ids():
     ids = [c.session_id for c in corpus.failures]
     assert len(ids) == len(set(ids))                    # all distinct
     assert not any(i in {"s1", "s2", "s3"} for i in ids)  # none is a real session id
+
+
+def test_objective_recurrence_populated_for_trend():
+    from clawjournal.skill.turns import add_env_candidates, add_rejection_candidate
+    corpus = SkillCorpus(window_start="a", window_end="b", eligible_scored=10,
+                         eligible_session_ids=["s1", "s2", "s3"])
+
+    def loader(conn, sid):
+        return {"project": "p", "source": "claude", "start_time": "2026-07-01T00:00:00+00:00",
+                "messages": [
+                    _at(_tu("Edit", "x", status="error",
+                            output="String to replace not found in file.")),
+                    _at(_tu("Bash", "git push", status="error",
+                            output="The user doesn't want to take this action right now.")),
+                ]}
+
+    add_env_candidates(None, corpus, loader=loader)
+    add_rejection_candidate(None, corpus, loader=loader)
+    assert corpus.objective_recurrence["string to replace not found in file"] == 3
+    assert corpus.objective_recurrence["user-rejected actions"] == 3
+    assert abs(corpus.objective_rates()["user-rejected actions"] - 0.3) < 1e-9   # 3/10
+
+
+def test_objective_recurrence_records_below_teach_bar():
+    # a signal at 2 sessions is RECORDED (so a later drop shows an improving trend)
+    # but must NOT become a taught candidate (bar is 3).
+    from clawjournal.skill.turns import add_env_candidates
+    corpus = SkillCorpus(window_start="a", window_end="b", eligible_scored=10,
+                         eligible_session_ids=["s1", "s2"])
+
+    def loader(conn, sid):
+        return {"messages": [_at(_tu("Edit", "x", status="error",
+                                     output="String to replace not found in file."))]}
+
+    add_env_candidates(None, corpus, loader=loader)
+    assert corpus.objective_recurrence.get("string to replace not found in file") == 2
+    assert corpus.failures == []   # below the teach bar


### PR DESCRIPTION
Gaps #2/#3 from the Mode A objective-feedback review (follow-up to #95/#96/#98).

## Why
After #98, the objective signals (tool-error signatures, human rejections) carry verifiable session counts — but they had **no cross-run memory and no trend**. So the judge-free "are these recurring less over time?" question — the most credible thing D9 (light validation) could show — went unanswered. The mode trend covers only the judge's `ai_failure_modes`.

## What
- **`SkillCorpus.objective_recurrence`** `{readable signal → distinct-session count}`, populated by `skill.turns` as a side effect of the candidate scan. Recorded at ≥2 sessions (one below the ≥3 teach bar) so a signal that *drops below* the bar still shows an improving trend instead of silently vanishing. `objective_rates()` normalizes by `eligible_scored` for window-size-robust comparison.
- **`store`**: a separate `skill_objective_snapshots` table (not an `ALTER`, so an older DB can't break) with `save_/last_objective_snapshot` mirroring the mode snapshot; `_read_last_snapshot` shared by both.
- **`generate_skill`** computes `objective_trend` as the union of what recurs now with what was tracked last run; **`run_skill`** prints an "Objective feedback recurrence vs your last run" section (capped to top 6, `n<10` guard) and snapshots the current rates alongside the mode snapshot — only when the window had scored sessions.

## Verified on the real 30-day corpus
read-before-edit tool errors **11%**, user-rejected actions **7%**, string-not-found **6%** — each a verifiable session count, now tracked run-over-run. A seeded prior snapshot produced correct `prev → cur (↓ improving)` deltas.

Full suite green (2463); 4 new tests (store round-trip, corpus population, below-teach-bar recording, generate_skill trend wiring).

## Limitation
The trend is per-signal recurrence, directional (not powered), consistent with the mode trend's framing. Fully-resolved signals only show while still tracked in the prior snapshot's window (the union preserves one run of memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnzqCuYZudab6cSjAgZvfE