### PR TITLE
Support revision-aware sharing for updated traces

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -76,4 +76,15 @@ Optional self-hosted path:
 
 The default configuration is local-first and does not require any hosted backend.
 
+### Trace revision contract
+
+`session_id` is the stable identity of a source trace, including traces that continue growing after an upload. Each normalized message snapshot also carries:
+
+- `revision_hash`: `sha256:<hex>` over the canonical normalized `messages` array.
+- `replaces_revision_hash`: the last successfully uploaded revision for that `session_id`, or `null` for its first upload.
+
+Both fields appear on the exported JSONL row and its manifest session entry. A receiver must upsert by `session_id`, treat an identical `revision_hash` as idempotent, replace only when `replaces_revision_hash` matches its current revision, and reject a stale predecessor instead of overwriting newer content.
+
+Schema-v6 migration gives an unreadable pre-v6 blob an opaque `legacy:<hex>` baseline and assigns the same value to its historical successful share. Receivers must compare this value exactly; they should not attempt to derive or validate legacy content from it.
+
 See [PRIVACY.md](PRIVACY.md) for the full redaction and upload model.

--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ clawjournal share --interactive --weekly
 
 It lists shareable traces, prioritizes AI-scored high-failure-value sessions, shows the redacted preview, asks for consent, then uploads when hosted submission is available or saves a ZIP for manual upload. Useful filters: `--all`, `--source codex`, `--source claude`, `--search "text"`, and `--ai-pii-review` for the optional AI PII pass.
 
+**Continuing an already-shared trace is supported.** A later `clawjournal scan` reports the existing trace as updated without creating a duplicate ID. Because the new content has not been reviewed, ClawJournal resets that trace to `new` and clears its old AI score. Approve it again in the Inbox; it will then reappear in Share with an **Updated since last share** label. The next bundle keeps the same trace identity and records which earlier revision it replaces.
+
 Or paste this into Claude Code, Codex, or another AI coding assistant on the remote machine:
 
 > *Install or update ClawJournal from https://github.com/rayward-external/clawjournal. Read its README and follow it for my operating system. Then help me share my recent coding-agent sessions from this terminal. If needed, configure source `all`, confirm projects, and scan first. Then run `clawjournal share --interactive --weekly`; guide me through selecting sessions, reviewing redactions, and consenting. Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP and tell me where it is so I can upload it at https://data.rayward.ai/share.*

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -1238,13 +1238,29 @@ def _run_scan(source_filter: str | None = None) -> None:
     results = scanner.scan_once()
 
     total_new = sum(results.values())
-    if total_new:
-        print(f"Indexed {total_new} new sessions:")
-        for source, count in sorted(results.items()):
-            if count > 0:
-                print(f"  {source}: {count}")
+    total_updated = scanner.last_updated_count
+    if total_new or total_updated:
+        new_label = "session" if total_new == 1 else "sessions"
+        updated_label = "trace" if total_updated == 1 else "traces"
+        print(
+            f"Indexed {total_new} new {new_label}; "
+            f"updated {total_updated} existing {updated_label}:"
+        )
+        sources = set(results) | set(scanner.last_updated_by_source)
+        for source in sorted(sources):
+            parts = []
+            new_count = results.get(source, 0)
+            updated_count = scanner.last_updated_by_source.get(source, 0)
+            if new_count:
+                label = "new session" if new_count == 1 else "new sessions"
+                parts.append(f"{new_count} {label}")
+            if updated_count:
+                label = "updated trace" if updated_count == 1 else "updated traces"
+                parts.append(f"{updated_count} {label}")
+            if parts:
+                print(f"  {source}: {', '.join(parts)}")
     else:
-        print("No new sessions found.")
+        print("No new or updated sessions found.")
 
     conn = open_index()
     try:
@@ -1414,10 +1430,14 @@ def _resolve_share_id(conn, prefix: str) -> str | None:
 def _run_bundle_create(args) -> None:
     """Create a bundle from session IDs or by review status."""
     from .workbench.index import (
+        already_shared_revision_blockers,
         create_share,
         get_effective_share_settings,
+        get_share_ready_stats,
         open_index,
         query_sessions,
+        RevisionConflictError,
+        revision_review_blockers,
         source_scope_blockers,
     )
 
@@ -1425,6 +1445,7 @@ def _run_bundle_create(args) -> None:
     try:
         settings = get_effective_share_settings(conn, load_config())
         session_ids = list(args.session_ids) if args.session_ids else []
+        explicitly_selected = bool(session_ids)
 
         if args.status and not session_ids:
             sessions = query_sessions(
@@ -1434,6 +1455,24 @@ def _run_bundle_create(args) -> None:
                 limit=10000,
             )
             session_ids = [s["session_id"] for s in sessions]
+
+        ready = get_share_ready_stats(
+            conn,
+            excluded_projects=settings["excluded_projects"],
+            source_filter=settings.get("source_filter"),
+            include_unapproved=True,
+        )
+        ready_ids = {session["session_id"] for session in ready["sessions"]}
+        ineligible_ids = [sid for sid in session_ids if sid not in ready_ids]
+        if explicitly_selected and ineligible_ids:
+            print(
+                "Selected sessions are not eligible to bundle. They may already "
+                "be shared at this revision, require fresh approval, or be missing: "
+                + ", ".join(ineligible_ids)
+            )
+            sys.exit(1)
+        if not explicitly_selected:
+            session_ids = [sid for sid in session_ids if sid in ready_ids]
 
         if not session_ids:
             print("No sessions to bundle. Provide session IDs or use --status approved.")
@@ -1446,13 +1485,36 @@ def _run_bundle_create(args) -> None:
         if source_blockers:
             print("Some selected sessions are outside the confirmed source scope.")
             sys.exit(1)
+        review_blockers = revision_review_blockers(conn, session_ids)
+        if review_blockers:
+            print("Updated traces require fresh approval before re-upload.")
+            sys.exit(1)
+        duplicate_blockers = already_shared_revision_blockers(conn, session_ids)
+        if duplicate_blockers:
+            print("One or more selected trace revisions were already shared.")
+            sys.exit(1)
 
-        share_id = create_share(
-            conn, session_ids,
-            attestation=args.attestation,
-            note=args.note,
-            source_filter=settings.get("source_filter"),
-        )
+        placeholders = ", ".join("?" for _ in session_ids)
+        revision_rows = conn.execute(
+            f"SELECT session_id, content_revision FROM sessions "
+            f"WHERE session_id IN ({placeholders})",
+            session_ids,
+        ).fetchall()
+        expected_revisions = {
+            row["session_id"]: row["content_revision"] for row in revision_rows
+        }
+
+        try:
+            share_id = create_share(
+                conn, session_ids,
+                attestation=args.attestation,
+                note=args.note,
+                source_filter=settings.get("source_filter"),
+                expected_revisions=expected_revisions,
+            )
+        except RevisionConflictError:
+            print("A selected trace changed while the bundle was being created. Review it and retry.")
+            sys.exit(1)
         # Get actual count from DB (create_share only links IDs that exist)
         from .workbench.index import get_share
         share = get_share(conn, share_id)
@@ -1957,8 +2019,10 @@ def _run_share(args) -> None:
         create_share,
         get_effective_share_settings,
         get_share,
+        get_share_ready_stats,
         open_index,
         query_sessions,
+        RevisionConflictError,
         session_matches_excluded_projects,
         source_scope_blockers,
     )
@@ -1969,6 +2033,7 @@ def _run_share(args) -> None:
     try:
         settings = get_effective_share_settings(conn, config)
         session_ids = list(args.session_ids) if args.session_ids else []
+        explicitly_selected = bool(session_ids)
 
         # Query once, reuse for both ID collection and preview
         if args.status and not session_ids:
@@ -1993,6 +2058,34 @@ def _run_share(args) -> None:
             session for session in session_rows
             if not session_matches_excluded_projects(session, settings["excluded_projects"])
         ]
