### PR TITLE
Detect new activity in submitted traces

### DIFF
--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -1238,6 +1238,7 @@ def _run_scan(source_filter: str | None = None) -> None:
     results = scanner.scan_once()
 
     total_new = sum(results.values())
+    updated = scanner.last_updated_count
     if total_new:
         print(f"Indexed {total_new} new sessions:")
         for source, count in sorted(results.items()):
@@ -1245,6 +1246,12 @@ def _run_scan(source_filter: str | None = None) -> None:
                 print(f"  {source}: {count}")
     else:
         print("No new sessions found.")
+    if updated:
+        noun = "trace" if updated == 1 else "traces"
+        print(
+            f"Detected new activity in {updated} existing {noun}; "
+            "they are available to share again."
+        )
 
     conn = open_index()
     try:

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -66,17 +66,20 @@ from .index import (
     get_share_ready_stats,
     get_stats,
     link_subagent_hierarchy,
+    mark_share_revisions_submitted,
     open_index,
     query_sessions,
     query_unscored_sessions,
     release_gate_blockers,
     remove_policy,
     search_fts,
+    seed_legacy_submission_revisions,
     SCORE_SETTLE_SECONDS,
     session_matches_excluded_projects,
     source_scope_blockers,
     update_session,
     upsert_sessions,
+    session_content_fingerprint,
 )
 from .timeline import (
     canonical_session_path,
@@ -407,6 +410,7 @@ class Scanner:
         self._thread: threading.Thread | None = None
         self._last_scan_mtimes: dict[str, float] = {}
         self.last_linked_count = 0
+        self.last_updated_count = 0
         self.last_scored_count = 0
         self._score_thread: threading.Thread | None = None
         self._score_lock = threading.Lock()
@@ -425,6 +429,7 @@ class Scanner:
         """Run a single scan pass. Returns {source: new_session_count}."""
         conn = open_index()
         try:
+            self.last_updated_count = 0
             config = load_config()
             # Ingest stores raw content; anonymization happens at egress
             # (apply_share_redactions, score_session).
@@ -454,6 +459,28 @@ class Scanner:
                         locator=project.get("locator"),
                     )
                     if sessions:
+                        session_ids = [s.get("session_id") for s in sessions if s.get("session_id")]
+                        previous_revisions: dict[str, str | None] = {}
+                        if session_ids:
+                            placeholders = ",".join("?" for _ in session_ids)
+                            rows = conn.execute(
+                                "SELECT session_id, content_fingerprint FROM sessions "
+                                f"WHERE session_id IN ({placeholders})",
+                                session_ids,
+                            ).fetchall()
+                            previous_revisions = {
+                                row["session_id"]: row["content_fingerprint"] for row in rows
+                            }
+                        changed_prior_revisions = {
+                            session["session_id"]: previous_revisions[session["session_id"]]
+                            for session in sessions
+                            if session.get("session_id") in previous_revisions
+                            and previous_revisions[session["session_id"]] is not None
+                            and previous_revisions[session["session_id"]]
+                            != session_content_fingerprint(session)
+                        }
+                        self.last_updated_count += len(changed_prior_revisions)
+                        seed_legacy_submission_revisions(conn, changed_prior_revisions)
                         new_count = upsert_sessions(conn, sessions)
                         results[source] = results.get(source, 0) + new_count
                         # Drive each freshly-upserted session through the
@@ -1827,6 +1854,7 @@ def upload_share_to_self_hosted_ingest(
         "UPDATE shares SET status = 'shared', shared_at = ?, gcs_uri = ?, bundle_hash = ? WHERE share_id = ?",
         (shared_at, gcs_uri, bundle_hash, share_id),
     )
+    mark_share_revisions_submitted(conn, share_id)
     conn.commit()
 
     redaction_summary = manifest.get("redaction_summary", {}) if manifest else {}
@@ -2070,6 +2098,7 @@ def submit_share_to_hosted(
             share_id,
         ),
     )
+    mark_share_revisions_submitted(conn, share_id)
     conn.commit()
 
     _clear_stored_upload_token()

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -1,5 +1,6 @@
 """Local SQLite + FTS5 index for the scientist workbench."""
 
