### PR TITLE
Bound Share redaction waits

### DIFF
--- a/clawjournal/redaction/pii.py
+++ b/clawjournal/redaction/pii.py
@@ -11,11 +11,13 @@ until LLM-PII gets a no-plaintext deterministic apply design.
 from __future__ import annotations
 
 import json
+import math
 import re
 import tempfile
 from collections.abc import Iterable
-from concurrent.futures import ThreadPoolExecutor, as_completed
+from concurrent.futures import FIRST_COMPLETED, ThreadPoolExecutor, wait
 from pathlib import Path
+from time import monotonic
 from typing import Any
 
 from ..findings import (
@@ -448,25 +450,80 @@ def review_session_pii_with_agent(
             if not ignore_errors:
                 raise
     else:
-        # Multiple batches — run in parallel
-        with ThreadPoolExecutor(max_workers=min(max_workers, len(batches))) as pool:
-            futures = {
-                pool.submit(
+        # Multiple batches share ONE request budget. Submitting every batch up
+        # front made timeout_seconds apply once per worker wave, so a large trace
+        # could keep the HTTP handler and agent CLIs alive long after the browser
+        # deadline. Refill only while time remains and pass each new worker the
+        # remaining budget. Backend wrappers retain their existing 10-second
+        # process-cleanup grace, so total wall time is bounded by budget + grace.
+        deadline = monotonic() + max(0.001, float(timeout_seconds))
+        worker_count = min(max_workers, len(batches))
+        pool = ThreadPoolExecutor(max_workers=worker_count)
+        futures: dict[Any, list[tuple[str, int, str, str]]] = {}
+        next_batch = 0
+        timed_out = False
+
+        def fill_workers() -> None:
+            nonlocal next_batch
+            while len(futures) < worker_count and next_batch < len(batches):
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    return
+                batch = batches[next_batch]
+                next_batch += 1
+                future = pool.submit(
                     _review_batch,
                     session_id,
                     batch,
                     rubric=rubric,
                     backend=backend,
-                    timeout_seconds=timeout_seconds,
-                ): batch
-                for batch in batches
-            }
-            for future in as_completed(futures):
-                try:
-                    findings.extend(future.result())
-                except RuntimeError as exc:
-                    if not ignore_errors:
-                        errors.append(exc)
+                    timeout_seconds=max(1, math.ceil(remaining)),
+                )
+                futures[future] = batch
+
+        try:
+            fill_workers()
+            while futures:
+                remaining = deadline - monotonic()
+                if remaining <= 0:
+                    timed_out = True
+                    break
+                # OpenClaw/Hermes wrappers allow ten seconds after their own
+                # deadline to terminate and collect output.
+                done, _ = wait(
+                    futures,
+                    timeout=remaining + 10,
+                    return_when=FIRST_COMPLETED,
+                )
+                if not done:
+                    timed_out = True
+                    break
+                for future in done:
+                    futures.pop(future, None)
+                    try:
+                        findings.extend(future.result())
+                    except RuntimeError as exc:
+                        if not ignore_errors:
+                            errors.append(exc)
+                if errors:
+                    break
+                if next_batch < len(batches) and monotonic() >= deadline:
+                    timed_out = True
+                    break
+                fill_workers()
+            if next_batch < len(batches):
+                timed_out = True
+        finally:
+            for future in futures:
+                future.cancel()
+            pool.shutdown(wait=True, cancel_futures=True)
+
+        if timed_out and not ignore_errors:
+            errors.append(
+                RuntimeError(
+                    f"PII review timed out after {timeout_seconds}s for session {session_id}"
+                )
+            )
         if errors:
             raise errors[0]
 

--- a/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
+++ b/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
@@ -117,11 +117,24 @@ assert.match(shareIndex, /cancelRedactionRun\(redactionRunRef\)/);
 assert.match(shareIndex, /return !data \|\| data\.loading/);
 assert.match(shareIndex, /signal: run\.controller\.signal/);
 assert.match(shareIndex, /if \(!isActive\(\)\) break/);
+assert.match(shareIndex, /error instanceof ApiError && error\.status === 408/);
+assert.match(shareIndex, /settlePendingRedactionEntries\(/);
+assert.match(shareIndex, /run\.controller\.abort\(\)/);
+assert.match(shareIndex, /beginRedactionRetry\(redactionRetryRef\.current, id\)/);
+assert.match(shareIndex, /isRedactionRetryActive\(redactionRetryRef\.current, id, run\)/);
+assert.match(shareIndex, /signal: run\.controller\.signal/);
+assert.match(shareIndex, /cancelRedactionRetries\(redactionRetryRef\.current\)/);
+assert.match(shareIndex, /if \(activeStep !== 'review'\) cancelAiRetries\(\)/);
+assert.match(shareIndex, /\[queuedSessions, aiPiiEnabled, cancelAiRetries\]/);
+assert.match(shareIndex, /\(\) => cancelRedactionRetries\(redactionRetryRef\.current\)/);
 assert.match(shareIndex, /const approvedSessions = useMemo\(/);
 assert.match(shareIndex, /approvedList=\{approvedSessions\}/);
 
+assert.match(reviewStep, /disabled=\{data\?\.loading\}/);
+assert.match(reviewStep, /data\?\.loading \? 'Retrying\.\.\.' : 'Retry AI'/);
+
 const apiSource = await readFile(new URL('../src/api.ts', import.meta.url), 'utf8');
-assert.match(apiSource, /REDACTION_REPORT_TIMEOUT_MS = 190_000/);
+assert.match(apiSource, /REDACTION_REPORT_TIMEOUT_MS = 200_000/);
 assert.match(apiSource, /redactionReport\(id: string, opts\?: \{ aiPii\?: boolean; signal\?: AbortSignal; timeoutMs\?: number \}\)/);
 assert.match(apiSource, /signal: controller\.signal/);
 
@@ -132,7 +145,9 @@ const apiOutput = ts.transpileModule(apiSource, {
   },
 }).outputText;
 const apiUrl = `data:text/javascript;base64,${Buffer.from(apiOutput).toString('base64')}`;
-const { api, ApiError } = await import(apiUrl);
+const { api, ApiError, REDACTION_REPORT_TIMEOUT_MS } = await import(apiUrl);
+assert.equal(REDACTION_REPORT_TIMEOUT_MS, 200_000);
+assert.ok(REDACTION_REPORT_TIMEOUT_MS >= 180_000 + 10_000 + 10_000);
 const originalFetch = globalThis.fetch;
 globalThis.fetch = (_url, init) => new Promise((_resolve, reject) => {
   init.signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
@@ -141,6 +156,17 @@ try {
   await assert.rejects(
     api.sessions.redactionReport('wedged-session', { timeoutMs: 5 }),
     (error) => error instanceof ApiError && error.status === 408,
+  );
+
+  const parentController = new AbortController();
+  const canceledRequest = api.sessions.redactionReport('canceled-session', {
+    signal: parentController.signal,
+    timeoutMs: 1_000,
+  });
+  parentController.abort();
+  await assert.rejects(
+    canceledRequest,
+    (error) => error?.name === 'AbortError' && !(error instanceof ApiError),
   );
 } finally {
   globalThis.fetch = originalFetch;
@@ -159,10 +185,16 @@ const redactionRunOutput = ts.transpileModule(redactionRunSource, {
 }).outputText;
 const redactionRunUrl = `data:text/javascript;base64,${Buffer.from(redactionRunOutput).toString('base64')}`;
 const {
+  beginRedactionRetry,
   beginRedactionRun,
+  cancelRedactionRetries,
+  cancelRedactionRetry,
   cancelRedactionRun,
+  finishRedactionRetry,
   finishRedactionRun,
+  isRedactionRetryActive,
   isRedactionRunActive,
+  settlePendingRedactionEntries,
 } = await import(redactionRunUrl);
 
 const runSlot = { current: null };
@@ -180,3 +212,35 @@ finishRedactionRun(runSlot, firstRun);
 assert.equal(isRedactionRunActive(runSlot, replacementRun), true);
 finishRedactionRun(runSlot, replacementRun);
 assert.equal(runSlot.current, null);
+
+const retrySlot = { current: new Map() };
+const firstRetry = beginRedactionRetry(retrySlot, 'session-a');
+assert.ok(firstRetry);
+assert.equal(beginRedactionRetry(retrySlot, 'session-a'), null);
+assert.equal(isRedactionRetryActive(retrySlot, 'session-a', firstRetry), true);
+cancelRedactionRetry(retrySlot, 'session-a');
+assert.equal(firstRetry.controller.signal.aborted, true);
+assert.equal(isRedactionRetryActive(retrySlot, 'session-a', firstRetry), false);
+
+const replacementRetry = beginRedactionRetry(retrySlot, 'session-a');
+const concurrentRetry = beginRedactionRetry(retrySlot, 'session-b');
+assert.ok(replacementRetry);
+assert.ok(concurrentRetry);
+finishRedactionRetry(retrySlot, 'session-a', firstRetry);
+assert.equal(isRedactionRetryActive(retrySlot, 'session-a', replacementRetry), true);
+cancelRedactionRetries(retrySlot);
+assert.equal(replacementRetry.controller.signal.aborted, true);
+assert.equal(concurrentRetry.controller.signal.aborted, true);
+assert.equal(retrySlot.current.size, 0);
+
+const completedEntry = { loading: false, value: 'complete' };
+const pendingEntry = { loading: true, value: 'pending' };
+const timedOutEntry = { loading: false, value: 'timed-out' };
+const settledEntries = settlePendingRedactionEntries(
+  { complete: completedEntry, current: pendingEntry },
+  ['complete', 'current', 'unstarted'],
+  timedOutEntry,
+);
+assert.equal(settledEntries.complete, completedEntry);
+assert.equal(settledEntries.current, timedOutEntry);
+assert.equal(settledEntries.unstarted, timedOutEntry);

--- a/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
+++ b/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
@@ -121,8 +121,30 @@ assert.match(shareIndex, /const approvedSessions = useMemo\(/);
 assert.match(shareIndex, /approvedList=\{approvedSessions\}/);
 
 const apiSource = await readFile(new URL('../src/api.ts', import.meta.url), 'utf8');
-assert.match(apiSource, /redactionReport\(id: string, opts\?: \{ aiPii\?: boolean; signal\?: AbortSignal \}\)/);
-assert.match(apiSource, /signal: opts\?\.signal/);
+assert.match(apiSource, /REDACTION_REPORT_TIMEOUT_MS = 190_000/);
+assert.match(apiSource, /redactionReport\(id: string, opts\?: \{ aiPii\?: boolean; signal\?: AbortSignal; timeoutMs\?: number \}\)/);
+assert.match(apiSource, /signal: controller\.signal/);
+
+const apiOutput = ts.transpileModule(apiSource, {
+  compilerOptions: {
+    module: ts.ModuleKind.ESNext,
+    target: ts.ScriptTarget.ES2022,
+  },
+}).outputText;
+const apiUrl = `data:text/javascript;base64,${Buffer.from(apiOutput).toString('base64')}`;
+const { api, ApiError } = await import(apiUrl);
+const originalFetch = globalThis.fetch;
+globalThis.fetch = (_url, init) => new Promise((_resolve, reject) => {
+  init.signal.addEventListener('abort', () => reject(new DOMException('Aborted', 'AbortError')), { once: true });
+});
+try {
+  await assert.rejects(
+    api.sessions.redactionReport('wedged-session', { timeoutMs: 5 }),
+    (error) => error instanceof ApiError && error.status === 408,
+  );
+} finally {
+  globalThis.fetch = originalFetch;
+}
 
 const packageStep = await readFile(new URL('../src/views/Share/PackageStep.tsx', import.meta.url), 'utf8');
 assert.match(packageStep, /p\.approvedList\.slice\(0, PACKAGE_ANIMATION_TRACE_LIMIT\)\.forEach/);

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -37,10 +37,11 @@ export class ApiError extends Error {
   }
 }
 
-// The server-side AI review is capped at 180 seconds. Keep a slightly wider
-// browser deadline so configured long reviews can finish, while a wedged daemon
-// or dropped response can never leave the Share workflow loading forever.
-export const REDACTION_REPORT_TIMEOUT_MS = 190_000;
+// The server-side AI review is capped at 180 seconds, and its agent runner gets
+// another 10 seconds to terminate and collect output. Leave a further 10
+// seconds for the daemon to serialize the report and the browser to receive it.
+// A wedged daemon or dropped response still gets a finite browser deadline.
+export const REDACTION_REPORT_TIMEOUT_MS = 200_000;
 
 declare global {
   interface Window {

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -37,6 +37,11 @@ export class ApiError extends Error {
   }
 }
 
+// The server-side AI review is capped at 180 seconds. Keep a slightly wider
+// browser deadline so configured long reviews can finish, while a wedged daemon
+// or dropped response can never leave the Share workflow loading forever.
+export const REDACTION_REPORT_TIMEOUT_MS = 190_000;
+
 declare global {
   interface Window {
     __CLAWJOURNAL_API_TOKEN__?: string;
@@ -112,11 +117,28 @@ export const api = {
       return request(`/sessions/${encodeURIComponent(id)}/redacted`);
     },
 
-    redactionReport(id: string, opts?: { aiPii?: boolean; signal?: AbortSignal }): Promise<RedactionReport> {
+    async redactionReport(id: string, opts?: { aiPii?: boolean; signal?: AbortSignal; timeoutMs?: number }): Promise<RedactionReport> {
       const q = opts?.aiPii ? '?ai_pii=1' : '';
-      return request(`/sessions/${encodeURIComponent(id)}/redaction-report${q}`, {
-        signal: opts?.signal,
-      });
+      const controller = new AbortController();
+      let timedOut = false;
+      const abortFromParent = () => controller.abort(opts?.signal?.reason);
+      if (opts?.signal?.aborted) abortFromParent();
+      else opts?.signal?.addEventListener('abort', abortFromParent, { once: true });
+      const timeout = globalThis.setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+      }, opts?.timeoutMs ?? REDACTION_REPORT_TIMEOUT_MS);
+      try {
+        return await request(`/sessions/${encodeURIComponent(id)}/redaction-report${q}`, {
+          signal: controller.signal,
+        });
+      } catch (error) {
+        if (timedOut) throw new ApiError(408, 'Redaction report timed out');
+        throw error;
+      } finally {
+        globalThis.clearTimeout(timeout);
+        opts?.signal?.removeEventListener('abort', abortFromParent);
+      }
     },
 
     update(id: string, body: { status?: string; notes?: string; reason?: string; ai_quality_score?: number; ai_score_reason?: string; ai_failure_value_score?: number; ai_failure_evidence?: string[]; ai_recovery_labels?: string[]; ai_failure_attribution?: string; ai_failure_modes?: string[]; ai_learning_summary?: string; hold_state?: HoldState; embargo_until?: string | null }): Promise<{ ok: boolean }> {

--- a/clawjournal/web/frontend/src/views/Share/ReviewStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/ReviewStep.tsx
@@ -288,12 +288,15 @@ function ReviewRow({
               {!approved && aiUnavailable && (
                 <button
                   onClick={onRetryAi}
+                  disabled={data?.loading}
                   style={{
                     ...btnGhost, color: colors.primary500, fontSize: 12.5,
                     border: `1px solid ${colors.primary200}`, padding: '4px 8px', background: colors.white,
+                    opacity: data?.loading ? 0.55 : 1,
+                    cursor: data?.loading ? 'not-allowed' : 'pointer',
                   }}
                 >
-                  <Icon name="retry" size={12} /> Retry AI
+                  <Icon name="retry" size={12} /> {data?.loading ? 'Retrying...' : 'Retry AI'}
                 </button>
               )}
             </div>

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useLocation, useSearchParams } from 'react-router-dom';
 import type { Session, Share as ShareType } from '../../types.ts';
-import { api } from '../../api.ts';
+import { api, ApiError } from '../../api.ts';
 import { useToast } from '../../components/Toast.tsx';
 import { Spinner } from '../../components/Spinner.tsx';
 import { Stepper } from '../../components/Stepper.tsx';
@@ -486,6 +486,9 @@ export function Share() {
         } catch (e) {
           lastErr = e;
           if (!isActive()) throw e;
+          // A hard request deadline means the daemon or response path is wedged.
+          // Retrying immediately would only double the bounded wait.
+          if (e instanceof ApiError && e.status === 408) break;
           if (attempt < REDACTION_RETRIES) {
             // brief pause to let a flaky CLI/model settle before retrying
             await new Promise((r) => setTimeout(r, 800));
@@ -629,7 +632,8 @@ export function Share() {
       try {
         report = await api.sessions.redactionReport(id, { aiPii: true });
         break;
-      } catch {
+      } catch (e) {
+        if (e instanceof ApiError && e.status === 408) break;
         if (attempt === 0) await new Promise((r) => setTimeout(r, 800));
       }
     }

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -34,12 +34,17 @@ import {
   syncQueueSelectionToSearchParams,
 } from './queueState.ts';
 import {
+  beginRedactionRetry,
   beginRedactionRun,
+  cancelRedactionRetries,
   cancelRedactionRun,
+  finishRedactionRetry,
   finishRedactionRun,
+  isRedactionRetryActive,
   isRedactionRunActive,
+  settlePendingRedactionEntries,
 } from './redactionRun.ts';
-import type { RedactionRun } from './redactionRun.ts';
+import type { RedactionRetrySlot, RedactionRun } from './redactionRun.ts';
 import { SHARE_SHELL_WIDTH, globalStyles } from './styles.tsx';
 import { QueueStep } from './QueueStep.tsx';
 import { RedactStep } from './RedactStep.tsx';
@@ -109,8 +114,26 @@ export function Share() {
   // Redaction state
   const [redactedSessions, setRedactedSessions] = useState<Record<string, RedactedSessionData>>({});
   const redactionRunRef = useRef<RedactionRun | null>(null);
+  const redactionRetryRef = useRef<RedactionRetrySlot>({ current: new Map() });
   const cancelRedaction = useCallback(() => {
     cancelRedactionRun(redactionRunRef);
+  }, []);
+  const cancelAiRetries = useCallback(() => {
+    const sessionIds = [...redactionRetryRef.current.current.keys()];
+    cancelRedactionRetries(redactionRetryRef.current);
+    if (sessionIds.length === 0) return;
+    setRedactedSessions((prev) => {
+      let changed = false;
+      const next = { ...prev };
+      sessionIds.forEach((sessionId) => {
+        const data = next[sessionId];
+        if (data?.loading) {
+          next[sessionId] = { ...data, loading: false };
+          changed = true;
+        }
+      });
+      return changed ? next : prev;
+    });
   }, []);
 
   // Review state
@@ -214,6 +237,7 @@ export function Share() {
     if (internalSearchRef.current === currentSearch) return;
 
     cancelRedaction();
+    cancelAiRetries();
     internalSearchRef.current = currentSearch;
     skipNextUrlSyncRef.current = true;
 
@@ -248,7 +272,7 @@ export function Share() {
 
     setQueueOrder(defaultQueue);
     setSelectionInitialized(!!readyStats);
-  }, [location.search, readyStats, searchParams, queueStorage, cancelRedaction]);
+  }, [location.search, readyStats, searchParams, queueStorage, cancelRedaction, cancelAiRetries]);
 
   useEffect(() => {
     if (skipNextUrlSyncRef.current) {
@@ -349,17 +373,20 @@ export function Share() {
   // =================================================
 
   const removeFromQueue = (id: string) => {
+    cancelAiRetries();
     const next = queueOrder.filter((x) => x !== id);
     setQueueOrder(next);
     if (next.length === 0) resetAddTracesPicker();
   };
 
   const addToQueue = (id: string) => {
+    cancelAiRetries();
     setQueueOrder((prev) => prev.includes(id) ? prev : [...prev, id]);
   };
 
   const updateAiPiiEnabled = (enabled: boolean) => {
     cancelRedaction();
+    cancelAiRetries();
     setAiPiiEnabled(enabled);
     setRedactedSessions({});
     setApprovedIds(new Set());
@@ -382,6 +409,7 @@ export function Share() {
 
   const reorderQueue = (fromId: string, overId: string) => {
     if (fromId === overId) return;
+    cancelAiRetries();
     setQueueOrder((prev) => {
       const fromIdx = prev.indexOf(fromId);
       const overIdx = prev.indexOf(overId);
@@ -395,6 +423,7 @@ export function Share() {
 
   const startFreshShare = useCallback(() => {
     cancelRedaction();
+    cancelAiRetries();
     setQueueOrder([]);
     setCompletedKeys(new Set());
     setPackagedShareId(null);
@@ -413,11 +442,12 @@ export function Share() {
     setBlockedPackageSessions([]);
     resetAddTracesPicker();
     setActiveStep('queue');
-  }, [cancelRedaction, resetAddTracesPicker]);
+  }, [cancelRedaction, cancelAiRetries, resetAddTracesPicker]);
 
   const onStepClick = (key: string) => {
     const k = key as StepKey;
     if (k === activeStep) return;
+    cancelAiRetries();
     if (k === 'queue') {
       cancelRedaction();
       setActiveStep('queue');
@@ -450,6 +480,16 @@ export function Share() {
   }, [queuedSessions, aiPiiEnabled, cancelRedaction]);
 
   useEffect(() => () => cancelRedaction(), [cancelRedaction]);
+
+  useEffect(() => {
+    if (activeStep !== 'review') cancelAiRetries();
+  }, [activeStep, cancelAiRetries]);
+
+  useEffect(() => {
+    cancelAiRetries();
+  }, [queuedSessions, aiPiiEnabled, cancelAiRetries]);
+
+  useEffect(() => () => cancelRedactionRetries(redactionRetryRef.current), []);
 
   const runRedaction = useCallback(async () => {
     const run = beginRedactionRun(redactionRunRef);
@@ -531,7 +571,11 @@ export function Share() {
             },
           };
         });
-      } catch {
+      } catch (error) {
+        // A browser deadline is a queue-level stop condition. Let the outer
+        // loop abort its sibling request and settle every unstarted trace
+        // instead of spending another full deadline on each later batch.
+        if (error instanceof ApiError && error.status === 408) throw error;
         if (!isActive()) return;
         setRedactedSessions((prev) => {
           if (!isActive()) return prev;
@@ -555,10 +599,26 @@ export function Share() {
         const batch = missing.slice(i, i + REDACTION_CONCURRENCY);
         await Promise.all(batch.map(processOne));
       }
+    } catch (error) {
+      if (error instanceof ApiError && error.status === 408 && isActive()) {
+        setRedactedSessions((prev) => settlePendingRedactionEntries(
+          prev,
+          missing.map((session) => session.session_id),
+          {
+            messages: [{ role: 'system', content: '(redaction preview timed out)' }],
+            loading: false,
+            redactionCount: 0,
+            aiCoverage: aiPiiEnabled ? 'rules_only' : 'disabled',
+            buckets: emptyBuckets(),
+          },
+        ));
+        run.controller.abort();
+        toast('Redaction preview timed out; stopped the remaining traces.', 'error');
+      }
     } finally {
       finishRedactionRun(redactionRunRef, run);
     }
-  }, [queuedSessions, redactedSessions, aiPiiEnabled]);
+  }, [queuedSessions, redactedSessions, aiPiiEnabled, toast]);
 
   const handleStartRedaction = () => {
     setCompletedKeys((prev) => new Set([...prev, 'queue']));
@@ -622,52 +682,76 @@ export function Share() {
   };
 
   const retryAiReview = async (id: string) => {
-    setRedactedSessions((prev) => ({
-      ...prev,
-      [id]: { ...(prev[id] || { messages: [] }), loading: true },
-    }));
-    // One automatic retry mirrors the initial-run policy.
-    let report: Awaited<ReturnType<typeof api.sessions.redactionReport>> | null = null;
-    for (let attempt = 0; attempt <= 1; attempt++) {
-      try {
-        report = await api.sessions.redactionReport(id, { aiPii: true });
-        break;
-      } catch (e) {
-        if (e instanceof ApiError && e.status === 408) break;
-        if (attempt === 0) await new Promise((r) => setTimeout(r, 800));
-      }
-    }
-    if (!report) {
-      toast('AI review retry failed', 'error');
+    const run = beginRedactionRetry(redactionRetryRef.current, id);
+    if (!run) return;
+    const isActive = () => isRedactionRetryActive(redactionRetryRef.current, id, run);
+
+    try {
       setRedactedSessions((prev) => ({
         ...prev,
-        [id]: { ...(prev[id] || { messages: [] }), loading: false },
+        [id]: { ...(prev[id] || { messages: [] }), loading: true },
       }));
-      return;
+
+      // One automatic retry mirrors the initial-run policy.
+      let report: Awaited<ReturnType<typeof api.sessions.redactionReport>> | null = null;
+      for (let attempt = 0; attempt <= 1; attempt++) {
+        if (!isActive()) return;
+        try {
+          report = await api.sessions.redactionReport(id, {
+            aiPii: true,
+            signal: run.controller.signal,
+          });
+          break;
+        } catch (e) {
+          if (!isActive()) return;
+          if (e instanceof ApiError && e.status === 408) break;
+          if (attempt === 0) await new Promise((r) => setTimeout(r, 800));
+        }
+      }
+      if (!isActive()) return;
+      if (!report) {
+        toast('AI review retry failed', 'error');
+        setRedactedSessions((prev) => ({
+          ...prev,
+          [id]: { ...(prev[id] || { messages: [] }), loading: false },
+        }));
+        return;
+      }
+      const msgs: RedactedReviewMessage[] = (report.redacted_session.messages || []).map((m) => ({
+        role: m.role,
+        content: m.content || '',
+        thinking: m.thinking,
+        tool_uses: m.tool_uses,
+        timestamp: m.timestamp,
+      }));
+      const buckets = emptyBuckets();
+      for (const entry of report.redaction_log || []) buckets[bucketOf(entry.type)] += 1;
+      const trufflehogHits = (report.redaction_log || [])
+        .filter((entry) => entry.type && entry.type.startsWith('trufflehog'))
+        .length;
+      if (!isActive()) return;
+      setRedactedSessions((prev) => ({
+        ...prev,
+        [id]: {
+          messages: msgs, loading: false,
+          redactionCount: report.redaction_count,
+          aiPiiFindings: report.ai_pii_findings || [],
+          aiCoverage: report.ai_coverage || 'rules_only',
+          buckets,
+          trufflehogHits,
+        },
+      }));
+    } catch {
+      if (isActive()) {
+        toast('AI review retry failed', 'error');
+        setRedactedSessions((prev) => ({
+          ...prev,
+          [id]: { ...(prev[id] || { messages: [] }), loading: false },
+        }));
+      }
+    } finally {
+      finishRedactionRetry(redactionRetryRef.current, id, run);
     }
-    const msgs: RedactedReviewMessage[] = (report.redacted_session.messages || []).map((m) => ({
-      role: m.role,
-      content: m.content || '',
-      thinking: m.thinking,
-      tool_uses: m.tool_uses,
-      timestamp: m.timestamp,
-    }));
-    const buckets = emptyBuckets();
-    for (const entry of report.redaction_log || []) buckets[bucketOf(entry.type)] += 1;
-    const trufflehogHits = (report.redaction_log || [])
-      .filter((entry) => entry.type && entry.type.startsWith('trufflehog'))
-      .length;
-    setRedactedSessions((prev) => ({
-      ...prev,
-      [id]: {
-        messages: msgs, loading: false,
-        redactionCount: report.redaction_count,
-        aiPiiFindings: report.ai_pii_findings || [],
-        aiCoverage: report.ai_coverage || 'rules_only',
-        buckets,
-        trufflehogHits,
-      },
-    }));
   };
 
   const toggleReviewExpand = (id: string) => {
@@ -797,6 +881,7 @@ export function Share() {
 
   const handleStartPackage = () => {
     if (queuedSessions.length === 0) return;
+    cancelAiRetries();
     setCompletedKeys((prev) => new Set([...prev, 'queue', 'redact', 'review']));
     setActiveStep('package');
     void runPackage();
@@ -1014,7 +1099,10 @@ export function Share() {
         onApproveAllClean={approveAllClean}
         onRemove={removeFromQueue}
         onRetryAi={retryAiReview}
-        onBack={() => setActiveStep('redact')}
+        onBack={() => {
+          cancelAiRetries();
+          setActiveStep('redact');
+        }}
         onPackage={handleStartPackage}
         globalStyles={globalStyles}
         showHelp={showHelp}

--- a/clawjournal/web/frontend/src/views/Share/redactionRun.ts
+++ b/clawjournal/web/frontend/src/views/Share/redactionRun.ts
@@ -6,6 +6,10 @@ export interface RedactionRunSlot {
   current: RedactionRun | null;
 }
 
+export interface RedactionRetrySlot {
+  current: Map<string, RedactionRun>;
+}
+
 export function beginRedactionRun(slot: RedactionRunSlot): RedactionRun | null {
   if (slot.current) return null;
   const run = { controller: new AbortController() };
@@ -25,4 +29,51 @@ export function isRedactionRunActive(slot: RedactionRunSlot, run: RedactionRun):
 
 export function finishRedactionRun(slot: RedactionRunSlot, run: RedactionRun): void {
   if (slot.current === run) slot.current = null;
+}
+
+export function beginRedactionRetry(slot: RedactionRetrySlot, sessionId: string): RedactionRun | null {
+  if (slot.current.has(sessionId)) return null;
+  const run = { controller: new AbortController() };
+  slot.current.set(sessionId, run);
+  return run;
+}
+
+export function cancelRedactionRetry(slot: RedactionRetrySlot, sessionId: string): void {
+  const run = slot.current.get(sessionId);
+  slot.current.delete(sessionId);
+  run?.controller.abort();
+}
+
+export function cancelRedactionRetries(slot: RedactionRetrySlot): void {
+  const runs = [...slot.current.values()];
+  slot.current.clear();
+  runs.forEach((run) => run.controller.abort());
+}
+
+export function isRedactionRetryActive(
+  slot: RedactionRetrySlot,
+  sessionId: string,
+  run: RedactionRun,
+): boolean {
+  return slot.current.get(sessionId) === run && !run.controller.signal.aborted;
+}
+
+export function finishRedactionRetry(
+  slot: RedactionRetrySlot,
+  sessionId: string,
+  run: RedactionRun,
+): void {
+  if (slot.current.get(sessionId) === run) slot.current.delete(sessionId);
+}
+
+export function settlePendingRedactionEntries<T extends { loading: boolean }>(
+  entries: Record<string, T>,
+  sessionIds: readonly string[],
+  failedEntry: T,
+): Record<string, T> {
+  const next = { ...entries };
+  for (const sessionId of sessionIds) {
+    if (!next[sessionId] || next[sessionId].loading) next[sessionId] = failedEntry;
+  }
+  return next;
 }

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -3112,7 +3112,10 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                     # Use AI-only detection (skip redundant rule-based PII scan
                     # since redact_session() already handles regex patterns)
                     findings = review_session_pii_with_agent(
-                        detail, ignore_errors=False, backend="auto",
+                        detail,
+                        ignore_errors=False,
+                        backend="auto",
+                        timeout_seconds=_upload_pii_timeout_seconds(),
                     )
                     ai_coverage = "full"
                     if findings:

--- a/tests/redaction/test_pii.py
+++ b/tests/redaction/test_pii.py
@@ -1,5 +1,6 @@
 import json
 import subprocess
+import time
 
 import pytest
 
@@ -556,3 +557,32 @@ def test_review_session_pii_with_agent_ignores_errors(monkeypatch):
     monkeypatch.setattr("clawjournal.redaction.pii._review_batch", failing_runner)
     findings = review_session_pii_with_agent(session, backend="claude", ignore_errors=True)
     assert findings == []
+
+
+def test_review_session_pii_with_agent_uses_one_deadline_across_batch_waves(monkeypatch):
+    session = {"session_id": "s1", "messages": [{"content": "test"}]}
+    batches = [[("s1", index, "content", "text")] for index in range(3)]
+    calls = []
+
+    monkeypatch.setattr("clawjournal.redaction.pii._split_into_batches", lambda _items: batches)
+
+    def slow_runner(*args, **kwargs):
+        calls.append(kwargs["timeout_seconds"])
+        time.sleep(0.03)
+        return []
+
+    monkeypatch.setattr("clawjournal.redaction.pii._review_batch", slow_runner)
+
+    with pytest.raises(RuntimeError, match="PII review timed out"):
+        review_session_pii_with_agent(
+            session,
+            backend="claude",
+            ignore_errors=False,
+            max_workers=1,
+            timeout_seconds=0.01,
+        )
+
+    # The old implementation submitted all three batches and restarted the
+    # timeout for each worker wave. Once the one request budget expires, no
+    # second or third agent process is launched.
+    assert calls == [1]

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -514,6 +514,29 @@ class TestSessionsAPI:
         assert data["ai_coverage"] == "disabled"
         assert any(entry["type"] == "blocked_domain" for entry in data["redaction_log"])
 
+    def test_redaction_report_ai_review_uses_bounded_configured_timeout(
+        self, server, monkeypatch
+    ):
+        captured = {}
+
+        def fake_review(session, **kwargs):
+            captured["session_id"] = session["session_id"]
+            captured["timeout_seconds"] = kwargs["timeout_seconds"]
+            return []
+
+        monkeypatch.setenv("CLAWJOURNAL_UPLOAD_PII_TIMEOUT_SECONDS", "23")
+        monkeypatch.setattr(
+            "clawjournal.redaction.pii.review_session_pii_with_agent", fake_review
+        )
+
+        status, data = _get(
+            server, "/api/sessions/sess-0/redaction-report?ai_pii=1"
+        )
+
+        assert status == 200
+        assert data["ai_coverage"] == "full"
+        assert captured == {"session_id": "sess-0", "timeout_seconds": 23}
+
     def test_update_session_status(self, server):
         status, data = _post(server, "/api/sessions/sess-0", {"status": "approved"})
         assert status == 200


### PR DESCRIPTION
## Summary

Prevent the Share workflow from remaining on `Redacting...` indefinitely when AI review, a daemon response, or a stale retry wedges.

## Root cause

The browser request had no hard deadline, retry responses could race newer Share state, and multi-batch AI review could start another worker wave after most of the request budget had already elapsed.

## Changes

- Apply `CLAWJOURNAL_UPLOAD_PII_TIMEOUT_SECONDS` to preview AI review
- Enforce one monotonic server budget across every batch in a session review
- Add a 200 second browser failsafe above the 180 second server maximum and cleanup grace
- Stop the current queue run on a hard deadline and settle every queued loading state
- Cancel or ignore stale queue and retry responses after settings, navigation, a newer run, or unmount
- Block duplicate retry clicks and guarantee retry cleanup on malformed responses
- Add server and frontend regression coverage for the timeout and cancellation paths

## Impact

With the default configuration, failed AI preview falls back to rules-only after at most 60 seconds. At the configured maximum, server work is bounded to 180 seconds plus cleanup grace. If the response path itself wedges, the browser clears the queue after 200 seconds instead of showing `Redacting...` forever.

## Validation

- `pytest -q` (2,511 passed, 4 skipped)
- `npm run test:share-queue`
- `npm run build`
- `npx eslint src/api.ts src/views/Share/index.tsx scripts/test-share-queue-state.mjs`
- `git diff --check`
