### PR TITLE
fix(auto-upload): migrate legacy session hooks

### DIFF
--- a/clawjournal/agent_hooks.py
+++ b/clawjournal/agent_hooks.py
@@ -161,13 +161,23 @@ def _handler_for(client: AgentName) -> dict[str, Any]:
     return handler
 
 
-def _handler_is_ours(handler: Any) -> bool:
+def _handler_is_current(handler: Any) -> bool:
     if not isinstance(handler, dict) or handler.get("type") != "command":
         return False
-    if handler.get("clawjournalProfile") == LEGACY_HOOK_PROFILE:
-        return True
     command = str(handler.get("command", ""))
     return f"-m {HOOK_MODULE}" in command and " run " in f" {command} "
+
+
+def _handler_is_legacy(handler: Any) -> bool:
+    return (
+        isinstance(handler, dict)
+        and handler.get("type") == "command"
+        and handler.get("clawjournalProfile") == LEGACY_HOOK_PROFILE
+    )
+
+
+def _handler_is_ours(handler: Any) -> bool:
+    return _handler_is_current(handler) or _handler_is_legacy(handler)
 
 
 def _upsert_session_start_hook(document: dict[str, Any], client: AgentName) -> bool:
@@ -358,7 +368,14 @@ def hook_diagnostics(
                     handler for handler in group["hooks"] if _handler_is_ours(handler)
                 )
     desired = _handler_for(agent)
-    configured = len(installed_handlers) == 1 and installed_handlers[0] == desired
+    current_handlers = [
+        handler for handler in installed_handlers if _handler_is_current(handler)
+    ]
+    # A leftover legacy handler is migrated only by the next install or
+    # uninstall; until then it must not flip `configured`, because the runner
+    # blocks scheduled cycles on any selected hook that is not configured.
+    configured = len(current_handlers) == 1 and current_handlers[0] == desired
+    legacy_installed = len(current_handlers) != len(installed_handlers)
     observed = (
         last_observed_at.isoformat()
         if isinstance(last_observed_at, datetime)
@@ -369,6 +386,7 @@ def hook_diagnostics(
         "path": str(path),
         "configured": configured,
         "installed": bool(installed_handlers),
+        "legacy_hook_installed": legacy_installed,
         "last_observed_at": observed,
     }
     if agent == "codex" and configured and not observed:

--- a/clawjournal/agent_hooks.py
+++ b/clawjournal/agent_hooks.py
@@ -27,6 +27,7 @@ from .paths import atomic_write_text
 
 HOOK_EVENT = "SessionStart"
 HOOK_MODULE = "clawjournal.agent_hooks"
+LEGACY_HOOK_PROFILE = "clawjournal-auto-upload-v1"
 SUPPORTED_AGENTS = ("claude", "codex")
 HOOK_TIMEOUT_SECONDS = 5
 
@@ -163,6 +164,8 @@ def _handler_for(client: AgentName) -> dict[str, Any]:
 def _handler_is_ours(handler: Any) -> bool:
     if not isinstance(handler, dict) or handler.get("type") != "command":
         return False
+    if handler.get("clawjournalProfile") == LEGACY_HOOK_PROFILE:
+        return True
     command = str(handler.get("command", ""))
     return f"-m {HOOK_MODULE}" in command and " run " in f" {command} "
 

--- a/clawjournal/cli_auto_upload.py
+++ b/clawjournal/cli_auto_upload.py
@@ -94,6 +94,17 @@ def _print_human(result: dict[str, Any]) -> None:
             ))
         if result.get("next_retry_at"):
             print(_sanitize_terminal_line(f"Next retry: {result['next_retry_at']}"))
