### PR TITLE
fix(skill): catch newer rejection phrasing + don't inflate the sources count

### DIFF
--- a/clawjournal/cli_skill.py
+++ b/clawjournal/cli_skill.py
@@ -295,6 +295,9 @@ def generate_skill(conn, *, window_days: int, backend: str = "auto",
         # they boost the session's rank into the pool and ride along to the distill
         # prompt (scrubbed at prompt-format time like every other field)
         excerpt_loader=lambda sid: _turns.excerpts_for_session(conn, sid))
+    # count the REAL source sessions before appending synthetic env/rejection candidates
+    # (whose ids are placeholders, not sessions) so the "sources=N" footer isn't inflated
+    n_source_sessions = len({c.session_id for c in corpus.candidates})
     # objective environment feedback: a tool-error signature recurring across the
     # window's (gated) sessions becomes an avoid-candidate whose support_count is
     # the REAL session count — evidence the judge can't fabricate
@@ -305,7 +308,7 @@ def generate_skill(conn, *, window_days: int, backend: str = "auto",
     meta: dict[str, Any] = {
         "generated_at": (now or datetime.now(timezone.utc)).date().isoformat(),
         "window_days": window_days,
-        "sources": len(corpus.session_ids),
+        "sources": n_source_sessions,
     }
     rules: list[SkillRule] = []
     blocked: list[tuple[SkillRule, list[str]]] = []

--- a/clawjournal/skill/turns.py
+++ b/clawjournal/skill/turns.py
@@ -187,10 +187,14 @@ _BENIGN_ERROR_RE = re.compile(
     re.I,
 )
 # Human rejections arrive AS tool errors (permission denials, interrupts). They are
-# human feedback, not environment feedback — never teach them as an env pitfall.
+# human feedback, not environment feedback — never teach them as an env pitfall, and
+# never miss one (an unmatched rejection LEAKS into the env-signature channel). Cover
+# both agent phrasings: Claude's "doesn't want to take this action" and the newer
+# "doesn't want to proceed with this tool use".
 _HUMAN_REJECTION_RE = re.compile(
     r"permission (?:to use|for this action)|denied by the|"
-    r"doesn'?t want to take this action|request interrupted|rejected the tool",
+    r"doesn'?t want to (?:take this action|proceed)|"
+    r"request interrupted|rejected the tool|tool use will be skipped",
     re.I,
 )
 

--- a/tests/skill/test_telemetry.py
+++ b/tests/skill/test_telemetry.py
@@ -74,3 +74,20 @@ def test_generate_reports_objective_trend(index_conn, ins, monkeypatch):
     assert "user-rejected actions" in res.objective_trend
     prev, cur = res.objective_trend["user-rejected actions"]
     assert prev == 0.40 and abs(cur - 3 / 12) < 1e-9
+
+
+def test_sources_count_excludes_synthetic_candidates(index_conn, ins, monkeypatch):
+    # the "sources=N" footer counts REAL source sessions, not the synthetic env/rejection
+    # candidate placeholders appended after selection.
+    from clawjournal.skill.select import SkillCandidate
+    for i in range(3):
+        ins(index_conn, f"ok{i}", quality=5, outcome="resolved", learning="y")
+
+    def fake_env(conn, corpus, **kw):
+        corpus.failures.append(SkillCandidate("env-signature-0", "p", "claude", "avoid",
+                                              support_count=5))
+    monkeypatch.setattr("clawjournal.cli_skill._turns.add_env_candidates", fake_env)
+    monkeypatch.setattr("clawjournal.cli_skill._turns.add_rejection_candidate", lambda *a, **k: None)
+    fake = FakeCaller({"rules": []})
+    res = generate_skill(index_conn, window_days=3650, caller=fake, now=NOW)
+    assert res.meta["sources"] == 3      # 3 real sessions, not 4 (synthetic excluded)

--- a/tests/skill/test_turns.py
+++ b/tests/skill/test_turns.py
@@ -368,3 +368,25 @@ def test_objective_recurrence_records_below_teach_bar():
     add_env_candidates(None, corpus, loader=loader)
     assert corpus.objective_recurrence.get("string to replace not found in file") == 2
     assert corpus.failures == []   # below the teach bar
+
+
+def test_newer_rejection_phrasing_is_human_not_env():
+    # "doesn't want to proceed with this tool use" (newer agent phrasing) must be
+    # counted as a rejection AND kept out of the env-signature channel.
+    from clawjournal.skill.turns import (add_env_candidates, add_rejection_candidate,
+                                         _teachable_error)
+    msg = "The user doesn't want to proceed with this tool use. The tool use will be skipped."
+    assert _teachable_error({"output": {"text": msg}}) == ""   # not an env signal
+
+    corpus = SkillCorpus(window_start="a", window_end="b", eligible_scored=10,
+                         eligible_session_ids=["s1", "s2", "s3"])
+
+    def loader(conn, sid):
+        return {"project": "p", "source": "codex", "start_time": "2026-07-01T00:00:00+00:00",
+                "messages": [_at(_tu("Bash", "rm x", status="error", output=msg))]}
+
+    add_env_candidates(None, corpus, loader=loader)
+    add_rejection_candidate(None, corpus, loader=loader)
+    # exactly one candidate, and it's the rejection one (no env leak)
+    assert [c.title for c in corpus.failures] == ["User-Rejected Actions"]
+    assert corpus.objective_recurrence == {"user-rejected actions": 3}


### PR DESCRIPTION
Two correctness nits surfaced by a real 14-day cross-agent run.

## 1. Newer rejection phrasing leaked into the environment channel
`_HUMAN_REJECTION_RE` only matched Claude's "doesn't want to **take this action**". The newer agent phrasing "doesn't want to **proceed** with this tool use" slipped through, so those rejections were:
- **undercounted** in the human-rejection candidate, and
- **miscategorized** — they leaked into the env-signature channel as a bogus "environment error" (it showed up as a phantom `"the user doesn't want to proceed…"` row in the objective trend).

Now matches both phrasings (plus "tool use will be skipped").

## 2. Synthetic candidates inflated the `sources=N` footer
`meta["sources"]` was computed *after* the synthetic env/rejection candidates were appended, so their placeholder ids (`env-signature-N`, `human-rejection`) counted as "sources" in the skill-file footer. Now counts distinct **real** candidate sessions, captured before the synthetics are added.

Both confirmed against real data (the `--window-days 14` run that prompted this); full suite green (2469), 2 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LnzqCuYZudab6cSjAgZvfE