### PR TITLE
fix(auto-upload): harden Windows credentials and gate rollout UI

### DIFF
--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -87,6 +87,7 @@ TELEMETRY_MAX_BYTES = 512 * 1024
 TELEMETRY_BACKUPS = 2
 SUPPORTED_HOOK_TARGETS = ("claude", "codex")
 HOOK_DB_BUSY_TIMEOUT_MS = 0
+AUTO_UPLOAD_UI_ENV = "CLAWJOURNAL_ENABLE_AUTO_UPLOAD_UI"
 _CONTROL_THREAD_LOCK = threading.Lock()
 
 # V1 supports only sources with both a SessionStart trigger and an audited,
@@ -557,6 +558,25 @@ def _has_successful_manual_receipt(conn: sqlite3.Connection) -> bool:
     )
 
 
+def _auto_upload_ui_visible(
+    config: Mapping[str, Any],
+    enrollment: Mapping[str, Any] | None = None,
+) -> bool:
+    explicitly_enabled = (
+        os.environ.get(AUTO_UPLOAD_UI_ENV) == "1"
+        or config.get("auto_upload_ui_enabled") is True
+    )
+    existing_authority = bool(
+        enrollment
+        and (
+            enrollment.get("mode") != "off"
+            or enrollment.get("server_enrollment_id")
+            or enrollment.get("revocation_pending")
+        )
+    )
+    return explicitly_enabled or existing_authority
+
+
 def _off_status(config: Mapping[str, Any]) -> dict[str, Any]:
     hooks = []
     for target in SUPPORTED_HOOK_TARGETS:
@@ -570,6 +590,7 @@ def _off_status(config: Mapping[str, Any]) -> dict[str, Any]:
         "run_now_allowed": False,
         "overlay": None,
         "pending_submission_state": None,
+        "ui_visible": _auto_upload_ui_visible(config),
         "offer_available": False,
         "scope": {"sources": [], "projects": []},
         "cap": MAX_SESSIONS,
@@ -671,6 +692,7 @@ def status(*, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
             ),
             "overlay": overlay,
             "pending_submission_state": pending_submission_state,