+import hashlib
 import json
 import logging
 import os
@@ -97,6 +98,7 @@ CREATE TABLE IF NOT EXISTS sessions (
     blob_path          TEXT,
     raw_source_path    TEXT,
     session_key        TEXT,
+    content_fingerprint TEXT,
     indexed_at         TEXT NOT NULL,
     updated_at         TEXT,
     share_id           TEXT REFERENCES shares(share_id),
@@ -134,6 +136,8 @@ CREATE TABLE IF NOT EXISTS share_sessions (
     share_id     TEXT NOT NULL REFERENCES shares(share_id),
     session_id   TEXT NOT NULL REFERENCES sessions(session_id),
     added_at     TEXT NOT NULL,
+    exported_content_fingerprint TEXT,
+    submitted_content_fingerprint TEXT,
     PRIMARY KEY (share_id, session_id)
 );
 
@@ -364,6 +368,10 @@ def open_index() -> sqlite3.Connection:
         # them the Token Usage chart under-counts Claude input by ~50x.
         ("cache_read_tokens", "INTEGER DEFAULT 0"),
         ("cache_creation_tokens", "INTEGER DEFAULT 0"),
+        # Stable digest of the trace payload.  Timestamps such as updated_at
+        # deliberately do not participate, so routine rescans do not make a
+        # previously shared trace look new.
+        ("content_fingerprint", "TEXT"),
     ]:
         try:
             conn.execute(f"ALTER TABLE sessions ADD COLUMN {col} {col_type}")
@@ -379,6 +387,17 @@ def open_index() -> sqlite3.Connection:
     ]:
         try:
             conn.execute(f"ALTER TABLE shares ADD COLUMN {col} {col_type}")
+            conn.commit()
+        except sqlite3.OperationalError as e:
+            if "duplicate column" not in str(e):
+                raise
+
+    for col, col_type in [
+        ("exported_content_fingerprint", "TEXT"),
+        ("submitted_content_fingerprint", "TEXT"),
+    ]:
+        try:
+            conn.execute(f"ALTER TABLE share_sessions ADD COLUMN {col} {col_type}")
             conn.commit()
         except sqlite3.OperationalError as e:
             if "duplicate column" not in str(e):
@@ -1741,6 +1760,25 @@ def recompute_estimated_costs(conn: sqlite3.Connection) -> int:
     return changed
 
 
