### PR TITLE
Default session and share selections to all

### DIFF
--- a/clawjournal/web/frontend/package.json
+++ b/clawjournal/web/frontend/package.json
@@ -5,9 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "prebuild": "npm run test:share-queue",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:share-queue": "node scripts/test-share-queue-state.mjs"
   },
   "dependencies": {
     "react": "^19.2.4",

--- a/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
+++ b/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
@@ -113,3 +113,48 @@ assert.doesNotMatch(reviewStep, /sorted\.map\(/);
 const shareIndex = await readFile(new URL('../src/views/Share/index.tsx', import.meta.url), 'utf8');
 assert.match(shareIndex, /\.slice\(0, PACKAGE_LOG_TRACE_LIMIT\)/);
 assert.match(shareIndex, /Math\.min\(PACKAGE_ANIMATION_MAX_MS, 2200 \+ approvedList\.length \* 220\)/);
+assert.match(shareIndex, /cancelRedactionRun\(redactionRunRef\)/);
+assert.match(shareIndex, /return !data \|\| data\.loading/);
+assert.match(shareIndex, /signal: run\.controller\.signal/);
+assert.match(shareIndex, /if \(!isActive\(\)\) break/);
+assert.match(shareIndex, /const approvedSessions = useMemo\(/);
+assert.match(shareIndex, /approvedList=\{approvedSessions\}/);
+
+const apiSource = await readFile(new URL('../src/api.ts', import.meta.url), 'utf8');
+assert.match(apiSource, /redactionReport\(id: string, opts\?: \{ aiPii\?: boolean; signal\?: AbortSignal \}\)/);
+assert.match(apiSource, /signal: opts\?\.signal/);
+
+const packageStep = await readFile(new URL('../src/views/Share/PackageStep.tsx', import.meta.url), 'utf8');
+assert.match(packageStep, /p\.approvedList\.slice\(0, PACKAGE_ANIMATION_TRACE_LIMIT\)\.forEach/);
+assert.doesNotMatch(packageStep, /p\.approvedList\.forEach\(/);
+
+const redactionRunSource = await readFile(new URL('../src/views/Share/redactionRun.ts', import.meta.url), 'utf8');
+const redactionRunOutput = ts.transpileModule(redactionRunSource, {
+  compilerOptions: {
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2022,
+  },
+}).outputText;
+const redactionRunUrl = `data:text/javascript;base64,${Buffer.from(redactionRunOutput).toString('base64')}`;
+const {
+  beginRedactionRun,
+  cancelRedactionRun,
+  finishRedactionRun,
+  isRedactionRunActive,
+} = await import(redactionRunUrl);
+
+const runSlot = { current: null };
+const firstRun = beginRedactionRun(runSlot);
+assert.ok(firstRun);
+assert.equal(beginRedactionRun(runSlot), null);
+assert.equal(isRedactionRunActive(runSlot, firstRun), true);
+cancelRedactionRun(runSlot);
+assert.equal(firstRun.controller.signal.aborted, true);
+assert.equal(isRedactionRunActive(runSlot, firstRun), false);
+
+const replacementRun = beginRedactionRun(runSlot);
+assert.ok(replacementRun);
+finishRedactionRun(runSlot, firstRun);
+assert.equal(isRedactionRunActive(runSlot, replacementRun), true);
+finishRedactionRun(runSlot, replacementRun);
+assert.equal(runSlot.current, null);

--- a/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
+++ b/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
@@ -1,0 +1,48 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { Buffer } from 'node:buffer';
+import ts from 'typescript';
+
+const sourceUrl = new URL('../src/views/Share/queueState.ts', import.meta.url);
+const source = await readFile(sourceUrl, 'utf8');
+const output = ts.transpileModule(source, {
+  compilerOptions: {
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2022,
+  },
+}).outputText;
+const moduleUrl = `data:text/javascript;base64,${Buffer.from(output).toString('base64')}`;
+const {
+  queueSelectionFromSearchParams,
+  syncQueueSelectionToSearchParams,
+} = await import(moduleUrl);
+
+const ids = Array.from({ length: 5_000 }, (_, index) => (
+  `session-${index.toString().padStart(5, '0')}-${'a'.repeat(48)}`
+));
+
+const defaultParams = new URLSearchParams();
+syncQueueSelectionToSearchParams(defaultParams, ids, ids);
+assert.equal(defaultParams.toString(), 'selection=all');
+assert.deepEqual(queueSelectionFromSearchParams(defaultParams, ids), ids);
+
+const optedOut = ids.filter((id) => id !== ids[2] && id !== ids[4_999]);
+const optedOutParams = new URLSearchParams();
+syncQueueSelectionToSearchParams(optedOutParams, optedOut, ids);
+assert.equal(optedOutParams.get('selection'), 'all');
+assert.equal(optedOutParams.get('exclude'), `${ids[2]},${ids[4_999]}`);
+assert.ok(optedOutParams.toString().length < 200);
+assert.deepEqual(queueSelectionFromSearchParams(optedOutParams, ids), optedOut);
+
+const explicit = [ids[9], ids[3]];
+const explicitParams = new URLSearchParams();
+syncQueueSelectionToSearchParams(explicitParams, explicit, ids);
+assert.equal(explicitParams.get('ids'), explicit.join(','));
+assert.deepEqual(queueSelectionFromSearchParams(explicitParams, ids), explicit);
+
+const emptyParams = new URLSearchParams();
+syncQueueSelectionToSearchParams(emptyParams, [], ids);
+assert.equal(emptyParams.toString(), 'ids=');
+assert.deepEqual(queueSelectionFromSearchParams(emptyParams, ids), []);
+
+assert.equal(queueSelectionFromSearchParams(new URLSearchParams(), ids), null);

--- a/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
+++ b/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
@@ -13,9 +13,17 @@ const output = ts.transpileModule(source, {
 }).outputText;
 const moduleUrl = `data:text/javascript;base64,${Buffer.from(output).toString('base64')}`;
 const {
+  MAX_QUEUE_QUERY_LENGTH,
   queueSelectionFromSearchParams,
   syncQueueSelectionToSearchParams,
 } = await import(moduleUrl);
+
+const storedValues = new Map();
+const storage = {
+  getItem: (key) => storedValues.get(key) ?? null,
+  setItem: (key, value) => storedValues.set(key, value),
+  removeItem: (key) => storedValues.delete(key),
+};
 
 const ids = Array.from({ length: 5_000 }, (_, index) => (
   `session-${index.toString().padStart(5, '0')}-${'a'.repeat(48)}`
@@ -40,9 +48,68 @@ syncQueueSelectionToSearchParams(explicitParams, explicit, ids);
 assert.equal(explicitParams.get('ids'), explicit.join(','));
 assert.deepEqual(queueSelectionFromSearchParams(explicitParams, ids), explicit);
 
+const reordered = [...ids.slice(1), ids[0]];
+const reorderedParams = new URLSearchParams();
+syncQueueSelectionToSearchParams(
+  reorderedParams,
+  reordered,
+  ids,
+  storage,
+  () => 'large-reordered',
+);
+assert.equal(reorderedParams.toString(), 'queue_ref=large-reordered');
+assert.ok(reorderedParams.toString().length < MAX_QUEUE_QUERY_LENGTH);
+assert.deepEqual(queueSelectionFromSearchParams(reorderedParams, ids, storage), reordered);
+
+const middleSubset = ids.filter((_, index) => index % 2 === 0);
+const middleSubsetParams = new URLSearchParams();
+syncQueueSelectionToSearchParams(
+  middleSubsetParams,
+  middleSubset,
+  ids,
+  storage,
+  () => 'large-middle-subset',
+);
+assert.equal(middleSubsetParams.toString(), 'queue_ref=large-middle-subset');
+assert.ok(middleSubsetParams.toString().length < MAX_QUEUE_QUERY_LENGTH);
+assert.deepEqual(queueSelectionFromSearchParams(middleSubsetParams, ids, storage), middleSubset);
+
+const unavailableStorage = {
+  getItem: () => null,
+  setItem: () => { throw new Error('quota exceeded'); },
+  removeItem: () => {},
+};
+const storageFailureParams = new URLSearchParams();
+syncQueueSelectionToSearchParams(storageFailureParams, reordered, ids, unavailableStorage);
+assert.equal(storageFailureParams.toString(), 'ids=');
+assert.deepEqual(queueSelectionFromSearchParams(storageFailureParams, ids, unavailableStorage), []);
+
+const missingRefParams = new URLSearchParams('queue_ref=missing');
+assert.deepEqual(queueSelectionFromSearchParams(missingRefParams, ids, storage), []);
+const invalidRefParams = new URLSearchParams('queue_ref=../../invalid');
+assert.deepEqual(queueSelectionFromSearchParams(invalidRefParams, ids, storage), []);
+
 const emptyParams = new URLSearchParams();
 syncQueueSelectionToSearchParams(emptyParams, [], ids);
 assert.equal(emptyParams.toString(), 'ids=');
 assert.deepEqual(queueSelectionFromSearchParams(emptyParams, ids), []);
 
 assert.equal(queueSelectionFromSearchParams(new URLSearchParams(), ids), null);
+
+const queueStep = await readFile(new URL('../src/views/Share/QueueStep.tsx', import.meta.url), 'utf8');
+assert.doesNotMatch(queueStep, /queueOrder\.includes\(/);
+assert.match(queueStep, /queuedIds\.has\(s\.session_id\)/);
+assert.match(queueStep, /p\.queuedSessions\.slice\(0, visibleQueueCount\)/);
+assert.match(queueStep, /available\.slice\(0, visibleAvailableCount\)/);
+
+const redactStep = await readFile(new URL('../src/views/Share/RedactStep.tsx', import.meta.url), 'utf8');
+assert.match(redactStep, /p\.queuedSessions\.slice\(0, visibleCount\)/);
+assert.doesNotMatch(redactStep, /p\.queuedSessions\.map\(/);
+
+const reviewStep = await readFile(new URL('../src/views/Share/ReviewStep.tsx', import.meta.url), 'utf8');
+assert.match(reviewStep, /sorted\.slice\(0, visibleCount\)/);
+assert.doesNotMatch(reviewStep, /sorted\.map\(/);
+
+const shareIndex = await readFile(new URL('../src/views/Share/index.tsx', import.meta.url), 'utf8');
+assert.match(shareIndex, /\.slice\(0, PACKAGE_LOG_TRACE_LIMIT\)/);
+assert.match(shareIndex, /Math\.min\(PACKAGE_ANIMATION_MAX_MS, 2200 \+ approvedList\.length \* 220\)/);

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -112,9 +112,11 @@ export const api = {
       return request(`/sessions/${encodeURIComponent(id)}/redacted`);
     },
 
-    redactionReport(id: string, opts?: { aiPii?: boolean }): Promise<RedactionReport> {
+    redactionReport(id: string, opts?: { aiPii?: boolean; signal?: AbortSignal }): Promise<RedactionReport> {
       const q = opts?.aiPii ? '?ai_pii=1' : '';
-      return request(`/sessions/${encodeURIComponent(id)}/redaction-report${q}`);
+      return request(`/sessions/${encodeURIComponent(id)}/redaction-report${q}`, {
+        signal: opts?.signal,
+      });
     },
 
     update(id: string, body: { status?: string; notes?: string; reason?: string; ai_quality_score?: number; ai_score_reason?: string; ai_failure_value_score?: number; ai_failure_evidence?: string[]; ai_recovery_labels?: string[]; ai_failure_attribution?: string; ai_failure_modes?: string[]; ai_learning_summary?: string; hold_state?: HoldState; embargo_until?: string | null }): Promise<{ ok: boolean }> {

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -228,6 +228,15 @@ export function Inbox() {
       if (requestSeq !== loadRequestSeqRef.current) return;
       const visibleRows = data.slice(0, pageSize);
       setSessions(prev => append ? [...prev, ...visibleRows] : visibleRows);
+      // Sessions are an opt-out bulk-selection surface: select every row as it
+      // becomes visible, while preserving any choices already made on rows
+      // from earlier pages.
+      setSelectedIds(prev => {
+        if (!append) return new Set(visibleRows.map(s => s.session_id));
+        const next = new Set(prev);
+        visibleRows.forEach(s => next.add(s.session_id));
+        return next;
+      });
       setOffset(currentOffset);
       setHasMore(data.length > pageSize);
     } catch (e) {

--- a/clawjournal/web/frontend/src/views/Share/PackageStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/PackageStep.tsx
@@ -4,6 +4,8 @@ import type { BlockedShareSession, ReadySession } from './types.ts';
 import { SHARE_SHELL_WIDTH, btnPrimary, btnSecondary } from './styles.tsx';
 import { Icon } from './shared.tsx';
 
+const PACKAGE_ANIMATION_TRACE_LIMIT = 20;
+
 export interface PackageStepProps {
   stepperHeader: React.ReactNode;
   approvedCount: number;
@@ -31,7 +33,7 @@ export function PackageStep(p: PackageStepProps) {
   useEffect(() => {
     if (p.failed) return;
     const timers: number[] = [];
-    p.approvedList.forEach((s, i) => {
+    p.approvedList.slice(0, PACKAGE_ANIMATION_TRACE_LIMIT).forEach((s, i) => {
       timers.push(window.setTimeout(() => {
         setFlying((prev) => [...prev, { id: `${s.session_id}-${Date.now()}-${i}`, title: `${s.session_id.slice(0, 10)}.jsonl` }]);
       }, 400 + i * 220));

--- a/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
@@ -10,6 +10,8 @@ import { autoDescription, formatDate, formatTokens, outcomeBadge, outcomeTooltip
 import { SHARE_SHELL_WIDTH, btnGhost, btnPrimary, btnSecondary } from './styles.tsx';
 import { CheckboxRow, HelpModal, Icon, SourceBadge, UsageDisclosure } from './shared.tsx';
 
+const QUEUE_PAGE_SIZE = 50;
+
 export interface QueueStepProps {
   stepperHeader: React.ReactNode;
   readyStats: ShareReadyStats | null;
@@ -64,6 +66,8 @@ function UpdatedSinceShareBadge({ session }: { session: ReadySession }) {
 
 export function QueueStep(p: QueueStepProps) {
   const [dragId, setDragId] = useState<string | null>(null);
+  const [visibleQueueCount, setVisibleQueueCount] = useState(QUEUE_PAGE_SIZE);
+  const [visibleAvailableCount, setVisibleAvailableCount] = useState(QUEUE_PAGE_SIZE);
 
   const allSessions = p.readyStats?.sessions || [];
   // `total_approved` counts every approved session; `allSessions` only holds the
@@ -73,6 +77,8 @@ export function QueueStep(p: QueueStepProps) {
   const totalApproved = p.readyStats?.total_approved ?? 0;
   const totalTokens = p.queuedSessions.reduce((sum, s) => sum + sessionTotalTokens(s), 0);
   const uniqueProjects = [...new Set(p.queuedSessions.map(s => s.project).filter(Boolean))];
+  const visibleQueuedSessions = p.queuedSessions.slice(0, visibleQueueCount);
+  const hiddenQueueCount = p.queuedSessions.length - visibleQueuedSessions.length;
 
   const onDragStart = (e: React.DragEvent, id: string) => {
     setDragId(id);
@@ -89,10 +95,11 @@ export function QueueStep(p: QueueStepProps) {
   // Add-traces filter list (everything not in queue)
   const sources = [...new Set(allSessions.map(s => s.source).filter(Boolean))].sort();
   const projects = [...new Set(allSessions.map(s => s.project).filter(Boolean))].sort();
+  const queuedIds = new Set(p.queueOrder);
   // eslint-disable-next-line react-hooks/purity
   const dateCutoffMs = p.dateFilter ? (Date.now() - ((p.dateFilter === '7d' ? 7 : p.dateFilter === '30d' ? 30 : 90) * 86_400_000)) : null;
 
-  const available = allSessions.filter((s) => !p.queueOrder.includes(s.session_id)).filter(s => {
+  const available = allSessions.filter((s) => !queuedIds.has(s.session_id)).filter(s => {
     if (p.searchQuery && !(s.display_title || '').toLowerCase().includes(p.searchQuery.toLowerCase())
       && !(s.project || '').toLowerCase().includes(p.searchQuery.toLowerCase())) return false;
     if (p.sourceFilter && s.source !== p.sourceFilter) return false;
@@ -101,6 +108,8 @@ export function QueueStep(p: QueueStepProps) {
     if (dateCutoffMs && (!s.start_time || new Date(s.start_time).getTime() < dateCutoffMs)) return false;
     return true;
   });
+  const visibleAvailable = available.slice(0, visibleAvailableCount);
+  const hiddenAvailableCount = available.length - visibleAvailable.length;
 
   const historyShares = p.shares.filter(b => b.status === 'shared' || b.status === 'exported');
 
@@ -156,11 +165,11 @@ export function QueueStep(p: QueueStepProps) {
           <div style={{ padding: 14, textAlign: 'center', color: colors.gray400, fontSize: 13 }}>
             {allSessions.length === p.queuedSessions.length ? 'All available traces are already in the queue.' : 'No sessions match your filters.'}
           </div>
-        ) : available.map((s, i) => (
+        ) : visibleAvailable.map((s, i) => (
           <div key={s.session_id} style={{
             display: 'grid', gridTemplateColumns: '1fr auto', gap: 10,
             alignItems: 'center', padding: '8px 12px',
-            borderBottom: i < available.length - 1 ? `1px solid ${colors.gray100}` : 'none',
+            borderBottom: i < visibleAvailable.length - 1 ? `1px solid ${colors.gray100}` : 'none',
           }}>
             <div style={{ minWidth: 0 }}>
               <div style={{ display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }}>
@@ -190,6 +199,17 @@ export function QueueStep(p: QueueStepProps) {
           </div>
         ))}
       </div>
+      {hiddenAvailableCount > 0 && (
+        <div style={{ display: 'flex', justifyContent: 'center', marginTop: 8 }}>
+          <button
+            onClick={() => setVisibleAvailableCount((count) => count + QUEUE_PAGE_SIZE)}
+            style={btnSecondary}
+          >
+            Show {Math.min(QUEUE_PAGE_SIZE, hiddenAvailableCount)} more
+            <span style={{ color: colors.gray400, fontWeight: 400 }}>({hiddenAvailableCount} remaining)</span>
+          </button>
+        </div>
+      )}
     </div>
   );
 
@@ -332,7 +352,7 @@ export function QueueStep(p: QueueStepProps) {
 
           {/* Trace list */}
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 18 }} onDragEnd={onDragEnd}>
-            {p.queuedSessions.map((s) => {
+            {visibleQueuedSessions.map((s) => {
               const isDragging = dragId === s.session_id;
               return (
                 <div
@@ -433,6 +453,17 @@ export function QueueStep(p: QueueStepProps) {
                 </div>
               );
             })}
+            {hiddenQueueCount > 0 && (
+              <div style={{ display: 'flex', justifyContent: 'center', paddingTop: 4 }}>
+                <button
+                  onClick={() => setVisibleQueueCount((count) => count + QUEUE_PAGE_SIZE)}
+                  style={btnSecondary}
+                >
+                  Show {Math.min(QUEUE_PAGE_SIZE, hiddenQueueCount)} more
+                  <span style={{ color: colors.gray400, fontWeight: 400 }}>({hiddenQueueCount} remaining)</span>
+                </button>
+              </div>
+            )}
           </div>
 
           {/* Add more traces */}

--- a/clawjournal/web/frontend/src/views/Share/RedactStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/RedactStep.tsx
@@ -1,8 +1,11 @@
+import { useState } from 'react';
 import { colors } from '../../theme.ts';
 import type { ReadySession, RedactedSessionData } from './types.ts';
 import { classify, emptyBuckets, formatTokens, sessionTotalTokens } from './helpers.ts';
 import { SHARE_SHELL_WIDTH, btnGhost, btnPrimary } from './styles.tsx';
 import { HelpModal, Icon, SourceBadge, UsageDisclosure } from './shared.tsx';
+
+const REDACTION_PAGE_SIZE = 50;
 
 export interface RedactStepProps {
   stepperHeader: React.ReactNode;
@@ -18,6 +21,7 @@ export interface RedactStepProps {
 }
 
 export function RedactStep(p: RedactStepProps) {
+  const [visibleCount, setVisibleCount] = useState(REDACTION_PAGE_SIZE);
   const totals = p.queuedSessions.reduce((acc, s) => {
     const d = p.redactedSessions[s.session_id];
     if (!d || d.loading || !d.buckets) return acc;
@@ -37,6 +41,8 @@ export function RedactStep(p: RedactStepProps) {
     return d && !d.loading;
   }).length;
   const overallPct = p.queuedSessions.length === 0 ? 0 : Math.round((doneCount / p.queuedSessions.length) * 100);
+  const visibleSessions = p.queuedSessions.slice(0, visibleCount);
+  const hiddenCount = p.queuedSessions.length - visibleSessions.length;
 
   // progress bar helper for category rows
   const categoryRow = (
@@ -130,7 +136,7 @@ export function RedactStep(p: RedactStepProps) {
         color: colors.gray400, margin: '0 0 10px', fontWeight: 600,
       }}>Per-trace progress</div>
 
-      {p.queuedSessions.map((s) => {
+      {visibleSessions.map((s) => {
         const d = p.redactedSessions[s.session_id];
         const finished = !!d && !d.loading;
         const flagged = finished && classify(d) === 'review';
@@ -203,6 +209,18 @@ export function RedactStep(p: RedactStepProps) {
           </div>
         );
       })}
+
+      {hiddenCount > 0 && (
+        <div style={{ display: 'flex', justifyContent: 'center', marginTop: 10 }}>
+          <button
+            onClick={() => setVisibleCount((count) => count + REDACTION_PAGE_SIZE)}
+            style={btnGhost}
+          >
+            Show {Math.min(REDACTION_PAGE_SIZE, hiddenCount)} more
+            <span style={{ color: colors.gray400, fontWeight: 400 }}>({hiddenCount} remaining)</span>
+          </button>
+        </div>
+      )}
 
       <div style={{
         position: 'sticky', bottom: 0, marginTop: 14, paddingTop: 14,

--- a/clawjournal/web/frontend/src/views/Share/ReviewStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/ReviewStep.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { RedactedText } from '../../components/RedactedText.tsx';
 import { ToolUseCard } from '../../components/ToolUseCard.tsx';
 import { colors } from '../../theme.ts';
@@ -5,6 +6,8 @@ import type { ReadySession, RedactedSessionData } from './types.ts';
 import { aggregateCategories, classify, formatTokens, hexAlpha, sessionTotalTokens } from './helpers.ts';
 import { SHARE_SHELL_WIDTH, btnGhost, btnPrimary, btnSecondary } from './styles.tsx';
 import { HelpModal, Icon, SourceBadge, StatusDot, ThinkingBlock, UsageDisclosure } from './shared.tsx';
+
+const REVIEW_PAGE_SIZE = 50;
 
 export interface ReviewStepProps {
   stepperHeader: React.ReactNode;
@@ -26,6 +29,7 @@ export interface ReviewStepProps {
 }
 
 export function ReviewStep(p: ReviewStepProps) {
+  const [visibleCount, setVisibleCount] = useState(REVIEW_PAGE_SIZE);
   const sorted = [...p.queuedSessions].sort((a, b) => {
     const sa = classify(p.redactedSessions[a.session_id]);
     const sb = classify(p.redactedSessions[b.session_id]);
@@ -38,6 +42,8 @@ export function ReviewStep(p: ReviewStepProps) {
   const cleanUnapprovedCount = p.queuedSessions.filter((s) => (
     classify(p.redactedSessions[s.session_id]) === 'clear' && !p.approvedIds.has(s.session_id)
   )).length;
+  const visibleSessions = sorted.slice(0, visibleCount);
+  const hiddenCount = sorted.length - visibleSessions.length;
 
   return (
     <div style={{ padding: '32px 24px 48px', maxWidth: SHARE_SHELL_WIDTH, margin: '0 auto' }}>
@@ -93,7 +99,7 @@ export function ReviewStep(p: ReviewStepProps) {
       </div>
 
       <div>
-        {sorted.map((s) => (
+        {visibleSessions.map((s) => (
           <ReviewRow
             key={s.session_id}
             session={s}
@@ -107,6 +113,17 @@ export function ReviewStep(p: ReviewStepProps) {
             onRetryAi={() => p.onRetryAi(s.session_id)}
           />
         ))}
+        {hiddenCount > 0 && (
+          <div style={{ display: 'flex', justifyContent: 'center', marginTop: 10 }}>
+            <button
+              onClick={() => setVisibleCount((count) => count + REVIEW_PAGE_SIZE)}
+              style={btnSecondary}
+            >
+              Show {Math.min(REVIEW_PAGE_SIZE, hiddenCount)} more
+              <span style={{ color: colors.gray400, fontWeight: 400 }}>({hiddenCount} remaining)</span>
+            </button>
+          </div>
+        )}
       </div>
 
       <div style={{

--- a/clawjournal/web/frontend/src/views/Share/helpers.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.ts
@@ -1,7 +1,6 @@
 import type { Share as ShareType } from '../../types.ts';
 import {
   CONFIDENCE_THRESHOLD,
-  DEFAULT_SHARE_QUEUE_SIZE,
   STEPS,
 } from './types.ts';
 import type {
@@ -140,13 +139,15 @@ export function formatShareDestination(url: string): string {
 export function queueFromStats(stats: ShareReadyStats): string[] {
   const validIds = new Set(stats.sessions.map((s) => s.session_id));
   const recommended = (stats.recommended_session_ids || [])
-    .filter((id) => validIds.has(id))
-    .slice(0, DEFAULT_SHARE_QUEUE_SIZE);
-  if (recommended.length > 0) return recommended;
-  return stats.sessions
-    .map((s) => s.session_id)
-    .filter(Boolean)
-    .slice(0, DEFAULT_SHARE_QUEUE_SIZE);
+    .filter((id) => validIds.has(id));
+
+  // Start with the server's highest-value recommendations, then include every
+  // other eligible trace. Share is opt-out: users remove traces they do not
+  // want in the bundle instead of adding the hidden pool one at a time.
+  return [...new Set([
+    ...recommended,
+    ...stats.sessions.map((s) => s.session_id).filter(Boolean),
+  ])];
 }
 
 export function completedKeysForStep(step: StepKey): Set<string> {

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -29,6 +29,10 @@ import {
   queueFromStats,
   sessionTotalTokens,
 } from './helpers.ts';
+import {
+  queueSelectionFromSearchParams,
+  syncQueueSelectionToSearchParams,
+} from './queueState.ts';
 import { SHARE_SHELL_WIDTH, globalStyles } from './styles.tsx';
 import { QueueStep } from './QueueStep.tsx';
 import { RedactStep } from './RedactStep.tsx';
@@ -57,10 +61,10 @@ export function Share() {
 
   // Queue state: ordered list (drag-reorder) with a derived Set for lookups.
   const [queueOrder, setQueueOrder] = useState<string[]>(() => {
-    const csv = searchParams.get('ids');
-    return csv ? csv.split(',').filter(Boolean) : [];
+    if (!searchParams.has('ids')) return [];
+    return queueSelectionFromSearchParams(searchParams, []) || [];
   });
-  const [selectionInitialized, setSelectionInitialized] = useState(() => !!searchParams.get('ids'));
+  const [selectionInitialized, setSelectionInitialized] = useState(() => searchParams.has('ids'));
   const queueSet = useMemo(() => new Set(queueOrder), [queueOrder]);
 
   const [note, setNote] = useState(() => searchParams.get('note') || '');
@@ -156,7 +160,8 @@ export function Share() {
         // Put server recommendations first, then default every other eligible
         // trace into the opt-out queue.
         const defaultQueue = queueFromStats(stats);
-        setQueueOrder(defaultQueue);
+        const urlQueue = queueSelectionFromSearchParams(searchParams, defaultQueue);
+        setQueueOrder(urlQueue ?? defaultQueue);
         setSelectionInitialized(true);
       }
       if (stats.sessions.length === 0) {
@@ -177,8 +182,10 @@ export function Share() {
   // =================================================
 
   useEffect(() => {
-    if (selectionInitialized || !readyStats || searchParams.get('ids')) return;
-    setQueueOrder(queueFromStats(readyStats));
+    if (selectionInitialized || !readyStats) return;
+    const defaultQueue = queueFromStats(readyStats);
+    const urlQueue = queueSelectionFromSearchParams(searchParams, defaultQueue);
+    setQueueOrder(urlQueue ?? defaultQueue);
     setSelectionInitialized(true);
   }, [readyStats, searchParams, selectionInitialized]);
 
@@ -189,8 +196,6 @@ export function Share() {
     internalSearchRef.current = currentSearch;
     skipNextUrlSyncRef.current = true;
 
-    const idsParam = searchParams.get('ids');
-    const ids = idsParam ? idsParam.split(',').filter(Boolean) : null;
     const step = parseStep(searchParams.get('step'));
 
     setActiveStep(step);
@@ -210,15 +215,14 @@ export function Share() {
     setPackagingFailed(null);
     setBlockedPackageSessions([]);
 
-    if (ids) {
-      setQueueOrder(ids);
+    const defaultQueue = readyStats ? queueFromStats(readyStats) : [];
+    const urlQueue = queueSelectionFromSearchParams(searchParams, defaultQueue);
+    if (urlQueue !== null && (readyStats !== null || searchParams.has('ids'))) {
+      setQueueOrder(urlQueue);
       setSelectionInitialized(true);
       return;
     }
 
-    const defaultQueue = readyStats && readyStats.sessions.length > 0
-      ? queueFromStats(readyStats)
-      : [];
     setQueueOrder(defaultQueue);
     setSelectionInitialized(!!readyStats);
   }, [location.search, readyStats, searchParams]);
@@ -231,15 +235,17 @@ export function Share() {
     setSearchParams((prev) => {
       const next = new URLSearchParams(prev);
       if (activeStep === 'queue') next.delete('step'); else next.set('step', activeStep);
-      const csv = queueOrder.join(',');
-      if (csv) next.set('ids', csv); else next.delete('ids');
+      if (selectionInitialized) {
+        const defaultQueue = readyStats ? queueFromStats(readyStats) : null;
+        syncQueueSelectionToSearchParams(next, queueOrder, defaultQueue);
+      }
       if (note) next.set('note', note); else next.delete('note');
       if (aiPiiEnabled) next.set('ai_pii', '1'); else next.delete('ai_pii');
       if (packagedShareId) next.set('share', packagedShareId); else next.delete('share');
       internalSearchRef.current = next.toString();
       return next;
     }, { replace: true });
-  }, [activeStep, queueOrder, note, aiPiiEnabled, packagedShareId, setSearchParams]);
+  }, [activeStep, queueOrder, selectionInitialized, readyStats, note, aiPiiEnabled, packagedShareId, setSearchParams]);
 
   // Drop cached redacted entries when sessions leave the queue.
   useEffect(() => {

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -153,11 +153,10 @@ export function Share() {
       setShares(shareList);
       setScoringBackend(backend);
       if (!selectionInitialized && stats.sessions.length > 0) {
-        // Server recommendation is an ordered, reviewable default package.
-        // Trust it and only filter out ids the client can't resolve
-        // (eg. excluded projects).
-        const recommended = queueFromStats(stats);
-        setQueueOrder(recommended);
+        // Put server recommendations first, then default every other eligible
+        // trace into the opt-out queue.
+        const defaultQueue = queueFromStats(stats);
+        setQueueOrder(defaultQueue);
         setSelectionInitialized(true);
       }
       if (stats.sessions.length === 0) {
@@ -217,10 +216,10 @@ export function Share() {
       return;
     }
 
-    const recommended = readyStats && readyStats.sessions.length > 0
+    const defaultQueue = readyStats && readyStats.sessions.length > 0
       ? queueFromStats(readyStats)
       : [];
-    setQueueOrder(recommended);
+    setQueueOrder(defaultQueue);
     setSelectionInitialized(!!readyStats);
   }, [location.search, readyStats, searchParams]);
 

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -41,10 +41,16 @@ import { PackageStep } from './PackageStep.tsx';
 import { SubmitStep } from './SubmitStep.tsx';
 import { DoneStep } from './DoneStep.tsx';
 
+const PACKAGE_LOG_TRACE_LIMIT = 20;
+const PACKAGE_ANIMATION_MAX_MS = 10_000;
+
 export function Share() {
   const { toast } = useToast();
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
+  const queueStorage = useMemo(() => {
+    try { return window.localStorage; } catch { return null; }
+  }, []);
   const internalSearchRef = useRef<string | null>(null);
   const skipNextUrlSyncRef = useRef(false);
 
@@ -61,10 +67,13 @@ export function Share() {
 
   // Queue state: ordered list (drag-reorder) with a derived Set for lookups.
   const [queueOrder, setQueueOrder] = useState<string[]>(() => {
-    if (!searchParams.has('ids')) return [];
-    return queueSelectionFromSearchParams(searchParams, []) || [];
+    if (!searchParams.has('ids') && !searchParams.has('queue_ref')) return [];
+    return queueSelectionFromSearchParams(searchParams, [], queueStorage) || [];
   });
-  const [selectionInitialized, setSelectionInitialized] = useState(() => searchParams.has('ids'));
+  const [selectionInitialized, setSelectionInitialized] = useState(() => (
+    (searchParams.has('ids') || searchParams.has('queue_ref'))
+    && queueSelectionFromSearchParams(searchParams, [], queueStorage) !== null
+  ));
   const queueSet = useMemo(() => new Set(queueOrder), [queueOrder]);
 
   const [note, setNote] = useState(() => searchParams.get('note') || '');
@@ -160,7 +169,7 @@ export function Share() {
         // Put server recommendations first, then default every other eligible
         // trace into the opt-out queue.
         const defaultQueue = queueFromStats(stats);
-        const urlQueue = queueSelectionFromSearchParams(searchParams, defaultQueue);
+        const urlQueue = queueSelectionFromSearchParams(searchParams, defaultQueue, queueStorage);
         setQueueOrder(urlQueue ?? defaultQueue);
         setSelectionInitialized(true);
       }
@@ -184,10 +193,10 @@ export function Share() {
   useEffect(() => {
     if (selectionInitialized || !readyStats) return;
     const defaultQueue = queueFromStats(readyStats);
-    const urlQueue = queueSelectionFromSearchParams(searchParams, defaultQueue);
+    const urlQueue = queueSelectionFromSearchParams(searchParams, defaultQueue, queueStorage);
     setQueueOrder(urlQueue ?? defaultQueue);
     setSelectionInitialized(true);
-  }, [readyStats, searchParams, selectionInitialized]);
+  }, [readyStats, searchParams, selectionInitialized, queueStorage]);
 
   useEffect(() => {
     const currentSearch = location.search.startsWith('?') ? location.search.slice(1) : location.search;
@@ -216,8 +225,10 @@ export function Share() {
     setBlockedPackageSessions([]);
 
     const defaultQueue = readyStats ? queueFromStats(readyStats) : [];
-    const urlQueue = queueSelectionFromSearchParams(searchParams, defaultQueue);
-    if (urlQueue !== null && (readyStats !== null || searchParams.has('ids'))) {
+    const urlQueue = queueSelectionFromSearchParams(searchParams, defaultQueue, queueStorage);
+    if (urlQueue !== null && (
+      readyStats !== null || searchParams.has('ids') || searchParams.has('queue_ref')
+    )) {
       setQueueOrder(urlQueue);
       setSelectionInitialized(true);
       return;
@@ -225,7 +236,7 @@ export function Share() {
 
     setQueueOrder(defaultQueue);
     setSelectionInitialized(!!readyStats);
-  }, [location.search, readyStats, searchParams]);
+  }, [location.search, readyStats, searchParams, queueStorage]);
 
   useEffect(() => {
     if (skipNextUrlSyncRef.current) {
@@ -237,7 +248,7 @@ export function Share() {
       if (activeStep === 'queue') next.delete('step'); else next.set('step', activeStep);
       if (selectionInitialized) {
         const defaultQueue = readyStats ? queueFromStats(readyStats) : null;
-        syncQueueSelectionToSearchParams(next, queueOrder, defaultQueue);
+        syncQueueSelectionToSearchParams(next, queueOrder, defaultQueue, queueStorage);
       }
       if (note) next.set('note', note); else next.delete('note');
       if (aiPiiEnabled) next.set('ai_pii', '1'); else next.delete('ai_pii');
@@ -245,7 +256,7 @@ export function Share() {
       internalSearchRef.current = next.toString();
       return next;
     }, { replace: true });
-  }, [activeStep, queueOrder, selectionInitialized, readyStats, note, aiPiiEnabled, packagedShareId, setSearchParams]);
+  }, [activeStep, queueOrder, selectionInitialized, readyStats, queueStorage, note, aiPiiEnabled, packagedShareId, setSearchParams]);
 
   // Drop cached redacted entries when sessions leave the queue.
   useEffect(() => {
@@ -622,17 +633,23 @@ export function Share() {
     setCompletedKeys((prev) => new Set([...prev, 'queue', 'redact', 'review']));
 
     const approvedList = queuedSessions.filter((s) => approvedIds.has(s.session_id));
+    const traceLogLines = approvedList
+      .slice(0, PACKAGE_LOG_TRACE_LIMIT)
+      .map((s) => `Adding ${s.session_id.slice(0, 10)}.jsonl...`);
+    if (approvedList.length > PACKAGE_LOG_TRACE_LIMIT) {
+      traceLogLines.push(`Adding ${approvedList.length - PACKAGE_LOG_TRACE_LIMIT} more traces...`);
+    }
     const logLines = [
       'Allocating bundle...',
       'Writing manifest.json...',
-      ...approvedList.map((s) => `Adding ${s.session_id.slice(0, 10)}.jsonl...`),
+      ...traceLogLines,
       aiPiiEnabled ? 'Running final AI PII review...' : 'Running final rules-only PII review...',
       'Running final secret scan...',
       'Sealing bundle...',
     ];
 
     const animStart = Date.now();
-    const duration = 2200 + approvedList.length * 220;
+    const duration = Math.min(PACKAGE_ANIMATION_MAX_MS, 2200 + approvedList.length * 220);
 
     const timers: number[] = [];
     logLines.forEach((line, i) => {

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -33,6 +33,13 @@ import {
   queueSelectionFromSearchParams,
   syncQueueSelectionToSearchParams,
 } from './queueState.ts';
+import {
+  beginRedactionRun,
+  cancelRedactionRun,
+  finishRedactionRun,
+  isRedactionRunActive,
+} from './redactionRun.ts';
+import type { RedactionRun } from './redactionRun.ts';
 import { SHARE_SHELL_WIDTH, globalStyles } from './styles.tsx';
 import { QueueStep } from './QueueStep.tsx';
 import { RedactStep } from './RedactStep.tsx';
@@ -101,6 +108,10 @@ export function Share() {
 
   // Redaction state
   const [redactedSessions, setRedactedSessions] = useState<Record<string, RedactedSessionData>>({});
+  const redactionRunRef = useRef<RedactionRun | null>(null);
+  const cancelRedaction = useCallback(() => {
+    cancelRedactionRun(redactionRunRef);
+  }, []);
 
   // Review state
   const [approvedIds, setApprovedIds] = useState<Set<string>>(new Set());
@@ -202,6 +213,7 @@ export function Share() {
     const currentSearch = location.search.startsWith('?') ? location.search.slice(1) : location.search;
     if (internalSearchRef.current === currentSearch) return;
 
+    cancelRedaction();
     internalSearchRef.current = currentSearch;
     skipNextUrlSyncRef.current = true;
 
@@ -236,7 +248,7 @@ export function Share() {
 
     setQueueOrder(defaultQueue);
     setSelectionInitialized(!!readyStats);
-  }, [location.search, readyStats, searchParams, queueStorage]);
+  }, [location.search, readyStats, searchParams, queueStorage, cancelRedaction]);
 
   useEffect(() => {
     if (skipNextUrlSyncRef.current) {
@@ -304,6 +316,10 @@ export function Share() {
     () => queueOrder.map((id) => sessionById[id]).filter((s): s is ReadySession => !!s),
     [queueOrder, sessionById],
   );
+  const approvedSessions = useMemo(
+    () => queuedSessions.filter((s) => approvedIds.has(s.session_id)),
+    [queuedSessions, approvedIds],
+  );
 
   useEffect(() => {
     if (!packagedShareId) return;
@@ -343,6 +359,7 @@ export function Share() {
   };
 
   const updateAiPiiEnabled = (enabled: boolean) => {
+    cancelRedaction();
     setAiPiiEnabled(enabled);
     setRedactedSessions({});
     setApprovedIds(new Set());
@@ -377,6 +394,7 @@ export function Share() {
   };
 
   const startFreshShare = useCallback(() => {
+    cancelRedaction();
     setQueueOrder([]);
     setCompletedKeys(new Set());
     setPackagedShareId(null);
@@ -395,12 +413,16 @@ export function Share() {
     setBlockedPackageSessions([]);
     resetAddTracesPicker();
     setActiveStep('queue');
-  }, [resetAddTracesPicker]);
+  }, [cancelRedaction, resetAddTracesPicker]);
 
   const onStepClick = (key: string) => {
     const k = key as StepKey;
     if (k === activeStep) return;
-    if (k === 'queue') { setActiveStep('queue'); return; }
+    if (k === 'queue') {
+      cancelRedaction();
+      setActiveStep('queue');
+      return;
+    }
     if (completedKeys.has(k)) setActiveStep(k);
   };
 
@@ -415,18 +437,35 @@ export function Share() {
   // transient timeouts without doubling the wait for the common case.
   const REDACTION_CONCURRENCY = 2;
   const REDACTION_RETRIES = 1;
-  const redactionStartedRef = useRef(false);
+
+  // Cancel work that no longer belongs to the active selection. Aborting the
+  // fetch stops the browser from waiting on in-flight reports; the per-run
+  // identity checks below also prevent stale results and future batches.
+  useEffect(() => {
+    if (activeStep !== 'redact') cancelRedaction();
+  }, [activeStep, cancelRedaction]);
+
+  useEffect(() => {
+    cancelRedaction();
+  }, [queuedSessions, aiPiiEnabled, cancelRedaction]);
+
+  useEffect(() => () => cancelRedaction(), [cancelRedaction]);
 
   const runRedaction = useCallback(async () => {
-    if (redactionStartedRef.current) return;
-    redactionStartedRef.current = true;
+    const run = beginRedactionRun(redactionRunRef);
+    if (!run) return;
+    const isActive = () => isRedactionRunActive(redactionRunRef, run);
     const sessions = queuedSessions;
     const cached = redactedSessions;
-    const missing = sessions.filter((s) => !cached[s.session_id]);
+    const missing = sessions.filter((s) => {
+      const data = cached[s.session_id];
+      return !data || data.loading;
+    });
 
     // mark missing ones as loading up-front so the per-trace list renders
     if (missing.length > 0) {
       setRedactedSessions((prev) => {
+        if (!isActive()) return prev;
         const next = { ...prev };
         missing.forEach((s) => {
           if (!next[s.session_id]) next[s.session_id] = { messages: [], loading: true };
@@ -438,10 +477,15 @@ export function Share() {
     const fetchReport = async (sessionId: string) => {
       let lastErr: unknown = null;
       for (let attempt = 0; attempt <= REDACTION_RETRIES; attempt++) {
+        if (!isActive()) throw new Error('Redaction canceled');
         try {
-          return await api.sessions.redactionReport(sessionId, { aiPii: aiPiiEnabled });
+          return await api.sessions.redactionReport(sessionId, {
+            aiPii: aiPiiEnabled,
+            signal: run.controller.signal,
+          });
         } catch (e) {
           lastErr = e;
+          if (!isActive()) throw e;
           if (attempt < REDACTION_RETRIES) {
             // brief pause to let a flaky CLI/model settle before retrying
             await new Promise((r) => setTimeout(r, 800));
@@ -453,7 +497,9 @@ export function Share() {
 
     const processOne = async (s: ReadySession) => {
       try {
+        if (!isActive()) return;
         const report = await fetchReport(s.session_id);
+        if (!isActive()) return;
         const msgs: RedactedReviewMessage[] = (report.redacted_session.messages || []).map((m) => ({
           role: m.role,
           content: m.content || '',
@@ -468,36 +514,47 @@ export function Share() {
         const trufflehogHits = (report.redaction_log || [])
           .filter((entry) => entry.type && entry.type.startsWith('trufflehog'))
           .length;
-        setRedactedSessions((prev) => ({
-          ...prev,
-          [s.session_id]: {
-            messages: msgs, loading: false,
-            redactionCount: report.redaction_count,
-            aiPiiFindings: report.ai_pii_findings || [],
-            aiCoverage: report.ai_coverage || (aiPiiEnabled ? 'rules_only' : 'disabled'),
-            buckets,
-            trufflehogHits,
-          },
-        }));
+        setRedactedSessions((prev) => {
+          if (!isActive()) return prev;
+          return {
+            ...prev,
+            [s.session_id]: {
+              messages: msgs, loading: false,
+              redactionCount: report.redaction_count,
+              aiPiiFindings: report.ai_pii_findings || [],
+              aiCoverage: report.ai_coverage || (aiPiiEnabled ? 'rules_only' : 'disabled'),
+              buckets,
+              trufflehogHits,
+            },
+          };
+        });
       } catch {
-        setRedactedSessions((prev) => ({
-          ...prev,
-          [s.session_id]: {
-            messages: [{ role: 'system', content: '(unable to load redacted content)' }],
-            loading: false,
-            redactionCount: 0,
-            aiCoverage: aiPiiEnabled ? 'rules_only' : 'disabled',
-            buckets: emptyBuckets(),
-          },
-        }));
+        if (!isActive()) return;
+        setRedactedSessions((prev) => {
+          if (!isActive()) return prev;
+          return {
+            ...prev,
+            [s.session_id]: {
+              messages: [{ role: 'system', content: '(unable to load redacted content)' }],
+              loading: false,
+              redactionCount: 0,
+              aiCoverage: aiPiiEnabled ? 'rules_only' : 'disabled',
+              buckets: emptyBuckets(),
+            },
+          };
+        });
       }
     };
 
-    for (let i = 0; i < missing.length; i += REDACTION_CONCURRENCY) {
-      const batch = missing.slice(i, i + REDACTION_CONCURRENCY);
-      await Promise.all(batch.map(processOne));
+    try {
+      for (let i = 0; i < missing.length; i += REDACTION_CONCURRENCY) {
+        if (!isActive()) break;
+        const batch = missing.slice(i, i + REDACTION_CONCURRENCY);
+        await Promise.all(batch.map(processOne));
+      }
+    } finally {
+      finishRedactionRun(redactionRunRef, run);
     }
-    redactionStartedRef.current = false;
   }, [queuedSessions, redactedSessions, aiPiiEnabled]);
 
   const handleStartRedaction = () => {
@@ -632,7 +689,7 @@ export function Share() {
     setPackageLog('Allocating bundle...');
     setCompletedKeys((prev) => new Set([...prev, 'queue', 'redact', 'review']));
 
-    const approvedList = queuedSessions.filter((s) => approvedIds.has(s.session_id));
+    const approvedList = approvedSessions;
     const traceLogLines = approvedList
       .slice(0, PACKAGE_LOG_TRACE_LIMIT)
       .map((s) => `Adding ${s.session_id.slice(0, 10)}.jsonl...`);
@@ -732,7 +789,7 @@ export function Share() {
     } finally {
       packagingStartedRef.current = false;
     }
-  }, [queuedSessions, approvedIds, note, toast, aiPiiEnabled]);
+  }, [approvedSessions, note, toast, aiPiiEnabled]);
 
   const handleStartPackage = () => {
     if (queuedSessions.length === 0) return;
@@ -924,7 +981,10 @@ export function Share() {
         redactedSessions={redactedSessions}
         allDone={redactAllDone}
         aiPiiEnabled={aiPiiEnabled}
-        onBack={() => setActiveStep('queue')}
+        onBack={() => {
+          cancelRedaction();
+          setActiveStep('queue');
+        }}
         onContinue={goToReview}
         globalStyles={globalStyles}
         showHelp={showHelp}
@@ -966,8 +1026,8 @@ export function Share() {
     return (
       <PackageStep
         stepperHeader={stepperHeader}
-        approvedCount={queuedSessions.filter((s) => approvedIds.has(s.session_id)).length}
-        approvedList={queuedSessions.filter((s) => approvedIds.has(s.session_id))}
+        approvedCount={approvedSessions.length}
+        approvedList={approvedSessions}
         progress={packageProgress}
         log={packageLog}
         failed={packagingFailed}

--- a/clawjournal/web/frontend/src/views/Share/queueState.ts
+++ b/clawjournal/web/frontend/src/views/Share/queueState.ts
@@ -1,9 +1,57 @@
 const IDS_PARAM = 'ids';
 const SELECTION_PARAM = 'selection';
 const EXCLUDE_PARAM = 'exclude';
+const QUEUE_REF_PARAM = 'queue_ref';
+const STORAGE_PREFIX = 'clawjournal.share.queue.';
+
+// Python's loopback HTTP server rejects request lines above 65,536 bytes.
+// Leave headroom for the path and the Share workflow's other query params.
+export const MAX_QUEUE_QUERY_LENGTH = 48_000;
+
+export interface QueueSelectionStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
 
 function parseIds(value: string | null): string[] {
   return value ? value.split(',').filter(Boolean) : [];
+}
+
+function storageKey(ref: string): string {
+  return `${STORAGE_PREFIX}${ref}`;
+}
+
+function parseStoredQueue(
+  params: URLSearchParams,
+  storage: QueueSelectionStorage | null,
+): string[] | null {
+  const ref = params.get(QUEUE_REF_PARAM);
+  if (!ref || !/^[A-Za-z0-9_-]{1,128}$/.test(ref) || !storage) return null;
+  try {
+    const raw = storage.getItem(storageKey(ref));
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed) || !parsed.every((id) => typeof id === 'string')) return null;
+    return parsed.filter(Boolean);
+  } catch {
+    return null;
+  }
+}
+
+function createQueueRef(): string {
+  try {
+    if (globalThis.crypto?.randomUUID) return globalThis.crypto.randomUUID();
+  } catch { /* fall through */ }
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+function replaceQueueParams(target: URLSearchParams, source: URLSearchParams): void {
+  target.delete(IDS_PARAM);
+  target.delete(SELECTION_PARAM);
+  target.delete(EXCLUDE_PARAM);
+  target.delete(QUEUE_REF_PARAM);
+  source.forEach((value, key) => target.set(key, value));
 }
 
 /**
@@ -13,6 +61,7 @@ function parseIds(value: string | null): string[] {
 export function queueSelectionFromSearchParams(
   params: URLSearchParams,
   defaultQueue: string[],
+  storage: QueueSelectionStorage | null = null,
 ): string[] | null {
   // `has` intentionally distinguishes an explicit empty queue (`ids=`) from
   // an absent parameter, which means "use the default".
@@ -22,6 +71,11 @@ export function queueSelectionFromSearchParams(
     const excluded = new Set(parseIds(params.get(EXCLUDE_PARAM)));
     return defaultQueue.filter((id) => !excluded.has(id));
   }
+
+  // A reference is an explicit selection even when its local entry was
+  // cleared, evicted, or opened in another browser. Fail closed instead of
+  // treating an unreadable reference as "no selection" and defaulting to all.
+  if (params.has(QUEUE_REF_PARAM)) return parseStoredQueue(params, storage) ?? [];
 
   return null;
 }
@@ -38,37 +92,65 @@ export function syncQueueSelectionToSearchParams(
   params: URLSearchParams,
   queueOrder: string[],
   defaultQueue: string[] | null,
+  storage: QueueSelectionStorage | null = null,
+  refFactory: () => string = createQueueRef,
 ): void {
-  params.delete(IDS_PARAM);
-  params.delete(SELECTION_PARAM);
-  params.delete(EXCLUDE_PARAM);
+  const existingRef = params.get(QUEUE_REF_PARAM);
+  const encoded = new URLSearchParams();
 
   if (defaultQueue === null) {
-    params.set(IDS_PARAM, queueOrder.join(','));
+    encoded.set(IDS_PARAM, queueOrder.join(','));
+  } else {
+    const selected = new Set(queueOrder);
+    const defaultIds = new Set(defaultQueue);
+    const canonicalSelection = defaultQueue.filter((id) => selected.has(id));
+    const preservesDefaultOrder = (
+      queueOrder.length === canonicalSelection.length
+      && queueOrder.every((id, index) => (
+        defaultIds.has(id) && canonicalSelection[index] === id
+      ))
+    );
+    const excluded = defaultQueue.filter((id) => !selected.has(id));
+    const explicitCsv = queueOrder.join(',');
+    const excludedCsv = excluded.join(',');
+
+    // Exclusions are lossless while selected rows retain the default order.
+    // Otherwise keep explicit ids so drag-reordering survives a reload.
+    if (preservesDefaultOrder && excludedCsv.length < explicitCsv.length) {
+      encoded.set(SELECTION_PARAM, 'all');
+      if (excludedCsv) encoded.set(EXCLUDE_PARAM, excludedCsv);
+    } else {
+      encoded.set(IDS_PARAM, explicitCsv);
+    }
+  }
+
+  if (encoded.toString().length <= MAX_QUEUE_QUERY_LENGTH) {
+    replaceQueueParams(params, encoded);
+    if (existingRef && storage) {
+      try { storage.removeItem(storageKey(existingRef)); } catch { /* ignore */ }
+    }
     return;
   }
 
-  const selected = new Set(queueOrder);
-  const defaultIds = new Set(defaultQueue);
-  const canonicalSelection = defaultQueue.filter((id) => selected.has(id));
-  const preservesDefaultOrder = (
-    queueOrder.length === canonicalSelection.length
-    && queueOrder.every((id, index) => (
-      defaultIds.has(id) && canonicalSelection[index] === id
-    ))
-  );
-  const excluded = defaultQueue.filter((id) => !selected.has(id));
-  const explicitCsv = queueOrder.join(',');
-  const excludedCsv = excluded.join(',');
-
-  // Exclusions are only lossless while the selected rows retain the default
-  // order. Otherwise keep the explicit queue so drag-reordering survives a
-  // reload. Choose ids for an empty or small subset because it is shorter.
-  if (preservesDefaultOrder && excludedCsv.length < explicitCsv.length) {
-    params.set(SELECTION_PARAM, 'all');
-    if (excludedCsv) params.set(EXCLUDE_PARAM, excludedCsv);
-    return;
+  // Arbitrary orderings and large middle-sized subsets cannot be represented
+  // safely in a request URL. Store their exact local-only state behind a short
+  // opaque reference; session ids are local identifiers and the workbench URL
+  // is only meaningful on this machine.
+  if (storage) {
+    const ref = existingRef || refFactory();
+    try {
+      storage.setItem(storageKey(ref), JSON.stringify(queueOrder));
+      const stored = new URLSearchParams();
+      stored.set(QUEUE_REF_PARAM, ref);
+      replaceQueueParams(params, stored);
+      return;
+    } catch { /* use the compact fallback below */ }
   }
 
-  params.set(IDS_PARAM, explicitCsv);
+  // Storage can be unavailable in locked-down browser contexts or when its
+  // quota is exhausted. Fail closed: a reload may lose the oversized queue,
+  // but it must never broaden the user's selection to every eligible trace.
+  const fallback = new URLSearchParams();
+  fallback.set(IDS_PARAM, '');
+  replaceQueueParams(params, fallback);
 }

--- a/clawjournal/web/frontend/src/views/Share/queueState.ts
+++ b/clawjournal/web/frontend/src/views/Share/queueState.ts
@@ -1,0 +1,74 @@
+const IDS_PARAM = 'ids';
+const SELECTION_PARAM = 'selection';
+const EXCLUDE_PARAM = 'exclude';
+
+function parseIds(value: string | null): string[] {
+  return value ? value.split(',').filter(Boolean) : [];
+}
+
+/**
+ * Restore queue membership from the URL once the eligible default queue is
+ * known. `null` means the URL does not carry an explicit selection.
+ */
+export function queueSelectionFromSearchParams(
+  params: URLSearchParams,
+  defaultQueue: string[],
+): string[] | null {
+  // `has` intentionally distinguishes an explicit empty queue (`ids=`) from
+  // an absent parameter, which means "use the default".
+  if (params.has(IDS_PARAM)) return parseIds(params.get(IDS_PARAM));
+
+  if (params.get(SELECTION_PARAM) === 'all') {
+    const excluded = new Set(parseIds(params.get(EXCLUDE_PARAM)));
+    return defaultQueue.filter((id) => !excluded.has(id));
+  }
+
+  return null;
+}
+
+/**
+ * Persist the queue using the shorter lossless representation.
+ *
+ * A default or near-default queue is encoded as `selection=all` plus the few
+ * exclusions. Explicit ids remain available for small subsets and custom
+ * reorderings. This keeps the normal opt-out flow compact even when thousands
+ * of sessions are eligible.
+ */
+export function syncQueueSelectionToSearchParams(
+  params: URLSearchParams,
+  queueOrder: string[],
+  defaultQueue: string[] | null,
+): void {
+  params.delete(IDS_PARAM);
+  params.delete(SELECTION_PARAM);
+  params.delete(EXCLUDE_PARAM);
+
+  if (defaultQueue === null) {
+    params.set(IDS_PARAM, queueOrder.join(','));
+    return;
+  }
+
+  const selected = new Set(queueOrder);
+  const defaultIds = new Set(defaultQueue);
+  const canonicalSelection = defaultQueue.filter((id) => selected.has(id));
+  const preservesDefaultOrder = (
+    queueOrder.length === canonicalSelection.length
+    && queueOrder.every((id, index) => (
+      defaultIds.has(id) && canonicalSelection[index] === id
+    ))
+  );
+  const excluded = defaultQueue.filter((id) => !selected.has(id));
+  const explicitCsv = queueOrder.join(',');
+  const excludedCsv = excluded.join(',');
+
+  // Exclusions are only lossless while the selected rows retain the default
+  // order. Otherwise keep the explicit queue so drag-reordering survives a
+  // reload. Choose ids for an empty or small subset because it is shorter.
+  if (preservesDefaultOrder && excludedCsv.length < explicitCsv.length) {
+    params.set(SELECTION_PARAM, 'all');
+    if (excludedCsv) params.set(EXCLUDE_PARAM, excludedCsv);
+    return;
+  }
+
+  params.set(IDS_PARAM, explicitCsv);
+}

--- a/clawjournal/web/frontend/src/views/Share/redactionRun.ts
+++ b/clawjournal/web/frontend/src/views/Share/redactionRun.ts
@@ -1,0 +1,28 @@
+export interface RedactionRun {
+  controller: AbortController;
+}
+
+export interface RedactionRunSlot {
+  current: RedactionRun | null;
+}
+
+export function beginRedactionRun(slot: RedactionRunSlot): RedactionRun | null {
+  if (slot.current) return null;
+  const run = { controller: new AbortController() };
+  slot.current = run;
+  return run;
+}
+
+export function cancelRedactionRun(slot: RedactionRunSlot): void {
+  const run = slot.current;
+  slot.current = null;
+  run?.controller.abort();
+}
+
+export function isRedactionRunActive(slot: RedactionRunSlot, run: RedactionRun): boolean {
+  return slot.current === run && !run.controller.signal.aborted;
+}
+
+export function finishRedactionRun(slot: RedactionRunSlot, run: RedactionRun): void {
+  if (slot.current === run) slot.current = null;
+}

--- a/clawjournal/web/frontend/src/views/Share/types.ts
+++ b/clawjournal/web/frontend/src/views/Share/types.ts
@@ -128,4 +128,3 @@ export interface RedactedSessionData {
 }
 
 export const CONFIDENCE_THRESHOLD = 0.85;
-export const DEFAULT_SHARE_QUEUE_SIZE = 10;


### PR DESCRIPTION
## Summary

* Select every displayed session by default in Sessions while preserving earlier per-row choices as more pages load.
* Add every eligible trace to Share by default, with server recommendations first and individual opt-out controls intact.
* Keep normal all-selected and opt-out URLs compact with `selection=all` plus exclusions.
* Store oversized arbitrary subsets and custom ordering behind a short local `queue_ref`, with fail-closed behavior if browser storage is unavailable or the reference cannot be read.
* Render Queue, Redact, and Review trace lists 50 rows at a time, and use set membership for queue filtering.
* Cancel stale redaction runs when the selection, workflow step, AI setting, URL state, or component lifetime changes. In-flight browser requests are aborted, future batches stop, and stale results are ignored.
* Cap Package trace logs and animations, and keep the approved list stable across progress renders so large selections do not create or repeatedly reschedule thousands of timers.

## Why

Sessions and Share previously started with only a limited or empty selection, forcing users to select sessions and add hidden traces manually. These defaults make both workflows opt-out while preserving explicit removal and deselection controls.

Serializing every selected session ID can exceed the daemon's request-line limit. Rendering, redacting, and packaging every default-selected trace eagerly also becomes impractical once the queue contains thousands of sessions. The bounded state and rendering paths keep the workflow usable without silently broadening a selection when persistence fails or continuing obsolete redaction work after the user changes course.

## Validation

* `npm run build` passed, including the queue-state regression test and production Vite build.
* `npm run test:share-queue` passed. It covers a 5,000-trace default queue, opt-out exclusions, a 5,000-trace reorder, a 2,500-trace middle subset, unreadable and unavailable storage, an empty queue, bounded list rendering, bounded packaging work, and redaction-run cancellation/replacement races.
* `npx eslint src/api.ts src/views/Share/index.tsx src/views/Share/PackageStep.tsx src/views/Share/redactionRun.ts` passed.
* `python -m pytest tests/benchmark/test_frontend_contract.py tests/workbench/test_daemon.py tests/workbench/test_share_gates.py -q` passed with 158 tests.
* An isolated daemon-backed browser check with 120 eligible traces confirmed 50-row rendering, incremental expansion, compact opt-out state, and exact selection restoration after reload.

The repository-wide frontend lint still reports existing unrelated diagnostics outside this change.