+        stale_hooks = [
+            str(row.get("agent"))
+            for row in result.get("hooks") or []
+            if isinstance(row, dict) and row.get("legacy_hook_installed")
+        ]
+        if stale_hooks:
+            print(_sanitize_terminal_line(
+                f"Legacy pre-release hook installed for: {', '.join(stale_hooks)}; "
+                "run 'clawjournal auto-upload enable' to migrate it "
+                "(or 'disable' to remove it)"
+            ))
         eligibility = result.get("eligibility") or {}
         print(_sanitize_terminal_line(
             "Eligible: "

--- a/tests/test_agent_hooks.py
+++ b/tests/test_agent_hooks.py
@@ -179,6 +179,63 @@ def test_install_migrates_legacy_profile_hook_and_preserves_foreign_hooks(
     assert foreign in handlers
 
 
+def test_diagnostics_reports_legacy_handler_without_blocking_configured(
+    isolated_home, monkeypatch
+):
+    """A stale legacy handler next to a healthy current hook is a migration
+    chore, not a broken configuration: an unconfigured selected hook blocks
+    scheduled cycles, and nothing reruns install until the next enable."""
+    monkeypatch.setattr(hooks.sys, "executable", "/tmp/current-python")
+    codex_path = isolated_home / ".codex" / "hooks.json"
+    codex_path.parent.mkdir(parents=True)
+    legacy = {
+        "type": "command",
+        "command": "old-python -m clawjournal.cli auto-upload hook --client codex",
+        "clawjournalProfile": hooks.LEGACY_HOOK_PROFILE,
+    }
+    codex_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {"hooks": [legacy]},
+                        {"hooks": [hooks._handler_for("codex")]},
+                    ]
+                }
+            }
+        )
+    )
+
+    before = hooks.hook_diagnostics("codex", home=isolated_home)
+    assert before["installed"] is True
+    assert before["configured"] is True
+    assert before["legacy_hook_installed"] is True
+
+    hooks.install_agent_hook("codex", home=isolated_home)
+
+    after = hooks.hook_diagnostics("codex", home=isolated_home)
+    assert after["configured"] is True
+    assert after["legacy_hook_installed"] is False
+    document = _read(codex_path)
+    assert _handlers(document, "SessionStart") == [hooks._handler_for("codex")]
+
+
+def test_diagnostics_marks_legacy_only_install_as_unconfigured(isolated_home):
+    codex_path = isolated_home / ".codex" / "hooks.json"
+    codex_path.parent.mkdir(parents=True)
+    legacy = {
+        "type": "command",
+        "command": "old-python -m clawjournal.cli auto-upload hook --client codex",
+        "clawjournalProfile": hooks.LEGACY_HOOK_PROFILE,
+    }
+    codex_path.write_text(json.dumps({"hooks": {"SessionStart": [{"hooks": [legacy]}]}}))
+
+    diagnostics = hooks.hook_diagnostics("codex", home=isolated_home)
+    assert diagnostics["installed"] is True
+    assert diagnostics["configured"] is False
+    assert diagnostics["legacy_hook_installed"] is True
+
+
 def test_uninstall_removes_only_auto_upload_hook_and_is_idempotent(isolated_home):
     path = isolated_home / ".codex" / "hooks.json"
     hooks.install_agent_hook("codex", home=isolated_home)

