### PR TITLE
[codex] Gate daemon scoring warmup egress

### DIFF
--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -117,7 +117,7 @@ def _normalize_score_source_filter(raw: str | None) -> str | list[str] | None:
     if value == "both":
         print(
             "Warning: --source both is deprecated for scoring; use "
-            "--source failure-corpus or --source claude,codex,opencode,openclaw.",
+            "--source failure-corpus or --source claude,claude-science,codex,opencode,openclaw.",
             file=sys.stderr,
         )
         return ["claude", "codex"]

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -104,6 +104,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_PORT = 8384
 SCAN_INTERVAL = 60  # seconds
 AUTO_SCORE_BATCH_SIZE = 20
+_NO_MATCHING_WARMUP_SOURCE = "__clawjournal_no_matching_warmup_source__"
 SCORING_DISPLAY_NAMES = {
     "claude": "Claude Code",
     "codex": "Codex",
@@ -291,6 +292,24 @@ def _score_redaction_settings(settings: dict[str, Any]) -> dict[str, Any] | None
     return scoped if any(scoped.values()) else None
 
 
+def _warmup_source_filter(settings: dict[str, Any]) -> str | tuple[str, ...]:
+    """Return the sources background scoring may egress.
+
+    Warmup scoring is a background AI call, so it must honor the same confirmed
+    source scope that share/skill paths use. Keep the unrestricted case on the
+    failure-value corpus, because not every indexed source has a scoring rollout.
+    """
+    allowed = settings.get("source_filter")
+    if allowed is None:
+        return FAILURE_VALUE_SOURCE_SCOPE
+    if isinstance(allowed, str):
+        allowed_values = {allowed}
+    else:
+        allowed_values = {str(source) for source in allowed if source}
+    scoped = tuple(source for source in FAILURE_VALUE_SOURCE_SCOPE if source in allowed_values)
+    return scoped or _NO_MATCHING_WARMUP_SOURCE
+
+
 def _filter_scoreable_warmup_sessions(
     conn: sqlite3.Connection,
     sessions: list[dict[str, Any]],
@@ -321,6 +340,7 @@ def _query_scoreable_warmup_sessions(
     *,
     limit: int,
     since: str | None,
+    source_filter: str | tuple[str, ...],
     excluded_projects: list[str],
     now: datetime | None = None,
 ) -> list[dict[str, Any]]:
@@ -334,7 +354,7 @@ def _query_scoreable_warmup_sessions(
         fetched = query_unscored_sessions(
             conn,
             limit=fetch_limit,
-            source=FAILURE_VALUE_SOURCE_SCOPE,
+            source=source_filter,
             since=since,
             include_stale_scored=True,
             settle_seconds=SCORE_SETTLE_SECONDS,
@@ -490,6 +510,7 @@ class Scanner:
                     conn,
                     limit=limit,
                     since=since,
+                    source_filter=_warmup_source_filter(effective_settings),
                     excluded_projects=excluded_projects,
                 )
                 if not sessions:

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -69,9 +69,11 @@ from .index import (
     open_index,
     query_sessions,
     query_unscored_sessions,
+    release_gate_blockers,
     remove_policy,
     search_fts,
     SCORE_SETTLE_SECONDS,
+    session_matches_excluded_projects,
     source_scope_blockers,
     update_session,
     upsert_sessions,
@@ -279,6 +281,76 @@ def trigger_scoring_warmup(
     return scanner.trigger_auto_score(limit=limit, backend=backend)
 
 
+def _score_redaction_settings(settings: dict[str, Any]) -> dict[str, Any] | None:
+    """Return only the policy fields that affect scoring-prompt redaction."""
+    scoped = {
+        "custom_strings": list(settings.get("custom_strings", []) or []),
+        "extra_usernames": list(settings.get("extra_usernames", []) or []),
+        "blocked_domains": list(settings.get("blocked_domains", []) or []),
+    }
+    return scoped if any(scoped.values()) else None
+
+
+def _filter_scoreable_warmup_sessions(
+    conn: sqlite3.Connection,
+    sessions: list[dict[str, Any]],
+    *,
+    excluded_projects: list[str],
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Apply the same egress gates before background AI scoring."""
+    if not sessions:
+        return []
+    blocker_ids = {
+        b["session_id"]
+        for b in release_gate_blockers(
+            conn,
+            [s["session_id"] for s in sessions],
+            now=now,
+        )
+    }
+    return [
+        s for s in sessions
+        if s["session_id"] not in blocker_ids
+        and not session_matches_excluded_projects(s, excluded_projects)
+    ]
+
+
+def _query_scoreable_warmup_sessions(
+    conn: sqlite3.Connection,
+    *,
+    limit: int,
+    since: str | None,
+    excluded_projects: list[str],
+    now: datetime | None = None,
+) -> list[dict[str, Any]]:
+    """Return latest scorable warmup rows without letting gated rows starve them."""
+    if limit <= 0:
+        return []
+
+    fetch_limit = limit
+    max_fetch = 10_000
+    while True:
+        fetched = query_unscored_sessions(
+            conn,
+            limit=fetch_limit,
+            source=FAILURE_VALUE_SOURCE_SCOPE,
+            since=since,
+            include_stale_scored=True,
+            settle_seconds=SCORE_SETTLE_SECONDS,
+            now=now,
+        )
+        scoreable = _filter_scoreable_warmup_sessions(
+            conn,
+            fetched,
+            excluded_projects=excluded_projects,
+            now=now,
+        )
+        if len(scoreable) >= limit or len(fetched) < fetch_limit or fetch_limit >= max_fetch:
+            return scoreable[:limit]
+        fetch_limit = min(max_fetch, max(fetch_limit * 2, fetch_limit + 1))
+
+
 def _maybe_create_trace_note(conn: sqlite3.Connection, session_id: str) -> None:
     """Create `notes/{session_id}.md` if it does not already exist.
 
@@ -401,6 +473,9 @@ class Scanner:
         try:
             conn = open_index()
             try:
+                effective_settings = get_effective_share_settings(conn, load_config())
+                excluded_projects = list(effective_settings.get("excluded_projects") or [])
+                redaction_settings = _score_redaction_settings(effective_settings)
                 # Warmup deliberately scores the latest `limit` unscored
                 # failure-corpus traces ordered by start_time DESC with no
                 # age cap (`since` is None for the background path). The
@@ -411,13 +486,11 @@ class Scanner:
                 # graded mid-flight and then grew (end_time advanced past
                 # ai_scored_at); `settle_seconds` defers sessions that are still
                 # active so we don't grade them prematurely in the first place.
-                sessions = query_unscored_sessions(
+                sessions = _query_scoreable_warmup_sessions(
                     conn,
                     limit=limit,
-                    source=FAILURE_VALUE_SOURCE_SCOPE,
                     since=since,
-                    include_stale_scored=True,
-                    settle_seconds=SCORE_SETTLE_SECONDS,
+                    excluded_projects=excluded_projects,
                 )
                 if not sessions:
                     return 0
@@ -454,7 +527,10 @@ class Scanner:
                                         self._auto_score_disabled_reason)
                             break
                         try:
-                            result = score_session(conn, sid, backend=active)
+                            score_kwargs: dict[str, Any] = {"backend": active}
+                            if redaction_settings is not None:
+                                score_kwargs["redaction_settings"] = redaction_settings
+                            result = score_session(conn, sid, **score_kwargs)
                         except RuntimeError as exc:
                             message = str(exc)
                             backend_dead = is_backend_unavailable_error(message) or any(

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -2673,8 +2673,19 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
 
         conn = open_index()
         try:
+            # Manual scoring is AI egress too: scrub configured redaction
+            # strings/usernames/blocked-domains before the prompt leaves the
+            # machine, matching the background warmup path. Unlike warmup we do
+            # not gate on hold/embargo/excluded-project here — scoring a
+            # specific session is an explicit user request for that session.
+            redaction_settings = _score_redaction_settings(
+                get_effective_share_settings(conn, load_config())
+            )
+            score_kwargs: dict[str, Any] = {"model": model, "backend": backend}
+            if redaction_settings is not None:
+                score_kwargs["redaction_settings"] = redaction_settings
             try:
-                result = score_session(conn, session_id, model=model, backend=backend)
+                result = score_session(conn, session_id, **score_kwargs)
             except RuntimeError as e:
                 _json_response(self, {"error": str(e)}, 503)
                 return

--- a/docs/automatic_failure_corpus_scoring.md
+++ b/docs/automatic_failure_corpus_scoring.md
@@ -7,9 +7,9 @@ student opens the local workbench, the daemon starts a background scoring warmup
 for the latest 20 unscored `failure-corpus` sessions. The UI remains usable
 while scoring runs.
 
-`failure-corpus` is the public scoring source preset for `claude`, `codex`,
-`opencode`, and `openclaw`. The older `failure-v1` alias remains accepted for
-backward compatibility.
+`failure-corpus` is the public scoring source preset for `claude`,
+`claude-science`, `codex`, `opencode`, and `openclaw`. The older `failure-v1`
+alias remains accepted for backward compatibility.
 
 ## Behavior
 
@@ -20,6 +20,10 @@ backward compatibility.
   reloaded.
 - Warmup scores the latest 20 unscored `failure-corpus` sessions by
   `start_time DESC`.
+- Warmup applies the same AI-egress gates as the skill/share path before
+  scoring: held or active-embargo sessions are skipped, excluded-project
+  policies are skipped, and configured redaction strings/usernames/domains are
+  applied to the scoring prompt.
 - Warmup uses the existing scorer lock, so repeated browser reloads cannot
   start duplicate scoring jobs.
 - Share-ready recommendations continue to require `ai_failure_value_score`.
@@ -64,3 +68,11 @@ clawjournal score --batch --source failure-corpus --limit 20
 clawjournal score --batch --source failure-corpus --window 7d --limit 50
 clawjournal rescore --source failure-corpus --window 7d --limit 50
 ```
+
+## Self-Improving Skills
+
+Automatic warmup is the feeder, not the installer. It keeps recent
+failure-corpus traces scored so `clawjournal skill --preview` and
+`clawjournal skill` have fresh local evidence to distill. Writing the generated
+`clawjournal-lessons` skill to Claude Code or Codex remains an explicit
+preview/approval step.

--- a/docs/automatic_failure_corpus_scoring.md
+++ b/docs/automatic_failure_corpus_scoring.md
@@ -19,11 +19,12 @@ alias remains accepted for backward compatibility.
   already-running daemon can start scoring when the browser is opened or
   reloaded.
 - Warmup scores the latest 20 unscored `failure-corpus` sessions by
-  `start_time DESC`.
+  `start_time DESC`, narrowed by the user's confirmed source scope when one is
+  configured.
 - Warmup applies the same AI-egress gates as the skill/share path before
-  scoring: held or active-embargo sessions are skipped, excluded-project
-  policies are skipped, and configured redaction strings/usernames/domains are
-  applied to the scoring prompt.
+  scoring: unconfirmed sources, held or active-embargo sessions, and
+  excluded-project policies are skipped, and configured redaction
+  strings/usernames/domains are applied to the scoring prompt.
 - Warmup uses the existing scorer lock, so repeated browser reloads cannot
   start duplicate scoring jobs.
 - Share-ready recommendations continue to require `ai_failure_value_score`.

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -608,6 +608,33 @@ class TestSessionsAPI:
         assert detail["ai_quality_score"] == 4
         assert detail["ai_summary"] == "Good progress"
 
+    def test_score_session_endpoint_applies_policy_redaction(self, server, monkeypatch):
+        """Manual scoring threads workbench-policy redaction into the prompt."""
+        conn = open_index()
+        add_policy(conn, "redact_string", "SecretProject")
+        add_policy(conn, "redact_username", "kai")
+        add_policy(conn, "block_domain", "api.internal")
+        conn.close()
+
+        seen_kwargs = {}
+
+        def fake_score(conn, session_id, **kwargs):
+            seen_kwargs.update(kwargs)
+            return SimpleNamespace(
+                quality=4, reason="ok", detail_json="{}", task_type="t",
+                outcome_label="resolved", value_labels=[], risk_level=[],
+                display_title="T", effort_estimate=0.5, summary="s",
+            )
+
+        monkeypatch.setattr("clawjournal.scoring.scoring.score_session", fake_score)
+
+        status, data = _post(server, "/api/sessions/sess-0/score", {"backend": "auto"})
+        assert status == 200
+        settings = seen_kwargs["redaction_settings"]
+        assert settings["custom_strings"] == ["SecretProject"]
+        assert settings["extra_usernames"] == ["kai"]
+        assert settings["blocked_domains"] == ["api.internal"]
+
     def test_score_session_endpoint_rejects_missing_transcript_blob(self, server, index_setup):
         (index_setup / "blobs" / "sess-0.json").unlink()
 

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -962,6 +962,65 @@ class TestScanner:
         assert scanner.score_unscored_once(limit=5) == 1
         assert scored_ids == ["codex-sess"]
 
+    def test_score_unscored_once_respects_confirmed_source_scope(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+        monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+        monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "clawjournal_config")
+        monkeypatch.setattr("clawjournal.workbench.daemon.CONFIG_DIR", tmp_path / "clawjournal_config")
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {"source": "claude"})
+
+        now = datetime.now(timezone.utc)
+        claude = self._settled_session("claude-sess", now)
+        codex = {
+            **self._settled_session("codex-sess", now),
+            "source": "codex",
+            "model": "gpt-5",
+            "start_time": (now - timedelta(minutes=5)).isoformat(),
+            "end_time": (now - timedelta(minutes=4)).isoformat(),
+        }
+        conn = open_index()
+        upsert_sessions(conn, [claude, codex])
+        conn.close()
+
+        scored_ids = []
+
+        def fake_score(conn, session_id, **kwargs):
+            scored_ids.append(session_id)
+            return self._ok_result(now)
+
+        monkeypatch.setattr("clawjournal.scoring.scoring.score_session", fake_score)
+
+        scanner = Scanner()
+        assert scanner.score_unscored_once(limit=5) == 1
+        assert scored_ids == ["claude-sess"]
+
+    def test_score_unscored_once_does_not_widen_unsupported_confirmed_source(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+        monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+        monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "clawjournal_config")
+        monkeypatch.setattr("clawjournal.workbench.daemon.CONFIG_DIR", tmp_path / "clawjournal_config")
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {"source": "gemini"})
+
+        now = datetime.now(timezone.utc)
+        codex = {
+            **self._settled_session("codex-sess", now),
+            "source": "codex",
+            "model": "gpt-5",
+        }
+        conn = open_index()
+        upsert_sessions(conn, [codex])
+        conn.close()
+
+        def fake_score(*args, **kwargs):
+            raise AssertionError("codex must not be scored under a gemini source scope")
+
+        monkeypatch.setattr("clawjournal.scoring.scoring.score_session", fake_score)
+
+        scanner = Scanner()
+        assert scanner.score_unscored_once(limit=5) == 0
+
     def test_score_unscored_once_skips_held_and_excluded_without_starving(self, tmp_path, monkeypatch):
         monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
         monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -25,7 +25,7 @@ from clawjournal.workbench.daemon import (
     _warn_if_frontend_stale,
     trigger_scoring_warmup,
 )
-from clawjournal.workbench.index import open_index, upsert_sessions
+from clawjournal.workbench.index import add_policy, open_index, set_hold_state, upsert_sessions
 
 
 @pytest.fixture
@@ -934,6 +934,71 @@ class TestScanner:
         scanner = Scanner(source_filter="cursor")
         assert scanner.score_unscored_once(limit=5) == 1
         assert scored_ids == ["codex-sess"]
+
+    def test_score_unscored_once_skips_held_and_excluded_without_starving(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+        monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+        monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "clawjournal_config")
+        monkeypatch.setattr("clawjournal.workbench.daemon.CONFIG_DIR", tmp_path / "clawjournal_config")
+
+        now = datetime.now(timezone.utc)
+        held = self._settled_session("held", now)
+        held["start_time"] = (now - timedelta(minutes=20)).isoformat()
+        held["end_time"] = (now - timedelta(minutes=10)).isoformat()
+        excluded = self._settled_session("excluded", now)
+        excluded["project"] = "claude:private-repo"
+        excluded["start_time"] = (now - timedelta(minutes=21)).isoformat()
+        excluded["end_time"] = (now - timedelta(minutes=11)).isoformat()
+        ok = self._settled_session("ok", now)
+        ok["start_time"] = (now - timedelta(minutes=22)).isoformat()
+        ok["end_time"] = (now - timedelta(minutes=12)).isoformat()
+
+        conn = open_index()
+        upsert_sessions(conn, [held, excluded, ok])
+        set_hold_state(conn, "held", "pending_review", changed_by="test", reason="test")
+        add_policy(conn, "exclude_project", "private-repo")
+        conn.close()
+
+        scored_ids = []
+
+        def fake_score(conn, session_id, **kwargs):
+            scored_ids.append(session_id)
+            return self._ok_result(now)
+
+        monkeypatch.setattr("clawjournal.scoring.scoring.score_session", fake_score)
+
+        scanner = Scanner(source_filter="claude")
+        assert scanner.score_unscored_once(limit=1) == 1
+        assert scored_ids == ["ok"]
+
+    def test_score_unscored_once_passes_policy_redaction_settings(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+        monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+        monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "clawjournal_config")
+        monkeypatch.setattr("clawjournal.workbench.daemon.CONFIG_DIR", tmp_path / "clawjournal_config")
+
+        now = datetime.now(timezone.utc)
+        conn = open_index()
+        upsert_sessions(conn, [self._settled_session("redact-me", now)])
+        add_policy(conn, "redact_string", "SecretProject")
+        add_policy(conn, "redact_username", "kai")
+        add_policy(conn, "block_domain", "api.internal")
+        conn.close()
+
+        seen_kwargs = []
+
+        def fake_score(conn, session_id, **kwargs):
+            seen_kwargs.append(kwargs)
+            return self._ok_result(now)
+
+        monkeypatch.setattr("clawjournal.scoring.scoring.score_session", fake_score)
+
+        scanner = Scanner(source_filter="claude")
+        assert scanner.score_unscored_once(limit=1) == 1
+        settings = seen_kwargs[0]["redaction_settings"]
+        assert settings["custom_strings"] == ["SecretProject"]
+        assert settings["extra_usernames"] == ["kai"]
+        assert settings["blocked_domains"] == ["api.internal"]
 
 
 class TestScoringWarmupAPI:

--- a/tests/workbench/test_daemon_config.py
+++ b/tests/workbench/test_daemon_config.py
@@ -1,6 +1,7 @@
 """Tests for the daemon config endpoints and the scoring-warmup decline gate."""
 
 import json
+from datetime import datetime, timedelta, timezone
 from http.client import HTTPConnection
 from pathlib import Path
 from threading import Thread
@@ -10,7 +11,7 @@ import pytest
 from clawjournal.config import load_config, save_config
 from clawjournal.workbench import daemon as dmod
 from clawjournal.workbench.daemon import WorkbenchHandler
-from clawjournal.workbench.index import open_index
+from clawjournal.workbench.index import open_index, upsert_sessions
 
 
 @pytest.fixture
@@ -161,7 +162,22 @@ class TestScoringBatchCancel:
         cfg_dir = tmp_path / ".clawjournal"
         monkeypatch.setattr("clawjournal.config.CONFIG_DIR", cfg_dir)
         monkeypatch.setattr("clawjournal.config.CONFIG_FILE", cfg_dir / "config.json")
-        open_index().close()
+        now = datetime.now(timezone.utc)
+        conn = open_index()
+        upsert_sessions(conn, [
+            {
+                "session_id": f"s{i}",
+                "project": "test-project",
+                "source": "claude",
+                "model": "m",
+                "start_time": (now - timedelta(minutes=20 + i)).isoformat(),
+                "end_time": (now - timedelta(minutes=10 + i)).isoformat(),
+                "messages": [{"role": "user", "content": "Fix it"}],
+                "stats": {"user_messages": 1, "assistant_messages": 0, "tool_uses": 0},
+            }
+            for i in range(3)
+        ])
+        conn.close()
 
         fake_sessions = [{"session_id": f"s{i}"} for i in range(3)]
         monkeypatch.setattr(dmod, "query_unscored_sessions", lambda *a, **k: fake_sessions)


### PR DESCRIPTION
## Summary

- gate daemon background scoring warmup through the same held/embargoed and excluded-project rules used by the share/skill paths
- pass configured scoring redaction settings into daemon-triggered scoring when custom redaction policies exist
- apply the same configured redaction to the daemon's manual single-session score handler (`_handle_score_session`), so an explicit "score this session" no longer egresses with weaker redaction than background warmup (manual scoring stays ungated on hold/embargo/excluded — it's an explicit request for that session)
- update the failure-corpus scoring design note for Claude Science, egress gates, and the explicit self-improving-skill install step

## Why

Background scoring is AI egress. It should not score sessions that the user has held, actively embargoed, or excluded by project policy, and it should respect configured redaction strings/usernames/domains before invoking a scoring backend. Manual scoring is AI egress too, so it applies the same redaction scrubbing.

## Validation

- python -m pytest tests/workbench/test_daemon.py::TestScanner tests/workbench/test_daemon.py::TestScoringWarmupAPI tests/workbench/test_daemon.py::TestSessionsAPI tests/workbench/test_daemon_config.py::TestScoringBatchCancel tests/workbench/test_daemon_config.py::TestTriggerWarmupGate -q
- python -m pytest tests/test_cli.py::TestScore tests/workbench/test_index.py::TestQueryUnscoredSessions tests/skill/test_orchestration.py -q
- python -m pytest tests/workbench/test_daemon.py tests/workbench/test_daemon_config.py -q
- python -m pytest -q  (full suite: 2475 passed)
- python -m compileall -q clawjournal tests
- git diff --check