+def session_content_fingerprint(session: dict[str, Any]) -> str:
+    """Return a stable digest of the parsed conversation payload.
+
+    Index timestamps, paths, and derived scores are deliberately excluded so
+    a routine rescan does not make an already submitted trace look new.
+    """
+    messages = session.get("messages")
+    if not isinstance(messages, list):
+        messages = []
+    canonical = json.dumps(
+        messages,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
 def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) -> int:
     """Index parsed sessions into the database.
 
@@ -1773,6 +1811,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
         session_key = _derive_session_key_from_source(
             source, session.get("raw_source_path")
         )
+        content_fingerprint = session_content_fingerprint(session)
         stats = session.get("stats", {})
         duration = _compute_duration(session)
 
@@ -1801,7 +1840,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
             "ai_value_badges, ai_risk_badges, "
             "ai_effort_estimate, ai_summary, "
             "share_id, session_key, parent_session_id, subagent_session_ids, "
-            "estimated_cost_usd, end_time "
+            "estimated_cost_usd, end_time, content_fingerprint "
             "FROM sessions WHERE session_id = ?",
             (session_id,),
         ).fetchone()
@@ -1878,6 +1917,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 files_touched, commands_run,
                 blob_path, raw_source_path,
                 session_key,
+                content_fingerprint,
                 indexed_at, updated_at,
                 review_status,
                 selection_reason, reviewer_notes, reviewed_at,
@@ -1906,6 +1946,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 ?, ?,
                 ?, ?,
                 ?, ?,
+                ?,
                 ?,
                 ?, ?, ?, ?,
                 ?, ?, ?,
@@ -1948,6 +1989,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 blob_path = excluded.blob_path,
                 raw_source_path = excluded.raw_source_path,
                 session_key = COALESCE(excluded.session_key, session_key),
+                content_fingerprint = excluded.content_fingerprint,
                 updated_at = excluded.updated_at,
                 parent_session_id = COALESCE(excluded.parent_session_id, parent_session_id),
                 segment_index = excluded.segment_index,
@@ -1983,6 +2025,7 @@ def upsert_sessions(conn: sqlite3.Connection, sessions: list[dict[str, Any]]) ->
                 str(blob_path),
                 session.get("raw_source_path"),
                 session_key or preserved_session_key,
+                content_fingerprint,
                 preserved_indexed_at,
                 now,
                 preserved_status,
@@ -3694,7 +3737,7 @@ def get_share_ready_stats(
     source_filter: str | list[str] | tuple[str, ...] | None = None,
     include_unapproved: bool = False,
 ) -> dict[str, Any]:
-    """Return sessions that have not been shared before.
+    """Return sessions that have not been submitted at their current revision.
 
     By default returns only `review_status='approved'` sessions; pass
     `include_unapproved=True` to widen the pool so the Preview UI can
@@ -3726,18 +3769,16 @@ def get_share_ready_stats(
         " runtime_channel, start_time, review_status, hold_state, embargo_until"
         " FROM sessions"
         f"{where_sql}"
-        f"{and_sql} session_id NOT IN ("
-        "   SELECT DISTINCT session_id FROM ("
-        "     SELECT s.session_id AS session_id"
-        "     FROM sessions s"
-        "     JOIN shares b ON s.share_id = b.share_id"
-        "     WHERE b.shared_at IS NOT NULL"
-        "     UNION"
-        "     SELECT bs.session_id AS session_id"
-        "     FROM share_sessions bs"
-        "     JOIN shares b ON bs.share_id = b.share_id"
-        "     WHERE b.shared_at IS NOT NULL"
-        "   )"
+        f"{and_sql} NOT EXISTS ("
+        "   SELECT 1 FROM share_sessions ss"
+        "   JOIN shares sh ON sh.share_id = ss.share_id"
+        "   WHERE ss.session_id = sessions.session_id"
+        "     AND sh.shared_at IS NOT NULL"
+        # A NULL snapshot is a legacy submission made before revision
+        # tracking. Keep it excluded rather than accidentally offering a
+        # duplicate; new submissions always receive a concrete fingerprint.
+        "     AND (ss.submitted_content_fingerprint IS NULL"
+        "          OR ss.submitted_content_fingerprint = sessions.content_fingerprint)"
         " )"
         " ORDER BY (ai_failure_value_score IS NULL),"
         " ai_failure_value_score DESC, start_time DESC,"
@@ -3862,6 +3903,59 @@ def get_share(
     return result
 
 
+def record_share_export_revisions(
+    conn: sqlite3.Connection,
+    share_id: str,
+    revisions: dict[str, str],
+) -> None:
+    """Record the trace revisions placed in this share's local export.
+
+    The values never leave the local database.  On a successful upload they
+    become the submission baseline, allowing a future scan to distinguish a
+    routine reparse from new conversation activity in the same session.
+    """
+    conn.execute(
+        "UPDATE share_sessions SET exported_content_fingerprint = NULL WHERE share_id = ?",
+        (share_id,),
+    )
+    conn.executemany(
+        "UPDATE share_sessions SET exported_content_fingerprint = ? "
+        "WHERE share_id = ? AND session_id = ?",
+        [(fingerprint, share_id, session_id) for session_id, fingerprint in revisions.items()],
+    )
+
+
+def mark_share_revisions_submitted(conn: sqlite3.Connection, share_id: str) -> None:
+    """Promote the exact exported revisions to the submission baseline."""
+    conn.execute(
+        "UPDATE share_sessions "
+        "SET submitted_content_fingerprint = exported_content_fingerprint "
+        "WHERE share_id = ? AND exported_content_fingerprint IS NOT NULL",
+        (share_id,),
+    )
+
+
+def seed_legacy_submission_revisions(
+    conn: sqlite3.Connection,
+    prior_revisions: dict[str, str],
+) -> None:
+    """Backfill a legacy submission baseline only after a real trace change.
+
+    Versions prior to revision tracking did not retain a content fingerprint
+    at upload time.  The scanner calls this with the indexed revision it saw
+    *before* a changed parse replaces it.  That lets an old uploaded trace
+    re-enter the share queue for the newly observed activity without making
+    every historical submission eligible again after an upgrade.
+    """
+    for session_id, fingerprint in prior_revisions.items():
+        conn.execute(
+            "UPDATE share_sessions SET submitted_content_fingerprint = ? "
+            "WHERE session_id = ? AND submitted_content_fingerprint IS NULL "
+            "AND share_id IN (SELECT share_id FROM shares WHERE shared_at IS NOT NULL)",
+            (fingerprint, session_id),
+        )
+
+
 EXPORT_FIELDS = {
     "session_id", "project", "source", "model",
     "start_time", "end_time", "duration_seconds",
@@ -3972,6 +4066,7 @@ def export_share_to_disk(
 
     total_redactions = 0
     redaction_types: dict[str, int] = {}
+    exported_revisions: dict[str, str] = {}
 
     try:
         with open(tmp_sessions_file, "w") as f:
@@ -3999,6 +4094,9 @@ def export_share_to_disk(
                         redaction_types["custom"] = redaction_types.get("custom", 0) + custom_count
                     clean = {k: v for k, v in detail.items() if k in EXPORT_FIELDS}
                     f.write(json.dumps(clean, default=str) + "\n")
+                    fingerprint = detail.get("content_fingerprint")
+                    if isinstance(fingerprint, str) and fingerprint:
+                        exported_revisions[s["session_id"]] = fingerprint
                     manifest["sessions"].append({
                         "session_id": clean.get("session_id") or s["session_id"],
                         "project": clean.get("project"),
@@ -4017,6 +4115,7 @@ def export_share_to_disk(
 
     # Update count to match actually exported sessions (some may have missing blobs)
     manifest["session_count"] = len(manifest["sessions"])
+    record_share_export_revisions(conn, share_id, exported_revisions)
     manifest["redaction_summary"] = {
         "total_redactions": total_redactions,
         "by_type": redaction_types,

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -25,7 +25,15 @@ from clawjournal.workbench.daemon import (
     _warn_if_frontend_stale,
     trigger_scoring_warmup,
 )
-from clawjournal.workbench.index import add_policy, open_index, set_hold_state, upsert_sessions
+from clawjournal.workbench.index import (
+    add_policy,
+    create_share,
+    get_share_ready_stats,
+    open_index,
+    set_hold_state,
+    update_session,
+    upsert_sessions,
+)
 
 
 @pytest.fixture
@@ -653,6 +661,59 @@ class TestStatsAPI:
 
 
 class TestScanner:
+    def test_scan_once_reports_new_activity_in_existing_trace(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+        monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+        monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "clawjournal_config")
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {})
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.discover_projects",
+            lambda source_filter=None: [{"dir_name": "demo", "source": "claude"}],
+        )
+        monkeypatch.setattr("clawjournal.workbench.daemon.run_findings_pipeline", lambda *args, **kwargs: None)
+
+        session = {
+            "session_id": "continued-session",
+            "project": "demo",
+            "source": "claude",
+            "messages": [{"role": "user", "content": "Investigate", "tool_uses": []}],
+            "stats": {},
+        }
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.parse_project_sessions",
+            lambda *args, **kwargs: [session],
+        )
+
+        scanner = Scanner()
+        assert scanner.scan_once() == {"claude": 1}
+        assert scanner.last_updated_count == 0
+
+        conn = open_index()
+        try:
+            update_session(conn, "continued-session", status="approved")
+            legacy_share = create_share(conn, ["continued-session"])
+            conn.execute(
+                "UPDATE shares SET status = 'shared', shared_at = ? WHERE share_id = ?",
+                ("2026-07-11T12:00:00+00:00", legacy_share),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        session["messages"].append(
+            {"role": "assistant", "content": "Found new evidence", "tool_uses": []}
+        )
+        assert scanner.scan_once() == {"claude": 0}
+        assert scanner.last_updated_count == 1
+
+        conn = open_index()
+        try:
+            assert [s["session_id"] for s in get_share_ready_stats(conn)["sessions"]] == [
+                "continued-session"
+            ]
+        finally:
+            conn.close()
+
     def test_scan_once_links_subagent_hierarchy(self, tmp_path, monkeypatch):
         monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
         monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -14,6 +14,8 @@ from clawjournal.workbench.index import (
     get_dashboard_analytics,
     get_share,
     get_shares,
+    mark_share_revisions_submitted,
+    record_share_export_revisions,
     get_policies,
     get_share_ready_stats,
     get_session_detail,
@@ -910,6 +912,51 @@ class TestShares:
         assert [s["session_id"] for s in stats["sessions"]] == ["s3", "s2"]
         # Recommendation is the same ordered list (recent high failure value, capped 5).
         assert stats["recommended_session_ids"] == ["s3", "s2"]
+
+    def test_share_ready_reoffers_trace_when_its_content_changes(self, index_conn):
+        """A continued session is eligible again, but not on a routine rescan."""
+        upsert_sessions(index_conn, [_make_session("continued", content="Initial investigation")])
+        update_session(index_conn, "continued", status="approved", ai_quality_score=5)
+
+        first_share = create_share(index_conn, ["continued"])
+        first_revision = index_conn.execute(
+            "SELECT content_fingerprint FROM sessions WHERE session_id = ?",
+            ("continued",),
+        ).fetchone()["content_fingerprint"]
+        record_share_export_revisions(index_conn, first_share, {"continued": first_revision})
+        mark_share_revisions_submitted(index_conn, first_share)
+        index_conn.execute(
+            "UPDATE shares SET status = 'shared', shared_at = ? WHERE share_id = ?",
+            ("2026-07-11T12:00:00+00:00", first_share),
+        )
+        index_conn.commit()
+
+        assert get_share_ready_stats(index_conn)["sessions"] == []
+
+        # The same parsed content should remain excluded after a normal scan.
+        upsert_sessions(index_conn, [_make_session("continued", content="Initial investigation")])
+        assert get_share_ready_stats(index_conn)["sessions"] == []
+
+        # Appended work produces a new content revision for the same session ID.
+        upsert_sessions(index_conn, [_make_session("continued", content="Initial investigation\nFound the root cause")])
+        ready = get_share_ready_stats(index_conn)["sessions"]
+        assert [session["session_id"] for session in ready] == ["continued"]
+
+        # Once the new revision is submitted it is again excluded.
+        second_share = create_share(index_conn, ["continued"])
+        second_revision = index_conn.execute(
+            "SELECT content_fingerprint FROM sessions WHERE session_id = ?",
+            ("continued",),
+        ).fetchone()["content_fingerprint"]
+        record_share_export_revisions(index_conn, second_share, {"continued": second_revision})
+        mark_share_revisions_submitted(index_conn, second_share)
+        index_conn.execute(
+            "UPDATE shares SET status = 'shared', shared_at = ? WHERE share_id = ?",
+            ("2026-07-11T12:10:00+00:00", second_share),
+        )
+        index_conn.commit()
+
+        assert get_share_ready_stats(index_conn)["sessions"] == []
 
     def test_share_ready_does_not_recommend_legacy_productivity_only_scores(self, index_conn):
         from datetime import datetime, timedelta, timezone


### PR DESCRIPTION
## Summary

- fingerprint parsed trace content during indexing
- record the exact revision included in an export and promote it after a successful upload
- make continued sessions share-ready again when their messages change
- preserve safe behavior for unchanged and legacy submissions
- report changed existing traces from `clawjournal scan`

## Root cause

The share queue permanently excluded any session ID associated with an uploaded share. Agent sessions can continue growing under the same session ID, so newly appended signals were indexed but remained hidden from the queue.

## Impact

Users can submit a trace, continue working in the same agent session, scan again, and package the updated trace in a new share. Routine rescans of unchanged traces remain idempotent.

## Validation

- `pytest tests/workbench/test_daemon.py::TestScanner tests/workbench/test_index.py::TestShares -q` — 26 passed
- `python -m compileall -q clawjournal`
- `git diff --check`