+        ready = get_share_ready_stats(
+            conn,
+            excluded_projects=settings["excluded_projects"],
+            source_filter=settings.get("source_filter"),
+            include_unapproved=True,
+        )
+        ready_by_id = {row["session_id"]: row for row in ready["sessions"]}
+        ineligible_ids = [sid for sid in session_ids if sid not in ready_by_id]
+        if explicitly_selected and ineligible_ids:
+            print(
+                "Selected sessions are not eligible to share. They may already "
+                "be uploaded at this revision or require fresh approval: "
+                + ", ".join(ineligible_ids)
+            )
+            sys.exit(1)
+        session_rows = [
+            session for session in session_rows
+            if session["session_id"] in ready_by_id
+        ]
+        for session in session_rows:
+            session.update({
+                key: ready_by_id[session["session_id"]].get(key)
+                for key in (
+                    "revision_hash",
+                    "last_shared_revision_hash",
+                    "updated_since_last_share",
+                )
+            })
         source_blockers = source_scope_blockers(
             conn,
             [s["session_id"] for s in session_rows],
@@ -2022,12 +2115,21 @@ def _run_share(args) -> None:
         from .workbench.daemon import _prepare_share_export_for_upload
 
         pii_status = _print_share_pii_warning(output_json=getattr(args, "json", False))
-        share_id = create_share(
-            conn,
-            session_ids,
-            note=args.note,
-            source_filter=settings.get("source_filter"),
-        )
+        try:
+            share_id = create_share(
+                conn,
+                session_ids,
+                note=args.note,
+                source_filter=settings.get("source_filter"),
+                expected_revisions={
+                    session["session_id"]: session["revision_hash"]
+                    for session in session_rows
+                    if session.get("revision_hash")
+                },
+            )
+        except RevisionConflictError:
+            print("A selected trace changed after review. Review it again and retry.")
+            sys.exit(1)
         share = get_share(conn, share_id)
         if share is None:
             print("Share failed: newly created share could not be loaded.")

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -42,6 +42,7 @@ from .workbench.index import (
     SHAREABLE_HOLD_STATES,
     effective_hold_state,
     get_effective_share_settings,
+    get_share_ready_stats,
     get_session_detail,
     open_index,
     query_sessions,
@@ -503,6 +504,27 @@ def step_queue(conn, settings, args) -> list[dict]:
     source_filter = _effective_source_filter(settings, args.source)
     candidates = query_sessions(conn, status=args.status, source=source_filter,
                                 limit=5000, sort="end_time", order="desc")
+    # Use the same revision-aware eligibility as the web queue. A stable
+    # session ID is shareable again only when its current content revision
+    # differs from the latest successful upload; drafts and failed uploads do
+    # not suppress it. The metadata merge also lets terminal presentation and
+    # future filters distinguish extended traces without duplicating SQL here.
+    ready = get_share_ready_stats(
+        conn,
+        excluded_projects=settings["excluded_projects"],
+        source_filter=source_filter,
+        include_unapproved=True,
+    )
+    ready_by_id = {row["session_id"]: row for row in ready["sessions"]}
+    candidates = [row for row in candidates if row["session_id"] in ready_by_id]
+    for row in candidates:
+        eligible = ready_by_id[row["session_id"]]
+        for field in (
+            "revision_hash",
+            "last_shared_revision_hash",
+            "updated_since_last_share",
+        ):
+            row[field] = eligible.get(field)
 
     # By default (like the web), score the in-window unscored traces on open so
     # the queue shows real failure values instead of "—". Skip with --no-score.
@@ -813,7 +835,19 @@ def step_package(conn, settings, included: list[dict], package_ai: bool, args):
             die("Resolve hold/embargo state (e.g. `clawjournal release <id>`) and retry.")
 
         print(f"  {DIM}sealing… (redact → TruffleHog → PII pass → re-scan){RST}")
-        res = share_flow.package(conn, session_ids, settings, ai_pii=package_ai, note=args.note)
+        expected_revisions = {
+            s["row"]["session_id"]: s["row"]["revision_hash"]
+            for s in recs
+            if s["row"].get("revision_hash")
+        }
+        res = share_flow.package(
+            conn,
+            session_ids,
+            settings,
+            ai_pii=package_ai,
+            note=args.note,
+            expected_revisions=expected_revisions or None,
+        )
         if res["ok"]:
             export_dir, manifest, share_id = res["export_dir"], res["manifest"], res["share_id"]
             try:
@@ -1108,13 +1142,14 @@ def add_share_cli_args(parser: argparse.ArgumentParser) -> argparse.ArgumentPars
     return parser
 
 
-def refresh_index(source_filter: str | None = None) -> int:
+def refresh_index(source_filter: str | None = None) -> tuple[int, int]:
     """One-shot incremental scan (same as `clawjournal scan` / the daemon's
     initial scan), so the wizard sees fresh traces without a running
-    `clawjournal serve`. Returns the number of newly indexed sessions."""
+    `clawjournal serve`. Returns ``(new_sessions, updated_traces)``."""
     from .workbench.daemon import Scanner
-    results = Scanner(source_filter=source_filter).scan_once()
-    return sum(results.values())
+    scanner = Scanner(source_filter=source_filter)
+    results = scanner.scan_once()
+    return sum(results.values()), scanner.last_updated_count
 
 
 def _normalize_indices(args):
@@ -1138,9 +1173,14 @@ def run(args) -> None:
     if not getattr(args, "no_refresh", False):
         print(f"{DIM}Refreshing trace index…{RST}")
         try:
-            n = refresh_index(args.source)
-            print(f"{DIM}{('Indexed %d new session(s).' % n) if n else 'Index already up to date.'}"
-                  f"{RST}")
+            new_count, updated_count = refresh_index(args.source)
+            if new_count or updated_count:
+                print(
+                    f"{DIM}Indexed {new_count} new session(s); updated "
+                    f"{updated_count} existing trace(s).{RST}"
+                )
+            else:
+                print(f"{DIM}Index already up to date.{RST}")
         except Exception as exc:  # noqa: BLE001
             print(f"{YEL}Index refresh skipped: {exc}{RST}")
     config = load_config()

--- a/clawjournal/share_flow.py
+++ b/clawjournal/share_flow.py
@@ -16,10 +16,13 @@ from pathlib import Path
 from typing import Any
 
 from .workbench.index import (
+    already_shared_revision_blockers,
     apply_share_redactions,
     create_share,
     get_share,
     release_gate_blockers,
+    RevisionConflictError,
+    revision_review_blockers,
     source_scope_blockers,
 )
 
@@ -210,7 +213,8 @@ def gate_blockers(conn, session_ids: list[str]) -> list[dict]:
 
 
 def package(conn, session_ids: list[str], settings: dict, *, ai_pii: bool,
-            note: str | None = None) -> dict:
+            note: str | None = None,
+            expected_revisions: dict[str, str] | None = None) -> dict:
     """Create a share row and seal the bundle. Returns:
         {ok, share_id, export_dir, manifest, blocked_sessions, error}
     blocked_sessions is the list of sessions TruffleHog/PII blocked (for recovery).
@@ -222,12 +226,35 @@ def package(conn, session_ids: list[str], settings: dict, *, ai_pii: bool,
             "error": "Share contains sessions outside the confirmed source scope",
             "blockers": source_blockers,
         }
-    share_id = create_share(
-        conn,
-        session_ids,
-        note=note,
-        source_filter=settings.get("source_filter"),
-    )
+    review_blockers = revision_review_blockers(conn, session_ids)
+    if review_blockers:
+        return {
+            "ok": False,
+            "error": "Updated traces require fresh approval before re-upload",
+            "blockers": review_blockers,
+        }
+    duplicate_blockers = already_shared_revision_blockers(conn, session_ids)
+    if duplicate_blockers:
+        return {
+            "ok": False,
+            "error": "One or more selected trace revisions were already shared",
+            "blockers": duplicate_blockers,
+        }
+    try:
+        share_id = create_share(
+            conn,
+            session_ids,
+            note=note,
+            source_filter=settings.get("source_filter"),
+            expected_revisions=expected_revisions,
+        )
+    except RevisionConflictError as exc:
+        return {
+            "ok": False,
+            "error": str(exc),
+            "block_reason": "revision_conflict",
+            "blockers": exc.blockers,
+        }
     share = get_share(conn, share_id)
     if share is None:
         return {"ok": False, "error": "Share row could not be loaded after creation."}

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -205,7 +205,7 @@ export const api = {
     return request('/projects');
   },
 
-  shareReady(opts?: { includeUnapproved?: boolean }): Promise<{ count: number; total_approved: number; projects: string[]; models: string[]; recommended_session_ids: string[]; sessions: Array<{ session_id: string; project: string; model: string | null; source: string; display_title: string; ai_quality_score: number | null; ai_failure_value_score: number | null; ai_recovery_labels: string[]; ai_failure_attribution: string | null; ai_failure_modes: string[]; ai_learning_summary: string | null; user_messages: number; assistant_messages: number; tool_uses: number; input_tokens: number; output_tokens: number; outcome_badge: string | null; client_origin: string | null; runtime_channel: string | null; start_time: string | null; review_status?: string }> }> {
+  shareReady(opts?: { includeUnapproved?: boolean }): Promise<{ count: number; total_approved: number; projects: string[]; models: string[]; recommended_session_ids: string[]; sessions: Array<{ session_id: string; project: string; model: string | null; source: string; display_title: string; ai_quality_score: number | null; ai_failure_value_score: number | null; ai_recovery_labels: string[]; ai_failure_attribution: string | null; ai_failure_modes: string[]; ai_learning_summary: string | null; user_messages: number; assistant_messages: number; tool_uses: number; input_tokens: number; output_tokens: number; outcome_badge: string | null; client_origin: string | null; runtime_channel: string | null; start_time: string | null; review_status?: string; revision_hash?: string | null; last_shared_revision_hash?: string | null; updated_since_last_share?: boolean }> }> {
     const q = opts?.includeUnapproved ? '?include_unapproved=1' : '';
     return request(`/share-ready${q}`);
   },
@@ -304,11 +304,21 @@ export const api = {
       return request(`/shares/${encodeURIComponent(id)}`);
     },
 
-    create(sessionIds: string[], note?: string, attestation?: string): Promise<{ share_id: string }> {
+    create(
+      sessionIds: string[],
+      note?: string,
+      attestation?: string,
+      expectedRevisions?: Record<string, string>,
+    ): Promise<{ share_id: string }> {
       return request('/shares', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ session_ids: sessionIds, note, attestation }),
+        body: JSON.stringify({
+          session_ids: sessionIds,
+          note,
+          attestation,
+          expected_revisions: expectedRevisions,
+        }),
       });
     },
 
@@ -446,7 +456,7 @@ export const api = {
     return request(`/advisor${qs(params)}`);
   },
 
-  scan(opts: { force?: boolean } = {}): Promise<{ ok: boolean; new_sessions: Record<string, number>; force_rescan?: { processed: number; errored: { session_id: string; error: string }[] } }> {
+  scan(opts: { force?: boolean } = {}): Promise<{ ok: boolean; new_sessions: Record<string, number>; updated_sessions?: Record<string, number>; unchanged_sessions?: Record<string, number>; force_rescan?: { processed: number; errored: { session_id: string; error: string }[] } }> {
     const path = opts.force ? '/scan?force=true' : '/scan';
     return request(path, { method: 'POST' });
   },

--- a/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
@@ -43,6 +43,25 @@ export interface QueueStepProps {
   toast: (msg: string, kind?: 'success' | 'error') => void;
 }
 
+function UpdatedSinceShareBadge({ session }: { session: ReadySession }) {
+  if (!session.updated_since_last_share) return null;
+
+  return (
+    <span
+      title="This trace has new content since its most recent successful share."
+      style={{
+        display: 'inline-flex', alignItems: 'center', flexShrink: 0,
+        padding: '1px 6px', borderRadius: 999,
+        background: colors.primary50, border: `1px solid ${colors.primary200}`,
+        color: colors.primary700, fontSize: 10.5, fontWeight: 600,
+        lineHeight: '16px', whiteSpace: 'nowrap',
+      }}
+    >
+      Updated since last share
+    </span>
+  );
+}
+
 export function QueueStep(p: QueueStepProps) {
   const [dragId, setDragId] = useState<string | null>(null);
 
@@ -144,11 +163,14 @@ export function QueueStep(p: QueueStepProps) {
             borderBottom: i < available.length - 1 ? `1px solid ${colors.gray100}` : 'none',
           }}>
             <div style={{ minWidth: 0 }}>
-              <div style={{
-                fontSize: 13, color: colors.gray900, fontWeight: 500,
-                whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
-              }}>
-                {s.display_title || 'Untitled'}
+              <div style={{ display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }}>
+                <span style={{
+                  minWidth: 0, fontSize: 13, color: colors.gray900, fontWeight: 500,
+                  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+                }}>
+                  {s.display_title || 'Untitled'}
+                </span>
+                <UpdatedSinceShareBadge session={s} />
               </div>
               <div style={{ fontSize: 11, color: colors.gray500, marginTop: 2, display: 'flex', gap: 8, alignItems: 'center' }}>
                 <SourceBadge s={s} />
@@ -334,11 +356,14 @@ export function QueueStep(p: QueueStepProps) {
                     <Icon name="grip" size={14} />
                   </div>
                   <div style={{ minWidth: 0 }}>
-                    <div style={{
-                      fontSize: 13.5, color: colors.gray900, fontWeight: 500,
-                      whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
-                    }}>
-                      {s.display_title || 'Untitled'}
+                    <div style={{ display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }}>
+                      <span style={{
+                        minWidth: 0, fontSize: 13.5, color: colors.gray900, fontWeight: 500,
+                        whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+                      }}>
+                        {s.display_title || 'Untitled'}
+                      </span>
+                      <UpdatedSinceShareBadge session={s} />
                     </div>
                     {/* Row 1: source · project · tokens · tools */}
                     <div style={{ fontSize: 11.5, color: colors.gray500, display: 'flex', gap: 8, alignItems: 'center', marginTop: 2, flexWrap: 'nowrap', overflow: 'hidden' }}>

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -645,7 +645,17 @@ export function Share() {
 
     try {
       const ids = approvedList.map((s) => s.session_id);
-      const { share_id } = await api.shares.create(ids, note || undefined);
+      const expectedRevisions = Object.fromEntries(
+        approvedList
+          .filter((s): s is ReadySession & { revision_hash: string } => Boolean(s.revision_hash))
+          .map((s) => [s.session_id, s.revision_hash]),
+      );
+      const { share_id } = await api.shares.create(
+        ids,
+        note || undefined,
+        undefined,
+        expectedRevisions,
+      );
 
       // Finish the animation cleanly before exposing the share id — the
       // `packageProgress >= 100 && packagedShareId` combination triggers the

--- a/clawjournal/web/frontend/src/views/Share/types.ts
+++ b/clawjournal/web/frontend/src/views/Share/types.ts
@@ -49,6 +49,12 @@ export interface ReadySession {
   runtime_channel?: string | null;
   start_time?: string | null;
   review_status?: string;
+  /** Current normalized trace-content revision. */
+  revision_hash?: string | null;
+  /** Revision included in the latest successful share, when one exists. */
+  last_shared_revision_hash?: string | null;
+  /** True when this stable trace has new content after its latest successful share. */
+  updated_since_last_share?: boolean;
 }
 
 export interface ShareReadyStats {

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -51,6 +51,7 @@ from .findings_pipeline import (
 )
 from .index import (
     add_policy,
+    already_shared_revision_blockers,
     apply_share_redactions,
     build_trufflehog_blocked_sessions,
     create_share,
@@ -70,10 +71,13 @@ from .index import (
     query_sessions,
     query_unscored_sessions,
     release_gate_blockers,
+    RevisionConflictError,
+    revision_review_blockers,
     remove_policy,
     search_fts,
     SCORE_SETTLE_SECONDS,
     session_matches_excluded_projects,
+    share_predecessor_blockers,
     source_scope_blockers,
     update_session,
     upsert_sessions,
@@ -399,7 +403,7 @@ def _maybe_create_trace_note(conn: sqlite3.Connection, session_id: str) -> None:
 
 
 class Scanner:
-    """Periodically scans source directories and indexes new sessions."""
+    """Periodically scans source directories and indexes new or changed sessions."""
 
     def __init__(self, source_filter: str | None = None):
         self.source_filter = source_filter
@@ -407,6 +411,10 @@ class Scanner:
         self._thread: threading.Thread | None = None
         self._last_scan_mtimes: dict[str, float] = {}
         self.last_linked_count = 0
+        self.last_updated_count = 0
+        self.last_unchanged_count = 0
+        self.last_updated_by_source: dict[str, int] = {}
+        self.last_unchanged_by_source: dict[str, int] = {}
         self.last_scored_count = 0
         self._score_thread: threading.Thread | None = None
         self._score_lock = threading.Lock()
@@ -422,7 +430,16 @@ class Scanner:
             self._thread.join(timeout=5)
 
     def scan_once(self) -> dict[str, int]:
-        """Run a single scan pass. Returns {source: new_session_count}."""
+        """Run a scan pass and return ``{source: new_session_count}``.
+
+        The return shape is retained for existing callers. Counts for traces
+        whose content changed (or remained unchanged) are exposed on the
+        ``last_updated_*`` and ``last_unchanged_*`` attributes.
+        """
+        self.last_updated_count = 0
+        self.last_unchanged_count = 0
+        self.last_updated_by_source = {}
+        self.last_unchanged_by_source = {}
         conn = open_index()
         try:
             config = load_config()
@@ -454,8 +471,19 @@ class Scanner:
                         locator=project.get("locator"),
                     )
                     if sessions:
-                        new_count = upsert_sessions(conn, sessions)
+                        upsert_stats: dict[str, int] = {}
+                        new_count = upsert_sessions(conn, sessions, stats=upsert_stats)
                         results[source] = results.get(source, 0) + new_count
+                        updated_count = upsert_stats.get("updated", 0)
+                        unchanged_count = upsert_stats.get("unchanged", 0)
+                        self.last_updated_count += updated_count
+                        self.last_unchanged_count += unchanged_count
+                        self.last_updated_by_source[source] = (
+                            self.last_updated_by_source.get(source, 0) + updated_count
+                        )
+                        self.last_unchanged_by_source[source] = (
+                            self.last_unchanged_by_source.get(source, 0) + unchanged_count
+                        )
                         # Drive each freshly-upserted session through the
                         # findings pipeline. Settle-threshold + revision
                         # check inside the driver keep this cheap on steady
@@ -616,12 +644,19 @@ class Scanner:
                 results = self.scan_once()
                 trigger_scoring_warmup(self)
                 total_new = sum(results.values())
-                if total_new > 0 or self.last_linked_count > 0:
+                if (
+                    total_new > 0
+                    or self.last_updated_count > 0
+                    or self.last_linked_count > 0
+                ):
                     logger.info(
-                        "Indexed %d new sessions, linked %d subagent relationships: %s",
+                        "Indexed %d new sessions, updated %d existing traces, "
+                        "linked %d subagent relationships: new=%s updated=%s",
                         total_new,
+                        self.last_updated_count,
                         self.last_linked_count,
                         results,
+                        self.last_updated_by_source,
                     )
             except Exception:
                 logger.exception("Scanner error")
@@ -1653,6 +1688,13 @@ def _prepare_share_export_for_upload(
     )
     if export_dir is None:
         return None, manifest, {"error": "Failed to prepare upload zip", "status": 500}
+    if manifest.get("block_reason") == "revision_conflict":
+        return export_dir, manifest, {
+            "error": manifest.get("block_message") or "Trace revisions changed after review.",
+            "block_reason": "revision_conflict",
+            "blocked_sessions": manifest.get("blocked_sessions", []),
+            "status": 409,
+        }
 
     # Stamp the redaction-settings fingerprint so a later reuse can detect when
     # the allowlist / custom redactions changed and rebuild instead of shipping
@@ -1727,27 +1769,38 @@ def upload_share_to_self_hosted_ingest(
             "blockers": source_blockers,
             "status": 409,
         }
+    predecessor_blockers = share_predecessor_blockers(conn, share_id)
+    if predecessor_blockers:
+        return {
+            "error": "Share revisions are duplicate or based on a stale predecessor",
+            "blockers": predecessor_blockers,
+            "status": 409,
+        }
 
-    # Re-export to ensure latest field filtering and secret redaction
-    export_dir, manifest = export_share_to_disk(
+    # Reuse the immutable artifact the user reviewed whenever one exists.
+    # Re-exporting live blobs here could silently include appended content that
+    # was never part of the bundle review. On a cache miss the export path
+    # verifies the create-time revision snapshot before reading current blobs.
+    export_dir, manifest, error = _prepare_share_export_for_upload(
         conn,
         share_id,
         share,
-        custom_strings=custom_strings,
-        extra_usernames=extra_usernames,
-        excluded_projects=excluded_projects,
-        blocked_domains=blocked_domains,
-        allowlist_entries=allowlist_entries,
-    )
-    if export_dir is None:
-        return {"error": "Export failed.", "status": 500}
-    error, manifest = finalize_share_export_for_upload(
-        export_dir,
-        manifest,
-        ai_pii=ai_pii_review_enabled,
+        {
+            "custom_strings": custom_strings or [],
+            "extra_usernames": extra_usernames or [],
+            "excluded_projects": excluded_projects or [],
+            "blocked_domains": blocked_domains or [],
+            "allowlist_entries": allowlist_entries or [],
+            "source_filter": source_filter,
+            "ai_pii_review_enabled": ai_pii_review_enabled,
+        },
+        reuse_finalized=True,
+        ai_pii_review_enabled=ai_pii_review_enabled,
     )
     if error:
         return error
+    if export_dir is None:
+        return {"error": "Export failed.", "status": 500}
 
     sessions_file = export_dir / "sessions.jsonl"
     manifest_file = export_dir / "manifest.json"
@@ -1801,14 +1854,28 @@ def upload_share_to_self_hosted_ingest(
         gcs_uri_from_server = upload_result.get("gcs_uri", "")
     except urllib.error.HTTPError as exc:
         error_body = exc.read().decode("utf-8", errors="replace")
+        error_data: dict[str, Any] = {}
         try:
-            error_data = json.loads(error_body)
+            parsed_error = json.loads(error_body)
+            if isinstance(parsed_error, dict):
+                error_data = parsed_error
             error_msg = error_data.get("error", error_body)
         except json.JSONDecodeError:
             error_msg = error_body
-        if exc.code == 409:
-            gcs_uri_from_server = ""
-        elif exc.code in (400, 401, 403, 429):
+        confirmed_hash = (
+            error_data.get("bundle_hash")
+            or error_data.get("existing_bundle_hash")
+        )
+        if (
+            exc.code == 409
+            and error_data.get("idempotent") is True
+            and confirmed_hash == bundle_hash
+        ):
+            # The service explicitly proved that the same immutable bundle is
+            # already stored. This is a safe retry after an ambiguous client
+            # timeout, not a stale-revision conflict.
+            gcs_uri_from_server = str(error_data.get("gcs_uri") or "")
+        elif exc.code in (400, 401, 403, 409, 429):
             if exc.code in (401, 403):
                 _clear_stored_upload_token()
             return {"error": error_msg, "status": exc.code}
@@ -1937,6 +2004,13 @@ def submit_share_to_hosted(
         return {
             "error": "Share contains sessions that are not released",
             "blockers": blockers,
+            "status": 409,
+        }
+    predecessor_blockers = share_predecessor_blockers(conn, share_id)
+    if predecessor_blockers:
+        return {
+            "error": "Share revisions are duplicate or based on a stale predecessor",
+            "blockers": predecessor_blockers,
             "status": 409,
         }
 
@@ -3425,12 +3499,43 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                     "blockers": source_blockers,
                 }, 409)
                 return
-            share_id = create_share(
-                conn,
+            review_blockers = revision_review_blockers(conn, session_ids)
+            if review_blockers:
+                _json_response(self, {
+                    "error": "Updated traces require fresh approval before re-upload.",
+                    "blockers": review_blockers,
+                }, 409)
+                return
+            duplicate_blockers = already_shared_revision_blockers(conn, session_ids)
+            if duplicate_blockers:
+                _json_response(self, {
+                    "error": "One or more selected trace revisions were already shared.",
+                    "blockers": duplicate_blockers,
+                }, 409)
+                return
+            current_rows = conn.execute(
+                f"SELECT session_id, content_revision FROM sessions WHERE session_id IN "
+                f"({','.join('?' for _ in session_ids)})",
                 session_ids,
-                note=note,
-                source_filter=settings.get("source_filter"),
-            )
+            ).fetchall()
+            expected_revisions = {
+                row["session_id"]: row["content_revision"] for row in current_rows
+            }
+            try:
+                share_id = create_share(
+                    conn,
+                    session_ids,
+                    note=note,
+                    source_filter=settings.get("source_filter"),
+                    expected_revisions=expected_revisions,
+                )
+            except RevisionConflictError as exc:
+                _json_response(self, {
+                    "error": str(exc),
+                    "block_reason": "revision_conflict",
+                    "blockers": exc.blockers,
+                }, 409)
+                return
             share = get_share(conn, share_id)
             if share is None:
                 _json_response(self, {"error": "Share not found"}, 404)
@@ -3504,6 +3609,10 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         if not session_ids:
             _json_response(self, {"error": "session_ids required"}, 400)
             return
+        expected_revisions = body.get("expected_revisions")
+        if expected_revisions is not None and not isinstance(expected_revisions, dict):
+            _json_response(self, {"error": "expected_revisions must be an object"}, 400)
+            return
         conn = open_index()
         try:
             settings = get_effective_share_settings(conn, load_config())
@@ -3514,12 +3623,35 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                     "blockers": source_blockers,
                 }, 409)
                 return
-            share_id = create_share(
-                conn, session_ids,
-                attestation=body.get("attestation"),
-                note=body.get("note"),
-                source_filter=settings.get("source_filter"),
-            )
+            review_blockers = revision_review_blockers(conn, session_ids)
+            if review_blockers:
+                _json_response(self, {
+                    "error": "Updated traces require fresh approval before re-upload.",
+                    "blockers": review_blockers,
+                }, 409)
+                return
+            duplicate_blockers = already_shared_revision_blockers(conn, session_ids)
+            if duplicate_blockers:
+                _json_response(self, {
+                    "error": "One or more selected trace revisions were already shared.",
+                    "blockers": duplicate_blockers,
+                }, 409)
+                return
+            try:
+                share_id = create_share(
+                    conn, session_ids,
+                    attestation=body.get("attestation"),
+                    note=body.get("note"),
+                    source_filter=settings.get("source_filter"),
+                    expected_revisions=expected_revisions,
+                )
+            except RevisionConflictError as exc:
+                _json_response(self, {
+                    "error": str(exc),
+                    "block_reason": "revision_conflict",
+                    "blockers": exc.blockers,
+                }, 409)
+                return
             _json_response(self, {"share_id": share_id, "bundle_id": share_id}, 201)
         finally:
             conn.close()
@@ -3662,13 +3794,14 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                 return
 
             if manifest.get("blocked"):
+                status_code = 409 if manifest.get("block_reason") == "revision_conflict" else 422
                 _json_response(self, {
                     "error": manifest.get("block_message") or "Share blocked by TruffleHog",
                     "block_reason": manifest.get("block_reason"),
                     "export_path": str(export_dir),
                     "blocked_sessions": manifest.get("blocked_sessions", []),
                     "trufflehog_summary": manifest.get("redaction_summary", {}).get("trufflehog"),
-                }, 422)
+                }, status_code)
                 return
 
             _json_response(self, {
@@ -3880,7 +4013,12 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         if scanner:
             results = scanner.scan_once()
             warmup = trigger_scoring_warmup(scanner)
-            payload: dict[str, Any] = {"ok": True, "new_sessions": results}
+            payload: dict[str, Any] = {
+                "ok": True,
+                "new_sessions": results,
+                "updated_sessions": scanner.last_updated_by_source,
+                "unchanged_sessions": scanner.last_unchanged_by_source,
+            }
             payload["scoring_warmup"] = warmup
             if force:
                 from ..config import load_config as _load_config
@@ -4392,8 +4530,10 @@ def run_server(
         trigger_scoring_warmup(scanner)
         total = sum(results.values())
         logger.info(
-            "Initial scan complete: %d sessions indexed, %d subagent relationships linked",
+            "Initial scan complete: %d new sessions indexed, %d existing traces updated, "
+            "%d subagent relationships linked",
             total,
+            scanner.last_updated_count,
             scanner.last_linked_count,
         )
         scanner.start()

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -1,5 +1,6 @@
 """Local SQLite + FTS5 index for the scientist workbench."""
 
+import hashlib
 import json
 import logging
 import os
@@ -27,15 +28,30 @@ BLOBS_DIR = CONFIG_DIR / "blobs"
 # `sessions.session_key` bridge to `event_sessions.session_key`, and
 # version 4 marks the workbench as widened-message-aware (parser path
 # now produces messages with optional `invocations` / `snippets` /
-# `extra` / `author` fields, all routed through redaction).
+# `extra` / `author` fields, all routed through redaction), version 5
+# stores hosted-submission receipts, and version 6 tracks immutable
+# content revisions for re-sharing traces that continue to grow.
 SECURITY_SCHEMA_VERSION = 2
 SESSION_IDENTITY_SCHEMA_VERSION = 3
 WIDENED_MESSAGE_SCHEMA_VERSION = 4
 HOSTED_SUBMISSION_SCHEMA_VERSION = 5
-WORKBENCH_SCHEMA_VERSION = HOSTED_SUBMISSION_SCHEMA_VERSION
+REVISION_TRACKING_SCHEMA_VERSION = 6
+WORKBENCH_SCHEMA_VERSION = REVISION_TRACKING_SCHEMA_VERSION
 BACKFILL_WINDOW = 100
 FAILURE_VALUE_SOURCE_SCOPE = ("claude", "claude-science", "codex", "opencode", "openclaw", "workbuddy")
 SHARE_RECOMMENDATION_LIMIT = 10
+
+
+class RevisionConflictError(ValueError):
+    """A selected trace no longer matches the revision a caller reviewed."""
+
+    def __init__(self, blockers: list[dict[str, Any]]):
+        self.blockers = blockers
+        session_ids = ", ".join(
+            str(blocker.get("session_id", "unknown")) for blocker in blockers
+        )
+        super().__init__(f"Trace revisions changed before share creation: {session_ids}")
+
 
 # Display-only normalization from the mixed AI/heuristic outcome vocabulary
 # onto a single coherent label set. Prevents the duplicate-meaning rows we
@@ -111,7 +127,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     ai_scorer_backend      TEXT,
     ai_scorer_model        TEXT,
     ai_rubric_git_sha      TEXT,
-    ai_scored_at           TEXT
+    ai_scored_at           TEXT,
+    content_revision       TEXT
 );
 
 CREATE TABLE IF NOT EXISTS shares (
@@ -131,9 +148,11 @@ CREATE TABLE IF NOT EXISTS shares (
 );
 
 CREATE TABLE IF NOT EXISTS share_sessions (
-    share_id     TEXT NOT NULL REFERENCES shares(share_id),
-    session_id   TEXT NOT NULL REFERENCES sessions(session_id),
-    added_at     TEXT NOT NULL,
+    share_id          TEXT NOT NULL REFERENCES shares(share_id),
+    session_id        TEXT NOT NULL REFERENCES sessions(session_id),
+    added_at          TEXT NOT NULL,
+    content_revision  TEXT,
+    replaces_revision TEXT,
     PRIMARY KEY (share_id, session_id)
 );
 
@@ -285,6 +304,79 @@ def _now_iso() -> str:
     return datetime.now(timezone.utc).isoformat()
 
 
+def _revision_json_value(value: Any) -> Any:
+    """Return a JSON-stable representation for content revision hashing."""
+    if isinstance(value, dict):
+        return {
+            str(key): _revision_json_value(item)
+            for key, item in value.items()
+        }
+    if isinstance(value, (list, tuple)):
+        return [_revision_json_value(item) for item in value]
+    if isinstance(value, (set, frozenset)):
+        normalized = [_revision_json_value(item) for item in value]
+        return sorted(
+            normalized,
+            key=lambda item: json.dumps(
+                item, sort_keys=True, separators=(",", ":"), default=str,
+            ),
+        )
+    if isinstance(value, Path):
+        return str(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    return value
+
+
+def compute_content_revision(session: dict[str, Any]) -> str:
+    """Hash the normalized transcript content of a parsed session.
+
+    Session identity, parser metadata, indexing timestamps, review state, and
+    scoring fields intentionally do not participate. This means parser-only
+    enrichment can refresh metadata without making a reviewed trace stale,
+    while an appended or edited message always creates a new revision.
+    """
+    payload = {
+        "messages": _revision_json_value(session.get("messages", [])),
+    }
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    ).encode("utf-8")
+    return f"sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _legacy_content_revision(session_id: str) -> str:
+    """Return a stable opaque baseline when a migrated blob is unreadable."""
+    digest = hashlib.sha256(f"legacy-session:{session_id}".encode("utf-8")).hexdigest()
+    return f"legacy:{digest}"
+
+
+def _read_blob_for_revision(
+    session_id: str,
+    blob_path: str | None,
+) -> dict[str, Any] | None:
+    """Load a migration-time blob, tolerating stale stored blob paths."""
+    candidates: list[Path] = []
+    if blob_path:
+        candidates.append(Path(blob_path))
+    canonical = BLOBS_DIR / f"{session_id}.json"
+    if canonical not in candidates:
+        candidates.append(canonical)
+    for candidate in candidates:
+        try:
+            with open(candidate) as f:
+                blob = json.load(f)
+            if isinstance(blob, dict):
+                return blob
+        except (OSError, json.JSONDecodeError):
+            continue
+    return None
+
+
 def open_index() -> sqlite3.Connection:
     """Open (and initialize if needed) the index database.
 
@@ -388,6 +480,7 @@ def open_index() -> sqlite3.Connection:
     _migrate_session_identity_bridge(conn)
     _migrate_widened_message_model(conn)
     _migrate_hosted_submission_receipts(conn)
+    _migrate_revision_tracking(conn)
 
     # Clean up ai_outcome_badge values that the judge wrote before the
     # resolution validator rejected invalid labels. Idempotent: after
@@ -575,6 +668,83 @@ def _migrate_hosted_submission_receipts(conn: sqlite3.Connection) -> None:
         raise
 
 
+def _migrate_revision_tracking(conn: sqlite3.Connection) -> None:
+    """Add trace/share revisions and advance the workbench schema v5 -> v6.
+
+    Existing sessions are hashed from their stored blobs. Historical shares
+    inherit that same revision as their selection baseline: completed shares
+    therefore stay suppressed, while old drafts can detect a later append
+    before export. Missing or unreadable blobs receive an explicit stable
+    legacy baseline, copied to their historical share selections as well.
+    """
+    version_row = conn.execute("PRAGMA user_version").fetchone()
+    version = version_row[0] if version_row else 0
+    if version >= REVISION_TRACKING_SCHEMA_VERSION:
+        return
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        for table, col, col_type in [
+            ("sessions", "content_revision", "TEXT"),
+            ("share_sessions", "content_revision", "TEXT"),
+            ("share_sessions", "replaces_revision", "TEXT"),
+        ]:
+            try:
+                conn.execute(f"ALTER TABLE {table} ADD COLUMN {col} {col_type}")
+            except sqlite3.OperationalError as e:
+                if "duplicate column" not in str(e):
+                    raise
+
+        session_columns = {
+            row[1] for row in conn.execute("PRAGMA table_info(sessions)").fetchall()
+        }
+        blob_path_expr = (
+            "blob_path" if "blob_path" in session_columns else "NULL AS blob_path"
+        )
+        rows = conn.execute(
+            f"SELECT session_id, {blob_path_expr} FROM sessions "
+            "WHERE content_revision IS NULL"
+        ).fetchall()
+        for row in rows:
+            blob = _read_blob_for_revision(row["session_id"], row["blob_path"])
+            revision = (
+                compute_content_revision(blob)
+                if blob is not None
+                else _legacy_content_revision(row["session_id"])
+            )
+            conn.execute(
+                "UPDATE sessions SET content_revision = ? WHERE session_id = ?",
+                (revision, row["session_id"]),
+            )
+
+        # Very old indexes also kept the latest share on sessions.share_id.
+        # Restore any missing join rows before stamping historical baselines.
+        if "share_id" in session_columns:
+            conn.execute(
+                "INSERT OR IGNORE INTO share_sessions "
+                "(share_id, session_id, added_at) "
+                "SELECT s.share_id, s.session_id, sh.created_at "
+                "FROM sessions s JOIN shares sh ON sh.share_id = s.share_id "
+                "WHERE s.share_id IS NOT NULL"
+            )
+        # Existing drafts also need a frozen selection baseline so a later
+        # append is detected before export. Successful rows use the same value
+        # as their initial post-upgrade uploaded baseline.
+        conn.execute(
+            "UPDATE share_sessions AS ss "
+            "SET content_revision = ("
+            "  SELECT s.content_revision FROM sessions s "
+            "  WHERE s.session_id = ss.session_id"
+            ") "
+            "WHERE ss.content_revision IS NULL"
+        )
+        conn.execute(f"PRAGMA user_version = {REVISION_TRACKING_SCHEMA_VERSION}")
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
 def _migrate_bundles_to_shares(conn: sqlite3.Connection) -> None:
     """One-time rename of bundles→shares, bundle_sessions→share_sessions, bundle_id→share_id.
 
@@ -640,15 +810,17 @@ def _migrate_bundles_to_shares(conn: sqlite3.Connection) -> None:
         # 2. Recreate share_sessions (FK column is share_id).
         conn.execute(
             """CREATE TABLE share_sessions (
-                share_id   TEXT NOT NULL REFERENCES shares(share_id),
-                session_id TEXT NOT NULL REFERENCES sessions(session_id),
-                added_at   TEXT NOT NULL,
+                share_id          TEXT NOT NULL REFERENCES shares(share_id),
+                session_id        TEXT NOT NULL REFERENCES sessions(session_id),
+                added_at          TEXT NOT NULL,
+                content_revision  TEXT,
+                replaces_revision TEXT,
                 PRIMARY KEY (share_id, session_id)
             )"""
         )
         conn.execute(
-            "INSERT INTO share_sessions (share_id, session_id, added_at)"
-            " SELECT bundle_id, session_id, added_at FROM bundle_sessions"
+            "INSERT INTO share_sessions (share_id, session_id, added_at) "
+            "SELECT bundle_id, session_id, added_at FROM bundle_sessions"
         )
         conn.execute("DROP TABLE bundle_sessions")
         conn.execute("DROP INDEX IF EXISTS idx_bundle_sessions_session_id")
@@ -714,6 +886,7 @@ def _migrate_bundles_to_shares(conn: sqlite3.Connection) -> None:
             "ai_scorer_model        TEXT",
             "ai_rubric_git_sha      TEXT",
             "ai_scored_at           TEXT",
+            "content_revision       TEXT",
         ]
         known_names = {
             "session_id", "project", "source", "model", "start_time",
@@ -727,7 +900,7 @@ def _migrate_bundles_to_shares(conn: sqlite3.Connection) -> None:
             "ai_display_title", "ai_failure_value_score", "ai_recovery_labels",
             "ai_failure_attribution", "ai_failure_modes", "ai_learning_summary",
             "ai_scorer_backend", "ai_scorer_model", "ai_rubric_git_sha",
-            "ai_scored_at",
+            "ai_scored_at", "content_revision",
         }
         # Map column name -> declared type from the old table so we preserve
         # types for any columns not in the base schema.
@@ -1741,7 +1914,12 @@ def recompute_estimated_costs(conn: sqlite3.Connection) -> int:
     return changed
 
 
-def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) -> int:
+def upsert_sessions(
+    conn: sqlite3.Connection,
+    sessions: list[dict[str, Any]],
+    *,
+    stats: dict[str, int] | None = None,
+) -> int:
     """Index parsed sessions into the database.
 
     Takes parsed session dicts (output of parser.parse_project_sessions).
@@ -1749,8 +1927,14 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
     BLOBS_DIR/{session_id}.json, and updates FTS index.
 
     Returns the count of new sessions inserted (sessions that did not
-    previously exist in the index).
+    previously exist in the index). When ``stats`` is provided, it is filled
+    with ``inserted``, ``updated`` (content revision changed), and
+    ``unchanged`` counts without changing the legacy integer return value.
     """
+    counts = {"inserted": 0, "updated": 0, "unchanged": 0}
+    if stats is not None:
+        stats.clear()
+        stats.update(counts)
     if not sessions:
         return 0
 
@@ -1773,8 +1957,9 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
         session_key = _derive_session_key_from_source(
             source, session.get("raw_source_path")
         )
-        stats = session.get("stats", {})
+        session_stats = session.get("stats", {})
         duration = _compute_duration(session)
+        content_revision = compute_content_revision(session)
 
         # Compute badges and signals
         badges = compute_all_badges(session)
@@ -1801,17 +1986,42 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
             "ai_value_badges, ai_risk_badges, "
             "ai_effort_estimate, ai_summary, "
             "share_id, session_key, parent_session_id, subagent_session_ids, "
-            "estimated_cost_usd, end_time "
+            "estimated_cost_usd, end_time, content_revision "
             "FROM sessions WHERE session_id = ?",
             (session_id,),
         ).fetchone()
         is_new = existing is None
+        content_updated = (
+            existing is not None
+            and existing["content_revision"] != content_revision
+        )
 
-        # Write blob
-        blob_path = _write_blob(session_id, session)
+        # Avoid rewriting the blob/FTS record for a byte-equivalent transcript.
+        # Metadata fields still flow through the SQL upsert below so parser
+        # enrichment and ongoing cost estimates can refresh independently.
+        metadata_updated = False
+        if is_new or content_updated:
+            blob_path = _write_blob(session_id, session)
+        else:
+            stored_blob_path = conn.execute(
+                "SELECT blob_path FROM sessions WHERE session_id = ?",
+                (session_id,),
+            ).fetchone()["blob_path"]
+            blob_path = (
+                Path(stored_blob_path)
+                if stored_blob_path
+                else BLOBS_DIR / f"{session_id}.json"
+            )
+            stored_blob = _read_blob_for_revision(session_id, str(blob_path))
+            metadata_updated = (
+                stored_blob is None
+                or _revision_json_value(stored_blob) != _revision_json_value(session)
+            )
+            if metadata_updated:
+                blob_path = _write_blob(session_id, session)
 
         # Delete old FTS entry before replacing.
-        if has_fts and not is_new:
+        if has_fts and not is_new and (content_updated or metadata_updated):
             conn.execute(
                 "DELETE FROM sessions_fts WHERE session_id = ?",
                 (session_id,),
@@ -1842,10 +2052,10 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
         preserved_subagent_session_ids = existing["subagent_session_ids"] if not is_new else None
 
         # Compute estimated cost from model + token counts
-        in_tok = stats.get("input_tokens", 0)
-        out_tok = stats.get("output_tokens", 0)
-        cache_read = stats.get("cache_read_tokens", 0)
-        cache_create = stats.get("cache_creation_tokens", 0)
+        in_tok = session_stats.get("input_tokens", 0)
+        out_tok = session_stats.get("output_tokens", 0)
+        cache_read = session_stats.get("cache_read_tokens", 0)
+        cache_create = session_stats.get("cache_creation_tokens", 0)
         cost = _resolve_estimated_cost(
             existing,
             model=session.get("model"),
@@ -1892,7 +2102,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 client_origin, runtime_channel, outer_session_id,
                 estimated_cost_usd,
                 tool_counts, user_interrupts,
-                hold_state
+                hold_state, content_revision
             ) VALUES (
                 ?, ?, ?, ?, ?,
                 ?, ?, ?,
@@ -1919,7 +2129,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 ?, ?, ?,
                 ?,
                 ?, ?,
-                'auto_redacted'
+                'auto_redacted', ?
             )
             ON CONFLICT(session_id) DO UPDATE SET
                 project = excluded.project,
@@ -1948,7 +2158,89 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 blob_path = excluded.blob_path,
                 raw_source_path = excluded.raw_source_path,
                 session_key = COALESCE(excluded.session_key, session_key),
-                updated_at = excluded.updated_at,
+                updated_at = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN excluded.updated_at ELSE sessions.updated_at END,
+                review_status = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN CASE
+                        WHEN sessions.review_status = 'segmented' THEN 'segmented'
+                        ELSE 'new'
+                    END
+                    ELSE sessions.review_status
+                END,
+                selection_reason = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.selection_reason END,
+                reviewer_notes = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.reviewer_notes END,
+                reviewed_at = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.reviewed_at END,
+                ai_quality_score = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_quality_score END,
+                ai_score_reason = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_score_reason END,
+                ai_episode_quality = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_episode_quality END,
+                ai_quality_tier = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_quality_tier END,
+                ai_scoring_detail = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_scoring_detail END,
+                ai_task_type = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_task_type END,
+                ai_outcome_badge = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_outcome_badge END,
+                ai_value_badges = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_value_badges END,
+                ai_risk_badges = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_risk_badges END,
+                ai_display_title = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_display_title END,
+                ai_effort_estimate = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_effort_estimate END,
+                ai_summary = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_summary END,
+                ai_failure_value_score = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_failure_value_score END,
+                ai_recovery_labels = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_recovery_labels END,
+                ai_failure_attribution = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_failure_attribution END,
+                ai_failure_modes = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_failure_modes END,
+                ai_learning_summary = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_learning_summary END,
+                ai_scorer_backend = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_scorer_backend END,
+                ai_scorer_model = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_scorer_model END,
+                ai_rubric_git_sha = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_rubric_git_sha END,
+                ai_scored_at = CASE
+                    WHEN sessions.content_revision IS NOT excluded.content_revision
+                    THEN NULL ELSE sessions.ai_scored_at END,
                 parent_session_id = COALESCE(excluded.parent_session_id, parent_session_id),
                 segment_index = excluded.segment_index,
                 segment_start_message = excluded.segment_start_message,
@@ -1959,15 +2251,16 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 outer_session_id = excluded.outer_session_id,
                 estimated_cost_usd = excluded.estimated_cost_usd,
                 tool_counts = excluded.tool_counts,
-                user_interrupts = excluded.user_interrupts
+                user_interrupts = excluded.user_interrupts,
+                content_revision = excluded.content_revision
             """,
             (
                 session_id, project, source, session.get("model"), session.get("model_effort"),
                 session.get("start_time"), session.get("end_time"), duration,
                 session.get("git_branch"),
-                stats.get("user_messages", 0),
-                stats.get("assistant_messages", 0),
-                stats.get("tool_uses", 0),
+                session_stats.get("user_messages", 0),
+                session_stats.get("assistant_messages", 0),
+                session_stats.get("tool_uses", 0),
                 in_tok,
                 out_tok,
                 cache_read,
@@ -2011,7 +2304,8 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 session.get("outer_session_id"),
                 cost,
                 json.dumps(badges.get("tool_counts", {})) or None,
-                stats.get("user_interrupts", 0),
+                session_stats.get("user_interrupts", 0),
+                content_revision,
             ),
         )
 
@@ -2029,7 +2323,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
             )
 
         # Insert FTS entry
-        if has_fts:
+        if has_fts and (is_new or content_updated or metadata_updated):
             transcript = _flatten_transcript(session)
             conn.execute(
                 "INSERT INTO sessions_fts("
@@ -2046,8 +2340,15 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
 
         if is_new:
             new_count += 1
+            counts["inserted"] += 1
+        elif content_updated:
+            counts["updated"] += 1
+        else:
+            counts["unchanged"] += 1
 
     conn.commit()
+    if stats is not None:
+        stats.update(counts)
     return new_count
 
 
@@ -3589,61 +3890,147 @@ def get_insights(
     return result
 
 
+def _latest_successful_revision(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    exclude_share_id: str | None = None,
+) -> str | None:
+    """Return the most recently uploaded content revision for a trace."""
+    where = [
+        "ss.session_id = ?",
+        "sh.shared_at IS NOT NULL",
+        "ss.content_revision IS NOT NULL",
+    ]
+    params: list[Any] = [session_id]
+    if exclude_share_id is not None:
+        where.append("ss.share_id != ?")
+        params.append(exclude_share_id)
+    row = conn.execute(
+        "SELECT ss.content_revision FROM share_sessions ss "
+        "JOIN shares sh ON sh.share_id = ss.share_id "
+        f"WHERE {' AND '.join(where)} "
+        "ORDER BY sh.shared_at DESC, sh.created_at DESC, ss.share_id DESC "
+        "LIMIT 1",
+        params,
+    ).fetchone()
+    return row["content_revision"] if row is not None else None
+
+
 def create_share(
     conn: sqlite3.Connection,
     session_ids: list[str],
     attestation: str | None = None,
     note: str | None = None,
     source_filter: str | list[str] | tuple[str, ...] | None = None,
+    expected_revisions: dict[str, str] | None = None,
 ) -> str:
     """Create a share linking the given sessions.
 
-    Returns the new share_id.
+    Returns the new share_id. ``expected_revisions`` lets callers bind a UI
+    selection to the exact revisions the user reviewed; a concurrent append
+    raises ``ValueError`` before any share row is created.
     """
     share_id = str(uuid.uuid4())
     now = _now_iso()
+    started_transaction = not conn.in_transaction
+    if started_transaction:
+        conn.execute("BEGIN IMMEDIATE")
+    try:
+        # Verify all sessions exist while holding the same write transaction
+        # that records their immutable share snapshots.
+        found_sessions: dict[str, str | None] = {}
+        if session_ids:
+            placeholders = ", ".join("?" for _ in session_ids)
+            source_clause = ""
+            params: list[Any] = list(session_ids)
+            if source_filter is not None:
+                if isinstance(source_filter, (list, tuple)):
+                    values = [s for s in source_filter if s]
+                    if values:
+                        source_clause = (
+                            f" AND source IN ({','.join('?' for _ in values)})"
+                        )
+                        params.extend(values)
+                else:
+                    source_clause = " AND source = ?"
+                    params.append(source_filter)
+            rows = conn.execute(
+                "SELECT session_id, content_revision FROM sessions "
+                f"WHERE session_id IN ({placeholders}){source_clause}",
+                params,
+            ).fetchall()
+            found_sessions = {
+                row["session_id"]: row["content_revision"]
+                for row in rows
+            }
 
-    # Verify all sessions exist
-    found_ids: set[str] = set()
-    if session_ids:
-        placeholders = ", ".join("?" for _ in session_ids)
-        source_clause = ""
-        params: list[Any] = list(session_ids)
-        if source_filter is not None:
-            if isinstance(source_filter, (list, tuple)):
-                values = [s for s in source_filter if s]
-                if values:
-                    source_clause = f" AND source IN ({','.join('?' for _ in values)})"
-                    params.extend(values)
-            else:
-                source_clause = " AND source = ?"
-                params.append(source_filter)
-        rows = conn.execute(
-            f"SELECT session_id FROM sessions WHERE session_id IN ({placeholders}){source_clause}",
-            params,
-        ).fetchall()
-        found_ids = {row["session_id"] for row in rows}
+        if expected_revisions is not None:
+            expected_ids = set(expected_revisions)
+            found_ids = set(found_sessions)
+            requested_ids = set(session_ids)
+            blockers = [
+                {
+                    "session_id": sid,
+                    "expected_revision_hash": expected_revisions.get(sid),
+                    "current_revision_hash": found_sessions.get(sid),
+                }
+                for sid in sorted(expected_ids | found_ids | requested_ids)
+                if (
+                    sid not in expected_ids
+                    or sid not in requested_ids
+                    or sid not in found_ids
+                    or expected_revisions[sid] != found_sessions[sid]
+                )
+            ]
+            if blockers:
+                raise RevisionConflictError(blockers)
 
-    conn.execute(
-        """INSERT INTO shares (
-            share_id, created_at, session_count, status,
-            attestation, submission_note
-        ) VALUES (?, ?, ?, 'draft', ?, ?)""",
-        (share_id, now, len(found_ids), attestation, note),
-    )
-
-    for sid in found_ids:
         conn.execute(
-            "INSERT OR IGNORE INTO share_sessions (share_id, session_id, added_at) VALUES (?, ?, ?)",
-            (share_id, sid, now),
-        )
-        conn.execute(
-            "UPDATE sessions SET share_id = ?, updated_at = ? WHERE session_id = ?",
-            (share_id, now, sid),
+            """INSERT INTO shares (
+                share_id, created_at, session_count, status,
+                attestation, submission_note
+            ) VALUES (?, ?, ?, 'draft', ?, ?)""",
+            (share_id, now, len(found_sessions), attestation, note),
         )
 
-    conn.commit()
+        for sid, content_revision in found_sessions.items():
+            replaces_revision = _latest_successful_revision(conn, sid)
+            conn.execute(
+                "INSERT OR IGNORE INTO share_sessions "
+                "(share_id, session_id, added_at, content_revision, replaces_revision) "
+                "VALUES (?, ?, ?, ?, ?)",
+                (share_id, sid, now, content_revision, replaces_revision),
+            )
+            conn.execute(
+                "UPDATE sessions SET share_id = ?, updated_at = ? "
+                "WHERE session_id = ?",
+                (share_id, now, sid),
+            )
+
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
     return share_id
+
+
+def share_revision_blockers(
+    conn: sqlite3.Connection,
+    share_id: str,
+) -> list[dict[str, Any]]:
+    """Return selected share snapshots whose local trace has since changed."""
+    rows = conn.execute(
+        "SELECT ss.session_id, ss.content_revision AS expected_revision_hash, "
+        "s.content_revision AS current_revision_hash, s.review_status "
+        "FROM share_sessions ss "
+        "JOIN sessions s ON s.session_id = ss.session_id "
+        "WHERE ss.share_id = ? "
+        "AND ss.content_revision IS NOT s.content_revision "
+        "ORDER BY ss.session_id",
+        (share_id,),
+    ).fetchall()
+    return [dict(row) for row in rows]
 
 
 def source_scope_blockers(
@@ -3687,6 +4074,115 @@ def get_shares(conn: sqlite3.Connection) -> list[dict[str, Any]]:
     return [_with_legacy_bundle_alias(dict(row)) for row in rows]
 
 
+_LATEST_SUCCESSFUL_REVISIONS_CTE = """
+WITH ranked_shared_revisions AS (
+    SELECT
+        ss.session_id,
+        ss.content_revision,
+        ROW_NUMBER() OVER (
+            PARTITION BY ss.session_id
+            ORDER BY sh.shared_at DESC, sh.created_at DESC, ss.share_id DESC
+        ) AS revision_rank
+    FROM share_sessions ss
+    JOIN shares sh ON sh.share_id = ss.share_id
+    WHERE sh.shared_at IS NOT NULL AND ss.content_revision IS NOT NULL
+),
+latest_shared_revisions AS (
+    SELECT session_id, content_revision
+    FROM ranked_shared_revisions
+    WHERE revision_rank = 1
+)
+"""
+
+
+def revision_review_blockers(
+    conn: sqlite3.Connection,
+    session_ids: list[str],
+) -> list[dict[str, Any]]:
+    """Return re-shared revisions that have not received fresh approval."""
+    if not session_ids:
+        return []
+    placeholders = ", ".join("?" for _ in session_ids)
+    rows = conn.execute(
+        _LATEST_SUCCESSFUL_REVISIONS_CTE
+        + "SELECT s.session_id, s.review_status, "
+        "s.content_revision AS revision_hash, "
+        "latest.content_revision AS last_shared_revision_hash "
+        "FROM sessions s "
+        "JOIN latest_shared_revisions latest ON latest.session_id = s.session_id "
+        f"WHERE s.session_id IN ({placeholders}) "
+        "AND s.content_revision IS NOT latest.content_revision "
+        "AND s.review_status != 'approved' "
+        "ORDER BY s.session_id",
+        session_ids,
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def already_shared_revision_blockers(
+    conn: sqlite3.Connection,
+    session_ids: list[str],
+) -> list[dict[str, Any]]:
+    """Return selected traces whose exact current revision already uploaded."""
+    if not session_ids:
+        return []
+    placeholders = ", ".join("?" for _ in session_ids)
+    rows = conn.execute(
+        _LATEST_SUCCESSFUL_REVISIONS_CTE
+        + "SELECT s.session_id, s.content_revision AS revision_hash, "
+        "latest.content_revision AS last_shared_revision_hash "
+        "FROM sessions s "
+        "JOIN latest_shared_revisions latest ON latest.session_id = s.session_id "
+        f"WHERE s.session_id IN ({placeholders}) "
+        "AND s.content_revision IS latest.content_revision "
+        "ORDER BY s.session_id",
+        session_ids,
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def share_predecessor_blockers(
+    conn: sqlite3.Connection,
+    share_id: str,
+) -> list[dict[str, Any]]:
+    """Return packaged replacements based on a stale uploaded predecessor.
+
+    The share remains valid when the latest successful revision is the
+    predecessor captured at creation. If a different share already uploaded
+    this share's own revision, it is a known duplicate. Any third revision
+    means a newer replacement won the race and this share must not overwrite
+    it.
+    """
+    rows = conn.execute(
+        "SELECT session_id, content_revision, replaces_revision "
+        "FROM share_sessions WHERE share_id = ? ORDER BY session_id",
+        (share_id,),
+    ).fetchall()
+    blockers: list[dict[str, Any]] = []
+    for row in rows:
+        latest = _latest_successful_revision(
+            conn,
+            row["session_id"],
+            exclude_share_id=share_id,
+        )
+        if latest is None:
+            continue
+        if latest == row["content_revision"]:
+            reason = "already_shared_revision"
+        elif latest == row["replaces_revision"]:
+            continue
+        else:
+            reason = "stale_predecessor"
+        blockers.append({
+            "session_id": row["session_id"],
+            "revision_hash": row["content_revision"],
+            "replaces_revision_hash": row["replaces_revision"],
+            "latest_shared_revision_hash": latest,
+            "reason": reason,
+        })
+    return blockers
+
+
 def get_share_ready_stats(
     conn: sqlite3.Connection,
     *,
@@ -3694,54 +4190,59 @@ def get_share_ready_stats(
     source_filter: str | list[str] | tuple[str, ...] | None = None,
     include_unapproved: bool = False,
 ) -> dict[str, Any]:
-    """Return sessions that have not been shared before.
+    """Return sessions whose current content revision has not been shared.
 
     By default returns only `review_status='approved'` sessions; pass
     `include_unapproved=True` to widen the pool so the Preview UI can
-    offer non-approved sessions for explicit review. Recommendations are
-    ranked by failure value first so the share wizard starts with the best
-    failure examples.
+    offer new, never-shared sessions for explicit review. A changed revision
+    of a previously shared trace still requires fresh approval before it is
+    offered. Recommendations are ranked by failure value first so the share
+    wizard starts with the best failure examples.
     """
     where_clauses: list[str] = []
     params: list[Any] = []
+    where_clauses.append("s.review_status != 'segmented'")
     if not include_unapproved:
-        where_clauses.append("review_status = 'approved'")
+        where_clauses.append("s.review_status = 'approved'")
     if source_filter is not None:
         if isinstance(source_filter, (list, tuple)):
             values = [s for s in source_filter if s]
             if values:
-                where_clauses.append(f"source IN ({','.join('?' for _ in values)})")
+                where_clauses.append(f"s.source IN ({','.join('?' for _ in values)})")
                 params.extend(values)
         else:
-            where_clauses.append("source = ?")
+            where_clauses.append("s.source = ?")
             params.append(source_filter)
-    where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
-    and_sql = " AND" if where_clauses else " WHERE"
+    # A current revision is eligible when no successful snapshot exists or it
+    # differs from the latest successful snapshot. Changed previously-shared
+    # traces are never exposed before fresh approval, even in the widened pool.
+    where_clauses.extend([
+        "(latest.content_revision IS NULL "
+        "OR s.content_revision IS NOT latest.content_revision)",
+        "NOT (latest.content_revision IS NOT NULL "
+        "AND s.content_revision IS NOT latest.content_revision "
+        "AND s.review_status != 'approved')",
+    ])
+    where_sql = f" WHERE {' AND '.join(where_clauses)}"
     rows = conn.execute(
-        "SELECT session_id, project, model, source, display_title,"
-        " ai_quality_score, ai_failure_value_score, ai_recovery_labels,"
-        " ai_failure_attribution, ai_failure_modes, ai_learning_summary,"
-        " user_messages, assistant_messages, tool_uses,"
-        f" input_tokens, output_tokens, ({_OUTCOME_NORMALIZE_SQL}) as outcome_badge, client_origin,"
-        " runtime_channel, start_time, review_status, hold_state, embargo_until"
-        " FROM sessions"
+        _LATEST_SUCCESSFUL_REVISIONS_CTE
+        + "SELECT s.session_id, s.project, s.model, s.source, s.display_title,"
+        " s.ai_quality_score, s.ai_failure_value_score, s.ai_recovery_labels,"
+        " s.ai_failure_attribution, s.ai_failure_modes, s.ai_learning_summary,"
+        " s.user_messages, s.assistant_messages, s.tool_uses,"
+        f" s.input_tokens, s.output_tokens, ({_OUTCOME_NORMALIZE_SQL}) as outcome_badge, s.client_origin,"
+        " s.runtime_channel, s.start_time, s.review_status, s.hold_state, s.embargo_until,"
+        " s.content_revision AS revision_hash,"
+        " latest.content_revision AS last_shared_revision_hash,"
+        " CASE WHEN latest.content_revision IS NOT NULL "
+        "      AND s.content_revision IS NOT latest.content_revision "
+        "      THEN 1 ELSE 0 END AS updated_since_last_share"
+        " FROM sessions s"
+        " LEFT JOIN latest_shared_revisions latest ON latest.session_id = s.session_id"
         f"{where_sql}"
-        f"{and_sql} session_id NOT IN ("
-        "   SELECT DISTINCT session_id FROM ("
-        "     SELECT s.session_id AS session_id"
-        "     FROM sessions s"
-        "     JOIN shares b ON s.share_id = b.share_id"
-        "     WHERE b.shared_at IS NOT NULL"
-        "     UNION"
-        "     SELECT bs.session_id AS session_id"
-        "     FROM share_sessions bs"
-        "     JOIN shares b ON bs.share_id = b.share_id"
-        "     WHERE b.shared_at IS NOT NULL"
-        "   )"
-        " )"
-        " ORDER BY (ai_failure_value_score IS NULL),"
-        " ai_failure_value_score DESC, start_time DESC,"
-        " (review_status = 'approved') DESC, ai_quality_score DESC",
+        " ORDER BY (s.ai_failure_value_score IS NULL),"
+        " s.ai_failure_value_score DESC, s.start_time DESC,"
+        " (s.review_status = 'approved') DESC, s.ai_quality_score DESC",
         params,
     ).fetchall()
     cols = ["session_id", "project", "model", "source", "display_title",
@@ -3749,9 +4250,14 @@ def get_share_ready_stats(
             "ai_failure_attribution", "ai_failure_modes", "ai_learning_summary",
             "user_messages", "assistant_messages", "tool_uses", "input_tokens",
             "output_tokens", "outcome_badge", "client_origin", "runtime_channel",
-            "start_time", "review_status", "hold_state", "embargo_until"]
+            "start_time", "review_status", "hold_state", "embargo_until",
+            "revision_hash", "last_shared_revision_hash",
+            "updated_since_last_share"]
     sessions = [dict(zip(cols, r)) for r in rows]
     for session in sessions:
+        session["updated_since_last_share"] = bool(
+            session["updated_since_last_share"]
+        )
         for field in ("ai_recovery_labels", "ai_failure_modes"):
             if isinstance(session.get(field), str):
                 try:
@@ -3839,7 +4345,9 @@ def get_share(
 
     # Fetch linked sessions
     session_rows = conn.execute(
-        "SELECT s.* FROM share_sessions bs"
+        "SELECT s.*, bs.content_revision AS share_content_revision, "
+        "bs.replaces_revision AS share_replaces_revision "
+        "FROM share_sessions bs"
         " JOIN sessions s ON s.session_id = bs.session_id"
         " WHERE bs.share_id = ?"
         " ORDER BY s.start_time ASC, bs.added_at ASC",
@@ -3873,6 +4381,7 @@ EXPORT_FIELDS = {
     "ai_quality_score", "ai_failure_value_score", "ai_recovery_labels",
     "ai_failure_attribution", "ai_failure_modes", "ai_learning_summary",
     "ai_scoring_detail", "task_type",
+    "revision_hash", "replaces_revision_hash",
     # NOTE: files_touched and commands_run are intentionally excluded from
     # exports — they contain unredacted file paths and shell commands that
     # could leak internal project structure or sensitive information.
@@ -3973,43 +4482,101 @@ def export_share_to_disk(
     total_redactions = 0
     redaction_types: dict[str, int] = {}
 
+    def block_revision_conflicts(
+        blockers: list[dict[str, Any]],
+    ) -> tuple[Path, dict[str, Any]]:
+        # This is deliberately in-memory only. A re-export attempt after a
+        # trace grows must not overwrite or delete the already-reviewed,
+        # pinned artifact for the older revision.
+        manifest["blocked"] = True
+        manifest["block_reason"] = "revision_conflict"
+        manifest["block_message"] = (
+            "One or more traces changed after selection. Review the updated "
+            "trace and create a new share."
+        )
+        manifest["blocked_sessions"] = blockers
+        return export_dir, manifest
+
+    stale_rows = share_revision_blockers(conn, share_id)
+    if stale_rows:
+        return block_revision_conflicts(stale_rows)
+
+    # Re-read the linked rows so the export uses authoritative create-time
+    # snapshots even if its caller holds an older share dictionary.
+    current_share = get_share(conn, share_id)
+    selected_sessions = (
+        current_share.get("sessions", []) if current_share is not None else []
+    )
+    prepared: list[tuple[dict[str, Any], dict[str, Any], str, str | None]] = []
+    skipped_session_ids: list[str] = []
+    preflight_blockers: list[dict[str, Any]] = []
+    for selected in selected_sessions:
+        session_id = selected["session_id"]
+        if session_matches_excluded_projects(selected, excluded_projects):
+            skipped_session_ids.append(session_id)
+            continue
+        detail = get_session_detail(conn, session_id)
+        if detail is None:
+            skipped_session_ids.append(session_id)
+            continue
+        expected_revision = selected.get("share_content_revision")
+        actual_revision = compute_content_revision(detail)
+        if actual_revision != expected_revision:
+            preflight_blockers.append({
+                "session_id": session_id,
+                "expected_revision_hash": expected_revision,
+                "current_revision_hash": actual_revision,
+                "review_status": selected.get("review_status"),
+            })
+            continue
+        prepared.append((
+            selected,
+            detail,
+            actual_revision,
+            selected.get("share_replaces_revision"),
+        ))
+    if preflight_blockers:
+        return block_revision_conflicts(preflight_blockers)
+
     try:
         with open(tmp_sessions_file, "w") as f:
-            for s in share.get("sessions", []):
-                if session_matches_excluded_projects(s, excluded_projects):
-                    continue
-                detail = get_session_detail(conn, s["session_id"])
-                if detail:
-                    detail, n_redacted, redaction_log = apply_share_redactions(
-                        conn,
-                        detail,
-                        custom_strings=custom_strings,
-                        user_allowlist=allowlist_entries,
-                        extra_usernames=extra_usernames,
-                        blocked_domains=blocked_domains,
+            for selected, detail, revision_hash, replaces_revision_hash in prepared:
+                detail, n_redacted, redaction_log = apply_share_redactions(
+                    conn,
+                    detail,
+                    custom_strings=custom_strings,
+                    user_allowlist=allowlist_entries,
+                    extra_usernames=extra_usernames,
+                    blocked_domains=blocked_domains,
+                )
+                total_redactions += n_redacted
+                for entry in redaction_log:
+                    rtype = entry.get("type", "unknown")
+                    redaction_types[rtype] = redaction_types.get(rtype, 0) + 1
+                # Custom string redactions are counted in n_redacted but
+                # don't produce log entries — track them separately.
+                custom_count = n_redacted - len(redaction_log)
+                if custom_count > 0:
+                    redaction_types["custom"] = (
+                        redaction_types.get("custom", 0) + custom_count
                     )
-                    total_redactions += n_redacted
-                    for entry in redaction_log:
-                        rtype = entry.get("type", "unknown")
-                        redaction_types[rtype] = redaction_types.get(rtype, 0) + 1
-                    # Custom string redactions are counted in n_redacted but
-                    # don't produce log entries — track them separately.
-                    custom_count = n_redacted - len(redaction_log)
-                    if custom_count > 0:
-                        redaction_types["custom"] = redaction_types.get("custom", 0) + custom_count
-                    clean = {k: v for k, v in detail.items() if k in EXPORT_FIELDS}
-                    f.write(json.dumps(clean, default=str) + "\n")
-                    manifest["sessions"].append({
-                        "session_id": clean.get("session_id") or s["session_id"],
-                        "project": clean.get("project"),
-                        "source": clean.get("source"),
-                        "model": clean.get("model"),
-                        # Aggregated counts per §Bundle manifest provenance —
-                        # no hashes, plaintext, or offsets.
-                        "redactions": build_session_redactions_summary(
-                            conn, s["session_id"],
-                        ),
-                    })
+                clean = {k: v for k, v in detail.items() if k in EXPORT_FIELDS}
+                clean["revision_hash"] = revision_hash
+                clean["replaces_revision_hash"] = replaces_revision_hash
+                f.write(json.dumps(clean, default=str) + "\n")
+                manifest["sessions"].append({
+                    "session_id": clean.get("session_id") or selected["session_id"],
+                    "project": clean.get("project"),
+                    "source": clean.get("source"),
+                    "model": clean.get("model"),
+                    "revision_hash": revision_hash,
+                    "replaces_revision_hash": replaces_revision_hash,
+                    # Aggregated counts per §Bundle manifest provenance —
+                    # no hashes, plaintext, or offsets.
+                    "redactions": build_session_redactions_summary(
+                        conn, selected["session_id"],
+                    ),
+                })
         os.replace(tmp_sessions_file, sessions_file)
     except BaseException:
         tmp_sessions_file.unlink(missing_ok=True)
@@ -4034,6 +4601,22 @@ def export_share_to_disk(
     trufflehog_scanner.write_report(export_dir / "trufflehog.json", trufflehog_report)
     manifest["redaction_summary"]["trufflehog"] = trufflehog_report.summary()
 
+    # A successful share baseline must describe only emitted sessions. Remove
+    # selections filtered out during packaging instead of letting their
+    # create-time snapshots masquerade as uploaded revisions later. Defer DB
+    # mutation until all scanners complete so an exception leaves no open
+    # partial selection change.
+    for session_id in skipped_session_ids:
+        conn.execute(
+            "DELETE FROM share_sessions WHERE share_id = ? AND session_id = ?",
+            (share_id, session_id),
+        )
+        conn.execute(
+            "UPDATE sessions SET share_id = NULL "
+            "WHERE session_id = ? AND share_id = ?",
+            (session_id, share_id),
+        )
+
     if trufflehog_report.blocking:
         manifest["blocked"] = True
         manifest["block_reason"] = trufflehog_report.block_reason
@@ -4047,8 +4630,8 @@ def export_share_to_disk(
         # but do NOT advance status to shared/exported — that would
         # silently imply the share is clean.
         conn.execute(
-            "UPDATE shares SET manifest = ? WHERE share_id = ?",
-            (json.dumps(manifest, default=str), share_id),
+            "UPDATE shares SET session_count = ?, manifest = ? WHERE share_id = ?",
+            (manifest["session_count"], json.dumps(manifest, default=str), share_id),
         )
         conn.commit()
         return export_dir, manifest
@@ -4058,8 +4641,14 @@ def export_share_to_disk(
 
     next_status = "shared" if share.get("status") == "shared" else "exported"
     conn.execute(
-        "UPDATE shares SET status = ?, manifest = ? WHERE share_id = ?",
-        (next_status, json.dumps(manifest, default=str), share_id),
+        "UPDATE shares SET status = ?, session_count = ?, manifest = ? "
+        "WHERE share_id = ?",
+        (
+            next_status,
+            manifest["session_count"],
+            json.dumps(manifest, default=str),
+            share_id,
+        ),
     )
     conn.commit()
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1034,6 +1034,43 @@ class TestBundleCreate:
         with pytest.raises(SystemExit):
             _run_bundle_create(args)
 
+    def test_create_by_status_filters_already_shared_revision(
+        self, bundle_index, capsys
+    ):
+        from clawjournal.cli import _run_bundle_create
+        from clawjournal.workbench.index import create_share, open_index
+
+        conn = open_index()
+        try:
+            shared_id = create_share(conn, ["sess-0"])
+            conn.execute(
+                "UPDATE shares SET status='shared', shared_at=? WHERE share_id=?",
+                ("2026-07-01T00:00:00+00:00", shared_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        args = MagicMock(
+            session_ids=[], status="approved", note=None, attestation=None, json=True
+        )
+        _run_bundle_create(args)
+
+        output = json.loads(capsys.readouterr().out)
+        assert output["session_count"] == 2
+
+    def test_create_explicit_missing_id_exits_cleanly(self, bundle_index, capsys):
+        from clawjournal.cli import _run_bundle_create
+
+        args = MagicMock(
+            session_ids=["missing"], status=None, note=None,
+            attestation=None, json=False,
+        )
+        with pytest.raises(SystemExit):
+            _run_bundle_create(args)
+
+        assert "not eligible to bundle" in capsys.readouterr().out
+
 
 class TestBundleList:
     def test_list_empty(self, bundle_index, capsys):
@@ -1332,6 +1369,70 @@ class TestSearch:
         _run_search(args)
         out = capsys.readouterr().out
         assert "No results" in out
+
+
+class TestScanOutput:
+    @staticmethod
+    def _patch_scan_dependencies(monkeypatch, scanner_cls):
+        class FakeConnection:
+            def close(self):
+                pass
+
+        monkeypatch.setattr("clawjournal.pricing.ensure_pricing_fresh", lambda: None)
+        monkeypatch.setattr("clawjournal.workbench.daemon.Scanner", scanner_cls)
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.open_index", lambda: FakeConnection()
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.get_stats",
+            lambda conn: {"total": 27, "by_status": {}, "by_source": {}},
+        )
+
+    def test_reports_updated_trace_when_no_new_session(self, monkeypatch, capsys):
+        class FakeScanner:
+            last_updated_count = 1
+            last_updated_by_source = {"codex": 1}
+            last_linked_count = 0
+
+            def __init__(self, source_filter=None):
+                pass
+
+            def scan_once(self):
+                return {"codex": 0}
+
+        self._patch_scan_dependencies(monkeypatch, FakeScanner)
+
+        from clawjournal.cli import _run_scan
+
+        _run_scan()
+        output = capsys.readouterr().out
+
+        assert "Indexed 0 new sessions; updated 1 existing trace:" in output
+        assert "codex: 1 updated trace" in output
+        assert "No new sessions found" not in output
+
+    def test_reports_no_changes_only_when_new_and_updated_are_zero(
+        self, monkeypatch, capsys
+    ):
+        class FakeScanner:
+            last_updated_count = 0
+            last_updated_by_source = {}
+            last_linked_count = 0
+
+            def __init__(self, source_filter=None):
+                pass
+
+            def scan_once(self):
+                return {"codex": 0}
+
+        self._patch_scan_dependencies(monkeypatch, FakeScanner)
+
+        from clawjournal.cli import _run_scan
+
+        _run_scan()
+        output = capsys.readouterr().out
+
+        assert "No new or updated sessions found." in output
 
 
 class TestWorkbenchSourceChoices:
@@ -1952,6 +2053,28 @@ class TestShare:
         assert captured.get("ai_pii_review_enabled") is True
         output = json.loads(capsys.readouterr().out)
         assert output["workbench_url"].endswith("&ai_pii=1")
+
+    def test_share_revision_race_exits_cleanly(
+        self, bundle_index, capsys, monkeypatch
+    ):
+        from clawjournal.cli import _run_share
+        from clawjournal.workbench.index import RevisionConflictError
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.create_share",
+            lambda *args, **kwargs: (_ for _ in ()).throw(
+                RevisionConflictError([{"session_id": "sess-0"}])
+            ),
+        )
+        args = MagicMock(
+            session_ids=[], status="approved", note=None,
+            force=False, json=False, preview=False,
+        )
+
+        with pytest.raises(SystemExit):
+            _run_share(args)
+
+        assert "changed after review" in capsys.readouterr().out
 
 
 class TestVerifyEmail:

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -171,7 +171,9 @@ def test_blocked_recovery_removes_and_retries(monkeypatch):
     monkeypatch.setattr(share_cli, "build_zip", lambda d: b"zip")
     calls = []
 
-    def _package(conn, session_ids, settings, *, ai_pii, note=None):
+    def _package(
+        conn, session_ids, settings, *, ai_pii, note=None, expected_revisions=None
+    ):
         calls.append(list(session_ids))
         if "bad" in session_ids:  # first attempt: block "bad"
             return {"ok": False, "blocked_sessions": ["bad"], "error": "blocked"}
@@ -191,7 +193,9 @@ def test_blocked_recovery_removes_and_retries(monkeypatch):
 def test_blocked_all_blocked_aborts(monkeypatch):
     monkeypatch.setattr(share_cli, "gate_blockers", lambda conn, ids: [])
 
-    def _package(conn, session_ids, settings, *, ai_pii, note=None):
+    def _package(
+        conn, session_ids, settings, *, ai_pii, note=None, expected_revisions=None
+    ):
         return {"ok": False, "blocked_sessions": list(session_ids), "error": "blocked"}
     monkeypatch.setattr(share_cli.share_flow, "package", _package)
 
@@ -277,6 +281,16 @@ def test_step_queue_scores_only_settled_unscored_candidates(monkeypatch):
     scored_ids = []
 
     monkeypatch.setattr(share_cli, "query_sessions", lambda *a, **k: rows)
+    monkeypatch.setattr(
+        share_cli,
+        "get_share_ready_stats",
+        lambda *a, **k: {
+            "sessions": [
+                {"session_id": row["session_id"], "revision_hash": f"rev-{row['session_id']}"}
+                for row in rows
+            ]
+        },
+    )
     monkeypatch.setattr(share_cli, "resolve_backend", lambda backend: "codex")
 
     def fake_unscored(conn, **kwargs):
@@ -385,13 +399,14 @@ def test_refresh_index_counts_new_sessions(monkeypatch):
     class FakeScanner:
         def __init__(self, source_filter=None):
             self.source_filter = source_filter
+            self.last_updated_count = 2
 
         def scan_once(self):
             return {"claude": 2, "codex": 1}
 
     monkeypatch.setattr(d, "Scanner", FakeScanner)
-    assert share_cli.refresh_index() == 3
-    assert share_cli.refresh_index("codex") == 3
+    assert share_cli.refresh_index() == (3, 2)
+    assert share_cli.refresh_index("codex") == (3, 2)
 
 
 # ---- queue selection input ('all') ------------------------------------------

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -682,6 +682,49 @@ class TestScanner:
         assert called["linked"] is True
         assert scanner.last_linked_count == 3
 
+    def test_scan_once_tracks_updated_and_unchanged_sessions(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+        monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.CONFIG_DIR", tmp_path / "clawjournal_config"
+        )
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {})
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.discover_projects",
+            lambda source_filter=None: [
+                {"source": "codex", "dir_name": "project", "locator": None}
+            ],
+        )
+        parsed = [{"session_id": "existing-session"}]
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.parse_project_sessions",
+            lambda *args, **kwargs: parsed,
+        )
+
+        def fake_upsert(conn, sessions, *, stats=None):
+            assert sessions is parsed
+            assert stats is not None
+            stats.update(inserted=0, updated=1, unchanged=2)
+            return 0
+
+        monkeypatch.setattr("clawjournal.workbench.daemon.upsert_sessions", fake_upsert)
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.run_findings_pipeline",
+            lambda *args, **kwargs: None,
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.link_subagent_hierarchy", lambda conn: 0
+        )
+
+        scanner = Scanner(source_filter="codex")
+        results = scanner.scan_once()
+
+        assert results == {"codex": 0}
+        assert scanner.last_updated_count == 1
+        assert scanner.last_unchanged_count == 2
+        assert scanner.last_updated_by_source == {"codex": 1}
+        assert scanner.last_unchanged_by_source == {"codex": 2}
+
     def test_score_unscored_once_uses_default_agent_scoring(self, tmp_path, monkeypatch):
         monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
         monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
@@ -1087,6 +1130,27 @@ class TestScanner:
         assert settings["blocked_domains"] == ["api.internal"]
 
 
+class TestScanAPI:
+    def test_endpoint_reports_new_updated_and_unchanged_by_source(
+        self, server_with_scanner, monkeypatch
+    ):
+        port, scanner = server_with_scanner
+        scanner.scan_once = lambda: {"codex": 0, "claude": 2}
+        scanner.last_updated_by_source = {"codex": 1}
+        scanner.last_unchanged_by_source = {"codex": 4, "claude": 3}
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.trigger_scoring_warmup",
+            lambda active_scanner: {"status": "disabled"},
+        )
+
+        status, data = _post(port, "/api/scan")
+
+        assert status == 200
+        assert data["new_sessions"] == {"codex": 0, "claude": 2}
+        assert data["updated_sessions"] == {"codex": 1}
+        assert data["unchanged_sessions"] == {"codex": 4, "claude": 3}
+
+
 class TestScoringWarmupAPI:
     def test_endpoint_returns_disabled_without_scanner(self, server):
         status, data = _post(server, "/api/scoring/warmup")
@@ -1336,6 +1400,103 @@ class TestSharesAPI:
     def test_create_empty_fails(self, server):
         status, data = _post(server, "/api/shares", {"session_ids": []})
         assert status == 400
+
+    def test_create_rejects_revision_changed_after_ui_review(self, server):
+        conn = open_index()
+        try:
+            reviewed_revision = conn.execute(
+                "SELECT content_revision FROM sessions WHERE session_id = 'sess-0'"
+            ).fetchone()[0]
+            session = {
+                "session_id": "sess-0",
+                "project": "test-project",
+                "source": "claude",
+                "model": "claude-sonnet-4",
+                "messages": [
+                    {"role": "user", "content": "Task 0: extended result", "tool_uses": []},
+                    {"role": "assistant", "content": "Done.", "tool_uses": []},
+                ],
+                "stats": {
+                    "user_messages": 1,
+                    "assistant_messages": 1,
+                    "tool_uses": 0,
+                    "input_tokens": 100,
+                    "output_tokens": 50,
+                },
+            }
+            upsert_sessions(conn, [session])
+        finally:
+            conn.close()
+
+        status, data = _post(server, "/api/shares", {
+            "session_ids": ["sess-0"],
+            "expected_revisions": {"sess-0": reviewed_revision},
+        })
+
+        assert status == 409
+        assert data["block_reason"] == "revision_conflict"
+        assert data["blockers"][0]["session_id"] == "sess-0"
+
+    def test_create_rejects_exact_revision_already_shared(self, server):
+        from clawjournal.workbench.index import create_share
+
+        conn = open_index()
+        try:
+            first_share = create_share(conn, ["sess-0"])
+            conn.execute(
+                "UPDATE shares SET status = 'shared', shared_at = ? WHERE share_id = ?",
+                ("2026-07-01T00:00:00+00:00", first_share),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        status, data = _post(server, "/api/shares", {
+            "session_ids": ["sess-0"],
+        })
+
+        assert status == 409
+        assert "already shared" in data["error"]
+        assert data["blockers"][0]["session_id"] == "sess-0"
+
+    def test_create_rejects_unapproved_extension_of_shared_trace(self, server):
+        from clawjournal.workbench.index import create_share
+
+        conn = open_index()
+        try:
+            first_share = create_share(conn, ["sess-0"])
+            conn.execute(
+                "UPDATE shares SET status = 'shared', shared_at = ? WHERE share_id = ?",
+                ("2026-07-01T00:00:00+00:00", first_share),
+            )
+            conn.commit()
+            upsert_sessions(conn, [{
+                "session_id": "sess-0",
+                "project": "test-project",
+                "source": "claude",
+                "model": "claude-sonnet-4",
+                "messages": [
+                    {"role": "user", "content": "Task 0: extended result", "tool_uses": []},
+                    {"role": "assistant", "content": "A new iteration.", "tool_uses": []},
+                ],
+                "stats": {
+                    "user_messages": 1,
+                    "assistant_messages": 1,
+                    "tool_uses": 0,
+                    "input_tokens": 120,
+                    "output_tokens": 60,
+                },
+            }])
+        finally:
+            conn.close()
+
+        status, data = _post(server, "/api/shares", {
+            "session_ids": ["sess-0"],
+        })
+
+        assert status == 409
+        assert "fresh approval" in data["error"]
+        assert data["blockers"][0]["review_status"] == "new"
 
     def test_create_rejects_sessions_outside_configured_source_scope(self, server, monkeypatch):
         monkeypatch.setattr(
@@ -1967,6 +2128,89 @@ def test_redaction_settings_fingerprint_covers_all_inputs():
         _redaction_settings_fingerprint({**base, "custom_strings": ["b", "a", "c"]})
         == _redaction_settings_fingerprint({**base, "custom_strings": ["c", "a", "b"]})
     )
+
+
+class TestSelfHostedRevisionConflicts:
+    def _share(self, monkeypatch):
+        from clawjournal.workbench.index import create_share
+
+        _mock_trufflehog_clean(monkeypatch)
+        conn = open_index()
+        set_hold_state(conn, "sess-0", "released", changed_by="user")
+        share_id = create_share(conn, ["sess-0"])
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon._ensure_self_hosted_upload_credentials",
+            lambda: ("test@university.edu", "token"),
+        )
+        return conn, share_id
+
+    @staticmethod
+    def _conflict_response(req, *, matching: bool):
+        import re
+
+        body = req.data.decode("utf-8", errors="replace")
+        match = re.search(
+            r'name="bundle_hash"\r\n\r\n([0-9a-f]{64})\r\n',
+            body,
+        )
+        assert match is not None
+        confirmed_hash = match.group(1) if matching else "0" * 64
+        payload = json.dumps({
+            "error": "already exists",
+            "idempotent": True,
+            "bundle_hash": confirmed_hash,
+            "gcs_uri": "gs://test/existing/sessions.jsonl",
+        }).encode()
+        raise urllib.error.HTTPError(
+            req.full_url,
+            409,
+            "Conflict",
+            hdrs=None,
+            fp=BytesIO(payload),
+        )
+
+    def test_accepts_only_proven_same_bundle_409(self, index_setup, monkeypatch):
+        from clawjournal.workbench.daemon import upload_share_to_self_hosted_ingest
+
+        conn, share_id = self._share(monkeypatch)
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            lambda req, timeout: self._conflict_response(req, matching=True),
+        )
+        try:
+            result = upload_share_to_self_hosted_ingest(conn, share_id)
+            row = conn.execute(
+                "SELECT status, shared_at FROM shares WHERE share_id = ?",
+                (share_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert result["ok"] is True
+        assert row["status"] == "shared"
+        assert row["shared_at"] is not None
+
+    def test_rejects_mismatched_409_without_marking_shared(
+        self, index_setup, monkeypatch
+    ):
+        from clawjournal.workbench.daemon import upload_share_to_self_hosted_ingest
+
+        conn, share_id = self._share(monkeypatch)
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            lambda req, timeout: self._conflict_response(req, matching=False),
+        )
+        try:
+            result = upload_share_to_self_hosted_ingest(conn, share_id)
+            row = conn.execute(
+                "SELECT status, shared_at FROM shares WHERE share_id = ?",
+                (share_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+
+        assert result["status"] == 409
+        assert tuple(row) == ("exported", None)
 
 
 def test_upload_pii_redaction_runs_sessions_in_parallel(tmp_path, monkeypatch):
@@ -2624,6 +2868,66 @@ class TestShareAPI:
         assert data["blockers"][0]["session_id"] == "qs-held"
         assert data["blockers"][0]["hold_state"] == "pending_review"
 
+    def test_quick_share_rejects_exact_revision_already_shared(self, server):
+        from clawjournal.workbench.index import create_share
+
+        WorkbenchHandler._last_share_time = 0.0
+        conn = open_index()
+        try:
+            share_id = create_share(conn, ["sess-0"])
+            conn.execute(
+                "UPDATE shares SET status='shared', shared_at=? WHERE share_id=?",
+                ("2026-07-01T00:00:00+00:00", share_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        status, data = _post(server, "/api/quick-share", {
+            "session_ids": ["sess-0"],
+        })
+
+        assert status == 409
+        assert "already shared" in data["error"]
+
+    def test_quick_share_rejects_unapproved_extension(self, server):
+        from clawjournal.workbench.index import create_share
+
+        WorkbenchHandler._last_share_time = 0.0
+        conn = open_index()
+        try:
+            share_id = create_share(conn, ["sess-0"])
+            conn.execute(
+                "UPDATE shares SET status='shared', shared_at=? WHERE share_id=?",
+                ("2026-07-01T00:00:00+00:00", share_id),
+            )
+            conn.commit()
+            upsert_sessions(conn, [{
+                "session_id": "sess-0",
+                "project": "test-project",
+                "source": "claude",
+                "model": "claude-sonnet-4",
+                "messages": [
+                    {"role": "user", "content": "extended iteration", "tool_uses": []},
+                ],
+                "stats": {
+                    "user_messages": 1,
+                    "assistant_messages": 0,
+                    "tool_uses": 0,
+                    "input_tokens": 100,
+                    "output_tokens": 0,
+                },
+            }])
+        finally:
+            conn.close()
+
+        status, data = _post(server, "/api/quick-share", {
+            "session_ids": ["sess-0"],
+        })
+
+        assert status == 409
+        assert "fresh approval" in data["error"]
+
     def test_share_duplicate_prevention(self, server, monkeypatch):
         """Already-submitted bundle → 409; force surfaces a clearer message."""
         WorkbenchHandler._last_share_time = 0.0
@@ -2647,6 +2951,63 @@ class TestShareAPI:
         assert status == 409
         assert "cannot be overwritten" in data["error"]
         assert data["receipt_id"] == "rcpt-test-123"
+
+    def test_hosted_upload_rejects_stale_replacement_predecessor(
+        self, server, monkeypatch
+    ):
+        from clawjournal.workbench.index import create_share, update_session
+
+        WorkbenchHandler._last_share_time = 0.0
+        conn = open_index()
+        try:
+            set_hold_state(conn, "sess-0", "released", changed_by="user")
+            share_r1 = create_share(conn, ["sess-0"])
+            conn.execute(
+                "UPDATE shares SET status='shared', shared_at=? WHERE share_id=?",
+                ("2026-07-01T00:00:00+00:00", share_r1),
+            )
+            conn.commit()
+
+            upsert_sessions(conn, [{
+                "session_id": "sess-0",
+                "project": "test-project",
+                "source": "claude",
+                "model": "claude-sonnet-4",
+                "messages": [{"role": "user", "content": "revision two"}],
+                "stats": {"user_messages": 1, "assistant_messages": 0, "tool_uses": 0},
+            }])
+            update_session(conn, "sess-0", status="approved")
+            share_r2 = create_share(conn, ["sess-0"])
+
+            upsert_sessions(conn, [{
+                "session_id": "sess-0",
+                "project": "test-project",
+                "source": "claude",
+                "model": "claude-sonnet-4",
+                "messages": [{"role": "user", "content": "revision three"}],
+                "stats": {"user_messages": 1, "assistant_messages": 0, "tool_uses": 0},
+            }])
+            update_session(conn, "sess-0", status="approved")
+            share_r3 = create_share(conn, ["sess-0"])
+            conn.execute(
+                "UPDATE shares SET status='shared', shared_at=? WHERE share_id=?",
+                ("2026-07-03T00:00:00+00:00", share_r3),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config", lambda: _share_config()
+        )
+        status, data = _post(
+            server,
+            f"/api/shares/{share_r2}/upload",
+            self._consent_body(),
+        )
+
+        assert status == 409
+        assert data["blockers"][0]["reason"] == "stale_predecessor"
 
     def test_duplicate_receipt_returned_even_without_valid_token(self, server, monkeypatch):
         """Receipt hydration/retry should not require a still-valid upload token."""

--- a/tests/workbench/test_revision_tracking.py
+++ b/tests/workbench/test_revision_tracking.py
@@ -1,0 +1,546 @@
+"""Revision tracking for long-running traces that grow after sharing."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from copy import deepcopy
+
+import pytest
+
+from clawjournal.workbench.index import (
+    REVISION_TRACKING_SCHEMA_VERSION,
+    RevisionConflictError,
+    already_shared_revision_blockers,
+    compute_content_revision,
+    create_share,
+    export_share_to_disk,
+    get_share,
+    get_share_ready_stats,
+    open_index,
+    revision_review_blockers,
+    set_hold_state,
+    share_predecessor_blockers,
+    share_revision_blockers,
+    update_session,
+    upsert_sessions,
+)
+
+
+@pytest.fixture
+def index_conn(tmp_path, monkeypatch):
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+    monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+    monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path)
+    conn = open_index()
+    yield conn
+    conn.close()
+
+
+def _session(session_id: str = "trace-1", content: str = "first message") -> dict:
+    return {
+        "session_id": session_id,
+        "project": "science-project",
+        "source": "codex",
+        "model": "gpt-5",
+        "start_time": "2026-07-01T00:00:00+00:00",
+        "end_time": "2026-07-01T01:00:00+00:00",
+        "git_branch": "main",
+        "messages": [
+            {"role": "user", "content": content, "tool_uses": []},
+            {"role": "assistant", "content": "working", "tool_uses": []},
+        ],
+        "stats": {
+            "user_messages": 1,
+            "assistant_messages": 1,
+            "tool_uses": 0,
+            "input_tokens": 10,
+            "output_tokens": 5,
+        },
+    }
+
+
+def _mark_shared(conn, share_id: str, when: str) -> None:
+    conn.execute(
+        "UPDATE shares SET status = 'shared', shared_at = ? WHERE share_id = ?",
+        (when, share_id),
+    )
+    conn.commit()
+
+
+def _approve(conn, session_id: str = "trace-1") -> None:
+    assert update_session(
+        conn,
+        session_id,
+        status="approved",
+        notes="reviewed",
+        reason="useful",
+        ai_quality_score=5,
+        ai_score_reason="strong",
+        ai_effort_estimate=0.8,
+        ai_summary="summary",
+        ai_scoring_detail="{}",
+        ai_task_type="research",
+        ai_outcome_badge="resolved",
+        ai_value_badges="[]",
+        ai_risk_badges="[]",
+        ai_display_title="Reviewed trace",
+        ai_failure_value_score=4,
+        ai_recovery_labels="[]",
+        ai_failure_attribution="agent",
+        ai_failure_modes="[]",
+        ai_learning_summary="lesson",
+        ai_scorer_backend="codex",
+        ai_scorer_model="gpt-5",
+        ai_rubric_git_sha="abc",
+        ai_scored_at="2026-07-01T02:00:00+00:00",
+    )
+
+
+def test_content_revision_hashes_messages_only():
+    original = _session()
+    metadata_only = deepcopy(original)
+    metadata_only["project"] = "renamed-project"
+    metadata_only["model"] = "new-parser-model-label"
+    metadata_only["stats"]["input_tokens"] = 999
+
+    assert compute_content_revision(original) == compute_content_revision(metadata_only)
+
+    appended = deepcopy(original)
+    appended["messages"].append({"role": "user", "content": "new result"})
+    assert compute_content_revision(original) != compute_content_revision(appended)
+
+
+def test_upsert_distinguishes_updates_and_resets_review_scoring(index_conn):
+    first = _session()
+    stats: dict[str, int] = {}
+    assert upsert_sessions(index_conn, [first], stats=stats) == 1
+    assert stats == {"inserted": 1, "updated": 0, "unchanged": 0}
+    _approve(index_conn)
+    set_hold_state(index_conn, "trace-1", "released", changed_by="user")
+    index_conn.execute(
+        "UPDATE sessions SET ai_episode_quality = 0.9, ai_quality_tier = 'high' "
+        "WHERE session_id = 'trace-1'"
+    )
+    index_conn.commit()
+    before = index_conn.execute(
+        "SELECT content_revision, updated_at FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()
+
+    assert upsert_sessions(index_conn, [deepcopy(first)], stats=stats) == 0
+    assert stats == {"inserted": 0, "updated": 0, "unchanged": 1}
+    unchanged = index_conn.execute(
+        "SELECT review_status, ai_quality_score, updated_at FROM sessions "
+        "WHERE session_id = 'trace-1'"
+    ).fetchone()
+    assert tuple(unchanged) == ("approved", 5, before["updated_at"])
+
+    extended = deepcopy(first)
+    extended["messages"].append({
+        "role": "user",
+        "content": "the experiment produced another result",
+        "tool_uses": [],
+    })
+    extended["stats"]["user_messages"] = 2
+    assert upsert_sessions(index_conn, [extended], stats=stats) == 0
+    assert stats == {"inserted": 0, "updated": 1, "unchanged": 0}
+
+    row = index_conn.execute(
+        "SELECT * FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()
+    assert row["content_revision"] != before["content_revision"]
+    assert row["review_status"] == "new"
+    assert row["hold_state"] == "released"
+    assert row["selection_reason"] is None
+    assert row["reviewer_notes"] is None
+    assert row["reviewed_at"] is None
+    for field in (
+        "ai_quality_score", "ai_score_reason", "ai_episode_quality",
+        "ai_quality_tier", "ai_scoring_detail", "ai_task_type",
+        "ai_outcome_badge", "ai_value_badges", "ai_risk_badges",
+        "ai_display_title", "ai_effort_estimate", "ai_summary",
+        "ai_failure_value_score", "ai_recovery_labels",
+        "ai_failure_attribution", "ai_failure_modes", "ai_learning_summary",
+        "ai_scorer_backend", "ai_scorer_model", "ai_rubric_git_sha",
+        "ai_scored_at",
+    ):
+        assert row[field] is None, field
+
+
+def test_content_update_preserves_segmented_parent_status(index_conn):
+    original = _session()
+    upsert_sessions(index_conn, [original])
+    index_conn.execute(
+        "UPDATE sessions SET review_status = 'segmented' WHERE session_id = 'trace-1'"
+    )
+    index_conn.commit()
+
+    extended = deepcopy(original)
+    extended["messages"].append({
+        "role": "user",
+        "content": "continue the outer trace after child segmentation",
+    })
+    stats: dict[str, int] = {}
+    upsert_sessions(index_conn, [extended], stats=stats)
+
+    row = index_conn.execute(
+        "SELECT review_status FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()
+    assert row["review_status"] == "segmented"
+    assert stats["updated"] == 1
+    assert get_share_ready_stats(index_conn, include_unapproved=True)["sessions"] == []
+
+
+def test_metadata_only_reparse_refreshes_blob_without_invalidating_review(index_conn):
+    original = _session()
+    upsert_sessions(index_conn, [original])
+    _approve(index_conn)
+    before = index_conn.execute(
+        "SELECT content_revision, updated_at FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()
+
+    enriched = deepcopy(original)
+    enriched["project"] = "renamed-science-project"
+    enriched["model"] = "gpt-5-enriched"
+    enriched["segment_title"] = "Updated parser title"
+    enriched["stats"]["input_tokens"] = 123
+    stats: dict[str, int] = {}
+    upsert_sessions(index_conn, [enriched], stats=stats)
+
+    row = index_conn.execute(
+        "SELECT project, model, display_title, review_status, content_revision, "
+        "updated_at, blob_path FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()
+    assert stats == {"inserted": 0, "updated": 0, "unchanged": 1}
+    assert row["project"] == "renamed-science-project"
+    assert row["model"] == "gpt-5-enriched"
+    assert row["display_title"] == "Updated parser title"
+    assert row["review_status"] == "approved"
+    assert row["content_revision"] == before["content_revision"]
+    assert row["updated_at"] == before["updated_at"]
+    with open(row["blob_path"]) as f:
+        blob = json.load(f)
+    assert blob["project"] == "renamed-science-project"
+    fts_title = index_conn.execute(
+        "SELECT display_title FROM sessions_fts WHERE session_id = 'trace-1'"
+    ).fetchone()[0]
+    assert fts_title == "Updated parser title"
+
+
+def test_revision_aware_eligibility_requires_fresh_review(index_conn):
+    upsert_sessions(index_conn, [_session()])
+    _approve(index_conn)
+    first_revision = index_conn.execute(
+        "SELECT content_revision FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()[0]
+    first_share = create_share(index_conn, ["trace-1"])
+    _mark_shared(index_conn, first_share, "2026-07-02T00:00:00+00:00")
+
+    assert get_share_ready_stats(index_conn)["sessions"] == []
+    assert already_shared_revision_blockers(index_conn, ["trace-1"]) == [{
+        "session_id": "trace-1",
+        "revision_hash": first_revision,
+        "last_shared_revision_hash": first_revision,
+    }]
+
+    upsert_sessions(index_conn, [_session(content="extended result")])
+    assert revision_review_blockers(index_conn, ["trace-1"])[0]["review_status"] == "new"
+    assert get_share_ready_stats(index_conn, include_unapproved=True)["sessions"] == []
+
+    _approve(index_conn)
+    ready = get_share_ready_stats(index_conn)["sessions"]
+    assert len(ready) == 1
+    assert ready[0]["revision_hash"] != first_revision
+    assert ready[0]["last_shared_revision_hash"] == first_revision
+    assert ready[0]["updated_since_last_share"] is True
+
+
+def test_create_share_expected_revisions_are_exact_and_atomic(index_conn):
+    upsert_sessions(index_conn, [_session(), _session("trace-2")])
+    revisions = {
+        row["session_id"]: row["content_revision"]
+        for row in index_conn.execute(
+            "SELECT session_id, content_revision FROM sessions ORDER BY session_id"
+        )
+    }
+
+    with pytest.raises(RevisionConflictError) as exc_info:
+        create_share(
+            index_conn,
+            ["trace-1", "trace-2"],
+            expected_revisions={"trace-1": revisions["trace-1"]},
+        )
+    assert exc_info.value.blockers == [{
+        "session_id": "trace-2",
+        "expected_revision_hash": None,
+        "current_revision_hash": revisions["trace-2"],
+    }]
+    assert index_conn.execute("SELECT COUNT(*) FROM shares").fetchone()[0] == 0
+
+    share_id = create_share(
+        index_conn,
+        ["trace-1", "trace-2"],
+        expected_revisions=revisions,
+    )
+    snapshots = index_conn.execute(
+        "SELECT session_id, content_revision FROM share_sessions "
+        "WHERE share_id = ? ORDER BY session_id",
+        (share_id,),
+    ).fetchall()
+    assert {row["session_id"]: row["content_revision"] for row in snapshots} == revisions
+
+
+def test_export_uses_snapshot_and_stale_reexport_preserves_artifact(index_conn):
+    upsert_sessions(index_conn, [_session()])
+    _approve(index_conn)
+    first_share_id = create_share(index_conn, ["trace-1"])
+    first_share = get_share(index_conn, first_share_id)
+    export_dir, manifest = export_share_to_disk(index_conn, first_share_id, first_share)
+    assert manifest.get("blocked") is not True
+    first_revision = manifest["sessions"][0]["revision_hash"]
+    assert manifest["sessions"][0]["replaces_revision_hash"] is None
+    payload = json.loads((export_dir / "sessions.jsonl").read_text().splitlines()[0])
+    assert payload["revision_hash"] == first_revision
+    assert payload["replaces_revision_hash"] is None
+    sessions_bytes = (export_dir / "sessions.jsonl").read_bytes()
+    manifest_bytes = (export_dir / "manifest.json").read_bytes()
+    persisted_manifest = index_conn.execute(
+        "SELECT manifest FROM shares WHERE share_id = ?", (first_share_id,)
+    ).fetchone()[0]
+    _mark_shared(index_conn, first_share_id, "2026-07-02T00:00:00+00:00")
+
+    upsert_sessions(index_conn, [_session(content="new unreviewed revision")])
+    blockers = share_revision_blockers(index_conn, first_share_id)
+    assert len(blockers) == 1
+    _, blocked = export_share_to_disk(
+        index_conn,
+        first_share_id,
+        get_share(index_conn, first_share_id),
+    )
+    assert blocked["block_reason"] == "revision_conflict"
+    assert (export_dir / "sessions.jsonl").read_bytes() == sessions_bytes
+    assert (export_dir / "manifest.json").read_bytes() == manifest_bytes
+    assert index_conn.execute(
+        "SELECT manifest FROM shares WHERE share_id = ?", (first_share_id,)
+    ).fetchone()[0] == persisted_manifest
+
+
+def test_finalized_bundle_stays_pinned_after_append_and_cache_miss(
+    index_conn, monkeypatch
+):
+    from clawjournal.redaction import trufflehog
+    from clawjournal.workbench import index as index_module
+    from clawjournal.workbench.daemon import _prepare_share_export_for_upload
+
+    monkeypatch.setattr(
+        "clawjournal.workbench.daemon.CONFIG_DIR", index_module.CONFIG_DIR
+    )
+    monkeypatch.delenv(trufflehog.SKIP_ENV_VAR, raising=False)
+    monkeypatch.setattr(trufflehog, "is_available", lambda: True)
+    monkeypatch.setattr(
+        trufflehog,
+        "scan_file",
+        lambda path: trufflehog.TruffleHogReport(
+            scanned_path=str(path),
+            scanned_sha256="sha256:clean",
+        ),
+    )
+    monkeypatch.setattr(trufflehog, "_scan_text_for_raw_matches", lambda text: [])
+
+    upsert_sessions(index_conn, [_session(content="reviewed revision")])
+    _approve(index_conn)
+    share_id = create_share(index_conn, ["trace-1"])
+    settings = {
+        "custom_strings": [],
+        "extra_usernames": [],
+        "excluded_projects": [],
+        "blocked_domains": [],
+        "allowlist_entries": [],
+        "source_filter": None,
+        "ai_pii_review_enabled": False,
+    }
+    export_dir, _manifest, error = _prepare_share_export_for_upload(
+        index_conn,
+        share_id,
+        get_share(index_conn, share_id),
+        settings,
+        reuse_finalized=True,
+    )
+    assert error is None
+    pinned_sessions = (export_dir / "sessions.jsonl").read_bytes()
+    pinned_manifest = (export_dir / "manifest.json").read_bytes()
+
+    upsert_sessions(index_conn, [_session(content="newer local revision")])
+
+    # Same settings reuse the finalized point-in-time artifact even though the
+    # live trace has moved on.
+    reused_dir, _reused_manifest, reused_error = _prepare_share_export_for_upload(
+        index_conn,
+        share_id,
+        get_share(index_conn, share_id),
+        settings,
+        reuse_finalized=True,
+    )
+    assert reused_error is None
+    assert reused_dir == export_dir
+    assert (export_dir / "sessions.jsonl").read_bytes() == pinned_sessions
+
+    # A settings change invalidates the cache, but the attempted rebuild must
+    # fail closed without destroying the reviewed old artifact.
+    changed_settings = {**settings, "custom_strings": ["new local rule"]}
+    _blocked_dir, _blocked_manifest, blocked_error = _prepare_share_export_for_upload(
+        index_conn,
+        share_id,
+        get_share(index_conn, share_id),
+        changed_settings,
+        reuse_finalized=True,
+    )
+    assert blocked_error["status"] == 409
+    assert blocked_error["block_reason"] == "revision_conflict"
+    assert (export_dir / "sessions.jsonl").read_bytes() == pinned_sessions
+    assert (export_dir / "manifest.json").read_bytes() == pinned_manifest
+
+
+def test_share_predecessor_detects_newer_successful_revision(index_conn):
+    upsert_sessions(index_conn, [_session(content="r1")])
+    _approve(index_conn)
+    share_r1 = create_share(index_conn, ["trace-1"])
+    _mark_shared(index_conn, share_r1, "2026-07-02T00:00:00+00:00")
+    revision_r1 = index_conn.execute(
+        "SELECT content_revision FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()[0]
+
+    upsert_sessions(index_conn, [_session(content="r2")])
+    _approve(index_conn)
+    share_r2 = create_share(index_conn, ["trace-1"])
+    snapshot_r2 = index_conn.execute(
+        "SELECT content_revision, replaces_revision FROM share_sessions "
+        "WHERE share_id = ?",
+        (share_r2,),
+    ).fetchone()
+    assert snapshot_r2["replaces_revision"] == revision_r1
+
+    upsert_sessions(index_conn, [_session(content="r3")])
+    _approve(index_conn)
+    share_r3 = create_share(index_conn, ["trace-1"])
+    _mark_shared(index_conn, share_r3, "2026-07-03T00:00:00+00:00")
+    revision_r3 = index_conn.execute(
+        "SELECT content_revision FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()[0]
+
+    assert share_predecessor_blockers(index_conn, share_r2) == [{
+        "session_id": "trace-1",
+        "revision_hash": snapshot_r2["content_revision"],
+        "replaces_revision_hash": revision_r1,
+        "latest_shared_revision_hash": revision_r3,
+        "reason": "stale_predecessor",
+    }]
+
+
+def test_share_predecessor_blocks_same_revision_uploaded_by_another_share(index_conn):
+    upsert_sessions(index_conn, [_session(content="r1")])
+    _approve(index_conn)
+    first_draft = create_share(index_conn, ["trace-1"])
+    second_draft = create_share(index_conn, ["trace-1"])
+    revision = index_conn.execute(
+        "SELECT content_revision FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()[0]
+
+    _mark_shared(index_conn, first_draft, "2026-07-02T00:00:00+00:00")
+
+    assert share_predecessor_blockers(index_conn, second_draft) == [{
+        "session_id": "trace-1",
+        "revision_hash": revision,
+        "replaces_revision_hash": None,
+        "latest_shared_revision_hash": revision,
+        "reason": "already_shared_revision",
+    }]
+
+    duplicate_after_upload = create_share(index_conn, ["trace-1"])
+    duplicate_snapshot = index_conn.execute(
+        "SELECT replaces_revision FROM share_sessions WHERE share_id = ?",
+        (duplicate_after_upload,),
+    ).fetchone()[0]
+    assert duplicate_snapshot == revision
+    assert share_predecessor_blockers(index_conn, duplicate_after_upload)[0][
+        "reason"
+    ] == "already_shared_revision"
+
+
+def test_v5_migration_backfills_blob_and_historical_share_baseline(
+    tmp_path,
+    monkeypatch,
+):
+    db_path = tmp_path / "index.db"
+    blobs_path = tmp_path / "blobs"
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", db_path)
+    monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", blobs_path)
+    monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path)
+    conn = open_index()
+    upsert_sessions(conn, [_session()])
+    _approve(conn)
+    share_id = create_share(conn, ["trace-1"])
+    _mark_shared(conn, share_id, "2026-07-02T00:00:00+00:00")
+    expected = compute_content_revision(_session())
+    conn.close()
+
+    raw = sqlite3.connect(db_path)
+    raw.execute("ALTER TABLE sessions DROP COLUMN content_revision")
+    raw.execute("ALTER TABLE share_sessions DROP COLUMN content_revision")
+    raw.execute("ALTER TABLE share_sessions DROP COLUMN replaces_revision")
+    raw.execute("PRAGMA user_version = 5")
+    raw.commit()
+    raw.close()
+
+    conn = open_index()
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == REVISION_TRACKING_SCHEMA_VERSION
+        session_revision = conn.execute(
+            "SELECT content_revision FROM sessions WHERE session_id = 'trace-1'"
+        ).fetchone()[0]
+        share_revision = conn.execute(
+            "SELECT content_revision FROM share_sessions WHERE share_id = ?",
+            (share_id,),
+        ).fetchone()[0]
+        assert session_revision == share_revision == expected
+        assert get_share_ready_stats(conn)["sessions"] == []
+    finally:
+        conn.close()
+
+
+def test_v5_migration_missing_blob_uses_safe_legacy_baseline(tmp_path, monkeypatch):
+    db_path = tmp_path / "index.db"
+    blobs_path = tmp_path / "blobs"
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", db_path)
+    monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", blobs_path)
+    monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path)
+    conn = open_index()
+    upsert_sessions(conn, [_session()])
+    _approve(conn)
+    share_id = create_share(conn, ["trace-1"])
+    _mark_shared(conn, share_id, "2026-07-02T00:00:00+00:00")
+    conn.close()
+    (blobs_path / "trace-1.json").unlink()
+
+    raw = sqlite3.connect(db_path)
+    raw.execute("ALTER TABLE sessions DROP COLUMN content_revision")
+    raw.execute("ALTER TABLE share_sessions DROP COLUMN content_revision")
+    raw.execute("ALTER TABLE share_sessions DROP COLUMN replaces_revision")
+    raw.execute("PRAGMA user_version = 5")
+    raw.commit()
+    raw.close()
+
+    conn = open_index()
+    try:
+        session_revision = conn.execute(
+            "SELECT content_revision FROM sessions WHERE session_id = 'trace-1'"
+        ).fetchone()[0]
+        share_revision = conn.execute(
+            "SELECT content_revision FROM share_sessions WHERE share_id = ?",
+            (share_id,),
+        ).fetchone()[0]
+        assert session_revision.startswith("legacy:")
+        assert share_revision == session_revision
+        assert get_share_ready_stats(conn)["sessions"] == []
+    finally:
+        conn.close()

--- a/tests/workbench/test_widened_message_migration.py
+++ b/tests/workbench/test_widened_message_migration.py
@@ -13,6 +13,7 @@ import pytest
 
 from clawjournal.workbench.index import (
     HOSTED_SUBMISSION_SCHEMA_VERSION,
+    REVISION_TRACKING_SCHEMA_VERSION,
     SESSION_IDENTITY_SCHEMA_VERSION,
     WIDENED_MESSAGE_SCHEMA_VERSION,
     WORKBENCH_SCHEMA_VERSION,
@@ -35,7 +36,8 @@ def _columns(conn, table):
 
 class TestFreshInstall:
     def test_workbench_version_advances_to_widened(self, fresh_db):
-        assert WORKBENCH_SCHEMA_VERSION == HOSTED_SUBMISSION_SCHEMA_VERSION
+        assert WORKBENCH_SCHEMA_VERSION == REVISION_TRACKING_SCHEMA_VERSION
+        assert REVISION_TRACKING_SCHEMA_VERSION > HOSTED_SUBMISSION_SCHEMA_VERSION
         assert HOSTED_SUBMISSION_SCHEMA_VERSION > WIDENED_MESSAGE_SCHEMA_VERSION
         assert WIDENED_MESSAGE_SCHEMA_VERSION > SESSION_IDENTITY_SCHEMA_VERSION
         conn = open_index()
@@ -190,7 +192,7 @@ class TestUpgradeFromV4:
             cols_after = _columns(conn, "shares")
             assert {"hosted_receipt_id", "hosted_status", "hosted_submission_url"}.issubset(cols_after)
             version_after = conn.execute("PRAGMA user_version").fetchone()[0]
-            assert version_after == HOSTED_SUBMISSION_SCHEMA_VERSION
+            assert version_after == WORKBENCH_SCHEMA_VERSION
             # Pre-existing rows keep their data; the new columns default to NULL.
             row = conn.execute(
                 "SELECT hosted_receipt_id, hosted_status, hosted_submission_url "
@@ -201,8 +203,8 @@ class TestUpgradeFromV4:
             conn.close()
 
     def test_upgrade_is_idempotent(self, fresh_db):
-        # Open twice from a fresh DB — second open is a no-op for the
-        # hosted-submission migration since user_version already == v5.
+        # Open twice from a fresh DB — the second open is a no-op at the
+        # current workbench schema version.
         conn = open_index()
         version_before = conn.execute("PRAGMA user_version").fetchone()[0]
         conn.close()
@@ -210,7 +212,7 @@ class TestUpgradeFromV4:
         conn = open_index()
         try:
             version_after = conn.execute("PRAGMA user_version").fetchone()[0]
-            assert version_after == version_before == HOSTED_SUBMISSION_SCHEMA_VERSION
+            assert version_after == version_before == WORKBENCH_SCHEMA_VERSION
             cols = _columns(conn, "shares")
             assert {"hosted_receipt_id", "hosted_status", "hosted_submission_url"}.issubset(cols)
         finally:


### PR DESCRIPTION
## Summary

- track a stable content revision for each trace while preserving its session ID
- report rescanned sessions as updated when an existing trace grows
- reset review and scoring state for changed content, then surface approved revisions in Share with an "Updated since last share" cue
- pin expected and predecessor revisions through share creation, export, and upload to reject stale or racing replacements
- add the schema migration, manifest metadata, receiver contract documentation, and regression coverage

## Root cause

ClawJournal treated a session ID as both the trace identity and the immutable unit of share history. Once that session had been shared, later content appended to the same long-running trace was neither reported as new nor eligible for sharing again.

This change separates stable trace identity from content revision identity. Re-sharing keeps the same session ID and records the revision it replaces.

## User impact

Users can continue working in an already-shared trace, rescan it, review the newly appended content, and share the updated revision without creating a duplicate trace identity.

Exact duplicate revisions remain suppressed, while stale or concurrent replacement attempts are rejected.

## Validation

- `pytest -q tests/workbench/test_revision_tracking.py tests/test_cli.py tests/test_share_cli.py` — 219 passed
- complete daemon suite — 129 passed in shards
- broader backend regression shards — passed
- frontend production build — passed
- wheel inspection confirmed rebuilt `dist/index.html` and JavaScript assets
- `python -m py_compile ...` and `git diff --check` — passed

## Follow-up

The separate hosted `clawjournal-share` service still needs to consume `revision_hash` and `replaces_revision_hash` to perform per-session trace replacement and stale-predecessor enforcement server-side. This PR emits and validates that contract on the ClawJournal side.