--- a/tests/test_agent_hooks.py
+++ b/tests/test_agent_hooks.py
@@ -128,10 +128,75 @@ def test_install_is_idempotent_and_collapses_stale_duplicates(isolated_home, mon
     assert any(handler.get("command") == "echo keep" for handler in _handlers(document, "SessionStart"))
 
 
+def test_install_migrates_legacy_profile_hook_and_preserves_foreign_hooks(
+    isolated_home, monkeypatch
+):
+    codex_path = isolated_home / ".codex" / "hooks.json"
+    codex_path.parent.mkdir(parents=True)
+    legacy = {
+        "type": "command",
+        "command": (
+            "old-python -m clawjournal.cli auto-upload hook --client codex"
+        ),
+        "commandWindows": (
+            "old-python -m clawjournal.cli auto-upload hook --client codex"
+        ),
+        "timeout": 5,
+        "statusMessage": "Checking automatic sharing schedule",
+        "clawjournalProfile": hooks.LEGACY_HOOK_PROFILE,
+    }
+    foreign = {
+        "type": "command",
+        "command": "echo keep",
+        "clawjournalProfile": "another-tool",
+    }
+    codex_path.write_text(
+        json.dumps(
+            {
+                "hooks": {
+                    "SessionStart": [
+                        {"hooks": [legacy, foreign]},
+                        {"hooks": [legacy]},
+                    ]
+                }
+            }
+        )
+    )
+    monkeypatch.setattr(hooks.sys, "executable", "/tmp/current-python")
+
+    first = hooks.install_agent_hook("codex", home=isolated_home)
+    first_bytes = codex_path.read_bytes()
+    second = hooks.install_agent_hook("codex", home=isolated_home)
+
+    assert first["changed"] is True
+    assert second["changed"] is False
+    assert codex_path.read_bytes() == first_bytes
+    document = _read(codex_path)
+    handlers = _handlers(document, "SessionStart")
+    own = [handler for handler in handlers if hooks._handler_is_ours(handler)]
+    assert own == [hooks._handler_for("codex")]
+    assert "clawjournalProfile" not in own[0]
+    assert foreign in handlers
+
+
 def test_uninstall_removes_only_auto_upload_hook_and_is_idempotent(isolated_home):
     path = isolated_home / ".codex" / "hooks.json"
     hooks.install_agent_hook("codex", home=isolated_home)
     document = _read(path)
+    document["hooks"]["SessionStart"].append(
+        {
+            "hooks": [
+                {
+                    "type": "command",
+                    "command": (
+                        "old-python -m clawjournal.cli auto-upload hook "
+                        "--client codex"
+                    ),
+                    "clawjournalProfile": hooks.LEGACY_HOOK_PROFILE,
+                }
+            ]
+        }
+    )
     document["hooks"]["SessionStart"].append(
         {"matcher": "startup", "hooks": [{"type": "command", "command": "echo keep"}]}
     )

--- a/tests/test_cli_auto_upload.py
+++ b/tests/test_cli_auto_upload.py
@@ -75,6 +75,7 @@ def test_human_output_sanitizes_all_dynamic_single_line_fields(capsys):
         "scope": {"sources": [attack], "projects": [attack]},
         "next_due_at": attack,
         "next_retry_at": attack,
+        "hooks": [{"agent": attack, "legacy_hook_installed": True}],
         "eligibility": {"eligible_count": 1, "selected_count": 1},
     })
     cli._print_human({
@@ -88,6 +89,25 @@ def test_human_output_sanitizes_all_dynamic_single_line_fields(capsys):
     assert "\x1b" not in captured.out + captured.err
     assert "\x07" not in captured.out + captured.err
     assert "Receipt: value[2J forged" in captured.out
+
+
+def test_human_status_surfaces_legacy_hook_migration_hint(capsys):
+    import clawjournal.cli_auto_upload as cli
+
+    cli._print_human({
+        "ok": True,
+        "mode": "enabled",
+        "health": "ready",
+        "hooks": [
+            {"agent": "claude", "legacy_hook_installed": False},
+            {"agent": "codex", "legacy_hook_installed": True},
+        ],
+        "eligibility": {},
+    })
+
+    out = capsys.readouterr().out
+    assert "Legacy pre-release hook installed for: codex" in out
+    assert "'clawjournal auto-upload enable'" in out
 
 
 def test_interactive_challenge_sanitizes_versions_scope_and_backend(


### PR DESCRIPTION
## Summary

Fix automatic-upload Hook migration for users upgrading from the earlier recurring-upload implementation.

Legacy installations used a `clawjournal.cli auto-upload hook` handler marked with `clawjournalProfile: clawjournal-auto-upload-v1`. The current installer only recognized `clawjournal.agent_hooks run`, leaving both handlers installed after an upgrade.

## Changes

- Recognize the exact legacy ClawJournal Hook profile marker.
- Replace legacy handlers with the current SessionStart handler during installation.
- Collapse legacy and current duplicates into one handler.
- Remove both legacy and current handlers when automatic upload is disabled.
- Preserve unrelated third-party hooks.
- Keep repeated installation and removal idempotent.

## Validation

- Added legacy upgrade and uninstall regression coverage.
- `106 passed` across Hook, automatic-upload, and CLI tests.
- `git diff --check` passed.