+            "ui_visible": _auto_upload_ui_visible(config, enrollment),
             "offer_available": bool(
                 mode == "off"
                 and successful_manual

--- a/clawjournal/auto_upload_client.py
+++ b/clawjournal/auto_upload_client.py
@@ -72,7 +72,14 @@ def _normalized_origin(
     allow_local_http: bool = False,
     require_exact_origin: bool = False,
 ) -> str:
-    parsed = urlsplit(value)
+    try:
+        parsed = urlsplit(value)
+        parsed_port = parsed.port
+    except ValueError as exc:
+        raise CapabilityError(
+            "invalid_destination",
+            "Recurring upload requires an exact HTTPS destination origin.",
+        ) from exc
     hostname = (parsed.hostname or "").lower()
     scheme = parsed.scheme.lower()
     local = hostname in {"localhost", "127.0.0.1", "::1"}
@@ -94,7 +101,7 @@ def _normalized_origin(
             "invalid_destination",
             "Recurring upload requires an exact HTTPS destination origin.",
         )
-    port = f":{parsed.port}" if parsed.port is not None else ""
+    port = f":{parsed_port}" if parsed_port is not None else ""
     rendered_host = f"[{hostname}]" if ":" in hostname else hostname
     return f"{scheme}://{rendered_host}{port}"
 

--- a/clawjournal/auto_upload_credentials.py
+++ b/clawjournal/auto_upload_credentials.py
@@ -133,41 +133,84 @@ $target = $env:CLAWJOURNAL_ACL_TARGET
 $identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
 $isDirectory = Test-Path -LiteralPath $target -PathType Container
 if ($isDirectory) {
-  $acl = New-Object System.Security.AccessControl.DirectorySecurity
-  $inheritance = [System.Security.AccessControl.InheritanceFlags]'ContainerInherit, ObjectInherit'
+  $grant = "*$($identity.Value):(OI)(CI)F"
 } else {
-  $acl = New-Object System.Security.AccessControl.FileSecurity
-  $inheritance = [System.Security.AccessControl.InheritanceFlags]::None
+  $grant = "*$($identity.Value):F"
 }
-$acl.SetAccessRuleProtection($true, $false)
-$acl.SetOwner($identity)
-$rule = New-Object System.Security.AccessControl.FileSystemAccessRule(
-  $identity,
-  [System.Security.AccessControl.FileSystemRights]::FullControl,
-  $inheritance,
-  [System.Security.AccessControl.PropagationFlags]::None,
-  [System.Security.AccessControl.AccessControlType]::Allow
+& icacls.exe $target /inheritance:r | Out-Null
+if ($LASTEXITCODE -ne 0) {
+  throw "icacls failed with exit code $LASTEXITCODE"
+}
+$existingAcl = Get-Acl -LiteralPath $target
+$otherIdentities = @(
+  $existingAcl.GetAccessRules(
+    $true,
+    $true,
+    [System.Security.Principal.SecurityIdentifier]
+  ) |
+    Where-Object { $_.IdentityReference -ne $identity } |
+    ForEach-Object { $_.IdentityReference.Value } |
+    Sort-Object -Unique
 )
-$acl.AddAccessRule($rule)
-Set-Acl -LiteralPath $target -AclObject $acl
+foreach ($otherIdentity in $otherIdentities) {
+  & icacls.exe $target /remove "*$otherIdentity" | Out-Null
+  if ($LASTEXITCODE -ne 0) {
+    throw "icacls could not remove an existing credential ACL entry"
+  }
+}
+& icacls.exe $target /grant:r $grant | Out-Null
+if ($LASTEXITCODE -ne 0) {
+  throw "icacls failed with exit code $LASTEXITCODE"
+}
+$acl = Get-Acl -LiteralPath $target
+$rules = @($acl.GetAccessRules(
+  $true,
+  $true,
+  [System.Security.Principal.SecurityIdentifier]
+))
+if (-not $acl.AreAccessRulesProtected -or $rules.Count -eq 0) {
+  throw 'credential ACL is not protected or has no access rules'
+}
+$unexpected = @($rules | Where-Object {
+  $_.IdentityReference -ne $identity -or
+  $_.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow
+})
+$fullControl = @($rules | Where-Object {
+  ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -eq
+    [System.Security.AccessControl.FileSystemRights]::FullControl
+})
+if ($unexpected.Count -ne 0 -or $fullControl.Count -eq 0) {
+  throw 'credential ACL does not grant full control exclusively to the current user'
+}
 """
         try:
+            child_env = os.environ.copy()
+            child_env["CLAWJOURNAL_ACL_TARGET"] = str(path)
             completed = subprocess.run(
                 ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script],
                 stdin=subprocess.DEVNULL,
-                stdout=subprocess.DEVNULL,
-                stderr=subprocess.DEVNULL,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                env=child_env,
                 check=False,
                 timeout=15,
-                env={**os.environ, "CLAWJOURNAL_ACL_TARGET": str(path)},
+                text=True,
+                encoding="utf-8",
+                errors="replace",
             )
         except (OSError, subprocess.SubprocessError) as exc:
             raise CredentialStoreError(
                 f"could not establish a current-user-only Windows ACL for {path}"
             ) from exc
         if completed.returncode != 0:
+            detail = (
+                getattr(completed, "stderr", "")
+                or getattr(completed, "stdout", "")
+                or ""
+            ).strip()
+            suffix = f": {detail}" if detail else ""
             raise CredentialStoreError(
-                f"could not establish a current-user-only Windows ACL for {path}"
+                f"could not establish a current-user-only Windows ACL for {path}{suffix}"
             )
         return
     actual = stat.S_IMODE(path.stat().st_mode)

--- a/clawjournal/auto_upload_credentials.py
+++ b/clawjournal/auto_upload_credentials.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 import json
 import os
 import stat
-import subprocess
 import tempfile
 from pathlib import Path
 from typing import Any, Mapping
@@ -59,7 +58,13 @@ def _validate_origin(value: Any, *, field: str) -> str:
     if not isinstance(value, str) or not value.strip():
         raise CredentialStoreError(f"{field} must be a non-empty HTTPS origin")
     candidate = value.strip()
-    parsed = urlsplit(candidate)
+    try:
+        parsed = urlsplit(candidate)
+        parsed_port = parsed.port
+    except ValueError as exc:
+        raise CredentialStoreError(
+            f"{field} must be an exact HTTPS origin, or explicitly enabled loopback HTTP origin"
+        ) from exc
     hostname = (parsed.hostname or "").lower()
     scheme = parsed.scheme.lower()
     local_http = (
@@ -79,7 +84,7 @@ def _validate_origin(value: Any, *, field: str) -> str:
         raise CredentialStoreError(
             f"{field} must be an exact HTTPS origin, or explicitly enabled loopback HTTP origin"
         )
-    port = f":{parsed.port}" if parsed.port is not None else ""
+    port = f":{parsed_port}" if parsed_port is not None else ""
     rendered_host = f"[{hostname}]" if ":" in hostname else hostname
     return f"{scheme}://{rendered_host}{port}"
 
@@ -115,103 +120,277 @@ def _validate_record(record: Mapping[str, Any]) -> dict[str, str | None]:
     return normalized
 
 
+def _set_windows_private_acl(path: Path) -> None:
+    import ctypes
+    from ctypes import wintypes
+
+    token_query = 0x0008
+    token_user_class = 1
+    error_insufficient_buffer = 122
+    acl_revision = 2
+    acl_size_information = 2
+    access_allowed_ace_type = 0
+    object_inherit_ace = 0x01
+    container_inherit_ace = 0x02
+    inherited_ace = 0x10
+    file_all_access = 0x001F01FF
+    se_file_object = 1
+    dacl_security_information = 0x00000004
+    protected_dacl_security_information = 0x80000000
+    se_dacl_protected = 0x1000
+
+    class SidAndAttributes(ctypes.Structure):
+        _fields_ = [("sid", ctypes.c_void_p), ("attributes", wintypes.DWORD)]
+
+    class TokenUser(ctypes.Structure):
+        _fields_ = [("user", SidAndAttributes)]
+
+    class Acl(ctypes.Structure):
+        _fields_ = [
+            ("revision", ctypes.c_ubyte),
+            ("sbz1", ctypes.c_ubyte),
+            ("size", wintypes.WORD),
+            ("ace_count", wintypes.WORD),
+            ("sbz2", wintypes.WORD),
+        ]
+
+    class AceHeader(ctypes.Structure):
+        _fields_ = [
+            ("ace_type", ctypes.c_ubyte),
+            ("ace_flags", ctypes.c_ubyte),
+            ("ace_size", wintypes.WORD),
+        ]
+
+    class AccessAllowedAce(ctypes.Structure):
+        _fields_ = [
+            ("header", AceHeader),
+            ("mask", wintypes.DWORD),
+            ("sid_start", wintypes.DWORD),
+        ]
+
+    class AclSizeInformation(ctypes.Structure):
+        _fields_ = [
+            ("ace_count", wintypes.DWORD),
+            ("acl_bytes_in_use", wintypes.DWORD),
+            ("acl_bytes_free", wintypes.DWORD),
+        ]
+
+    advapi32 = ctypes.WinDLL("advapi32", use_last_error=True)
+    kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+
+    kernel32.GetCurrentProcess.restype = wintypes.HANDLE
+    kernel32.CloseHandle.argtypes = [wintypes.HANDLE]
+    kernel32.CloseHandle.restype = wintypes.BOOL
+    kernel32.LocalFree.argtypes = [ctypes.c_void_p]
+    kernel32.LocalFree.restype = ctypes.c_void_p
+
+    advapi32.OpenProcessToken.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.HANDLE),
+    ]
+    advapi32.OpenProcessToken.restype = wintypes.BOOL
+    advapi32.GetTokenInformation.argtypes = [
+        wintypes.HANDLE,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    advapi32.GetTokenInformation.restype = wintypes.BOOL
+    advapi32.GetLengthSid.argtypes = [ctypes.c_void_p]
+    advapi32.GetLengthSid.restype = wintypes.DWORD
+    advapi32.InitializeAcl.argtypes = [ctypes.c_void_p, wintypes.DWORD, wintypes.DWORD]
+    advapi32.InitializeAcl.restype = wintypes.BOOL
+    advapi32.AddAccessAllowedAceEx.argtypes = [
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+    ]
+    advapi32.AddAccessAllowedAceEx.restype = wintypes.BOOL
+    advapi32.SetNamedSecurityInfoW.argtypes = [
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+    ]
+    advapi32.SetNamedSecurityInfoW.restype = wintypes.DWORD
+    advapi32.GetNamedSecurityInfoW.argtypes = [
+        wintypes.LPWSTR,
+        wintypes.DWORD,
+        wintypes.DWORD,
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_void_p),
+        ctypes.c_void_p,
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    advapi32.GetNamedSecurityInfoW.restype = wintypes.DWORD
+    advapi32.GetSecurityDescriptorControl.argtypes = [
+        ctypes.c_void_p,
+        ctypes.POINTER(wintypes.WORD),
+        ctypes.POINTER(wintypes.DWORD),
+    ]
+    advapi32.GetSecurityDescriptorControl.restype = wintypes.BOOL
+    advapi32.GetAclInformation.argtypes = [
+        ctypes.c_void_p,
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        wintypes.DWORD,
+    ]
+    advapi32.GetAclInformation.restype = wintypes.BOOL
+    advapi32.GetAce.argtypes = [
+        ctypes.c_void_p,
+        wintypes.DWORD,
+        ctypes.POINTER(ctypes.c_void_p),
+    ]
+    advapi32.GetAce.restype = wintypes.BOOL
+    advapi32.EqualSid.argtypes = [ctypes.c_void_p, ctypes.c_void_p]
+    advapi32.EqualSid.restype = wintypes.BOOL
+
+    def raise_last_error(api_name: str) -> None:
+        error = ctypes.get_last_error()
+        raise OSError(error, f"{api_name} failed: {ctypes.FormatError(error).strip()}")
+
+    token = wintypes.HANDLE()
+    if not advapi32.OpenProcessToken(
+        kernel32.GetCurrentProcess(), token_query, ctypes.byref(token)
+    ):
+        raise_last_error("OpenProcessToken")
+    try:
+        required = wintypes.DWORD()
+        ctypes.set_last_error(0)
+        advapi32.GetTokenInformation(
+            token, token_user_class, None, 0, ctypes.byref(required)
+        )
+        if ctypes.get_last_error() != error_insufficient_buffer or required.value == 0:
+            raise_last_error("GetTokenInformation")
+        token_buffer = ctypes.create_string_buffer(required.value)
+        if not advapi32.GetTokenInformation(
+            token,
+            token_user_class,
+            token_buffer,
+            required.value,
+            ctypes.byref(required),
+        ):
+            raise_last_error("GetTokenInformation")
+        current_sid = ctypes.cast(
+            token_buffer, ctypes.POINTER(TokenUser)
+        ).contents.user.sid
+        sid_length = advapi32.GetLengthSid(current_sid)
+        if sid_length == 0:
+            raise_last_error("GetLengthSid")
+
+        acl_size = ctypes.sizeof(Acl) + AccessAllowedAce.sid_start.offset + sid_length
+        acl_buffer = ctypes.create_string_buffer(acl_size)
+        acl_pointer = ctypes.cast(acl_buffer, ctypes.c_void_p)
+        if not advapi32.InitializeAcl(acl_pointer, acl_size, acl_revision):
+            raise_last_error("InitializeAcl")
+        inheritance = object_inherit_ace | container_inherit_ace if path.is_dir() else 0
+        if not advapi32.AddAccessAllowedAceEx(
+            acl_pointer,
+            acl_revision,
+            inheritance,
+            file_all_access,
+            current_sid,
+        ):
+            raise_last_error("AddAccessAllowedAceEx")
+
+        security_information = (
+            dacl_security_information | protected_dacl_security_information
+        )
+        status = advapi32.SetNamedSecurityInfoW(
+            str(path),
+            se_file_object,
+            security_information,
+            None,
+            None,
+            acl_pointer,
+            None,
+        )
+        if status != 0:
+            raise OSError(
+                status,
+                f"SetNamedSecurityInfoW failed: {ctypes.FormatError(status).strip()}",
+            )
+
+        stored_acl = ctypes.c_void_p()
+        descriptor = ctypes.c_void_p()
+        status = advapi32.GetNamedSecurityInfoW(
+            str(path),
+            se_file_object,
+            dacl_security_information,
+            None,
+            None,
+            ctypes.byref(stored_acl),
+            None,
+            ctypes.byref(descriptor),
+        )
+        if status != 0:
+            raise OSError(
+                status,
+                f"GetNamedSecurityInfoW failed: {ctypes.FormatError(status).strip()}",
+            )
+        try:
+            control = wintypes.WORD()
+            revision = wintypes.DWORD()
+            if not advapi32.GetSecurityDescriptorControl(
+                descriptor, ctypes.byref(control), ctypes.byref(revision)
+            ):
+                raise_last_error("GetSecurityDescriptorControl")
+            acl_info = AclSizeInformation()
+            if not advapi32.GetAclInformation(
+                stored_acl,
+                ctypes.byref(acl_info),
+                ctypes.sizeof(acl_info),
+                acl_size_information,
+            ):
+                raise_last_error("GetAclInformation")
+            ace_pointer = ctypes.c_void_p()
+            if acl_info.ace_count != 1 or not advapi32.GetAce(
+                stored_acl, 0, ctypes.byref(ace_pointer)
+            ):
+                raise CredentialStoreError(
+                    "credential ACL does not contain exactly one access rule"
+                )
+            ace = ctypes.cast(
+                ace_pointer, ctypes.POINTER(AccessAllowedAce)
+            ).contents
+            ace_sid = ctypes.c_void_p(
+                ace_pointer.value + AccessAllowedAce.sid_start.offset
+            )
+            if (
+                not control.value & se_dacl_protected
+                or ace.header.ace_type != access_allowed_ace_type
+                or ace.header.ace_flags & inherited_ace
+                or ace.header.ace_flags & (object_inherit_ace | container_inherit_ace)
+                != inheritance
+                or ace.mask != file_all_access
+                or not advapi32.EqualSid(ace_sid, current_sid)
+            ):
+                raise CredentialStoreError(
+                    "credential ACL does not grant full control exclusively to the current user"
+                )
+        finally:
+            if descriptor:
+                kernel32.LocalFree(descriptor)
+    finally:
+        kernel32.CloseHandle(token)
+
+
 def _require_private_mode(path: Path, expected: int) -> None:
     if os.name == "nt":
-        # POSIX mode bits do not establish a Windows credential boundary.
-        # Replace the DACL with one FullControl ACE for the current user and
-        # disable inheritance.  PowerShell/.NET ships with supported Windows
-        # Python versions; any failure blocks enrollment rather than falling
-        # back to a best-effort chmod.
-        # The target path is passed via an environment variable, NOT a
-        # positional argument: `powershell.exe -Command <script> <path>` does
-        # not populate $args (only -File does), so $args[0] would be $null and
-        # every ACL call would fail. Reading $env avoids that and cannot be
-        # command-injected the way string interpolation could.
-        script = r"""
-$ErrorActionPreference = 'Stop'
-$target = $env:CLAWJOURNAL_ACL_TARGET
-$identity = [System.Security.Principal.WindowsIdentity]::GetCurrent().User
-$isDirectory = Test-Path -LiteralPath $target -PathType Container
-if ($isDirectory) {
-  $grant = "*$($identity.Value):(OI)(CI)F"
-} else {
-  $grant = "*$($identity.Value):F"
-}
-& icacls.exe $target /inheritance:r | Out-Null
-if ($LASTEXITCODE -ne 0) {
-  throw "icacls failed with exit code $LASTEXITCODE"
-}
-$existingAcl = Get-Acl -LiteralPath $target
-$otherIdentities = @(
-  $existingAcl.GetAccessRules(
-    $true,
-    $true,
-    [System.Security.Principal.SecurityIdentifier]
-  ) |
-    Where-Object { $_.IdentityReference -ne $identity } |
-    ForEach-Object { $_.IdentityReference.Value } |
-    Sort-Object -Unique
-)
-foreach ($otherIdentity in $otherIdentities) {
-  & icacls.exe $target /remove "*$otherIdentity" | Out-Null
-  if ($LASTEXITCODE -ne 0) {
-    throw "icacls could not remove an existing credential ACL entry"
-  }
-}
-& icacls.exe $target /grant:r $grant | Out-Null
-if ($LASTEXITCODE -ne 0) {
-  throw "icacls failed with exit code $LASTEXITCODE"
-}
-$acl = Get-Acl -LiteralPath $target
-$rules = @($acl.GetAccessRules(
-  $true,
-  $true,
-  [System.Security.Principal.SecurityIdentifier]
-))
-if (-not $acl.AreAccessRulesProtected -or $rules.Count -eq 0) {
-  throw 'credential ACL is not protected or has no access rules'
-}
-$unexpected = @($rules | Where-Object {
-  $_.IdentityReference -ne $identity -or
-  $_.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow
-})
-$fullControl = @($rules | Where-Object {
-  ($_.FileSystemRights -band [System.Security.AccessControl.FileSystemRights]::FullControl) -eq
-    [System.Security.AccessControl.FileSystemRights]::FullControl
-})
-if ($unexpected.Count -ne 0 -or $fullControl.Count -eq 0) {
-  throw 'credential ACL does not grant full control exclusively to the current user'
-}
-"""
         try:
-            child_env = os.environ.copy()
-            child_env["CLAWJOURNAL_ACL_TARGET"] = str(path)
-            completed = subprocess.run(
-                ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command", script],
-                stdin=subprocess.DEVNULL,
-                stdout=subprocess.PIPE,
-                stderr=subprocess.PIPE,
-                env=child_env,
-                check=False,
-                timeout=15,
-                text=True,
-                encoding="utf-8",
-                errors="replace",
-            )
-        except (OSError, subprocess.SubprocessError) as exc:
+            _set_windows_private_acl(path)
+        except (OSError, CredentialStoreError) as exc:
             raise CredentialStoreError(
-                f"could not establish a current-user-only Windows ACL for {path}"
+                f"could not establish a current-user-only Windows ACL for {path}: {exc}"
             ) from exc
-        if completed.returncode != 0:
-            detail = (
-                getattr(completed, "stderr", "")
-                or getattr(completed, "stdout", "")
-                or ""
-            ).strip()
-            suffix = f": {detail}" if detail else ""
-            raise CredentialStoreError(
-                f"could not establish a current-user-only Windows ACL for {path}{suffix}"
-            )
         return
     actual = stat.S_IMODE(path.stat().st_mode)
     if actual != expected:

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -128,6 +128,7 @@ class ClawJournalConfig(TypedDict, total=False):
     benchmark_tab_enabled: bool  # show/hide the Benchmark tab in the workbench UI (default on)
     scoring_warmup_declined: bool  # user declined the background auto-scorer (suppresses prompt + server-side auto-start)
     auto_upload_capability_available: bool  # non-authoritative UI offer cache; Enable revalidates live
+    auto_upload_ui_enabled: bool  # internal rollout flag; default hidden
 
 
 DEFAULT_CONFIG: ClawJournalConfig = {
@@ -137,6 +138,7 @@ DEFAULT_CONFIG: ClawJournalConfig = {
     "redact_strings": [],
     "allowlist_entries": [],
     "benchmark_tab_enabled": True,
+    "auto_upload_ui_enabled": False,
 }
 
 

--- a/clawjournal/scoring/scoring.py
+++ b/clawjournal/scoring/scoring.py
@@ -706,7 +706,7 @@ def load_scoring_rubric() -> str:
     """Load the scoring rubric from the canonical prompt copy."""
     for path in _RUBRIC_SEARCH_PATHS:
         if path.exists():
-            text = path.read_text()
+            text = path.read_text(encoding="utf-8")
             if text.startswith("---"):
                 try:
                     end = text.index("---", 3)
@@ -1693,7 +1693,7 @@ def score_session(
     progress: Callable[[str], None] | None = None,
 ) -> ScoringResult:
     """Score a session: format → judge → store. No aggregation formulas."""
-    from ..workbench.index import BLOBS_DIR, get_session_detail
+    from ..workbench.index import get_session_detail, resolve_blob_path
 
     detail = get_session_detail(conn, session_id)
     if not detail:
@@ -1707,13 +1707,12 @@ def score_session(
 
     messages = detail.get("messages", [])
     blob_path_str = detail.get("blob_path")
-    blob_path = Path(blob_path_str) if isinstance(blob_path_str, str) and blob_path_str else None
-    if blob_path and not blob_path.exists():
-        fallback = BLOBS_DIR / f"{session_id}.json"
-        if fallback.exists():
-            blob_path = fallback
+    blob_path = resolve_blob_path(
+        session_id,
+        blob_path_str if isinstance(blob_path_str, str) else None,
+    )
 
-    if blob_path is None or not blob_path.exists():
+    if blob_path is None:
         raise RuntimeError(
             "Session transcript is unavailable. Re-run `clawjournal scan` to rebuild the index."
         )
@@ -1722,7 +1721,7 @@ def score_session(
     # do not persist a false 1/5 score for broken index state.
     if not messages:
         try:
-            blob_data = json.loads(blob_path.read_text())
+            blob_data = json.loads(blob_path.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as exc:
             raise RuntimeError(
                 "Session transcript is unreadable. Re-run `clawjournal scan` to rebuild the index."

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -393,7 +393,10 @@ export const api = {
     submit_page_url?: string | null;
     maximum_bundle_size?: number | null;
     accepted_manifest_schema_versions?: string[];
-    supported_institution_email_policy?: { domain_suffixes?: string[] } | null;
+    supported_institution_email_policy?: {
+      domain_suffixes?: string[];
+      explicit_collaborators_supported?: boolean;
+    } | null;
     support_contact?: string | null;
     message?: string;
   }> {

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -112,6 +112,7 @@ function normalizeAutoUploadStatus(raw: Partial<AutoUploadStatus>): AutoUploadSt
       || raw.pending_submission_state === 'submitting'
       ? raw.pending_submission_state
       : null,
+    ui_visible: raw.ui_visible === true,
     offer_available: raw.offer_available === true,
     scope: {
       sources: Array.isArray(scope.sources) ? scope.sources : [],

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
@@ -383,4 +383,44 @@ describe('AuthorizationDialog focus and dismissal', () => {
     fireEvent.click(cancel);
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
+
+  it('ignores a stale challenge response from a prior dialog opening', async () => {
+    const enrolled = status({
+      mode: 'enabled',
+      run_now_allowed: true,
+      scope: { sources: ['claude'], projects: ['project-a'] },
+      authorization: { version: 'recurring-v1', text: 'terms' },
+      hooks: [
+        { agent: 'claude', selected: true, configured: true, installed: true, last_observed_at: null },
+      ],
+    });
+    const staleChallenge = deferred<AutoUploadStatus>();
+    const freshChallenge = deferred<AutoUploadStatus>();
+    const staleError = authorizationRequired();
+    const freshError = authorizationRequired();
+    (staleError.body.authorization as Record<string, unknown>).text = 'Stale authorization text';
+    (freshError.body.authorization as Record<string, unknown>).text = 'Fresh authorization text';
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValue(enrolled);
+    vi.spyOn(api.autoUpload, 'enable')
+      .mockReturnValueOnce(staleChallenge.promise)
+      .mockReturnValueOnce(freshChallenge.promise);
+
+    renderControl(<AutoUploadPanel />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Review scope and terms' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Cancel' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Review scope and terms' }));
+
+    await act(async () => {
+      freshChallenge.reject(freshError);
+      await flushPromises();
+    });
+    expect(await screen.findByText('Fresh authorization text')).toBeInTheDocument();
+
+    await act(async () => {
+      staleChallenge.reject(staleError);
+      await flushPromises();
+    });
+    expect(screen.getByText('Fresh authorization text')).toBeInTheDocument();
+    expect(screen.queryByText('Stale authorization text')).not.toBeInTheDocument();
+  });
 });

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
@@ -13,6 +13,7 @@ function status(overrides: Partial<AutoUploadStatus> = {}): AutoUploadStatus {
     run_now_allowed: false,
     overlay: null,
     pending_submission_state: null,
+    ui_visible: true,
     offer_available: false,
     scope: { sources: [], projects: [] },
     cap: 5,
@@ -79,6 +80,18 @@ afterEach(() => {
 });
 
 describe('AutoUploadOffer', () => {
+  it('stays hidden when the internal rollout flag is off', async () => {
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValueOnce(status({
+      ui_visible: false,
+      offer_available: true,
+    }));
+
+    renderControl(<AutoUploadOffer manualReceiptId="receipt-hidden" />);
+    await flushPromises();
+
+    expect(screen.queryByText('Share future traces automatically?')).not.toBeInTheDocument();
+  });
+
   it('requires a manual receipt and server capability, then persists dismissal', async () => {
     const statusSpy = vi.spyOn(api.autoUpload, 'status');
 
@@ -115,6 +128,18 @@ describe('AutoUploadOffer', () => {
     statusSpy.mockResolvedValueOnce(status({ offer_available: true }));
     renderControl(<AutoUploadOffer manualReceiptId="receipt-3" />);
     expect(await screen.findByText('Share future traces automatically?')).toBeInTheDocument();
+  });
+});
+
+describe('AutoUploadPanel visibility', () => {
+  it('renders nothing when the internal rollout flag is off', async () => {
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValueOnce(status({ ui_visible: false }));
+
+    renderControl(<AutoUploadPanel />);
+    await waitFor(() => expect(api.autoUpload.status).toHaveBeenCalledTimes(1));
+
+    expect(screen.queryByRole('heading', { name: 'Automatic uploads' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Review and enable' })).not.toBeInTheDocument();
   });
 });
 

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
@@ -141,6 +141,24 @@ describe('AutoUploadPanel visibility', () => {
     expect(screen.queryByRole('heading', { name: 'Automatic uploads' })).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Review and enable' })).not.toBeInTheDocument();
   });
+
+  it('keeps the error and Retry path when the status fetch fails, so an enrolled user can reach the controls', async () => {
+    vi.spyOn(api.autoUpload, 'status')
+      .mockRejectedValueOnce(new ApiError(500, 'daemon unreachable'))
+      .mockResolvedValueOnce(status({ mode: 'enabled', run_now_allowed: true }));
+
+    renderControl(<AutoUploadPanel />);
+
+    expect(await screen.findByRole('button', { name: 'Retry' })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: 'Automatic uploads' })).toBeInTheDocument();
+    expect(screen.getByText('daemon unreachable')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Retry' }));
+
+    expect(await screen.findByRole('button', { name: 'Pause' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Turn off' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Retry' })).not.toBeInTheDocument();
+  });
 });
 
 describe('AutoUploadPanel authorization', () => {

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
@@ -714,7 +714,7 @@ export function AutoUploadOffer({ manualReceiptId }: { manualReceiptId: string |
     try { window.localStorage.setItem(OFFER_DISMISSED_KEY, manualReceiptId); } catch { /* best effort */ }
   };
 
-  if (!status || dismissed || status.mode !== 'off' || !status.offer_available) return null;
+  if (!status || !status.ui_visible || dismissed || status.mode !== 'off' || !status.offer_available) return null;
 
   return (
     <>
@@ -838,6 +838,8 @@ export function AutoUploadPanel() {
     padding: '16px 20px',
     marginBottom: 14,
   };
+
+  if (!status || !status.ui_visible) return null;
 
   if (!status && !loadError) {
     return <div style={panelStyle}><span style={{ color: colors.gray500, fontSize: 13 }}>Loading automatic-upload status…</span></div>;

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
@@ -189,6 +189,7 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
   const { toast } = useToast();
   const titleId = useId();
   const requestedRef = useRef(false);
+  const challengeRequestRef = useRef(0);
   const dialogRef = useRef<HTMLElement>(null);
   const [agent, setAgent] = useState<AutoUploadAgent>(() => selectedAgent(initialStatus));
   const [challenge, setChallenge] = useState<AutoUploadAuthorizationChallenge | null>(null);
@@ -208,45 +209,66 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
   const [code, setCode] = useState('');
   const [devCode, setDevCode] = useState<string | null>(null);
 
-  const showEmailVerification = useCallback(async (message: string) => {
+  const showEmailVerification = useCallback(async (
+    message: string,
+    isCurrent: () => boolean = () => true,
+  ) => {
+    if (!isCurrent()) return;
     setVerificationRequired(true);
     setTokenValid(false);
     try {
       const status = await api.share.uploadStatus();
+      if (!isCurrent()) return;
       setVerifiedEmail(status.verified_email);
       setPendingEmail(status.pending_email);
       setEmail(status.pending_email || status.verified_email || '');
     } catch {
       // Keep the verification form usable even if the status refresh failed.
     }
-    setError(message);
+    if (isCurrent()) setError(message);
   }, []);
 
   const requestChallenge = useCallback(async (requestedAgent: AutoUploadAgent = agent) => {
+    const requestId = challengeRequestRef.current + 1;
+    challengeRequestRef.current = requestId;
+    const isCurrent = () => challengeRequestRef.current === requestId;
     setLoading(true);
     setError(null);
     setAccepted(false);
+    setChallenge(null);
     try {
       // challenge_only can never enroll by contract, so a success here means
       // the daemon violated that contract; refuse to treat it as enabled.
       await api.autoUpload.enable({ agent: requestedAgent, challenge_only: true });
-      setError('The service did not return the required authorization challenge. Review status before continuing.');
+      if (isCurrent()) {
+        setError('The service did not return the required authorization challenge. Review status before continuing.');
+      }
     } catch (requestError) {
+      if (!isCurrent()) return;
       const next = challengeFromError(requestError);
       if (next) {
         setChallenge(next);
       } else if (requiresEmailVerification(requestError)) {
-        await showEmailVerification('Verify your email before loading the recurring authorization.');
+        await showEmailVerification(
+          'Verify your email before loading the recurring authorization.',
+          isCurrent,
+        );
       } else {
         setError(errorMessage(requestError, 'Could not load recurring authorization.'));
       }
     } finally {
-      setLoading(false);
+      if (isCurrent()) setLoading(false);
     }
   }, [agent, showEmailVerification]);
 
+  const dismissDialog = useCallback(() => {
+    challengeRequestRef.current += 1;
+    onClose();
+  }, [onClose]);
+
   useEffect(() => {
     if (!open) {
+      challengeRequestRef.current += 1;
       requestedRef.current = false;
       setChallenge(null);
       setAccepted(false);
@@ -287,7 +309,7 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         event.stopPropagation();
-        if (!submitting) { event.preventDefault(); onClose(); }
+        if (!submitting) { event.preventDefault(); dismissDialog(); }
         return;
       }
       if (event.key === 'Tab') {
@@ -311,7 +333,7 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
     };
     window.addEventListener('keydown', onKeyDown, true);
     return () => window.removeEventListener('keydown', onKeyDown, true);
-  }, [submitting, onClose, open]);
+  }, [dismissDialog, submitting, open]);
 
   if (!open) return null;
 
@@ -332,7 +354,7 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
       });
       onEnabled(next);
       toast('Automatic upload enabled', 'success');
-      onClose();
+      dismissDialog();
     } catch (enableError) {
       const refreshedChallenge = challengeFromError(enableError);
       if (refreshedChallenge) {
@@ -427,7 +449,7 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
   return (
     <div
       role="presentation"
-      onMouseDown={event => { if (event.target === event.currentTarget && !submitting) onClose(); }}
+      onMouseDown={event => { if (event.target === event.currentTarget && !submitting) dismissDialog(); }}
       style={{
         position: 'fixed', inset: 0, zIndex: 9998, padding: 20,
         display: 'grid', placeItems: 'center', background: 'rgba(27, 26, 23, 0.45)',
@@ -637,7 +659,7 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
         )}
 
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 20 }}>
-          <button disabled={submitting} onClick={onClose} style={{ ...btnSecondary, ...disabledStyle(submitting) }}>
+          <button disabled={submitting} onClick={dismissDialog} style={{ ...btnSecondary, ...disabledStyle(submitting) }}>
             Cancel
           </button>
           {!verificationRequired && (

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
@@ -861,8 +861,6 @@ export function AutoUploadPanel() {
     marginBottom: 14,
   };
 
-  if (!status || !status.ui_visible) return null;
-
   if (!status && !loadError) {
     return <div style={panelStyle}><span style={{ color: colors.gray500, fontSize: 13 }}>Loading automatic-upload status…</span></div>;
   }
@@ -875,6 +873,10 @@ export function AutoUploadPanel() {
       </div>
     );
   }
+
+  // The rollout gate must stay below the error branch: an enrolled user whose
+  // status fetch failed still needs the Retry path to reach Pause/Turn off.
+  if (!status.ui_visible) return null;
 
   const exclusionEntries = Object.entries(status.eligibility.exclusion_counts)
     .filter(([, count]) => count > 0)

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -256,6 +256,7 @@ export interface AutoUploadStatus {
   run_now_allowed: boolean;
   overlay: AutoUploadOverlay;
   pending_submission_state: 'sealed' | 'submitting' | null;
+  ui_visible: boolean;
   offer_available: boolean;
   scope: {
     sources: string[];

--- a/clawjournal/web/frontend/src/views/Share/types.ts
+++ b/clawjournal/web/frontend/src/views/Share/types.ts
@@ -76,7 +76,10 @@ export interface ShareDestination {
   submit_page_url?: string | null;
   maximum_bundle_size?: number | null;
   accepted_manifest_schema_versions?: string[];
-  supported_institution_email_policy?: { domain_suffixes?: string[] } | null;
+  supported_institution_email_policy?: {
+    domain_suffixes?: string[];
+    explicit_collaborators_supported?: boolean;
+  } | null;
   support_contact?: string | null;
   message?: string;
 }

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -1095,9 +1095,11 @@ def _email_domain_allowed(
     capabilities: dict[str, Any] | None = None,
 ) -> bool:
     normalized = _normalize_email(email)
-    if "@" not in normalized:
+    if normalized.count("@") != 1:
         return False
-    domain = normalized.rsplit("@", 1)[1]
+    local_part, domain = normalized.rsplit("@", 1)
+    if not local_part or not domain or any(character.isspace() for character in normalized):
+        return False
     policy = (capabilities or {}).get("supported_institution_email_policy")
     suffixes = _HOSTED_EMAIL_SUFFIXES_DEFAULT
     if isinstance(policy, dict) and isinstance(policy.get("domain_suffixes"), list):
@@ -1109,7 +1111,10 @@ def _email_domain_allowed(
         bare_suffix = normalized_suffix[1:] if normalized_suffix.startswith(".") else normalized_suffix
         if domain == bare_suffix or domain.endswith(f".{bare_suffix}"):
             return True
-    return False
+    return bool(
+        isinstance(policy, dict)
+        and policy.get("explicit_collaborators_supported") is True
+    )
 
 
 def _expiry_timestamp(value: Any) -> float | None:
@@ -1153,11 +1158,18 @@ def _validated_hosted_share_url() -> tuple[str | None, str]:
     """Return a configured hosted share URL, or a user-facing disabled reason."""
     if not _HOSTED_SHARE_URL:
         return None, "Hosted submission is not configured for this install."
-    parsed = urlparse(_HOSTED_SHARE_URL)
-    is_https = parsed.scheme == "https" and bool(parsed.netloc)
+    try:
+        parsed = urlparse(_HOSTED_SHARE_URL)
+        parsed.port
+    except ValueError:
+        return None, "CLAWJOURNAL_SHARE_URL must be a valid HTTPS URL, or localhost."
+    hostname = (parsed.hostname or "").lower()
+    has_credentials = parsed.username is not None or parsed.password is not None
+    is_https = parsed.scheme == "https" and bool(hostname) and not has_credentials
     is_local_dev = (
         parsed.scheme == "http"
-        and parsed.hostname in {"localhost", "127.0.0.1", "::1"}
+        and hostname in {"localhost", "127.0.0.1", "::1"}
+        and not has_credentials
     )
     if is_https or is_local_dev:
         return _HOSTED_SHARE_URL, "Hosted submission is configured for browser zip upload."

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -406,14 +406,63 @@ def _legacy_content_revision(session_id: str) -> str:
     return f"legacy:{digest}"
 
 
+_WINDOWS_RESERVED_BLOB_NAMES = {
+    "CON",
+    "PRN",
+    "AUX",
+    "NUL",
+    *(f"COM{index}" for index in range(1, 10)),
+    *(f"LPT{index}" for index in range(1, 10)),
+}
+_HASHED_BLOB_PREFIX = "session-sha256-"
+
+
+def _blob_storage_path(session_id: str) -> Path:
+    """Return a cross-platform-safe canonical path for one session blob."""
+
+    basename = session_id.split(".", 1)[0].upper()
+    utf8_length = len(session_id.encode("utf-8"))
+    utf16_length = len(session_id.encode("utf-16-le")) // 2
+    safe_component = bool(session_id) and not any(
+        ord(character) < 32 or character in '<>:"/\\|?*'
+        for character in session_id
+    )
+    if (
+        safe_component
+        and not session_id.startswith(_HASHED_BLOB_PREFIX)
+        and not session_id.endswith((" ", "."))
+        and basename not in _WINDOWS_RESERVED_BLOB_NAMES
+        and utf8_length <= 200
+        and utf16_length <= 200
+    ):
+        filename = f"{session_id}.json"
+    else:
+        digest = hashlib.sha256(session_id.encode("utf-8")).hexdigest()
+        filename = f"{_HASHED_BLOB_PREFIX}{digest}.json"
+    return BLOBS_DIR / filename
+
+
 def _blob_candidate_paths(session_id: str, blob_path: str | None) -> list[Path]:
     candidates: list[Path] = []
     if blob_path:
         candidates.append(Path(blob_path))
-    canonical = BLOBS_DIR / f"{session_id}.json"
+    canonical = _blob_storage_path(session_id)
     if canonical not in candidates:
         candidates.append(canonical)
+    if session_id and "/" not in session_id and "\\" not in session_id:
+        legacy = BLOBS_DIR / f"{session_id}.json"
+        if legacy not in candidates:
+            candidates.append(legacy)
     return candidates
+
+
+def resolve_blob_path(session_id: str, blob_path: str | None = None) -> Path | None:
+    """Resolve the stored, canonical, or safe legacy blob path."""
+
+    for candidate in _blob_candidate_paths(session_id, blob_path):
+        if candidate.is_file():
+            return candidate
+    return None
 
 
 def _blob_present_for_revision(session_id: str, blob_path: str | None) -> bool:
@@ -426,7 +475,7 @@ def _blob_present_for_revision(session_id: str, blob_path: str | None) -> bool:
     validates the blob before any egress, so a present-but-corrupt blob is
     still caught there rather than crossing the machine boundary.
     """
-    return any(path.is_file() for path in _blob_candidate_paths(session_id, blob_path))
+    return resolve_blob_path(session_id, blob_path) is not None
 
 
 def _read_blob_for_revision(
@@ -436,7 +485,7 @@ def _read_blob_for_revision(
     """Load a migration-time blob, tolerating stale stored blob paths."""
     for candidate in _blob_candidate_paths(session_id, blob_path):
         try:
-            with open(candidate) as f:
+            with open(candidate, encoding="utf-8") as f:
                 blob = json.load(f)
             if isinstance(blob, dict):
                 return blob
@@ -1197,17 +1246,18 @@ def _derive_session_key_from_source(
     """Best-effort `event_sessions.session_key` derivation from workbench provenance."""
     if not isinstance(source, str) or not isinstance(raw_source_path, str):
         return None
-    if not raw_source_path.strip():
+    normalized_source_path = raw_source_path.strip()
+    if not normalized_source_path:
         return None
 
-    path = Path(raw_source_path)
     if source == "codex":
-        return f"codex:{path}"
+        return f"codex:{normalized_source_path}"
     if source == "openclaw":
-        return f"openclaw:{path}"
+        return f"openclaw:{normalized_source_path}"
     if source != "claude":
         return None
 
+    path = Path(normalized_source_path)
     if ".claude" in path.parts and path.suffix == ".jsonl":
         la_key = _derive_local_agent_claude_session_key(path)
         if la_key is not None:
@@ -2009,8 +2059,8 @@ def _generate_display_title(session: dict[str, Any]) -> str:
 def _write_blob(session_id: str, session: dict[str, Any]) -> Path:
     """Write full session JSON to blob storage. Returns the blob file path."""
     BLOBS_DIR.mkdir(parents=True, exist_ok=True)
-    blob_path = BLOBS_DIR / f"{session_id}.json"
-    with open(blob_path, "w") as f:
+    blob_path = _blob_storage_path(session_id)
+    with open(blob_path, "w", encoding="utf-8") as f:
         json.dump(session, f, default=str)
     return blob_path
 
@@ -2026,16 +2076,10 @@ def read_blob(
     need the already-anonymized blob text to re-scan or re-apply
     without re-parsing from the source.
     """
-    blob_path = BLOBS_DIR / f"{session_id}.json"
-    if not blob_path.exists():
-        return None
-    try:
-        with open(blob_path) as f:
-            return json.load(f)
-    except (OSError, json.JSONDecodeError):
-        if log_errors:
-            logger.warning("Could not read blob for session %s", session_id)
-        return None
+    blob = _read_blob_for_revision(session_id, None)
+    if blob is None and log_errors:
+        logger.warning("Could not read blob for session %s", session_id)
+    return blob
 
 
 def _resolve_estimated_cost(
@@ -2116,8 +2160,8 @@ def upsert_sessions(
     """Index parsed sessions into the database.
 
     Takes parsed session dicts (output of parser.parse_project_sessions).
-    Stores metadata in sessions table, writes full session JSON to
-    BLOBS_DIR/{session_id}.json, and updates FTS index.
+    Stores metadata in sessions table, writes full session JSON to a
+    cross-platform-safe path under BLOBS_DIR, and updates FTS index.
 
     Returns the count of new sessions inserted (sessions that did not
     previously exist in the index). When ``stats`` is provided, it is filled
@@ -2203,7 +2247,7 @@ def upsert_sessions(
             blob_path = (
                 Path(stored_blob_path)
                 if stored_blob_path
-                else BLOBS_DIR / f"{session_id}.json"
+                else _blob_storage_path(session_id)
             )
             stored_blob = _read_blob_for_revision(session_id, str(blob_path))
             metadata_updated = (
@@ -2712,22 +2756,8 @@ def get_session_detail(conn: sqlite3.Connection, session_id: str) -> dict[str, A
     result = dict(row)
 
     # Load messages from blob
-    blob_path_str = result.get("blob_path")
-    blob_path = Path(blob_path_str) if blob_path_str else None
-    # Fallback: if stored path is stale, try the canonical location
-    if blob_path and not blob_path.exists():
-        fallback = BLOBS_DIR / f"{session_id}.json"
-        if fallback.exists():
-            blob_path = fallback
-    if blob_path and blob_path.exists():
-        try:
-            with open(blob_path) as f:
-                blob_data = json.load(f)
-            result["messages"] = blob_data.get("messages", [])
-        except (json.JSONDecodeError, OSError):
-            result["messages"] = []
-    else:
-        result["messages"] = []
+    blob_data = _read_blob_for_revision(session_id, result.get("blob_path"))
+    result["messages"] = blob_data.get("messages", []) if blob_data else []
 
     # Parse JSON fields
     for field in (

--- a/tests/scoring/test_scoring.py
+++ b/tests/scoring/test_scoring.py
@@ -758,7 +758,9 @@ class TestBackendSelection:
         captured = {}
 
         def fake_run(*, cwd, **kw):
-            captured["session_payload"] = json.loads((cwd / "session.json").read_text())
+            captured["session_payload"] = json.loads(
+                (cwd / "session.json").read_text(encoding="utf-8")
+            )
             scoring = {
                 "substance": 4,
                 **_failure_fields(ai_quality_score=4),

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -344,6 +344,31 @@ def test_status_is_read_only_without_an_install(
     assert not isolated_auto_upload["install"].exists()
 
 
+def test_auto_upload_ui_is_hidden_unless_internal_rollout_is_enabled(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    monkeypatch.delenv(auto.AUTO_UPLOAD_UI_ENV, raising=False)
+    assert auto.status()["ui_visible"] is False
+
+    monkeypatch.setenv(auto.AUTO_UPLOAD_UI_ENV, "1")
+    assert auto.status()["ui_visible"] is True
+
+
+def test_existing_auto_upload_authority_keeps_controls_visible(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    monkeypatch.delenv(auto.AUTO_UPLOAD_UI_ENV, raising=False)
+    config = _save_scope_config()
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    _save_enabled_enrollment(conn, config)
+    conn.close()
+
+    assert auto.status()["ui_visible"] is True
+
+
 @pytest.mark.parametrize("receipt_kind", ["missing", "auto_weekly"])
 def test_enable_requires_a_successful_hosted_manual_receipt_before_network(
     isolated_auto_upload,

--- a/tests/test_auto_upload_client.py
+++ b/tests/test_auto_upload_client.py
@@ -51,6 +51,16 @@ def test_capabilities_reject_cross_origin_endpoint():
         )
 
 
+def test_capabilities_reject_malformed_origin_port_with_typed_error():
+    with pytest.raises(client.CapabilityError) as exc_info:
+        client.validate_capabilities(
+            _caps(),
+            origin="https://data.rayward.ai:not-a-port",
+        )
+
+    assert exc_info.value.code == "invalid_destination"
+
+
 @pytest.mark.parametrize(
     "origin",
     (

--- a/tests/test_auto_upload_credentials.py
+++ b/tests/test_auto_upload_credentials.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import json
 import os
 import stat
-import subprocess
 
 import pytest
 
@@ -68,6 +67,13 @@ def test_remove_active_token_keeps_only_recovery_authority(isolated_store):
 def test_invalid_origin_and_unknown_fields_fail_loudly(isolated_store):
     with pytest.raises(store.CredentialStoreError, match="exact HTTPS origin"):
         store.write_credentials(_record(api_origin="http://data.rayward.ai/api"))
+    with pytest.raises(store.CredentialStoreError, match="exact HTTPS origin"):
+        store.write_credentials(
+            _record(
+                issuer="https://data.rayward.ai:not-a-port",
+                api_origin="https://data.rayward.ai:not-a-port",
+            )
+        )
     with pytest.raises(store.CredentialStoreError, match="unsupported credential fields"):
         store.write_credentials(_record(manual_upload_token="must-not-be-here"))
     with pytest.raises(store.CredentialStoreError, match="same pinned origin"):
@@ -152,55 +158,31 @@ def test_insecure_existing_file_is_rejected(isolated_store):
         store.load_credentials()
 
 
-def test_windows_acl_passes_target_via_env_not_positional(tmp_path, monkeypatch):
-    # Create the target before patching os.name — patching it to "nt" makes
-    # pathlib build a WindowsPath, which cannot instantiate on POSIX. The nt
-    # branch of _require_private_mode itself constructs no Path, so calling it
-    # directly exercises the ACL invocation safely.
-    target = tmp_path / "credentials;$(whoami)'"
+def test_windows_acl_uses_native_backend(tmp_path, monkeypatch):
+    target = tmp_path / "credentials"
     target.mkdir()
     calls = []
 
-    class _Done:
-        returncode = 0
-
-    def fake_run(argv, **kwargs):
-        calls.append({"argv": list(argv), "env": kwargs.get("env")})
-        return _Done()
-
-    monkeypatch.setattr(store.subprocess, "run", fake_run)
+    monkeypatch.setattr(store, "_set_windows_private_acl", calls.append)
     monkeypatch.setattr(store.os, "name", "nt")
 
     store._require_private_mode(target, 0o700)
 
-    assert len(calls) == 1
-    argv = calls[0]["argv"]
-    # powershell.exe -NoProfile -NonInteractive -Command <script> : the path
-    # must NOT be a trailing positional (that never populates $args).
-    assert argv[:4] == ["powershell.exe", "-NoProfile", "-NonInteractive", "-Command"]
-    assert len(argv) == 5
-    assert "$env:CLAWJOURNAL_ACL_TARGET" in argv[4]
-    assert "$args" not in argv[4]
-    assert all(str(target) not in arg for arg in argv)
-    assert calls[0]["env"]["CLAWJOURNAL_ACL_TARGET"] == str(target)
+    assert calls == [target]
 
 
-@pytest.mark.parametrize("failure", ("nonzero", "launch-error", "timeout"))
+@pytest.mark.parametrize(
+    "failure",
+    (OSError("API unavailable"), store.CredentialStoreError("invalid ACL")),
+)
 def test_windows_acl_failure_is_fail_closed(tmp_path, monkeypatch, failure):
     target = tmp_path / "credentials"
     target.mkdir()
 
-    class _Failed:
-        returncode = 1
+    def fail(_path):
+        raise failure
 
-    def fake_run(_argv, **_kwargs):
-        if failure == "launch-error":
-            raise OSError("PowerShell unavailable")
-        if failure == "timeout":
-            raise subprocess.TimeoutExpired("powershell.exe", 15)
-        return _Failed()
-
-    monkeypatch.setattr(store.subprocess, "run", fake_run)
+    monkeypatch.setattr(store, "_set_windows_private_acl", fail)
     monkeypatch.setattr(store.os, "name", "nt")
 
     with pytest.raises(

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -1904,6 +1904,25 @@ class TestShareDestinationAPI:
         assert data["configured"] is False
         assert data["share_page_url"] is None
 
+    @pytest.mark.parametrize(
+        "share_url",
+        (
+            "https://data.rayward.ai:not-a-port/share",
+            "https://user:password@data.rayward.ai/share",
+            "https://[invalid/share",
+        ),
+    )
+    def test_malformed_or_credentialed_share_destination_is_disabled(
+        self, monkeypatch, share_url
+    ):
+        from clawjournal.workbench import daemon
+
+        monkeypatch.setattr(daemon, "_HOSTED_SHARE_URL", share_url)
+
+        configured_url, _message = daemon._validated_hosted_share_url()
+
+        assert configured_url is None
+
     def test_ipv6_loopback_share_destination_is_allowed(self, monkeypatch):
         from clawjournal.workbench import daemon
 
@@ -3229,6 +3248,43 @@ class TestVerifyEmailAPI:
         with patch("clawjournal.workbench.daemon.urllib.request.urlopen", side_effect=mock_urlopen):
             with pytest.raises(ValueError):
                 request_email_verification("someone@gmail.com")
+
+    def test_request_verification_defers_explicit_collaborator_check_to_host(self, monkeypatch):
+        from clawjournal.workbench.daemon import request_email_verification
+
+        saved = {}
+        capabilities = {
+            "supported_institution_email_policy": {
+                "domain_suffixes": [".edu", "rayward.ai"],
+                "explicit_collaborators_supported": True,
+            },
+        }
+        monkeypatch.setattr("clawjournal.workbench.daemon._HOSTED_SHARE_URL", "https://hosted.example.test/share")
+        monkeypatch.setattr("clawjournal.workbench.daemon._hosted_capabilities_cache", None)
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {})
+        monkeypatch.setattr("clawjournal.workbench.daemon.save_config", lambda config: saved.update(config))
+
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(capabilities=capabilities),
+        ):
+            result = request_email_verification("Collaborator@Gmail.com")
+
+        assert result["verification_id"] == "verify-123"
+        assert saved["pending_verification_email"] == "collaborator@gmail.com"
+
+    @pytest.mark.parametrize("email", ["@gmail.com", "collaborator@", "two@@gmail.com", "first last@gmail.com"])
+    def test_explicit_collaborator_policy_still_rejects_malformed_email(self, email):
+        from clawjournal.workbench.daemon import _email_domain_allowed
+
+        capabilities = {
+            "supported_institution_email_policy": {
+                "domain_suffixes": [".edu"],
+                "explicit_collaborators_supported": True,
+            },
+        }
+
+        assert _email_domain_allowed(email, capabilities) is False
 
     def test_request_verification_clears_stale_token_on_email_switch(self, monkeypatch):
         """Requesting a code for a different email must drop the previously

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -2,6 +2,7 @@
 
 import json
 import sqlite3
+from pathlib import Path
 
 import pytest
 
@@ -85,6 +86,26 @@ class TestUpsertSessions:
         ]
         new_count = upsert_sessions(index_conn, sessions)
         assert new_count == 2
+
+    @pytest.mark.parametrize(
+        "session_id",
+        ("claude-science:org-1:frame-1", "../outside-the-blob-directory"),
+    )
+    def test_unsafe_session_ids_use_safe_blob_filenames(
+        self, index_conn, tmp_path, session_id
+    ):
+        assert upsert_sessions(index_conn, [_make_session(session_id)]) == 1
+
+        row = index_conn.execute(
+            "SELECT blob_path FROM sessions WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        blob_path = Path(row["blob_path"])
+
+        assert blob_path.parent == tmp_path / "blobs"
+        assert blob_path.name.startswith("session-")
+        assert get_session_detail(index_conn, session_id)["messages"]
+        assert not (tmp_path / "outside-the-blob-directory.json").exists()
 
     @pytest.mark.parametrize("status", ["approved", "blocked"])
     def test_upsert_preserves_review_status(self, index_conn, status):


### PR DESCRIPTION
## Summary

This PR prepares recurring automatic uploads for a limited rollout.

It:

- gates the Automatic Upload settings UI behind `CLAWJOURNAL_ENABLE_AUTO_UPLOAD_UI=1`
- keeps the CLI and local API available for internal testing
- keeps the controls visible for already-enrolled users so they can pause or revoke access
- fixes Windows credential-directory ACL handling
- preserves the existing capped, future-only recurring-upload behavior

## Rollout behavior

For a new user, the Automatic Upload UI is hidden by default.

Internal testers can enable it before starting the workbench:

```powershell
$env:CLAWJOURNAL_ENABLE_AUTO_UPLOAD_UI="1"
clawjournal serve
```

Removing the variable hides the UI again for users who are not enrolled:

```powershell
Remove-Item Env:CLAWJOURNAL_ENABLE_AUTO_UPLOAD_UI -ErrorAction SilentlyContinue
clawjournal serve
```

Users with an active, paused, or revocation-pending enrollment continue to see the controls even without the rollout flag. This ensures that hiding the enrollment entry point never prevents an existing participant from pausing or revoking authorization.

## Local end-to-end validation

I tested the complete client-to-server recurring-upload workflow against a locally deployed `clawjournal-share` service backed by PostgreSQL and filesystem bundle storage.

### Environment

- Windows PowerShell
- Python virtual environment with the client installed in editable mode
- Codex CLI
- Docker Compose
- Local `clawjournal-share` application
- Local PostgreSQL
- Local bundle storage mounted at `/var/clawjournal/bundles`
- Hosted-share origin: `http://localhost:8080`
- Workbench origin: `http://localhost:8384`

The local-only recurring-upload HTTP exception was explicitly enabled:

```powershell
$env:CLAWJOURNAL_SHARE_URL="http://localhost:8080/share"
$env:CLAWJOURNAL_ALLOW_INSECURE_LOOPBACK_RECURRING="1"
$env:CLAWJOURNAL_ENABLE_AUTO_UPLOAD_UI="1"
$env:NO_PROXY="localhost,127.0.0.1,::1"
```

Production HTTPS validation remains unchanged.

### Server startup

I started a clean local service stack with:

```powershell
docker compose -p clawjournal-v1test up --build -d
docker compose -p clawjournal-v1test ps
```

I verified the hosted capability document:

```powershell
curl.exe --noproxy "*" \
  http://localhost:8080/.well-known/clawjournal-share.json
```

The service reported:

- `recurring_upload_api_version: 1`
- recurring enrollment open
- recurring submissions open
- maximum five recurring sessions
- exact artifact idempotency enabled
- duplicate revision enforcement enabled

### Manual-share prerequisite

I completed a normal hosted manual share through the existing Share workflow.

The server accepted the bundle and returned a hosted receipt. This established the manual-share prerequisite before recurring enrollment was offered.

### Enrollment flow

From Settings, I:

1. opened **Review and enable**
2. selected Codex as the agent source
3. reviewed the exact source and project snapshot
4. reviewed the recurring authorization and retention text
5. completed email verification
6. accepted the authorization checkbox
7. enabled automatic uploads

The resulting client state reported:

```json
{
  "mode": "enabled",
  "health": "ready",
  "overlay": null,
  "authorization": {
    "version": "consent-v1"
  },
  "retention": {
    "version": "retention-v1"
  },
  "scope": {
    "sources": ["codex"]
  }
}
```

The UI displayed:

- Automatic Uploads: On
- Codex hook: configured
- a future-only enrollment cutoff
- a seven-day cadence
- a five-trace per-cycle cap
- the next scheduled due time

### Future-only session test

After enrollment, I created a new persisted Codex session:

```powershell
codex exec \
  --model gpt-5.4-mini \
  -c 'model_reasoning_effort="low"' \
  "Inspect README.md and return one short improvement suggestion."
```

I did not use `--ephemeral`, so the session was saved and available to ClawJournal.

A refreshed candidate preview correctly separated:

- sessions completed before enrollment
- sessions outside the enrolled source
- newly completed append-only sessions that had not reached the 24-hour stability period

### Immediate local cycle test

The production behavior requires an append-only Codex trace to remain unchanged for 24 hours.

To test the rest of the workflow without waiting 24 hours, I changed `AUTO_UPLOAD_STABILITY_HOURS` to zero only inside a temporary Python process:

```powershell
@'
import json
from clawjournal.workbench import index

index.AUTO_UPLOAD_STABILITY_HOURS = 0

from clawjournal.auto_upload import run_cycle

result = run_cycle(force=True)
print(json.dumps(result, ensure_ascii=False, indent=2))
'@ | python -
```

This bypassed only the local stability delay. Candidate selection, redaction, secret scanning, artifact construction, authorization checks, upload, persistence, and receipt handling still used the real implementation.

The cycle returned:

```json
{
  "ok": true,
  "code": "uploaded",
  "count": 1,
  "receipt_reference": "cj_ly4PvU2h_JuMEv3-VKxXXWOHqNvCuJNK",
  "client_submission_id": "637d397e-4dfd-4744-ace0-47784b7b9ae3",
  "artifact_sha256": "a698804372e73f57fe2b8c8011989369683f771734731c1c0ef51d4ab6baa5f5",
  "deferred_by_size": 0
}
```

### Client-state verification

After upload, `clawjournal auto-upload status --json` reported:

- `mode: enabled`
- `health: ready`
- `overlay: null`
- `last_result.code: uploaded`
- `last_result.count: 1`
- the same receipt reference returned by the server
- a new `next_due_at` seven days later

This confirms the successful cycle advanced the recurring schedule.

### PostgreSQL verification

I queried the recurring submission table:

```sql
SELECT
    client_submission_id,
    receipt_id,
    status,
    artifact_hash,
    object_path,
    created_at
FROM recurring_upload_submissions
ORDER BY created_at DESC
LIMIT 5;
```

The server stored:

- the expected client submission ID
- the expected receipt ID
- status `received`
- the expected artifact SHA-256
- a ZIP path under `/var/clawjournal/bundles`
- the upload timestamp

The stored artifact hash exactly matched the client result:

```text
a698804372e73f57fe2b8c8011989369683f771734731c1c0ef51d4ab6baa5f5
```

### Receipt verification

I queried the hosted receipt endpoint:

```powershell
Invoke-RestMethod \
  http://localhost:8080/api/receipts/cj_ly4PvU2h_JuMEv3-VKxXXWOHqNvCuJNK |
  ConvertTo-Json -Depth 5
```

The receipt reported:

- status `accepted`
- one accepted session
- `consent-v1`
- `retention-v1`
- the same ZIP hash as the client and PostgreSQL
- nine redactions
- no deduplication on the first submission

Redactions included:

- private URLs
- project names
- username data

### Storage verification

I verified that the ZIP existed in the server container:

```powershell
docker compose -p clawjournal-v1test exec app sh -lc \
  "find /var/clawjournal/bundles -type f -name '*.zip' -ls"
```

The uploaded artifact was stored at:

```text
/var/clawjournal/bundles/2026-07-19/cj_ly4PvU2h_JuMEv3-VKxXXWOHqNvCuJNK.zip
```

## Windows ACL validation

I also exercised recurring credential persistence on Windows.

The credential store successfully created and accessed:

```text
%USERPROFILE%\.clawjournal\credentials\auto_upload.json
```

The updated ACL handling allows the current Windows user to store recurring credentials while continuing to reject credential directories that cannot be secured to the current user.

This fixes the previous failure:

```text
could not establish a current-user-only Windows ACL
```

## UI-gating validation

I tested the hidden rollout behavior with a clean temporary user profile.

Without the rollout variable:

```powershell
Remove-Item Env:CLAWJOURNAL_ENABLE_AUTO_UPLOAD_UI -ErrorAction SilentlyContinue
clawjournal auto-upload status --json
```

The client returned:

```json
{
  "mode": "off",
  "ui_visible": false
}
```

The Automatic Upload panel was absent from Settings.

With the rollout variable enabled, the panel and enrollment workflow became available.

I also confirmed that an existing enabled enrollment remains visible after removing the rollout variable, preserving access to Preview, Run now, Pause, Review scope and terms, and Turn off.

## Automated validation

The focused client test suites cover:

- recurring enrollment state transitions
- Windows credential storage and ACL validation
- automatic-upload UI visibility rules
- visibility for existing enrollments
- hidden state for new users without the rollout flag
- authorization and retention challenge handling
- pause, resume, disable, and revocation states
- candidate selection and capped cycles
- submission and receipt persistence

## Remaining scheduling note

The real candidate-selection, artifact, upload, database, storage, and receipt path was tested end to end.

The seven-day wait was not observed in real time. For the end-to-end test, only the 24-hour append-only stability delay was overridden in-process. The successful cycle correctly persisted the next due time seven days later.

The Codex SessionStart hook was installed and reported as configured. The upload cycle itself was validated directly with `run_cycle(force=True)`; natural execution after the seven-day due time remains a scheduling observation rather than a blocking functional gap.


## Additional bug fixes

- Fixed Windows credential-store ACL operations hanging or timing out because each credential read/write launched multiple PowerShell processes. ACL setup now uses native Windows security APIs while preserving current-user-only access and fail-closed verification.
- Fixed recurring-upload authorization accepting stale responses after the dialog was closed and reopened, which could display outdated terms or interfere with a newer enrollment request.
- Fixed explicit collaborator emails being rejected client-side when they did not match an academic domain. When the hosted service advertises collaborator support, final allowlist validation is now delegated to the server.
- Fixed malformed destination URLs, invalid ports, credential-bearing URLs, and malformed IPv6 addresses escaping validation or causing raw exceptions later in the upload flow.
- Fixed session IDs containing Windows-invalid filename characters, reserved device names, path separators, or excessive lengths preventing indexing and automatic-upload eligibility. Unsafe IDs now use deterministic SHA-256 blob filenames.
- Fixed path-traversal risk from using raw session IDs as blob filenames while retaining compatibility with existing safe blob paths.
- Fixed Codex and OpenClaw session keys changing between Windows and POSIX because source paths were normalized using platform-specific `Path` behavior.
- Fixed scoring rubric and session blob reads relying on the Windows GBK default encoding instead of explicit UTF-8.

## Additional validation

- `146 passed, 1 skipped` — recurring-upload client, credentials, hooks, CLI, runner, and persistence tests.
- `243 passed` — workbench index and daemon tests.
- `70 passed` — scoring tests.
- `13 passed` — recurring-upload frontend tests.
- Production frontend TypeScript/Vite build completed successfully.
- `git diff --check` completed without errors.