### PR TITLE
[codex] add WorkBuddy source support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ClawJournal
 
-Review and curate your coding-agent session traces — 100% locally. ClawJournal scans session logs from Claude Code, Claude Desktop, Claude Science, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline, anonymizes secrets and personal information, and gives you a browser workbench to review everything before it ever leaves your machine.
+Review and curate your coding-agent session traces — 100% locally. ClawJournal scans session logs from Claude Code, Claude Desktop, Claude Science, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, WorkBuddy, and Cline, anonymizes secrets and personal information, and gives you a browser workbench to review everything before it ever leaves your machine.
 
 ## Copy-paste prompts
 
@@ -173,7 +173,7 @@ Tell ClawJournal which agents to scan and what to exclude or redact.
 <summary><b>Show shell commands</b></summary>
 
 ```bash
-clawjournal config --source all                   # claude | claude-science | codex | gemini | opencode | openclaw | kimi | custom | all
+clawjournal config --source all                   # claude | claude-science | codex | gemini | opencode | openclaw | kimi | workbuddy | custom | all
 clawjournal list                                  # see discovered projects
 clawjournal config --exclude "project1,project2"  # optional (appends)
 clawjournal config --redact "string1,string2"     # optional custom redactions (appends)
@@ -414,9 +414,26 @@ Each line of the exported JSONL is one session: `session_id`, `project`, `model`
 
 </details>
 
+## WorkBuddy traces
+
+WorkBuddy support is best-effort because Tencent documents log access through the desktop app rather than a stable public trace schema. ClawJournal scans JSON, JSONL, log, and zip files from:
+
+- `~/WorkBuddy/*/.workbuddy/`
+- `~/.clawjournal/workbuddy/`
+- common WorkBuddy support/log folders on macOS and Windows
+
+If automatic discovery does not find sessions, use WorkBuddy's Help menu to open the local log folder or directory, then copy the resulting zip or trace folder into `~/.clawjournal/workbuddy/<project-name>/` and run:
+
+```bash
+clawjournal scan --source workbuddy
+clawjournal list --source workbuddy
+```
+
+On Windows, the import folder is `%USERPROFILE%\.clawjournal\workbuddy\<project-name>\`.
+
 ## Supported agents
 
-Claude Code, Claude Desktop, Claude Science, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline.
+Claude Code, Claude Desktop, Claude Science, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, WorkBuddy, and Cline.
 
 ## Project docs
 

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -34,6 +34,8 @@ from .parsing.parser import (
     LOCAL_AGENT_DIR,
     OPENCODE_DIR,
     OPENCLAW_DIR,
+    WORKBUDDY_DIR,
+    WORKBUDDY_IMPORT_DIR,
     discover_projects,
     parse_project_sessions,
 )
@@ -76,18 +78,18 @@ EXPORT_REVIEW_PUBLISH_STEPS = [
 
 SETUP_TO_PUBLISH_STEPS = [
     "Step 1/5: Run prep/list to review project scope: clawjournal prep && clawjournal list",
-    "Step 2/5: Explicitly choose source scope: clawjournal config --source <claude|claude-science|codex|gemini|all>",
+    "Step 2/5: Explicitly choose source scope: clawjournal config --source <claude|claude-science|codex|gemini|workbuddy|all>",
     "Step 3/5: Configure exclusions/redactions and confirm projects: clawjournal config ...",
     "Step 4/5: Export locally: clawjournal export --output /tmp/clawjournal_export.jsonl",
     "Step 5/5: Review and confirm: clawjournal confirm ...",
 ]
 
-EXPLICIT_SOURCE_CHOICES = {"claude", "claude-science", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "all", "both"}
-SOURCE_CHOICES = ["auto", "claude", "claude-science", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "all", "both"]
-WORKBENCH_SOURCE_CHOICES = ["claude", "claude-science", "codex", "opencode", "openclaw", "cursor", "copilot", "aider", "gemini", "kimi"]
+EXPLICIT_SOURCE_CHOICES = {"claude", "claude-science", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "workbuddy", "all", "both"}
+SOURCE_CHOICES = ["auto", "claude", "claude-science", "codex", "custom", "gemini", "kimi", "opencode", "openclaw", "cursor", "copilot", "aider", "workbuddy", "all", "both"]
+WORKBENCH_SOURCE_CHOICES = ["claude", "claude-science", "codex", "opencode", "openclaw", "cursor", "copilot", "aider", "workbuddy", "gemini", "kimi"]
 EVENT_SOURCE_CHOICES = ["auto", "claude", "codex", "openclaw", "all"]
 PII_PROVIDER_CHOICES = ("rules", "ai", "hybrid")
-FAILURE_VALUE_SOURCE_SCOPE = ("claude", "claude-science", "codex", "opencode", "openclaw")
+FAILURE_VALUE_SOURCE_SCOPE = ("claude", "claude-science", "codex", "opencode", "openclaw", "workbuddy")
 SCORE_SOURCE_CHOICES = set(WORKBENCH_SOURCE_CHOICES) | {"failure-corpus", "failure-v1", "all", "auto", "both"}
 
 
@@ -117,7 +119,7 @@ def _normalize_score_source_filter(raw: str | None) -> str | list[str] | None:
     if value == "both":
         print(
             "Warning: --source both is deprecated for scoring; use "
-            "--source failure-corpus or --source claude,codex,opencode,openclaw.",
+            "--source failure-corpus or --source claude,codex,opencode,openclaw,workbuddy.",
             file=sys.stderr,
         )
         return ["claude", "codex"]
@@ -177,9 +179,11 @@ def _source_label(source_filter: str) -> str:
         return "Copilot CLI"
     if source_filter == "aider":
         return "Aider"
+    if source_filter == "workbuddy":
+        return "WorkBuddy"
     if source_filter == "custom":
         return "Custom"
-    return "Claude Code, Claude Science, Codex, Cursor, Copilot CLI, Aider, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, or Custom"
+    return "Claude Code, Claude Science, Codex, Cursor, Copilot CLI, Aider, WorkBuddy, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, or Custom"
 
 
 def _normalize_source_filter(source_filter: str) -> str:
@@ -238,7 +242,9 @@ def _has_session_sources(source_filter: str = "auto") -> bool:
     if source_filter == "aider":
         from .parsing.parser import _get_aider_project_index
         return bool(_get_aider_project_index())
-    return CLAUDE_DIR.exists() or LOCAL_AGENT_DIR.exists() or CLAUDE_SCIENCE_DIR.exists() or CODEX_DIR.exists() or CUSTOM_DIR.exists() or GEMINI_DIR.exists() or KIMI_DIR.exists() or OPENCODE_DIR.exists() or OPENCLAW_DIR.exists() or CURSOR_DIR.exists() or COPILOT_DIR.exists()
+    if source_filter == "workbuddy":
+        return WORKBUDDY_DIR.exists() or WORKBUDDY_IMPORT_DIR.exists()
+    return CLAUDE_DIR.exists() or LOCAL_AGENT_DIR.exists() or CLAUDE_SCIENCE_DIR.exists() or CODEX_DIR.exists() or CUSTOM_DIR.exists() or GEMINI_DIR.exists() or KIMI_DIR.exists() or OPENCODE_DIR.exists() or OPENCLAW_DIR.exists() or CURSOR_DIR.exists() or COPILOT_DIR.exists() or WORKBUDDY_DIR.exists() or WORKBUDDY_IMPORT_DIR.exists()
 
 
 def _filter_projects_by_source(projects: list[dict], source_filter: str) -> list[dict]:
@@ -299,14 +305,14 @@ def _build_status_next_steps(
         steps = []
         if not source_confirmed:
             steps.append(
-                "Ask the user to explicitly choose export source scope: Claude Code, Claude Science, Codex, Gemini, or all. "
-                "Then set it: clawjournal config --source <claude|claude-science|codex|gemini|all>. "
+                "Ask the user to explicitly choose export source scope: Claude Code, Claude Science, Codex, Gemini, WorkBuddy, or all. "
+                "Then set it: clawjournal config --source <claude|claude-science|codex|gemini|workbuddy|all>. "
                 "Do not run export until source scope is explicitly confirmed."
             )
         else:
             steps.append(
                 f"Source scope is currently set to '{configured_source}'. "
-                "If the user wants a different scope, run: clawjournal config --source <claude|claude-science|codex|gemini|all>."
+                "If the user wants a different scope, run: clawjournal config --source <claude|claude-science|codex|gemini|workbuddy|all>."
             )
         if not projects_confirmed:
             steps.append(
@@ -1167,7 +1173,7 @@ def prep(source_filter: str = "auto") -> None:
             from .parsing.parser import GEMINI_DIR
             err = f"{GEMINI_DIR} was not found."
         else:
-            err = "None of ~/.claude, ~/.claude-science, ~/.codex, or ~/.gemini/tmp were found."
+            err = "None of ~/.claude, ~/.claude-science, ~/.codex, ~/.gemini/tmp, ~/WorkBuddy, or ~/.clawjournal/workbuddy were found."
         print(json.dumps({"error": err}))
         sys.exit(1)
 
@@ -3847,7 +3853,7 @@ def main() -> None:
     cfg = sub.add_parser("config", help="View or set config")
     cfg.add_argument("--repo", type=str, help=argparse.SUPPRESS)
     cfg.add_argument("--source", choices=sorted(EXPLICIT_SOURCE_CHOICES),
-                     help="Set export source scope explicitly: claude, claude-science, codex, gemini, or all")
+                     help="Set export source scope explicitly: claude, claude-science, codex, gemini, workbuddy, or all")
     cfg.add_argument("--scorer-backend", choices=[b for b in SCORING_BACKEND_CHOICES if b != "auto"] + ["none"],
                      help="Confirm the AI scoring backend for automatic workbench scoring")
     cfg.add_argument("--exclude", type=str, help="Comma-separated projects to exclude")
@@ -6546,12 +6552,12 @@ def _run_export(args) -> None:
             "error": "Source scope is not confirmed yet.",
             "hint": (
                 "Explicitly choose one source scope before exporting: "
-                "`claude`, `claude-science`, `codex`, `gemini`, or `all`."
+                "`claude`, `claude-science`, `codex`, `gemini`, `workbuddy`, or `all`."
             ),
             "required_action": (
-                "Ask the user whether to export Claude Code, Claude Science, Codex, Gemini, or all. "
-                "Then run `clawjournal config --source <claude|claude-science|codex|gemini|all>` "
-                "or pass `--source <claude|claude-science|codex|gemini|all>` on the export command."
+                "Ask the user whether to export Claude Code, Claude Science, Codex, Gemini, WorkBuddy, or all. "
+                "Then run `clawjournal config --source <claude|claude-science|codex|gemini|workbuddy|all>` "
+                "or pass `--source <claude|claude-science|codex|gemini|workbuddy|all>` on the export command."
             ),
             "allowed_sources": sorted(EXPLICIT_SOURCE_CHOICES),
             "blocked_on_step": "Step 2/5",
@@ -6575,7 +6581,7 @@ def _run_export(args) -> None:
             from .parsing.parser import GEMINI_DIR
             print(f"Error: {GEMINI_DIR} not found.", file=sys.stderr)
         else:
-            print("Error: none of ~/.claude, ~/.claude-science, ~/.codex, or ~/.gemini/tmp were found.", file=sys.stderr)
+            print("Error: none of ~/.claude, ~/.claude-science, ~/.codex, ~/.gemini/tmp, ~/WorkBuddy, or ~/.clawjournal/workbuddy were found.", file=sys.stderr)
         sys.exit(1)
 
     projects = discover_projects(source_filter=source_filter)

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -51,7 +51,7 @@ DEFAULT_CONFIG: ClawJournalConfig = {
 }
 
 
-_KNOWN_PREFIXES = ("claude:", "claude-science:", "codex:", "gemini:", "opencode:", "openclaw:", "kimi:", "cline:", "custom:")
+_KNOWN_PREFIXES = ("claude:", "claude-science:", "codex:", "gemini:", "opencode:", "openclaw:", "kimi:", "cline:", "workbuddy:", "custom:")
 _BOTH_SOURCES = ("claude", "codex")
 
 

--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -60,6 +60,7 @@ CURSOR_DIR = Path.home() / ".cursor"
 COPILOT_DIR = Path.home() / ".copilot" / "session-state"
 AIDER_HISTORY_FILENAME = ".aider.chat.history.md"
 WORKBUDDY_DIR = Path.home() / "WorkBuddy"
+WORKBUDDY_AI_PROJECTS_DIR = Path.home() / ".workbuddy-ai" / "projects"
 WORKBUDDY_IMPORT_DIR = Path.home() / ".clawjournal" / "workbuddy"
 WORKBUDDY_MAX_FILE_BYTES = 100 * 1024 * 1024
 WORKBUDDY_MAX_ZIP_MEMBER_BYTES = 25 * 1024 * 1024
@@ -794,6 +795,7 @@ def _iter_existing_workbuddy_roots() -> list[tuple[Path, str]]:
     roots: list[tuple[Path, str]] = [
         (WORKBUDDY_IMPORT_DIR, "manual"),
         (WORKBUDDY_DIR, "workspace"),
+        (WORKBUDDY_AI_PROJECTS_DIR, "project-tree"),
     ]
     if platform.system() == "Darwin":
         roots.extend(
@@ -853,6 +855,11 @@ def _iter_workbuddy_candidate_files(root: Path, kind: str) -> list[Path]:
             candidates.extend(
                 p for p in root.glob("*.zip") if p.is_file()
             )
+        elif kind == "project-tree":
+            candidates.extend(
+                p for p in root.rglob("*")
+                if p.is_file() and p.suffix.lower() in suffixes
+            )
         else:
             candidates.extend(
                 p for p in root.rglob("*")
@@ -877,6 +884,8 @@ def _workbuddy_project_key(path: Path, root: Path, kind: str) -> str:
         rel = Path(path.name)
     if kind == "manual":
         return rel.parts[0] if len(rel.parts) > 1 else "manual"
+    if kind == "project-tree":
+        return rel.parts[0] if len(rel.parts) > 1 else "workbuddy-ai"
     if kind == "workspace":
         return rel.parts[0] if rel.parts else "workspace"
     return kind

--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -4,9 +4,11 @@ import dataclasses
 import hashlib
 import json
 import logging
+import os
 import platform
 import re
 import sqlite3
+import zipfile
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -26,6 +28,7 @@ KIMI_SOURCE = "kimi"
 CURSOR_SOURCE = "cursor"
 COPILOT_SOURCE = "copilot"
 AIDER_SOURCE = "aider"
+WORKBUDDY_SOURCE = "workbuddy"
 CUSTOM_SOURCE = "custom"
 
 CLAUDE_DIR = Path.home() / ".claude"
@@ -56,6 +59,12 @@ UNKNOWN_KIMI_CWD = "<unknown-cwd>"
 CURSOR_DIR = Path.home() / ".cursor"
 COPILOT_DIR = Path.home() / ".copilot" / "session-state"
 AIDER_HISTORY_FILENAME = ".aider.chat.history.md"
+WORKBUDDY_DIR = Path.home() / "WorkBuddy"
+WORKBUDDY_IMPORT_DIR = Path.home() / ".clawjournal" / "workbuddy"
+WORKBUDDY_MAX_FILE_BYTES = 100 * 1024 * 1024
+WORKBUDDY_MAX_ZIP_MEMBER_BYTES = 25 * 1024 * 1024
+WORKBUDDY_TRACE_SUFFIXES = {".json", ".jsonl", ".ndjson", ".log"}
+WORKBUDDY_ARCHIVE_SUFFIXES = {".zip"}
 
 CUSTOM_DIR = Path.home() / ".clawjournal" / "custom"
 
@@ -99,6 +108,7 @@ _OPENCLAW_PROJECT_INDEX: dict[str, list[Path]] = {}
 _KIMI_PROJECT_INDEX: dict[str, list[Path]] = {}
 _CURSOR_PROJECT_INDEX: dict[str, list[Path]] = {}
 _AIDER_PROJECT_INDEX: dict[str, Path] = {}
+_WORKBUDDY_PROJECT_INDEX: dict[str, list[Path]] = {}
 
 
 def _build_gemini_hash_map() -> dict[str, str]:
@@ -381,6 +391,7 @@ def discover_projects(source_filter: str | None = None) -> list[dict]:
         CURSOR_SOURCE: _discover_cursor_projects,
         COPILOT_SOURCE: _discover_copilot_projects,
         AIDER_SOURCE: _discover_aider_projects,
+        WORKBUDDY_SOURCE: _discover_workbuddy_projects,
         CUSTOM_SOURCE: _discover_custom_projects,
     }
 
@@ -766,6 +777,612 @@ def _build_kimi_project_name(cwd: str, hash_to_path: dict[str, str] | None = Non
     if cwd == UNKNOWN_KIMI_CWD:
         return "kimi:unknown"
     return f"kimi:{Path(cwd).name or cwd}"
+
+
+def _workbuddy_env_dir(name: str, fallback: Path) -> Path:
+    value = os.environ.get(name)
+    return Path(value) if value else fallback
+
+
+def _iter_existing_workbuddy_roots() -> list[tuple[Path, str]]:
+    """Return WorkBuddy locations we can scan without product internals.
+
+    Official docs expose logs through the in-app Help menu, so the manual
+    import directory is first. The other roots are known user/workspace/cache
+    locations; nonexistent paths are ignored.
+    """
+    roots: list[tuple[Path, str]] = [
+        (WORKBUDDY_IMPORT_DIR, "manual"),
+        (WORKBUDDY_DIR, "workspace"),
+    ]
+    if platform.system() == "Darwin":
+        roots.extend(
+            [
+                (Path.home() / "Library" / "Application Support" / "WorkBuddy", "support"),
+                (Path.home() / "Library" / "Caches" / "WorkBuddy", "logs"),
+                (Path.home() / "Library" / "Caches" / "com.tencent.WorkBuddy", "logs"),
+                (Path.home() / "Library" / "Logs" / "WorkBuddy", "logs"),
+            ]
+        )
+    else:
+        appdata = _workbuddy_env_dir(
+            "APPDATA", Path.home() / "AppData" / "Roaming"
+        )
+        localappdata = _workbuddy_env_dir(
+            "LOCALAPPDATA", Path.home() / "AppData" / "Local"
+        )
+        roots.extend(
+            [
+                (appdata / "Tencent" / "WorkBuddy", "support"),
+                (appdata / "Tencent" / "WorkBuddy" / "Logs", "logs"),
+                (appdata / "WorkBuddy", "support"),
+                (localappdata / "Tencent" / "WorkBuddy", "support"),
+                (localappdata / "Tencent" / "WorkBuddy" / "Logs", "logs"),
+                (localappdata / "WorkBuddy", "support"),
+            ]
+        )
+
+    seen: set[Path] = set()
+    existing: list[tuple[Path, str]] = []
+    for root, kind in roots:
+        try:
+            resolved = root.expanduser().resolve()
+        except OSError:
+            resolved = root.expanduser()
+        if resolved in seen or not root.exists():
+            continue
+        seen.add(resolved)
+        existing.append((root, kind))
+    return existing
+
+
+def _iter_workbuddy_candidate_files(root: Path, kind: str) -> list[Path]:
+    suffixes = WORKBUDDY_TRACE_SUFFIXES | WORKBUDDY_ARCHIVE_SUFFIXES
+    candidates: list[Path] = []
+    try:
+        if kind == "workspace":
+            workspace_dirs = [d for d in root.iterdir() if d.is_dir()]
+            for workspace in sorted(workspace_dirs):
+                wb_dir = workspace / ".workbuddy"
+                scan_roots = [wb_dir] if wb_dir.is_dir() else []
+                for scan_root in scan_roots:
+                    candidates.extend(
+                        p for p in scan_root.rglob("*")
+                        if p.is_file() and p.suffix.lower() in suffixes
+                    )
+            candidates.extend(
+                p for p in root.glob("*.zip") if p.is_file()
+            )
+        else:
+            candidates.extend(
+                p for p in root.rglob("*")
+                if p.is_file() and p.suffix.lower() in suffixes
+            )
+    except OSError:
+        return []
+    return [p for p in sorted(candidates) if _workbuddy_file_size_ok(p)]
+
+
+def _workbuddy_file_size_ok(path: Path) -> bool:
+    try:
+        return path.stat().st_size <= WORKBUDDY_MAX_FILE_BYTES
+    except OSError:
+        return False
+
+
+def _workbuddy_project_key(path: Path, root: Path, kind: str) -> str:
+    try:
+        rel = path.relative_to(root)
+    except ValueError:
+        rel = Path(path.name)
+    if kind == "manual":
+        return rel.parts[0] if len(rel.parts) > 1 else "manual"
+    if kind == "workspace":
+        return rel.parts[0] if rel.parts else "workspace"
+    return kind
+
+
+def _get_workbuddy_project_index(refresh: bool = False) -> dict[str, list[Path]]:
+    global _WORKBUDDY_PROJECT_INDEX
+    if refresh or not _WORKBUDDY_PROJECT_INDEX:
+        index: dict[str, list[Path]] = {}
+        for root, kind in _iter_existing_workbuddy_roots():
+            for path in _iter_workbuddy_candidate_files(root, kind):
+                key = _workbuddy_project_key(path, root, kind)
+                index.setdefault(key, []).append(path)
+        _WORKBUDDY_PROJECT_INDEX = {
+            key: sorted(paths) for key, paths in sorted(index.items())
+        }
+    return _WORKBUDDY_PROJECT_INDEX
+
+
+def _discover_workbuddy_projects() -> list[dict]:
+    index = _get_workbuddy_project_index(refresh=True)
+    projects: list[dict[str, Any]] = []
+    anonymizer = Anonymizer(enabled=False)
+    for key, files in sorted(index.items()):
+        sessions = []
+        total_size = 0
+        for path in files:
+            try:
+                total_size += path.stat().st_size
+            except OSError:
+                pass
+            sessions.extend(_parse_workbuddy_trace_file(path, anonymizer))
+        if not sessions:
+            continue
+        projects.append(
+            {
+                "dir_name": key,
+                "display_name": _build_workbuddy_project_name(key),
+                "session_count": len(sessions),
+                "total_size_bytes": total_size,
+                "source": WORKBUDDY_SOURCE,
+            }
+        )
+    return projects
+
+
+def _parse_workbuddy_project_sessions(
+    project_dir_name: str,
+    anonymizer: Anonymizer,
+    include_thinking: bool = True,
+) -> list[dict]:
+    index = _get_workbuddy_project_index()
+    sessions: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    for path in index.get(project_dir_name, []):
+        for session in _parse_workbuddy_trace_file(path, anonymizer, include_thinking):
+            if not session.get("messages"):
+                continue
+            session["project"] = _build_workbuddy_project_name(project_dir_name)
+            session["source"] = WORKBUDDY_SOURCE
+            sid = str(session.get("session_id") or "")
+            if sid in seen_ids:
+                session["session_id"] = hashlib.sha256(
+                    f"{sid}:{session.get('raw_source_path', path)}".encode()
+                ).hexdigest()[:16]
+            seen_ids.add(str(session["session_id"]))
+            sessions.append(session)
+    return sessions
+
+
+def _parse_workbuddy_trace_file(
+    path: Path,
+    anonymizer: Anonymizer,
+    include_thinking: bool = True,
+) -> list[dict]:
+    suffix = path.suffix.lower()
+    if suffix in WORKBUDDY_ARCHIVE_SUFFIXES:
+        return _parse_workbuddy_zip(path, anonymizer, include_thinking)
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return []
+    return _parse_workbuddy_text(
+        text,
+        anonymizer=anonymizer,
+        include_thinking=include_thinking,
+        raw_source_path=str(path),
+    )
+
+
+def _parse_workbuddy_zip(
+    path: Path,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> list[dict]:
+    sessions: list[dict[str, Any]] = []
+    try:
+        with zipfile.ZipFile(path) as archive:
+            for info in sorted(archive.infolist(), key=lambda i: i.filename):
+                if info.is_dir() or info.file_size > WORKBUDDY_MAX_ZIP_MEMBER_BYTES:
+                    continue
+                suffix = Path(info.filename).suffix.lower()
+                if suffix not in WORKBUDDY_TRACE_SUFFIXES:
+                    continue
+                try:
+                    data = archive.read(info)
+                except (KeyError, RuntimeError, zipfile.BadZipFile):
+                    continue
+                text = data.decode("utf-8", errors="replace")
+                sessions.extend(
+                    _parse_workbuddy_text(
+                        text,
+                        anonymizer=anonymizer,
+                        include_thinking=include_thinking,
+                        raw_source_path=f"{path}#{info.filename}",
+                    )
+                )
+    except (OSError, zipfile.BadZipFile):
+        return []
+    return sessions
+
+
+def _parse_workbuddy_text(
+    text: str,
+    *,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+    raw_source_path: str,
+) -> list[dict]:
+    values = _load_workbuddy_json_values(text)
+    if not values:
+        return []
+
+    sessions: list[dict[str, Any]] = []
+    message_groups: dict[str, list[dict[str, Any]]] = {}
+    for value in values:
+        extracted = _extract_workbuddy_sessions(
+            value,
+            anonymizer=anonymizer,
+            include_thinking=include_thinking,
+            raw_source_path=raw_source_path,
+        )
+        if extracted:
+            sessions.extend(extracted)
+            continue
+        if isinstance(value, dict) and _is_workbuddy_message_like(value):
+            group_key = _workbuddy_group_id(value, raw_source_path)
+            message_groups.setdefault(group_key, []).append(value)
+
+    for group_id, rows in message_groups.items():
+        parsed = _build_workbuddy_session_from_messages(
+            rows,
+            anonymizer=anonymizer,
+            include_thinking=include_thinking,
+            raw_source_path=raw_source_path,
+            fallback_session_id=group_id,
+            metadata={},
+        )
+        if parsed:
+            sessions.append(parsed)
+
+    return _dedupe_workbuddy_sessions(sessions, raw_source_path)
+
+
+def _load_workbuddy_json_values(text: str) -> list[Any]:
+    stripped = text.strip()
+    if not stripped:
+        return []
+    try:
+        return [json.loads(stripped)]
+    except json.JSONDecodeError:
+        pass
+
+    values: list[Any] = []
+    for line in text.splitlines():
+        row = line.strip()
+        if not row:
+            continue
+        parsed = _parse_workbuddy_json_fragment(row)
+        if parsed is not None:
+            values.append(parsed)
+    return values
+
+
+def _parse_workbuddy_json_fragment(row: str) -> Any | None:
+    candidates = [row]
+    if not row.startswith(("{", "[")):
+        start = min(
+            (idx for idx in (row.find("{"), row.find("[")) if idx >= 0),
+            default=-1,
+        )
+        if start >= 0:
+            candidates.append(row[start:])
+    for candidate in candidates:
+        try:
+            return json.loads(candidate)
+        except json.JSONDecodeError:
+            continue
+    return None
+
+
+_WORKBUDDY_MESSAGE_KEYS = (
+    "messages", "messageList", "chatMessages", "conversation", "history",
+    "records", "dialogue", "turns",
+)
+_WORKBUDDY_SESSION_LIST_KEYS = (
+    "sessions", "conversations", "tasks", "items", "data", "list",
+)
+
+
+def _extract_workbuddy_sessions(
+    value: Any,
+    *,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+    raw_source_path: str,
+) -> list[dict]:
+    if isinstance(value, list):
+        if value and all(isinstance(item, dict) and _is_workbuddy_message_like(item) for item in value):
+            parsed = _build_workbuddy_session_from_messages(
+                value,
+                anonymizer=anonymizer,
+                include_thinking=include_thinking,
+                raw_source_path=raw_source_path,
+                fallback_session_id=_workbuddy_hash_id(raw_source_path, "list"),
+                metadata={},
+            )
+            return [parsed] if parsed else []
+        sessions: list[dict[str, Any]] = []
+        for item in value:
+            sessions.extend(
+                _extract_workbuddy_sessions(
+                    item,
+                    anonymizer=anonymizer,
+                    include_thinking=include_thinking,
+                    raw_source_path=raw_source_path,
+                )
+            )
+        return sessions
+
+    if not isinstance(value, dict):
+        return []
+
+    for key in _WORKBUDDY_MESSAGE_KEYS:
+        raw_messages = value.get(key)
+        if isinstance(raw_messages, list) and raw_messages:
+            parsed = _build_workbuddy_session_from_messages(
+                raw_messages,
+                anonymizer=anonymizer,
+                include_thinking=include_thinking,
+                raw_source_path=raw_source_path,
+                fallback_session_id=_workbuddy_session_id(value, raw_source_path),
+                metadata=value,
+            )
+            return [parsed] if parsed else []
+
+    for key in _WORKBUDDY_SESSION_LIST_KEYS:
+        nested = value.get(key)
+        if isinstance(nested, list) and nested:
+            sessions: list[dict[str, Any]] = []
+            for item in nested:
+                sessions.extend(
+                    _extract_workbuddy_sessions(
+                        item,
+                        anonymizer=anonymizer,
+                        include_thinking=include_thinking,
+                        raw_source_path=raw_source_path,
+                    )
+                )
+            if sessions:
+                return sessions
+
+    return []
+
+
+def _build_workbuddy_session_from_messages(
+    raw_messages: list[Any],
+    *,
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+    raw_source_path: str,
+    fallback_session_id: str,
+    metadata: dict[str, Any],
+) -> dict | None:
+    messages: list[dict[str, Any]] = []
+    stats = _make_stats()
+    session_meta = {
+        "session_id": _workbuddy_session_id(metadata, raw_source_path, fallback_session_id),
+        "cwd": _first_str(metadata, ("cwd", "workspace", "workspacePath", "workdir")),
+        "git_branch": _first_str(metadata, ("git_branch", "gitBranch", "branch")),
+        "model": _first_str(metadata, ("model", "modelName", "model_id", "modelId")) or "workbuddy-unknown",
+        "model_effort": _extract_model_effort(metadata),
+        "start_time": _normalize_timestamp(
+            _first_present(metadata, ("start_time", "startTime", "createdAt", "created_at", "timeCreated"))
+        ),
+        "end_time": _normalize_timestamp(
+            _first_present(metadata, ("end_time", "endTime", "updatedAt", "finishedAt", "lastActivityAt"))
+        ),
+    }
+
+    for raw in raw_messages:
+        if not isinstance(raw, dict):
+            continue
+        msg = _workbuddy_message(raw, anonymizer, include_thinking)
+        if not msg:
+            continue
+        timestamp = msg.get("timestamp")
+        if session_meta["start_time"] is None and timestamp:
+            session_meta["start_time"] = timestamp
+        if timestamp:
+            session_meta["end_time"] = timestamp
+        model = _first_str(raw, ("model", "modelName", "model_id", "modelId"))
+        if model and session_meta["model"] == "workbuddy-unknown":
+            session_meta["model"] = model
+        effort = _extract_model_effort(raw)
+        if effort and session_meta["model_effort"] is None:
+            session_meta["model_effort"] = effort
+        usage = raw.get("usage") if isinstance(raw.get("usage"), dict) else raw
+        stats["input_tokens"] += _safe_int(
+            _first_present(usage, ("input_tokens", "inputTokens", "prompt_tokens", "promptTokens"))
+        )
+        stats["output_tokens"] += _safe_int(
+            _first_present(usage, ("output_tokens", "outputTokens", "completion_tokens", "completionTokens"))
+        )
+        messages.append(msg)
+        if msg.get("role") == "user":
+            stats["user_messages"] += 1
+        elif msg.get("role") == "assistant":
+            stats["assistant_messages"] += 1
+        stats["tool_uses"] += len(msg.get("tool_uses", []))
+
+    result = _make_session_result(session_meta, messages, stats)
+    if result:
+        result["raw_source_path"] = raw_source_path
+    return result
+
+
+def _workbuddy_message(
+    raw: dict[str, Any],
+    anonymizer: Anonymizer,
+    include_thinking: bool,
+) -> dict[str, Any] | None:
+    role = _workbuddy_role(raw)
+    text = _workbuddy_text(raw)
+    tool_uses = _workbuddy_tool_uses(raw, anonymizer)
+    if role is None and tool_uses:
+        role = "assistant"
+    if role is None:
+        return None
+
+    msg: dict[str, Any] = {"role": role}
+    timestamp = _normalize_timestamp(
+        _first_present(raw, ("timestamp", "createdAt", "created_at", "time", "timeCreated"))
+    )
+    if timestamp:
+        msg["timestamp"] = timestamp
+    if text:
+        redacted, _, _ = redact_text(text)
+        msg["content"] = anonymizer.text(redacted)
+    thinking = _first_str(raw, ("thinking", "reasoning", "thought", "plan"))
+    if include_thinking and thinking:
+        redacted, _, _ = redact_text(thinking)
+        msg["thinking"] = anonymizer.text(redacted)
+    if tool_uses:
+        msg["tool_uses"] = tool_uses
+    if not msg.get("content") and not msg.get("thinking") and not tool_uses:
+        return None
+    return msg
+
+
+def _workbuddy_tool_uses(raw: dict[str, Any], anonymizer: Anonymizer) -> list[dict[str, Any]]:
+    entries = []
+    for key in ("tool_uses", "toolUses", "tool_calls", "toolCalls", "tools"):
+        value = raw.get(key)
+        if isinstance(value, list):
+            entries.extend(item for item in value if isinstance(item, dict))
+    if not entries and (
+        any(k in raw for k in ("tool", "toolName", "functionName"))
+        or ("name" in raw and any(k in raw for k in ("input", "arguments", "args", "parameters")))
+    ):
+        entries.append(raw)
+
+    tool_uses: list[dict[str, Any]] = []
+    for item in entries:
+        name = _first_str(item, ("tool", "toolName", "name", "functionName")) or "tool"
+        input_data = (
+            item.get("input")
+            if "input" in item
+            else item.get("arguments", item.get("args", item.get("parameters", {})))
+        )
+        tool_uses.append(
+            {
+                "tool": name,
+                "input": _parse_tool_input(name, input_data, anonymizer),
+            }
+        )
+    return tool_uses
+
+
+def _is_workbuddy_message_like(value: dict[str, Any]) -> bool:
+    return _workbuddy_role(value) is not None or any(
+        key in value for key in ("content", "text", "message", "prompt", "answer", "response")
+    )
+
+
+def _workbuddy_role(value: dict[str, Any]) -> str | None:
+    raw = _first_str(value, ("role", "author", "sender", "type", "event"))
+    if raw is None:
+        return None
+    normalized = raw.strip().lower()
+    if normalized in {"user", "human", "customer", "client", "request", "user_message"}:
+        return "user"
+    if normalized in {
+        "assistant", "ai", "agent", "bot", "workbuddy", "answer",
+        "assistant_message", "model",
+    }:
+        return "assistant"
+    if "user" in normalized:
+        return "user"
+    if any(token in normalized for token in ("assistant", "agent", "bot", "reply", "answer")):
+        return "assistant"
+    return None
+
+
+def _workbuddy_text(value: dict[str, Any]) -> str | None:
+    for key in ("content", "text", "message", "prompt", "answer", "response", "output", "result"):
+        if key not in value:
+            continue
+        text = _stringify_workbuddy_content(value.get(key))
+        if text:
+            return text
+    return None
+
+
+def _stringify_workbuddy_content(value: Any) -> str | None:
+    if isinstance(value, str):
+        stripped = value.strip()
+        return stripped or None
+    if isinstance(value, dict):
+        for key in ("text", "content", "markdown", "value", "body"):
+            text = _stringify_workbuddy_content(value.get(key))
+            if text:
+                return text
+        return None
+    if isinstance(value, list):
+        parts = [
+            text for item in value
+            if (text := _stringify_workbuddy_content(item))
+        ]
+        return "\n\n".join(parts).strip() or None
+    return None
+
+
+def _workbuddy_group_id(value: dict[str, Any], raw_source_path: str) -> str:
+    for key in ("session_id", "sessionId", "conversation_id", "conversationId", "task_id", "taskId", "threadId"):
+        val = value.get(key)
+        if isinstance(val, (str, int)) and str(val).strip():
+            return str(val).strip()
+    return _workbuddy_hash_id(raw_source_path, "events")
+
+
+def _workbuddy_session_id(
+    metadata: dict[str, Any],
+    raw_source_path: str,
+    fallback: str | None = None,
+) -> str:
+    for key in ("session_id", "sessionId", "conversation_id", "conversationId", "task_id", "taskId", "id", "uuid"):
+        val = metadata.get(key)
+        if isinstance(val, (str, int)) and str(val).strip():
+            return str(val).strip()
+    return fallback or _workbuddy_hash_id(raw_source_path, "session")
+
+
+def _workbuddy_hash_id(raw_source_path: str, salt: str) -> str:
+    return hashlib.sha256(f"workbuddy:{raw_source_path}:{salt}".encode()).hexdigest()[:16]
+
+
+def _dedupe_workbuddy_sessions(sessions: list[dict], raw_source_path: str) -> list[dict]:
+    seen: set[str] = set()
+    deduped: list[dict] = []
+    for index, session in enumerate(sessions):
+        sid = str(session.get("session_id") or "")
+        if sid in seen:
+            sid = _workbuddy_hash_id(raw_source_path, f"{sid}:{index}")
+            session["session_id"] = sid
+        seen.add(sid)
+        deduped.append(session)
+    return deduped
+
+
+def _first_present(data: Any, keys: tuple[str, ...]) -> Any:
+    if not isinstance(data, dict):
+        return None
+    for key in keys:
+        if key in data and data[key] not in (None, ""):
+            return data[key]
+    return None
+
+
+def _first_str(data: Any, keys: tuple[str, ...]) -> str | None:
+    value = _first_present(data, keys)
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if isinstance(value, int):
+        return str(value)
+    return None
 
 
 def _discover_custom_projects() -> list[dict]:
@@ -1193,6 +1810,11 @@ def parse_project_sessions(
 
     if source == CUSTOM_SOURCE:
         return _parse_custom_sessions(project_dir_name, anonymizer)
+
+    if source == WORKBUDDY_SOURCE:
+        return _parse_workbuddy_project_sessions(
+            project_dir_name, anonymizer, include_thinking,
+        )
 
     if source == KIMI_SOURCE:
         project_hash = _get_kimi_project_hash(project_dir_name)
@@ -2705,6 +3327,10 @@ def _build_gemini_project_name(project_hash: str) -> str:
 
 def _build_custom_project_name(dir_name: str) -> str:
     return f"custom:{dir_name}"
+
+
+def _build_workbuddy_project_name(dir_name: str) -> str:
+    return f"workbuddy:{Path(dir_name).name or dir_name}"
 
 
 def _get_opencode_project_index(refresh: bool = False) -> dict[str, list[str]]:

--- a/clawjournal/web/frontend/src/components/TraceCard.tsx
+++ b/clawjournal/web/frontend/src/components/TraceCard.tsx
@@ -9,6 +9,7 @@ const SOURCE_ICONS: Record<string, string> = {
   'claude-science': 'CS',
   codex: 'CX',
   openclaw: 'OC',
+  workbuddy: 'WB',
 };
 
 function formatDuration(seconds: number | null): string {

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -129,6 +129,8 @@ function sourceInfo(s: Session): { label: string; color: string } {
     return { label: 'Claude Science', color: '#9333ea' };
   if (s.source === 'openclaw')
     return { label: 'OpenClaw', color: '#6b7280' };
+  if (s.source === 'workbuddy')
+    return { label: 'WorkBuddy', color: '#0f766e' };
   return { label: s.source, color: '#6b7280' };
 }
 

--- a/clawjournal/web/frontend/src/views/SessionDetail.tsx
+++ b/clawjournal/web/frontend/src/views/SessionDetail.tsx
@@ -35,6 +35,8 @@ function sourceLabel(s: { source: string; client_origin?: string | null; runtime
     return { label: 'Claude Science', color: '#9333ea' };
   if (s.source === 'openclaw')
     return { label: 'OpenClaw', color: '#6b7280' };
+  if (s.source === 'workbuddy')
+    return { label: 'WorkBuddy', color: '#0f766e' };
   return { label: s.source, color: '#6b7280' };
 }
 

--- a/clawjournal/web/frontend/src/views/Settings.tsx
+++ b/clawjournal/web/frontend/src/views/Settings.tsx
@@ -93,7 +93,7 @@ export function Settings() {
         >
           <option value="" disabled>Select a source…</option>
           {cfg.source_choices.map(s => (
-            <option key={s} value={s}>{s === 'all' ? 'All agents' : s === 'claude-science' ? 'Claude Science' : s}</option>
+            <option key={s} value={s}>{s === 'all' ? 'All agents' : s === 'claude-science' ? 'Claude Science' : s === 'workbuddy' ? 'WorkBuddy' : s}</option>
           ))}
         </select>
       </div>

--- a/clawjournal/web/frontend/src/views/Share/helpers.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.ts
@@ -39,6 +39,7 @@ export function sourceFullLabel(s: { source: string; client_origin?: string | nu
   }
   if (s.source === 'claude-science') return { label: 'Claude Science', color: '#9333ea' };
   if (s.source === 'openclaw') return { label: 'OpenClaw', color: '#6b7280' };
+  if (s.source === 'workbuddy') return { label: 'WorkBuddy', color: '#0f766e' };
   return { label: s.source, color: '#6b7280' };
 }
 

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -93,6 +93,7 @@ from ..parsing.parser import (
     KIMI_SOURCE,
     OPENCODE_SOURCE,
     OPENCLAW_SOURCE,
+    WORKBUDDY_SOURCE,
     discover_projects,
     parse_project_sessions,
 )
@@ -133,7 +134,7 @@ _hosted_capabilities_cache: tuple[str, float, dict[str, Any]] | None = None
 WORKBENCH_SOURCES = {
     CLAUDE_SOURCE, CLAUDE_SCIENCE_SOURCE, CODEX_SOURCE, OPENCLAW_SOURCE,
     CURSOR_SOURCE, COPILOT_SOURCE, AIDER_SOURCE,
-    GEMINI_SOURCE, OPENCODE_SOURCE, KIMI_SOURCE,
+    GEMINI_SOURCE, OPENCODE_SOURCE, KIMI_SOURCE, WORKBUDDY_SOURCE,
 }
 
 # Path to the built frontend dist directory.

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -34,7 +34,7 @@ WIDENED_MESSAGE_SCHEMA_VERSION = 4
 HOSTED_SUBMISSION_SCHEMA_VERSION = 5
 WORKBENCH_SCHEMA_VERSION = HOSTED_SUBMISSION_SCHEMA_VERSION
 BACKFILL_WINDOW = 100
-FAILURE_VALUE_SOURCE_SCOPE = ("claude", "claude-science", "codex", "opencode", "openclaw")
+FAILURE_VALUE_SOURCE_SCOPE = ("claude", "claude-science", "codex", "opencode", "openclaw", "workbuddy")
 SHARE_RECOMMENDATION_LIMIT = 10
 
 # Display-only normalization from the mixed AI/heuristic outcome vocabulary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ readme = "README.md"
 authors = [
     {name = "rayward-external"},
 ]
-keywords = ["claude-code", "claude-science", "codex", "gemini-cli", "opencode", "openclaw", "dataset", "conversations"]
+keywords = ["claude-code", "claude-science", "codex", "gemini-cli", "opencode", "openclaw", "workbuddy", "dataset", "conversations"]
 classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Developers",

--- a/tests/parsing/test_parser.py
+++ b/tests/parsing/test_parser.py
@@ -32,6 +32,14 @@ from clawjournal.parsing.parser import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolate_workbuddy_ai_projects(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "clawjournal.parsing.parser.WORKBUDDY_AI_PROJECTS_DIR",
+        tmp_path / "no-workbuddy-ai-projects",
+    )
+
+
 def test_iter_jsonl_reads_utf8_explicitly(tmp_path, monkeypatch):
     path = tmp_path / "session.jsonl"
     payload = {"message": "research note with Cyrillic: с"}
@@ -2407,6 +2415,7 @@ class TestDiscoverWorkBuddyProjects:
         monkeypatch.setattr("clawjournal.parsing.parser._AIDER_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser._get_aider_project_index", lambda refresh=False: {})
         monkeypatch.setattr("clawjournal.parsing.parser.CUSTOM_DIR", tmp_path / "no-custom")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_AI_PROJECTS_DIR", tmp_path / "no-workbuddy-ai-projects")
         monkeypatch.setattr("clawjournal.parsing.parser._WORKBUDDY_PROJECT_INDEX", {})
 
     def _workbuddy_session(self, *, session_id="wb-task-1", content="Summarize the report"):
@@ -2482,6 +2491,38 @@ class TestDiscoverWorkBuddyProjects:
         assert sessions[0]["session_id"] == "conv-1"
         assert sessions[0]["stats"]["user_messages"] == 1
         assert sessions[0]["stats"]["assistant_messages"] == 1
+
+    def test_discovers_workbuddy_ai_project_tree_trace(self, tmp_path, monkeypatch, mock_anonymizer):
+        self._disable_others(tmp_path, monkeypatch)
+        projects_dir = tmp_path / ".workbuddy-ai" / "projects"
+        project_dir = projects_dir / "Users-alice-WorkBuddy AI-2026-07-09-06-28-50"
+        project_dir.mkdir(parents=True)
+        trace_file = project_dir / "97f35c9a-9794-4978-a61a-edcc67be2058.jsonl"
+        events = [
+            {"conversationId": "conv-1", "role": "user", "text": "Check the test trace", "timestamp": "2026-07-09T10:00:00Z"},
+            {"conversationId": "conv-1", "role": "assistant", "text": "Found it.", "timestamp": "2026-07-09T10:00:01Z"},
+        ]
+        trace_file.write_text(
+            "\n".join(json.dumps(e) for e in events) + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_DIR", tmp_path / "no-workbuddy")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_IMPORT_DIR", tmp_path / "no-manual")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_AI_PROJECTS_DIR", projects_dir)
+
+        projects = discover_projects(source_filter="workbuddy")
+        sessions = parse_project_sessions(
+            "Users-alice-WorkBuddy AI-2026-07-09-06-28-50",
+            mock_anonymizer,
+            source="workbuddy",
+        )
+
+        assert len(projects) == 1
+        assert projects[0]["display_name"] == "workbuddy:Users-alice-WorkBuddy AI-2026-07-09-06-28-50"
+        assert projects[0]["session_count"] == 1
+        assert len(sessions) == 1
+        assert sessions[0]["session_id"] == "conv-1"
+        assert sessions[0]["raw_source_path"] == str(trace_file)
 
     def test_parses_manual_workbuddy_support_zip(self, tmp_path, monkeypatch, mock_anonymizer):
         self._disable_others(tmp_path, monkeypatch)

--- a/tests/parsing/test_parser.py
+++ b/tests/parsing/test_parser.py
@@ -3,6 +3,7 @@
 import hashlib
 import json
 import sqlite3
+import zipfile
 
 import pytest
 
@@ -582,6 +583,9 @@ class TestDiscoverProjects:
         monkeypatch.setattr("clawjournal.parsing.parser.COPILOT_DIR", tmp_path / "no-copilot")
         monkeypatch.setattr("clawjournal.parsing.parser._AIDER_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser._get_aider_project_index", lambda refresh=False: {})
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_DIR", tmp_path / "no-workbuddy")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_IMPORT_DIR", tmp_path / "no-workbuddy-import")
+        monkeypatch.setattr("clawjournal.parsing.parser._WORKBUDDY_PROJECT_INDEX", {})
 
     def _write_opencode_db(self, db_path):
         conn = sqlite3.connect(db_path)
@@ -1274,6 +1278,9 @@ class TestDiscoverSubagentProjects:
         monkeypatch.setattr("clawjournal.parsing.parser.COPILOT_DIR", tmp_path / "no-copilot")
         monkeypatch.setattr("clawjournal.parsing.parser._AIDER_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser._get_aider_project_index", lambda refresh=False: {})
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_DIR", tmp_path / "no-workbuddy")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_IMPORT_DIR", tmp_path / "no-workbuddy-import")
+        monkeypatch.setattr("clawjournal.parsing.parser._WORKBUDDY_PROJECT_INDEX", {})
 
     def test_discover_includes_subagent_sessions(self, tmp_path, monkeypatch, mock_anonymizer):
         self._disable_codex(tmp_path, monkeypatch)
@@ -1978,6 +1985,9 @@ class TestDiscoverOpenclawProjects:
         monkeypatch.setattr("clawjournal.parsing.parser.COPILOT_DIR", tmp_path / "no-copilot")
         monkeypatch.setattr("clawjournal.parsing.parser._AIDER_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser._get_aider_project_index", lambda refresh=False: {})
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_DIR", tmp_path / "no-workbuddy")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_IMPORT_DIR", tmp_path / "no-workbuddy-import")
+        monkeypatch.setattr("clawjournal.parsing.parser._WORKBUDDY_PROJECT_INDEX", {})
 
     def test_discover_openclaw_projects(self, tmp_path, monkeypatch, mock_anonymizer):
         self._disable_others(tmp_path, monkeypatch)
@@ -2072,6 +2082,9 @@ class TestDiscoverClaudeScienceProjects:
         monkeypatch.setattr("clawjournal.parsing.parser.COPILOT_DIR", tmp_path / "no-copilot")
         monkeypatch.setattr("clawjournal.parsing.parser._AIDER_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser._get_aider_project_index", lambda refresh=False: {})
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_DIR", tmp_path / "no-workbuddy")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_IMPORT_DIR", tmp_path / "no-workbuddy-import")
+        monkeypatch.setattr("clawjournal.parsing.parser._WORKBUDDY_PROJECT_INDEX", {})
 
     def _write_db(self, db_path, *, with_execution=False, hidden_frame=False):
         db_path.parent.mkdir(parents=True)
@@ -2298,6 +2311,9 @@ class TestDiscoverKimiProjects:
         monkeypatch.setattr("clawjournal.parsing.parser.COPILOT_DIR", tmp_path / "no-copilot")
         monkeypatch.setattr("clawjournal.parsing.parser._AIDER_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser._get_aider_project_index", lambda refresh=False: {})
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_DIR", tmp_path / "no-workbuddy")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_IMPORT_DIR", tmp_path / "no-workbuddy-import")
+        monkeypatch.setattr("clawjournal.parsing.parser._WORKBUDDY_PROJECT_INDEX", {})
 
     @staticmethod
     def _write_kimi_context(session_dir):
@@ -2370,6 +2386,126 @@ class TestDiscoverAiderProjects:
         assert projects[0]["session_count"] == 2
 
 
+class TestDiscoverWorkBuddyProjects:
+    def _disable_others(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.parsing.parser.PROJECTS_DIR", tmp_path / "no-claude")
+        monkeypatch.setattr("clawjournal.parsing.parser.LOCAL_AGENT_DIR", tmp_path / "no-local-agent")
+        monkeypatch.setattr("clawjournal.parsing.parser.CLAUDE_SCIENCE_DIR", tmp_path / "no-claude-science")
+        monkeypatch.setattr("clawjournal.parsing.parser._CLAUDE_SCIENCE_PROJECT_INDEX", {})
+        monkeypatch.setattr("clawjournal.parsing.parser.CODEX_SESSIONS_DIR", tmp_path / "no-codex-sessions")
+        monkeypatch.setattr("clawjournal.parsing.parser.CODEX_ARCHIVED_DIR", tmp_path / "no-codex-archived")
+        monkeypatch.setattr("clawjournal.parsing.parser._CODEX_PROJECT_INDEX", {})
+        monkeypatch.setattr("clawjournal.parsing.parser.GEMINI_DIR", tmp_path / "no-gemini")
+        monkeypatch.setattr("clawjournal.parsing.parser.OPENCODE_DB_PATH", tmp_path / "no-opencode.db")
+        monkeypatch.setattr("clawjournal.parsing.parser._OPENCODE_PROJECT_INDEX", {})
+        monkeypatch.setattr("clawjournal.parsing.parser.OPENCLAW_AGENTS_DIR", tmp_path / "no-openclaw-agents")
+        monkeypatch.setattr("clawjournal.parsing.parser._OPENCLAW_PROJECT_INDEX", {})
+        monkeypatch.setattr("clawjournal.parsing.parser.KIMI_SESSIONS_DIR", tmp_path / "no-kimi-sessions")
+        monkeypatch.setattr("clawjournal.parsing.parser.CURSOR_DIR", tmp_path / "no-cursor")
+        monkeypatch.setattr("clawjournal.parsing.parser._CURSOR_PROJECT_INDEX", {})
+        monkeypatch.setattr("clawjournal.parsing.parser.COPILOT_DIR", tmp_path / "no-copilot")
+        monkeypatch.setattr("clawjournal.parsing.parser._AIDER_PROJECT_INDEX", {})
+        monkeypatch.setattr("clawjournal.parsing.parser._get_aider_project_index", lambda refresh=False: {})
+        monkeypatch.setattr("clawjournal.parsing.parser.CUSTOM_DIR", tmp_path / "no-custom")
+        monkeypatch.setattr("clawjournal.parsing.parser._WORKBUDDY_PROJECT_INDEX", {})
+
+    def _workbuddy_session(self, *, session_id="wb-task-1", content="Summarize the report"):
+        return {
+            "taskId": session_id,
+            "modelName": "hunyuan-t1",
+            "workspacePath": "/Users/alice/WorkBuddy/task",
+            "createdAt": "2026-07-01T10:00:00+00:00",
+            "messages": [
+                {
+                    "role": "user",
+                    "content": content,
+                    "createdAt": "2026-07-01T10:00:01+00:00",
+                },
+                {
+                    "role": "assistant",
+                    "content": "Drafted a summary.",
+                    "createdAt": "2026-07-01T10:00:02+00:00",
+                    "usage": {"inputTokens": 12, "outputTokens": 5},
+                },
+            ],
+        }
+
+    def test_discovers_workspace_workbuddy_trace(self, tmp_path, monkeypatch, mock_anonymizer):
+        self._disable_others(tmp_path, monkeypatch)
+        workbuddy_dir = tmp_path / "WorkBuddy"
+        trace_dir = workbuddy_dir / "20260701100000" / ".workbuddy"
+        trace_dir.mkdir(parents=True)
+        trace_file = trace_dir / "conversation.json"
+        trace_file.write_text(json.dumps(self._workbuddy_session()), encoding="utf-8")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_DIR", workbuddy_dir)
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_IMPORT_DIR", tmp_path / "no-import")
+
+        projects = discover_projects(source_filter="workbuddy")
+
+        assert len(projects) == 1
+        assert projects[0]["display_name"] == "workbuddy:20260701100000"
+        assert projects[0]["session_count"] == 1
+        assert projects[0]["source"] == "workbuddy"
+
+        sessions = parse_project_sessions(
+            "20260701100000", mock_anonymizer, source="workbuddy"
+        )
+        assert len(sessions) == 1
+        assert sessions[0]["session_id"] == "wb-task-1"
+        assert sessions[0]["model"] == "hunyuan-t1"
+        assert sessions[0]["source"] == "workbuddy"
+        assert sessions[0]["project"] == "workbuddy:20260701100000"
+        assert sessions[0]["raw_source_path"] == str(trace_file)
+        assert sessions[0]["stats"]["input_tokens"] == 12
+        assert sessions[0]["messages"][0]["content"] == "Summarize the report"
+
+    def test_parses_manual_jsonl_events_by_conversation(self, tmp_path, monkeypatch, mock_anonymizer):
+        self._disable_others(tmp_path, monkeypatch)
+        import_dir = tmp_path / "manual" / "research-task"
+        import_dir.mkdir(parents=True)
+        events = [
+            {"conversationId": "conv-1", "role": "user", "text": "Find the source file", "timestamp": "2026-07-02T10:00:00Z"},
+            {"conversationId": "conv-1", "role": "assistant", "text": "The logs are in Help.", "timestamp": "2026-07-02T10:00:01Z"},
+        ]
+        (import_dir / "events.jsonl").write_text(
+            "\n".join(json.dumps(e) for e in events) + "\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_DIR", tmp_path / "no-workbuddy")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_IMPORT_DIR", tmp_path / "manual")
+
+        projects = discover_projects(source_filter="workbuddy")
+        sessions = parse_project_sessions("research-task", mock_anonymizer, source="workbuddy")
+
+        assert projects[0]["display_name"] == "workbuddy:research-task"
+        assert len(sessions) == 1
+        assert sessions[0]["session_id"] == "conv-1"
+        assert sessions[0]["stats"]["user_messages"] == 1
+        assert sessions[0]["stats"]["assistant_messages"] == 1
+
+    def test_parses_manual_workbuddy_support_zip(self, tmp_path, monkeypatch, mock_anonymizer):
+        self._disable_others(tmp_path, monkeypatch)
+        import_dir = tmp_path / "manual" / "support-export"
+        import_dir.mkdir(parents=True)
+        zip_path = import_dir / "workbuddy-log.zip"
+        with zipfile.ZipFile(zip_path, "w") as archive:
+            archive.writestr(
+                "logs/conversation.json",
+                json.dumps({"sessions": [self._workbuddy_session(session_id="zip-1")]}),
+            )
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_DIR", tmp_path / "no-workbuddy")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_IMPORT_DIR", tmp_path / "manual")
+
+        projects = discover_projects(source_filter="workbuddy")
+        sessions = parse_project_sessions("support-export", mock_anonymizer, source="workbuddy")
+
+        assert len(projects) == 1
+        assert projects[0]["session_count"] == 1
+        assert len(sessions) == 1
+        assert sessions[0]["session_id"] == "zip-1"
+        assert sessions[0]["raw_source_path"].endswith("workbuddy-log.zip#logs/conversation.json")
+
+
 class TestDiscoverCustomProjects:
     def _disable_others(self, tmp_path, monkeypatch):
         monkeypatch.setattr("clawjournal.parsing.parser.PROJECTS_DIR", tmp_path / "no-claude")
@@ -2390,6 +2526,9 @@ class TestDiscoverCustomProjects:
         monkeypatch.setattr("clawjournal.parsing.parser.COPILOT_DIR", tmp_path / "no-copilot")
         monkeypatch.setattr("clawjournal.parsing.parser._AIDER_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser._get_aider_project_index", lambda refresh=False: {})
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_DIR", tmp_path / "no-workbuddy")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_IMPORT_DIR", tmp_path / "no-workbuddy-import")
+        monkeypatch.setattr("clawjournal.parsing.parser._WORKBUDDY_PROJECT_INDEX", {})
 
     def _make_valid_session(self, session_id="s1", model="gpt-4", content="hello"):
         return json.dumps({
@@ -2662,6 +2801,9 @@ class TestDiscoverClaudeProjectsWithLocalAgent:
         monkeypatch.setattr("clawjournal.parsing.parser.COPILOT_DIR", tmp_path / "no-copilot")
         monkeypatch.setattr("clawjournal.parsing.parser._AIDER_PROJECT_INDEX", {})
         monkeypatch.setattr("clawjournal.parsing.parser._get_aider_project_index", lambda refresh=False: {})
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_DIR", tmp_path / "no-workbuddy")
+        monkeypatch.setattr("clawjournal.parsing.parser.WORKBUDDY_IMPORT_DIR", tmp_path / "no-workbuddy-import")
+        monkeypatch.setattr("clawjournal.parsing.parser._WORKBUDDY_PROJECT_INDEX", {})
 
     def test_la_only_project_with_host_path(self, tmp_path, monkeypatch):
         """Local-agent session with userSelectedFolders gets proper display name."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -614,7 +614,7 @@ class TestListProjects:
         monkeypatch.setattr("clawjournal.cli.discover_projects", lambda source_filter=None: [])
         list_projects()
         captured = capsys.readouterr()
-        assert "No Claude Code, Claude Science, Codex, Cursor, Copilot CLI, Aider, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, or Custom sessions" in captured.out
+        assert "No Claude Code, Claude Science, Codex, Cursor, Copilot CLI, Aider, WorkBuddy, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, or Custom sessions" in captured.out
 
     def test_source_filter_codex(self, monkeypatch, capsys):
         monkeypatch.setattr(
@@ -794,7 +794,7 @@ class TestWorkflowGateMessages:
         assert payload["error"] == "Source scope is not confirmed yet."
         assert payload["blocked_on_step"] == "Step 2/5"
         assert len(payload["process_steps"]) == 5
-        assert payload["allowed_sources"] == ["aider", "all", "both", "claude", "claude-science", "codex", "copilot", "cursor", "custom", "gemini", "kimi", "openclaw", "opencode"]
+        assert payload["allowed_sources"] == ["aider", "all", "both", "claude", "claude-science", "codex", "copilot", "cursor", "custom", "gemini", "kimi", "openclaw", "opencode", "workbuddy"]
         assert payload["next_command"] == "clawjournal config --source all"
 
     def test_configure_next_steps_require_full_folder_presentation(self):


### PR DESCRIPTION
## Summary

- Add a first-class `workbuddy` source for ClawJournal discovery, parsing, scanning, scoring scope, and source filtering.
- Parse best-effort WorkBuddy JSON, JSONL/log, and support zip traces from known local locations and `~/.clawjournal/workbuddy/` manual imports.
- Add WorkBuddy labels in the workbench UI and document the manual log-zip import flow.

## Why

Tencent WorkBuddy exposes local diagnostic log archives through the desktop Help menu, and the public FAQ notes those logs can contain conversation records. Since the public docs do not publish a stable trace schema, this adapter keeps the parser format-tolerant and preserves `raw_source_path` provenance for review.

## Validation

- `python -m pytest tests\parsing\test_parser.py tests\test_cli.py -q` -> 322 passed
- `npm run build` -> passed
- `git diff --check` -> passed
- `python -m compileall clawjournal` -> passed