### PR TITLE
feat(redaction): Betterleaks scanner foundation (PR 1/4)

### DIFF
--- a/.github/workflows/betterleaks-pin.yml
+++ b/.github/workflows/betterleaks-pin.yml
@@ -1,0 +1,66 @@
+name: Betterleaks Pin Integrity
+
+# Verifies that the sha256 checksums vendored in
+# clawjournal/redaction/betterleaks_install.py still match the upstream
+# release they pin. Unit tests are hermetic and cannot see this — only a
+# real fetch of upstream's checksums.txt catches a bad pin bump or a
+# release asset that was silently re-uploaded.
+#
+# IMPORTANT: do NOT add this workflow's check to branch-protection
+# required checks. It is path-filtered at the trigger level, so on PRs
+# that do not touch the pinned files it produces no check run at all — a
+# required status would then sit "Expected" forever and block the PR.
+
+on:
+  pull_request:
+    paths:
+      - 'clawjournal/redaction/betterleaks_install.py'
+      - 'scripts/check_betterleaks_pin.py'
+      - '.github/workflows/betterleaks-pin.yml'
+  schedule:
+    # Mondays 06:23 UTC — off the top of the hour, which GitHub delays
+    # under load, and offset from trufflehog-pin.yml's 06:17. Note:
+    # scheduled runs fire only from the default branch (so this
+    # activates after merge), and GitHub auto-disables crons on public
+    # repos after 60 days with no repository activity. Cron failure
+    # emails go to whoever last edited this file.
+    - cron: '23 6 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: betterleaks-pin-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pin-integrity:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Fetch upstream checksums.txt (authenticated, retried)
+        env:
+          # Authenticated so we get this repo's GITHUB_TOKEN rate limit
+          # rather than the shared runner-IP unauthenticated limit.
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          PINNED=$(python -c "from clawjournal.redaction.betterleaks_install import PINNED_VERSION; print(PINNED_VERSION)")
+          echo "Pinned Betterleaks version: v$PINNED"
+          for attempt in 1 2 3; do
+            if gh release download "v$PINNED" \
+                 -R betterleaks/betterleaks \
+                 -p '*checksums.txt' -O checksums.txt --clobber; then
+              break
+            fi
+            echo "fetch attempt $attempt failed; retrying..." >&2
+            sleep $((attempt * 5))
+          done
+          test -s checksums.txt
+      - name: Compare vendored checksums against upstream
+        run: python scripts/check_betterleaks_pin.py checksums.txt

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3994,6 +3994,19 @@ def main() -> None:
         "status", help="Show which TruffleHog binary clawjournal will use")
     th_status.add_argument("--json", action="store_true", help="Output result as JSON")
 
+    bl = sub.add_parser("betterleaks",
+                        help="Manage the Betterleaks binary used by the share gate")
+    bl_sub = bl.add_subparsers(dest="betterleaks_command")
+    bl_install = bl_sub.add_parser(
+        "install",
+        help="Download the pinned, checksum-verified Betterleaks into ~/.clawjournal/bin")
+    bl_install.add_argument("--force", action="store_true",
+                            help="Reinstall even if a managed binary already exists")
+    bl_install.add_argument("--json", action="store_true", help="Output result as JSON")
+    bl_status = bl_sub.add_parser(
+        "status", help="Show which Betterleaks binary clawjournal will use")
+    bl_status.add_argument("--json", action="store_true", help="Output result as JSON")
+
     cfg = sub.add_parser("config", help="View or set config")
     cfg.add_argument("--repo", type=str, help=argparse.SUPPRESS)
     cfg.add_argument("--source", choices=sorted(EXPLICIT_SOURCE_CHOICES),
@@ -5191,6 +5204,10 @@ def main() -> None:
         _run_trufflehog_command(args)
         return
 
+    if command == "betterleaks":
+        _run_betterleaks_command(args)
+        return
+
     if command == "list":
         config = load_config()
         resolved_source_choice, _ = _resolve_source_choice(args.source, config)
@@ -5752,6 +5769,83 @@ def _run_trufflehog_command(args) -> None:
     if not is_managed:
         print(f"A pinned v{PINNED_VERSION} can be installed with "
               "`clawjournal trufflehog install` (managed copy takes precedence).")
+
+
+def _run_betterleaks_command(args) -> None:
+    """`clawjournal betterleaks install|status` — manage the primary share-gate scanner."""
+    from .redaction import betterleaks
+    from .redaction.betterleaks_install import PINNED_VERSION, install
+
+    sub_command = getattr(args, "betterleaks_command", None)
+
+    if sub_command == "install":
+        result = install(force=args.force, progress=None if args.json else print)
+        if args.json:
+            print(json.dumps(result, indent=2))
+        else:
+            status = result["status"]
+            if status == "installed":
+                print(f"Installed Betterleaks {result['version']} at {result['path']}.")
+            elif status == "already-installed":
+                print(
+                    f"Already installed ({result['version']}) at {result['path']}. "
+                    "Pass --force to reinstall."
+                )
+            else:
+                print(f"Install failed ({status}): {result.get('error', '')}")
+                if result.get("url"):
+                    print(f"  URL: {result['url']}")
+                if result.get("hint"):
+                    print(f"  {result['hint']}")
+        if result["status"] not in ("installed", "already-installed"):
+            sys.exit(1)
+        return
+
+    # Default (and explicit `status`): report what the share gate will use.
+    import shutil
+
+    resolved = betterleaks.resolve_binary()
+    managed = betterleaks.managed_binary_path()
+    fingerprint = betterleaks.engine_fingerprint()
+    version_match = betterleaks._BARE_VERSION_RE.search(fingerprint)
+    off_pin = betterleaks.managed_off_pin()
+    is_managed = resolved == str(managed)
+    shadowed_path = shutil.which("betterleaks") if is_managed else None
+    payload = {
+        "resolved_path": resolved,
+        "managed": is_managed,
+        "managed_path": str(managed),
+        # Bare version (e.g. "1.6.1") to match install --json; the raw
+        # engine fingerprint (e.g. "betterleaks 1.6.1") rides alongside.
+        "version": version_match.group(1) if version_match else None,
+        "fingerprint": fingerprint,
+        "pinned_version": PINNED_VERSION,
+        # True when the managed copy drifted from the source pin (e.g.
+        # selfupdate bumped PINNED_VERSION but install was never re-run).
+        "managed_off_pin": off_pin is not None,
+        "shadowed_path_binary": shadowed_path,
+        "available": resolved is not None,
+    }
+    if getattr(args, "json", False):
+        print(json.dumps(payload, indent=2))
+        if resolved is None:
+            sys.exit(1)
+        return
+    if resolved is None:
+        print("Betterleaks: not installed.")
+        print("Run `clawjournal betterleaks install` to install "
+              f"the pinned v{PINNED_VERSION}.")
+        sys.exit(1)
+    origin = "managed install" if is_managed else "PATH"
+    print(f"Betterleaks: {fingerprint} ({origin}: {resolved})")
+    if off_pin is not None:
+        print(f"Warning: the managed copy is v{off_pin[0]} but this clawjournal "
+              f"pins v{off_pin[1]} — run `clawjournal betterleaks install` to update.")
+    if shadowed_path:
+        print(f"(The managed copy takes precedence over the PATH copy at {shadowed_path}.)")
+    if not is_managed:
+        print(f"A pinned v{PINNED_VERSION} can be installed with "
+              "`clawjournal betterleaks install` (managed copy takes precedence).")
 
 
 def _run_events_features(args) -> None:

--- a/clawjournal/redaction/betterleaks.py
+++ b/clawjournal/redaction/betterleaks.py
@@ -1,0 +1,703 @@
+"""Betterleaks secrets scanner — the share gate's primary detection layer.
+
+Betterleaks (MIT, by the original Gitleaks author) is invoked as a
+subprocess with network validation **always off**: candidate secrets
+must never leave the machine from the detection layer. Live-credential
+verification is TruffleHog's job (see ``trufflehog.py``), which the
+gate runs verified-only as a secondary check.
+
+The binary is resolved managed-install first (``~/.clawjournal/bin/``,
+populated by ``clawjournal betterleaks install`` — see
+``betterleaks_install.py``), then ``PATH`` (e.g. ``brew install
+betterleaks``). The escape hatch ``CLAWJOURNAL_SKIP_BETTERLEAKS=1``
+exists for CI / development only and is recorded in scan reports so
+downstream reviewers can tell a scanned share from a bypassed one.
+
+Verified against betterleaks 1.6.1:
+
+- ``betterleaks dir <path>`` / ``betterleaks stdin`` write a JSON
+  **array** of findings to ``--report-path`` (a bare ``null`` on a
+  clean scan); findings carry ``RuleID``, ``StartLine`` (1-based file
+  line, which for a one-session-per-line ``sessions.jsonl`` is the
+  session index), ``Secret``, ``Match``, ``Entropy``, ``Tags``,
+  ``Fingerprint``.
+- ``--exit-code 183`` makes the findings exit status match the
+  TruffleHog wrapper convention, so ``{0, 183}`` means "scan ran".
+- ``--redact`` would scrub ``Secret`` from the report too, so it is
+  never passed: the raw is needed transiently to compute the mask and
+  the salted hash, exactly like the TruffleHog wrapper parses ``Raw``
+  from stdout. Raw values never leave this module via public helpers.
+- Secrets are reported in *file-level* form: a private key inside a
+  JSONL string arrives with literal ``\\n`` escape sequences, matching
+  the bytes on disk rather than the decoded JSON value.
+"""
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING
+
+from .trufflehog import (
+    _iter_session_text_fields,
+    _scrubbed_subprocess_env,
+    _serialize_session_for_scan,
+    _sha256_file,
+    mask_secret,
+)
+
+if TYPE_CHECKING:
+    from ..findings import RawFinding
+
+BETTERLEAKS_ENGINE_ID = "betterleaks"
+
+SKIP_ENV_VAR = "CLAWJOURNAL_SKIP_BETTERLEAKS"
+
+_MAX_SCAN_BYTES = 200 * 1024 * 1024  # 200 MB — cap on engine-path payload
+
+# Findings exit status we ask for via --exit-code so both scanner
+# wrappers share the "{0, 183} means the scan ran" contract.
+_FINDINGS_EXIT_CODE = 183
+
+INSTALL_HINT = (
+    "Betterleaks is required to export shares but was not found.\n"
+    "Install a pinned, checksum-verified copy with:\n"
+    "  clawjournal betterleaks install\n"
+    "Or install it yourself:\n"
+    "  macOS:  brew install betterleaks\n"
+    "  Linux:  https://github.com/betterleaks/betterleaks#installation\n"
+    "Or set CLAWJOURNAL_SKIP_BETTERLEAKS=1 to bypass (unsafe — the share "
+    "may leak secrets that survived our redaction layers)."
+)
+
+
+@dataclass
+class BetterleaksFinding:
+    rule_id: str
+    description: str
+    line: int | None
+    masked: str
+    raw_sha256: str | None
+    entropy: float | None
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class BetterleaksReport:
+    scanned_path: str
+    scanned_sha256: str
+    findings: list[BetterleaksFinding] = field(default_factory=list)
+    top_rules: list[str] = field(default_factory=list)
+    bypassed: bool = False
+    binary_missing: bool = False
+    scan_error: str | None = None
+    # Which engine actually scanned (engine_fingerprint() form, e.g.
+    # "betterleaks 1.6.1"). Stamped by the export chokepoints before the
+    # report is persisted. "" means not stamped (preview scans).
+    engine: str = ""
+
+    # Deliberately no ``.blocking`` / ``.block_reason`` here: unlike the
+    # legacy TruffleHog gate, whether a Betterleaks finding blocks a
+    # share is a per-finding tier decision owned by the policy layer
+    # (``scan_policy``), not by the scanner wrapper.
+
+    def summary(self) -> dict:
+        """Public summary safe for the share manifest — no raw values."""
+        return {
+            "findings": len(self.findings),
+            "top_rules": list(self.top_rules),
+            "bypassed": self.bypassed,
+            "binary_missing": self.binary_missing,
+            "scan_error": self.scan_error,
+            "engine": self.engine,
+            "examples": [
+                {
+                    "rule": f.rule_id,
+                    "line": f.line,
+                    "masked": f.masked,
+                    "entropy": f.entropy,
+                }
+                for f in self.findings[:5]
+            ],
+        }
+
+
+def bundled_config_path() -> Path:
+    """The share-gate TOML shipped in the wheel: extends the default
+    ruleset and allowlists clawjournal's own ``[REDACTED_*]`` placeholders
+    so the gate's redact-and-rescan loop converges instead of re-flagging
+    its own output."""
+    return Path(__file__).parent / "betterleaks.toml"
+
+
+def managed_binary_path() -> Path:
+    """Path of the managed binary that ``clawjournal betterleaks install``
+    maintains. Reads ``config.CONFIG_DIR`` at call time (not import time)
+    so tests and future env overrides that monkeypatch the attribute see
+    the change.
+    """
+    from .. import config  # noqa: PLC0415 — call-time so CONFIG_DIR patches apply
+
+    name = "betterleaks.exe" if os.name == "nt" else "betterleaks"
+    return config.CONFIG_DIR / "bin" / name
+
+
+def resolve_binary() -> str | None:
+    """Resolve the Betterleaks binary: managed install first, then PATH.
+
+    The managed copy wins because its version is pinned and its archive
+    checksum was verified at install time; an unmanaged PATH binary is
+    whatever brew/go last put there.
+    """
+    managed = managed_binary_path()
+    try:
+        if managed.is_file() and os.access(managed, os.X_OK):
+            return str(managed)
+    except OSError:
+        pass
+    return shutil.which("betterleaks")
+
+
+def is_available() -> bool:
+    return resolve_binary() is not None
+
+
+def managed_off_pin() -> tuple[str, str] | None:
+    """``(actual_version, pinned_version)`` when the gate resolves the
+    managed copy and that copy is off the source pin; ``None`` otherwise.
+
+    Only the managed copy is judged against the pin — a PATH binary's
+    freshness is the user's package manager's business. Warn, never
+    block: an off-pin scanner is still a working backstop.
+    """
+    from .betterleaks_install import PINNED_VERSION  # noqa: PLC0415 — avoid import cycle
+
+    resolved = resolve_binary()
+    if resolved is None or resolved != str(managed_binary_path()):
+        return None
+    match = _BARE_VERSION_RE.search(engine_fingerprint())
+    if match is None:
+        return None
+    actual = match.group(1)
+    if actual == PINNED_VERSION:
+        return None
+    return (actual, PINNED_VERSION)
+
+
+_version_cache: dict[tuple, str] = {}
+
+# `betterleaks --version` prints "betterleaks version 1.6.1"; the
+# `version` subcommand prints a bare "1.6.1". Match either.
+_VERSION_RE = re.compile(r"\bbetterleaks\s+version\s+(\d+\.\d+\.\d+)", re.IGNORECASE)
+_BARE_VERSION_RE = re.compile(r"(\d+\.\d+\.\d+)")
+
+
+def _binary_signature() -> tuple:
+    """Stable per-binary key for the fingerprint cache.
+
+    Folds the resolved path and its mtime+size so a ``brew upgrade``
+    or ``clawjournal betterleaks install`` (new inode, new size, new
+    mtime) invalidates cached entries in a long-running daemon without
+    requiring a restart. Returns ``("missing",)`` if no binary resolves.
+    """
+    resolved = resolve_binary()
+    if resolved is None:
+        return ("missing",)
+    try:
+        st = os.stat(resolved)
+    except OSError:
+        return ("unknown", resolved)
+    return (resolved, st.st_mtime_ns, st.st_size)
+
+
+def engine_fingerprint() -> str:
+    """Return a short fingerprint folded into ``findings_revision``.
+
+    Captures presence + version so cached session revisions invalidate
+    when the user installs or upgrades Betterleaks. Missing binary
+    reports ``"missing"``; parse/timeout errors report ``"unknown"``.
+    Result is memoized per ``(path, mtime, size)`` tuple so a long-
+    running daemon notices upgrades without a restart.
+    """
+    signature = _binary_signature()
+    cached = _version_cache.get(signature)
+    if cached is not None:
+        return cached
+    if signature[0] == "missing":
+        _version_cache[signature] = "missing"
+        return "missing"
+    binary = signature[1] if signature[0] == "unknown" else signature[0]
+    try:
+        result = subprocess.run(
+            [binary, "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+            stdin=subprocess.DEVNULL,
+            env=_scrubbed_subprocess_env(),
+        )
+        blob = (result.stdout or "") + "\n" + (result.stderr or "")
+        match = _VERSION_RE.search(blob) or _BARE_VERSION_RE.search(blob)
+        if match:
+            fingerprint = f"betterleaks {match.group(1)}"
+        else:
+            # Fallback for an unrecognized banner — take the first
+            # non-empty line verbatim.
+            lines = [ln.strip() for ln in blob.splitlines() if ln.strip()]
+            fingerprint = lines[0] if lines else "unknown"
+        _version_cache[signature] = fingerprint
+        return fingerprint
+    except (subprocess.TimeoutExpired, OSError):
+        _version_cache[signature] = "unknown"
+        return "unknown"
+
+
+def reset_version_cache() -> None:
+    """Clear the cached version fingerprint — for tests only."""
+    _version_cache.clear()
+
+
+def is_bypassed() -> bool:
+    return os.environ.get(SKIP_ENV_VAR) == "1"
+
+
+def _base_args(binary: str, mode_args: list[str]) -> list[str]:
+    """Common argv for every scan invocation.
+
+    ``--validation`` must NEVER appear here: it would send candidate
+    secrets to provider APIs, and the detection layer is local-only by
+    design (PRIVACY.md). Verification is TruffleHog's role.
+    """
+    args = [binary, *mode_args]
+    config_path = bundled_config_path()
+    # The bundled config only ADDS an allowlist on top of the default
+    # rules, so a missing file (unusual dev tree) degrades toward MORE
+    # findings, never fewer — safe to omit rather than fail.
+    if config_path.is_file():
+        args += ["--config", str(config_path)]
+    args += [
+        "--report-format", "json",
+        "--exit-code", str(_FINDINGS_EXIT_CODE),
+        "--no-banner",
+        "--no-color",
+        "--log-level", "error",
+    ]
+    return args
+
+
+def _read_report_payload(report_path: Path) -> list[dict] | None:
+    """Parse the JSON report file. Returns the findings list, or None
+    when the file is missing/unreadable/malformed (a scan error, since
+    exit-status checking already passed). A clean scan writes ``null``,
+    which normalizes to ``[]``."""
+    try:
+        content = report_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return None
+    if not content.strip():
+        return None
+    try:
+        parsed = json.loads(content)
+    except json.JSONDecodeError:
+        return None
+    if parsed is None:
+        return []
+    if not isinstance(parsed, list):
+        return None
+    return [item for item in parsed if isinstance(item, dict)]
+
+
+def _parse_finding(parsed: dict) -> BetterleaksFinding | None:
+    rule_id = parsed.get("RuleID")
+    if not isinstance(rule_id, str) or not rule_id:
+        return None
+
+    description = parsed.get("Description")
+    description = description if isinstance(description, str) else ""
+
+    line_no: int | None = None
+    start_line = parsed.get("StartLine")
+    if isinstance(start_line, int) and start_line >= 1:
+        line_no = start_line
+
+    secret = parsed.get("Secret")
+    raw_str = secret if isinstance(secret, str) and secret else None
+    raw_sha = (
+        f"sha256:{hashlib.sha256(raw_str.encode()).hexdigest()}" if raw_str else None
+    )
+    masked = mask_secret(raw_str) if raw_str else "[REDACTED]"
+
+    entropy: float | None = None
+    raw_entropy = parsed.get("Entropy")
+    if isinstance(raw_entropy, (int, float)):
+        entropy = float(raw_entropy)
+
+    tags = parsed.get("Tags")
+    tags = [t for t in tags if isinstance(t, str)] if isinstance(tags, list) else []
+
+    return BetterleaksFinding(
+        rule_id=rule_id,
+        description=description,
+        line=line_no,
+        masked=masked,
+        raw_sha256=raw_sha,
+        entropy=entropy,
+        tags=tags,
+    )
+
+
+def scan_file(path: Path) -> BetterleaksReport:
+    """Scan ``path`` with Betterleaks. Returns a report.
+
+    Never raises on missing-binary, findings, subprocess timeouts,
+    spawn failures, unexpected exit statuses, or I/O errors — every
+    failure is surfaced on the report (``scan_error`` /
+    ``binary_missing``) so the policy layer can fail closed rather
+    than the caller handling a raw exception.
+    """
+    try:
+        scanned_sha256 = _sha256_file(path)
+    except OSError as exc:
+        return BetterleaksReport(
+            scanned_path=str(path),
+            scanned_sha256="",
+            scan_error=f"could not hash scan target: {exc.__class__.__name__}",
+        )
+
+    if is_bypassed():
+        return BetterleaksReport(
+            scanned_path=str(path),
+            scanned_sha256=scanned_sha256,
+            bypassed=True,
+        )
+
+    if not is_available():
+        return BetterleaksReport(
+            scanned_path=str(path),
+            scanned_sha256=scanned_sha256,
+            binary_missing=True,
+        )
+
+    parsed_findings, error = _run_report_scan(
+        ["dir", str(path)], input_bytes=None, timeout=120
+    )
+    if error is not None:
+        return BetterleaksReport(
+            scanned_path=str(path),
+            scanned_sha256=scanned_sha256,
+            scan_error=error,
+        )
+
+    findings: list[BetterleaksFinding] = []
+    rule_counts: dict[str, int] = {}
+    seen_keys: set[tuple] = set()
+    for parsed in parsed_findings:
+        finding = _parse_finding(parsed)
+        if finding is None:
+            continue
+        key = (finding.rule_id, finding.line, finding.raw_sha256)
+        if key in seen_keys:
+            continue
+        seen_keys.add(key)
+        findings.append(finding)
+        rule_counts[finding.rule_id] = rule_counts.get(finding.rule_id, 0) + 1
+
+    findings.sort(key=lambda f: (f.line if f.line is not None else 10**9, f.rule_id))
+    top = sorted(rule_counts.items(), key=lambda item: (-item[1], item[0]))[:8]
+
+    return BetterleaksReport(
+        scanned_path=str(path),
+        scanned_sha256=scanned_sha256,
+        findings=findings,
+        top_rules=[rule for rule, _ in top],
+    )
+
+
+def _run_report_scan(
+    mode_args: list[str],
+    *,
+    input_bytes: bytes | None,
+    timeout: int,
+) -> tuple[list[dict], str | None]:
+    """Run one scan subprocess and return ``(parsed_findings, error)``.
+
+    The report goes through a 0600 temp file (mkstemp) because
+    Betterleaks cannot stream JSON reports to stdout; it is read and
+    unlinked in ``finally`` so raw secrets never persist past the call.
+    Callers have already handled bypass/missing-binary.
+    """
+    fd, report_name = tempfile.mkstemp(prefix=".betterleaks-report.", suffix=".json")
+    os.close(fd)
+    report_path = Path(report_name)
+
+    # `or "betterleaks"` covers callers that stub is_available() without
+    # providing a real binary (tests); production always resolves a path.
+    args = _base_args(resolve_binary() or "betterleaks", mode_args)
+    args += ["--report-path", str(report_path)]
+
+    # DEVNULL on stdin (when not streaming a payload) prevents any
+    # interactive prompt from deadlocking a non-interactive runner.
+    # Scrubbed env keeps the parent process's API keys out of the child.
+    io_kwargs: dict = {"env": _scrubbed_subprocess_env()}
+    if input_bytes is not None:
+        io_kwargs["input"] = input_bytes
+    else:
+        io_kwargs["stdin"] = subprocess.DEVNULL
+
+    try:
+        try:
+            result = subprocess.run(
+                args,
+                capture_output=True,
+                check=False,
+                timeout=timeout,
+                **io_kwargs,
+            )
+        except subprocess.TimeoutExpired:
+            return [], f"timed out after {timeout} seconds"
+        except OSError:
+            return [], "could not execute the betterleaks binary"
+        if result.returncode not in (0, _FINDINGS_EXIT_CODE):
+            return [], f"unexpected exit status {result.returncode}"
+
+        payload = _read_report_payload(report_path)
+        if payload is None:
+            return [], "scan produced no readable JSON report"
+        return payload, None
+    finally:
+        try:
+            report_path.unlink()
+        except OSError:
+            pass
+
+
+def scan_text(text: str) -> BetterleaksReport:
+    """Scan an in-memory string by dropping it to a temp file.
+
+    Used by preview scans that want the full report shape without
+    managing their own temp dir. The authoritative gate still runs on
+    the merged sessions.jsonl at Package time.
+    """
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".jsonl", delete=False, encoding="utf-8"
+    ) as tf:
+        tf.write(text)
+        tmp_path = Path(tf.name)
+    try:
+        return scan_file(tmp_path)
+    finally:
+        tmp_path.unlink(missing_ok=True)
+
+
+def write_report(path: Path, report: BetterleaksReport) -> None:
+    payload = {
+        # Record only the basename so tempfile paths (e.g., /var/folders/...
+        # on macOS) don't leak the user's tmpdir structure into the
+        # manifest bundle.
+        "scanned_path": Path(report.scanned_path).name,
+        "scanned_sha256": report.scanned_sha256,
+        "bypassed": report.bypassed,
+        "binary_missing": report.binary_missing,
+        "scan_error": report.scan_error,
+        "engine": report.engine,
+        "findings": [
+            {
+                "rule": f.rule_id,
+                "description": f.description,
+                "line": f.line,
+                "masked": f.masked,
+                "raw_sha256": f.raw_sha256,
+                "entropy": f.entropy,
+            }
+            for f in report.findings
+        ],
+        "summary": report.summary(),
+    }
+    path.write_text(json.dumps(payload, indent=2) + "\n")
+
+
+def _raw_matches_from_payload(parsed_findings: list[dict]) -> list[dict]:
+    """Normalize report entries to raw-bearing dicts for internal use.
+
+    Returns ``[{"raw": str, "rule_id": str, "entropy": float | None,
+    "line": int | None}]``, deduped on ``(rule_id, raw)`` keeping the
+    first line each pair was seen on.
+    """
+    out: list[dict] = []
+    seen: set[tuple] = set()
+    for parsed in parsed_findings:
+        rule_id = parsed.get("RuleID")
+        raw = parsed.get("Secret")
+        if not isinstance(rule_id, str) or not rule_id:
+            continue
+        if not isinstance(raw, str) or not raw:
+            continue
+        key = (rule_id, raw)
+        if key in seen:
+            continue
+        seen.add(key)
+        entropy = parsed.get("Entropy")
+        start_line = parsed.get("StartLine")
+        out.append({
+            "raw": raw,
+            "rule_id": rule_id,
+            "entropy": float(entropy) if isinstance(entropy, (int, float)) else None,
+            "line": start_line if isinstance(start_line, int) and start_line >= 1 else None,
+        })
+    return out
+
+
+def _scan_file_for_raw_matches(path: Path) -> list[dict]:
+    """Internal: dir-mode scan of ``path`` returning raw-bearing dicts.
+
+    Used by the share gate's redact-and-rescan loop, which must know
+    the exact on-disk byte sequence to replace (``Secret`` arrives in
+    file-level escaped form) and the 1-based line for session mapping.
+    Raw values must never be persisted or returned from public
+    ``scan_*`` helpers.
+
+    Fails soft to ``[]`` when bypassed or the binary is missing; the
+    caller distinguishes "no findings" from "cannot scan" by running
+    ``scan_file`` alongside (its report carries ``binary_missing`` /
+    ``scan_error``).
+    """
+    if is_bypassed() or not is_available():
+        return []
+    parsed_findings, error = _run_report_scan(
+        ["dir", str(path)], input_bytes=None, timeout=120
+    )
+    if error is not None:
+        return []
+    return _raw_matches_from_payload(parsed_findings)
+
+
+def _scan_text_for_raw_matches(text: str) -> list[dict]:
+    """Internal: stdin-mode scan of ``text`` returning raw-bearing dicts.
+
+    Used only by the findings-engine entry points — the apply path
+    needs ``raw`` to build the replace map and to compute salted
+    hashes. Streaming via stdin means no plaintext tempfile of the
+    session can be orphaned by a SIGKILL.
+
+    Silently returns ``[]`` when the binary is missing or bypassed;
+    the findings pipeline should not fail a scan just because the
+    optional engine is unavailable.
+    """
+    if is_bypassed() or not is_available() or not text.strip():
+        return []
+
+    try:
+        encoded = text.encode("utf-8", errors="replace")
+    except (UnicodeError, AttributeError):
+        return []
+    if len(encoded) > _MAX_SCAN_BYTES:
+        return []
+
+    parsed_findings, error = _run_report_scan(
+        ["stdin"], input_bytes=encoded, timeout=30
+    )
+    if error is not None:
+        # Engine path intentionally fails soft — a broken scan
+        # shouldn't block the whole findings rebuild.
+        return []
+    return _raw_matches_from_payload(parsed_findings)
+
+
+def placeholder_for_rule(rule_id: str) -> str:
+    """``[REDACTED_<RULE_ID>]`` — matches the style of SECRET_PLACEHOLDER."""
+    normalized = re.sub(r"\W+", "_", rule_id).upper().strip("_")
+    return f"[REDACTED_{normalized}]" if normalized else "[REDACTED_BETTERLEAKS]"
+
+
+def scan_session_for_betterleaks_findings(
+    session: dict,
+    *,
+    user_allowlist: list[dict] | None = None,  # noqa: ARG001 — reserved for parity with other engines
+) -> list["RawFinding"]:
+    """Emit one ``RawFinding`` per occurrence of each Betterleaks match.
+
+    One subprocess call per session: all text fields are concatenated
+    into a single payload scanned once. Each raw match is then
+    re-located in every text field so the resulting findings have
+    field-local offsets (the same shape the share-time apply path
+    expects from ``_iter_text_locations``).
+    """
+    from ..findings import RawFinding  # noqa: PLC0415 — lazy to avoid cycle
+
+    payload = _serialize_session_for_scan(session)
+    matches = _scan_text_for_raw_matches(payload)
+    if not matches:
+        return []
+
+    findings: list[RawFinding] = []
+    for match in matches:
+        raw = match["raw"]
+        if len(raw) < 3:
+            continue
+        rule_id = match["rule_id"]
+        for text, field_name, msg_idx, tool_field in _iter_session_text_fields(
+            session, include_widened=True
+        ):
+            start = 0
+            while True:
+                idx = text.find(raw, start)
+                if idx < 0:
+                    break
+                findings.append(RawFinding(
+                    engine=BETTERLEAKS_ENGINE_ID,
+                    rule=rule_id,
+                    entity_type=rule_id,
+                    entity_text=raw,
+                    field=field_name,
+                    offset=idx,
+                    length=len(raw),
+                    confidence=0.9,
+                    message_index=msg_idx,
+                    tool_field=tool_field,
+                ))
+                start = idx + len(raw)
+    return findings
+
+
+def betterleaks_secret_map_from_blob(
+    blob: dict,
+    decisions: dict[str, str],
+    user_allowlist: list[dict] | None = None,  # noqa: ARG001 — reserved
+) -> dict[str, str]:
+    """Apply-path contribution: map ``raw → placeholder`` for each
+    surviving Betterleaks hit that is not ``ignored``.
+
+    The caller (``apply_findings_to_blob`` in ``secrets.py``) hoists
+    this call *outside* its per-pass loop, so this function runs
+    exactly once per apply — the raws Betterleaks finds don't change
+    after their first replacement, and paying the subprocess cost
+    on every pass would be pure waste. When the binary is
+    unavailable the engine produces no replacements and the other
+    engines still run.
+
+    When two rules flag the same raw, placeholder selection is
+    stabilized by sorting matches ``(rule_id, raw)`` ascending so
+    the tiebreaker is deterministic across runs.
+    """
+    from ..findings import hash_entity  # noqa: PLC0415 — lazy
+
+    payload = _serialize_session_for_scan(blob)
+    matches = _scan_text_for_raw_matches(payload)
+    if not matches:
+        return {}
+
+    out: dict[str, str] = {}
+    for match in sorted(matches, key=lambda m: (m["rule_id"], m["raw"])):
+        raw = match["raw"]
+        if len(raw) < 3:
+            continue
+        if decisions.get(hash_entity(raw)) == "ignored":
+            continue
+        out.setdefault(raw, placeholder_for_rule(match["rule_id"]))
+    return out

--- a/clawjournal/redaction/betterleaks.py
+++ b/clawjournal/redaction/betterleaks.py
@@ -583,7 +583,10 @@ def _scan_text_for_raw_matches(text: str) -> list[dict]:
     Used only by the findings-engine entry points — the apply path
     needs ``raw`` to build the replace map and to compute salted
     hashes. Streaming via stdin means no plaintext tempfile of the
-    session can be orphaned by a SIGKILL.
+    *session* is ever written. The JSON *report* (which carries the
+    matched ``Secret`` values) still goes through a 0600 mkstemp file
+    that is unlinked in ``finally`` — a SIGKILL in that window can
+    orphan it; betterleaks cannot stream reports to stdout.
 
     Silently returns ``[]`` when the binary is missing or bypassed;
     the findings pipeline should not fail a scan just because the

--- a/clawjournal/redaction/betterleaks.toml
+++ b/clawjournal/redaction/betterleaks.toml
@@ -1,0 +1,27 @@
+# Betterleaks configuration for the clawjournal share gate.
+#
+# Shipped in the wheel (see [tool.setuptools.package-data]) and passed
+# via --config on every scan (betterleaks.py `_base_args`). Extends the
+# full default ruleset — this file must only ever ADD allowlist entries,
+# never disable rules: the wrapper treats a missing config as "scan with
+# defaults", so anything load-bearing for detection must not live here.
+#
+# Tier policy (block / review / redact / warn) deliberately lives in
+# Python (`scan_policy.py`), not in Expr filters here, so the share
+# gate's behavior is reviewable in one place.
+
+title = "clawjournal share-gate config"
+
+[extend]
+useDefault = true
+
+[allowlist]
+description = "clawjournal-emitted redaction placeholders must never re-trigger the gate"
+regexes = [
+    # Every placeholder the redaction layers emit follows this shape:
+    # [REDACTED], [REDACTED_JWT], [REDACTED_SLACK_BOT_TOKEN], ... —
+    # see secrets.SECRET_PLACEHOLDER, findings.PLACEHOLDER_BY_TYPE,
+    # trufflehog.placeholder_for_detector, betterleaks.placeholder_for_rule.
+    # Allowlisting them guarantees the redact-and-rescan loop converges.
+    '''\[REDACTED(?:_[A-Z0-9_]+)?\]''',
+]

--- a/clawjournal/redaction/betterleaks_install.py
+++ b/clawjournal/redaction/betterleaks_install.py
@@ -1,0 +1,399 @@
+"""Managed Betterleaks binary install.
+
+``clawjournal betterleaks install`` downloads a pinned release archive
+from betterleaks/betterleaks' official GitHub releases, verifies it
+against the sha256 checksums vendored below (taken from the release's
+``checksums.txt`` at pin time — verification never trusts what the
+network just served), extracts the single binary, and installs it
+atomically under ``~/.clawjournal/bin/``.
+
+``betterleaks.resolve_binary()`` prefers this managed copy over PATH.
+
+Betterleaks is MIT-licensed, but the invocation posture matches
+TruffleHog's anyway: only ever run as a subprocess with a scrubbed
+environment (see ``betterleaks.py``), never linked in-process.
+"""
+
+from __future__ import annotations
+
+import gzip
+import hashlib
+import http.client
+import os
+import platform
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.error
+import urllib.request
+import zipfile
+from pathlib import Path
+from typing import Callable
+
+from .betterleaks import (
+    _BARE_VERSION_RE,
+    _VERSION_RE,
+    managed_binary_path,
+)
+from .trufflehog import _scrubbed_subprocess_env
+
+PINNED_VERSION = "1.6.1"
+
+# sha256 of the official release archives, copied from checksums.txt on
+# the v1.6.1 release page. When bumping PINNED_VERSION, refresh every
+# row from the new release's checksums.txt — a stale row fails closed.
+# Note upstream's arch naming: x64 (not amd64), and .zip on Windows.
+_ARCHIVE_SHA256: dict[str, str] = {
+    "darwin_arm64": "9996bfcc93fd2ae6976c7902e3b2177766ec1960c1e30a15398609d5177ef3f8",
+    "darwin_x64": "07ddb85c4b2c55da6b671a6af667c89d89c68c52aff8fd73a1118a92d373db8c",
+    "linux_arm64": "bab9688ba968264ace67b608fc7a7d8f5e61218cde70029d32cbc894e3808fdf",
+    "linux_x64": "fbefc700a0bd4522cc952dd2a8f259cdb80526d7e60114aca19bb2d6fdc80f81",
+    "windows_arm64": "fc9bc3d554161e4c94f3510f59d6a790c2ce52f25a5b99520efe1e529efa0912",
+    "windows_x64": "3ada08a8b19afab75b111e10f38682a64c0582824c9903ce868b09b0c3c2cf37",
+}
+
+_DOWNLOAD_URL_TEMPLATE = (
+    "https://github.com/betterleaks/betterleaks/releases/download/"
+    "v{version}/{filename}"
+)
+
+_MAX_DOWNLOAD_BYTES = 200 * 1024 * 1024  # archives are ~10–30 MB
+_MAX_BINARY_BYTES = 500 * 1024 * 1024  # decompressed binary cap
+_DOWNLOAD_TIMEOUT_SECONDS = 120
+_PROGRESS_TICK_BYTES = 16 * 1024 * 1024
+
+DOWNLOAD_FAILED_HINT = (
+    "Check your network and proxy settings (HTTPS_PROXY/HTTP_PROXY are honored) "
+    "and retry. If this machine is offline, install Betterleaks manually: "
+    "https://github.com/betterleaks/betterleaks#installation"
+)
+CHECKSUM_MISMATCH_HINT = (
+    "The downloaded archive does not match the checksum pinned in this clawjournal "
+    "release. Common causes: a TLS-intercepting (corporate/campus) proxy rewriting "
+    "the download, a truncated transfer, or an outdated clawjournal — run "
+    "`clawjournal selfupdate` and retry. Nothing was installed."
+)
+
+
+def platform_key() -> str | None:
+    """``{os}_{arch}`` key into ``_ARCHIVE_SHA256``, or None if this
+    platform has no pinned archive."""
+    if sys.platform == "darwin":
+        os_part = "darwin"
+    elif sys.platform.startswith("linux"):
+        os_part = "linux"
+    elif os.name == "nt":
+        os_part = "windows"
+    else:
+        return None
+
+    machine = platform.machine().lower()
+    if machine in ("x86_64", "amd64"):
+        arch = "x64"
+    elif machine in ("arm64", "aarch64"):
+        arch = "arm64"
+    else:
+        return None
+
+    key = f"{os_part}_{arch}"
+    return key if key in _ARCHIVE_SHA256 else None
+
+
+def archive_filename(key: str) -> str:
+    """Upstream asset name for a platform key — tar.gz everywhere
+    except Windows, which ships zips."""
+    extension = "zip" if key.startswith("windows") else "tar.gz"
+    return f"betterleaks_{PINNED_VERSION}_{key}.{extension}"
+
+
+def download_url(key: str) -> str:
+    return _DOWNLOAD_URL_TEMPLATE.format(
+        version=PINNED_VERSION, filename=archive_filename(key)
+    )
+
+
+def _download_archive(
+    url: str,
+    dest_fd: int,
+    progress: Callable[[str], None] | None = None,
+) -> str:
+    """Stream ``url`` into ``dest_fd``; return the payload's sha256 hex.
+
+    Raises ``urllib.error.URLError``/``OSError`` on network trouble and
+    ``ValueError`` if the payload exceeds the size cap. ``progress``
+    (if given) receives a start line and a tick every ~16 MB so a slow
+    link doesn't look like a hang.
+    """
+    digest = hashlib.sha256()
+    total = 0
+    request = urllib.request.Request(url, headers={"User-Agent": "clawjournal"})
+    with urllib.request.urlopen(request, timeout=_DOWNLOAD_TIMEOUT_SECONDS) as response:
+        if progress is not None:
+            length = getattr(response, "headers", None)
+            length = length.get("Content-Length") if length else None
+            size = f" ({int(length) // (1024 * 1024)} MB)" if length and str(length).isdigit() else ""
+            progress(f"Downloading Betterleaks v{PINNED_VERSION}{size} from GitHub releases…")
+        next_tick = _PROGRESS_TICK_BYTES
+        while True:
+            chunk = response.read(65536)
+            if not chunk:
+                break
+            total += len(chunk)
+            if total > _MAX_DOWNLOAD_BYTES:
+                raise ValueError(
+                    f"download exceeded {_MAX_DOWNLOAD_BYTES // (1024 * 1024)} MB cap"
+                )
+            digest.update(chunk)
+            os.write(dest_fd, chunk)
+            if progress is not None and total >= next_tick:
+                progress(f"  … {total // (1024 * 1024)} MB")
+                next_tick += _PROGRESS_TICK_BYTES
+    return digest.hexdigest()
+
+
+def _stage_member_stream(source, member_size: int, binary_name: str, dest_dir: Path) -> Path:
+    """Stream an open archive member into a staged temp file under
+    ``dest_dir`` and return its path. The staged file is chmod 0o755 and
+    fsynced but NOT published: the caller verifies it executes before
+    os.replace()-ing it into place, so a bad download can never displace
+    a working managed binary."""
+    if member_size > _MAX_BINARY_BYTES:
+        raise ValueError("binary member exceeds size cap")
+    fd, tmp_name = tempfile.mkstemp(dir=str(dest_dir), prefix=f".{binary_name}.")
+    try:
+        try:
+            with source:
+                while True:
+                    chunk = source.read(65536)
+                    if not chunk:
+                        break
+                    os.write(fd, chunk)
+            os.fsync(fd)
+        finally:
+            os.close(fd)
+        # os.chmod on the path, not os.fchmod on the fd — fchmod doesn't
+        # exist on Windows before Python 3.13 and this must run on 3.10+.
+        os.chmod(tmp_name, 0o755)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+    return Path(tmp_name)
+
+
+def _extract_binary(archive_path: Path, binary_name: str, dest_dir: Path) -> Path:
+    """Stage exactly the ``binary_name`` member of the release archive
+    (tar.gz on darwin/linux, zip on Windows) into a temp file under
+    ``dest_dir`` and return its path. Member names are matched exactly —
+    anything resembling a path (``/``, ``..``) is never written, so a
+    malicious archive cannot traverse out of the target directory.
+
+    Raises ``ValueError`` if the member is absent or oversized, and
+    ``tarfile.TarError``/``zipfile.BadZipFile`` on a corrupt archive.
+    """
+    if archive_path.suffix == ".zip":
+        with zipfile.ZipFile(archive_path) as archive:
+            member = None
+            for candidate in archive.infolist():
+                if candidate.filename == binary_name and not candidate.is_dir():
+                    member = candidate
+                    break
+            if member is None:
+                raise ValueError(f"archive has no '{binary_name}' member")
+            return _stage_member_stream(
+                archive.open(member), member.file_size, binary_name, dest_dir
+            )
+
+    with tarfile.open(archive_path, mode="r:gz") as tar:
+        member = None
+        for candidate in tar:
+            if candidate.name == binary_name and candidate.isfile():
+                member = candidate
+                break
+        if member is None:
+            raise ValueError(f"archive has no '{binary_name}' member")
+        source = tar.extractfile(member)
+        if source is None:
+            raise ValueError(f"archive member '{binary_name}' is not readable")
+        return _stage_member_stream(source, member.size, binary_name, dest_dir)
+
+
+def _verify_installed_binary(path: Path) -> str | None:
+    """Run ``<path> --version`` as a post-install sanity check (catches a
+    wrong-arch or truncated binary before the share gate ever trusts it).
+    Returns the parsed version string, or None if the binary doesn't run.
+    """
+    try:
+        result = subprocess.run(
+            [str(path), "--version"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=15,
+            stdin=subprocess.DEVNULL,
+            env=_scrubbed_subprocess_env(),
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    blob = (result.stdout or "") + "\n" + (result.stderr or "")
+    match = _VERSION_RE.search(blob) or _BARE_VERSION_RE.search(blob)
+    return match.group(1) if match else None
+
+
+def install(
+    *,
+    force: bool = False,
+    progress: Callable[[str], None] | None = None,
+) -> dict:
+    """Install the pinned Betterleaks into ``~/.clawjournal/bin``.
+
+    Returns a result dict with ``status`` plus context fields (and a
+    ``hint`` with remediation advice on network/checksum failures);
+    never raises. Statuses: ``installed``, ``already-installed``,
+    ``unsupported-platform``, ``download-failed``, ``checksum-mismatch``,
+    ``archive-invalid``, ``verify-failed``, ``install-failed``.
+
+    ``progress`` (if given) receives human-readable download progress
+    lines — the CLI passes ``print`` so a slow link doesn't look hung.
+    """
+    try:
+        return _install(force=force, progress=progress)
+    except Exception as exc:
+        # Backstop for anything the specific handlers below don't name
+        # (e.g. a stray file blocking the bin-dir mkdir). The CLI shows a
+        # status, not a traceback; failure direction is always "nothing
+        # installed".
+        return {
+            "status": "install-failed",
+            "error": f"{exc.__class__.__name__}: {exc}",
+        }
+
+
+def _install(
+    *,
+    force: bool = False,
+    progress: Callable[[str], None] | None = None,
+) -> dict:
+    target = managed_binary_path()
+    binary_name = target.name
+
+    # "Already installed" must mean "the share gate will use it AND it
+    # is the pinned version" — an unexecutable file, a directory, or an
+    # off-pin copy from an older clawjournal falls through to a fresh
+    # install (the atomic publish below makes overwriting safe).
+    if not force and target.is_file() and os.access(target, os.X_OK):
+        current = _verify_installed_binary(target)
+        if current == PINNED_VERSION:
+            return {
+                "status": "already-installed",
+                "path": str(target),
+                "version": current,
+            }
+
+    key = platform_key()
+    if key is None:
+        return {
+            "status": "unsupported-platform",
+            "error": (
+                f"no pinned Betterleaks v{PINNED_VERSION} archive for "
+                f"{sys.platform}/{platform.machine()}; install it manually "
+                "(https://github.com/betterleaks/betterleaks#installation)"
+            ),
+        }
+
+    expected_sha256 = _ARCHIVE_SHA256[key]
+    url = download_url(key)
+    target.parent.mkdir(parents=True, exist_ok=True)
+
+    archive_suffix = ".zip" if key.startswith("windows") else ".tar.gz"
+    archive_fd, archive_name = tempfile.mkstemp(
+        dir=str(target.parent), prefix=".betterleaks-download.", suffix=archive_suffix
+    )
+    archive_path = Path(archive_name)
+    staged: Path | None = None
+    try:
+        try:
+            actual_sha256 = _download_archive(url, archive_fd, progress=progress)
+        except (urllib.error.URLError, http.client.HTTPException, OSError, ValueError) as exc:
+            # HTTPException covers e.g. IncompleteRead on a truncated
+            # chunked response; URLError is already an OSError subclass
+            # but is named for clarity.
+            return {
+                "status": "download-failed",
+                "url": url,
+                "error": str(exc),
+                "hint": DOWNLOAD_FAILED_HINT,
+            }
+        finally:
+            os.close(archive_fd)
+
+        if actual_sha256 != expected_sha256:
+            # Fail closed: nothing is extracted or installed.
+            return {
+                "status": "checksum-mismatch",
+                "url": url,
+                "error": (
+                    f"sha256 {actual_sha256} does not match the pinned "
+                    f"checksum {expected_sha256} for {key}"
+                ),
+                "hint": CHECKSUM_MISMATCH_HINT,
+            }
+
+        # Failure domains are reported distinctly: a bad archive is
+        # "archive-invalid" (re-download might help), local file I/O is
+        # "install-failed" (the archive already passed its checksum).
+        # gzip.BadGzipFile and EOFError are raised by truncated/corrupt
+        # streams mid-extract; BadGzipFile subclasses OSError so it must
+        # be matched before the OSError clause.
+        try:
+            staged = _extract_binary(archive_path, binary_name, target.parent)
+        except (tarfile.TarError, zipfile.BadZipFile, gzip.BadGzipFile, EOFError, ValueError) as exc:
+            return {"status": "archive-invalid", "url": url, "error": str(exc)}
+        except OSError as exc:
+            return {
+                "status": "install-failed",
+                "error": f"local file I/O failed while staging the binary: {exc}",
+            }
+
+        # Verify BEFORE publish: a binary that doesn't run (wrong arch,
+        # truncation the checksum somehow missed) never displaces an
+        # existing working managed binary.
+        version = _verify_installed_binary(staged)
+        if version is None:
+            return {
+                "status": "verify-failed",
+                "path": str(target),
+                "error": (
+                    "downloaded binary failed to execute `--version`; "
+                    "the existing managed binary (if any) was left untouched"
+                ),
+            }
+
+        try:
+            os.replace(staged, target)
+        except OSError as exc:
+            # E.g. Windows refusing to replace a running .exe, or a
+            # directory squatting on the target path.
+            return {
+                "status": "install-failed",
+                "error": (
+                    f"could not move the verified binary into place at "
+                    f"{target}: {exc}"
+                ),
+            }
+        staged = None  # published — nothing to clean up
+    finally:
+        for leftover in (archive_path, staged):
+            if leftover is None:
+                continue
+            try:
+                leftover.unlink()
+            except OSError:
+                pass
+
+    return {"status": "installed", "path": str(target), "version": version}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,6 +47,7 @@ exclude = ["clawjournal.web*"]
     "web/frontend/dist/**/*",
     "events/docs/*.md",
     "events/docs/_features.yaml",
+    "redaction/*.toml",
 ]
 
 [project.optional-dependencies]

--- a/scripts/check_betterleaks_pin.py
+++ b/scripts/check_betterleaks_pin.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""Verify the vendored Betterleaks checksums match upstream's release.
+
+Compares ``clawjournal/redaction/betterleaks_install.py``'s
+``_ARCHIVE_SHA256`` (and ``PINNED_VERSION``) against an upstream
+``checksums.txt``. Exits non-zero with a clear diff on any mismatch.
+
+This catches a fat-fingered or partial pin bump — a maintainer updating
+``PINNED_VERSION`` but forgetting a hash row, or pasting one platform's
+checksum into another's — that the hermetic unit tests cannot see
+because they never touch the network. The network fetch itself lives in
+the CI workflow (authenticated, with retry); this script is pure
+comparison so it stays unit-testable.
+
+Usage:
+    python scripts/check_betterleaks_pin.py path/to/checksums.txt
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Importable without `pip install` regardless of cwd: clawjournal/ lives
+# one level up from scripts/.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from clawjournal.redaction.betterleaks_install import (  # noqa: E402
+    PINNED_VERSION,
+    _ARCHIVE_SHA256,
+    archive_filename,
+)
+
+
+def parse_checksums(text: str) -> dict[str, str]:
+    """Parse upstream ``checksums.txt`` lines of the form ``<sha256>  <filename>``."""
+    out: dict[str, str] = {}
+    for line in text.splitlines():
+        parts = line.split()
+        if len(parts) != 2:
+            continue
+        sha, name = parts
+        out[name] = sha.lower()
+    return out
+
+
+def compare(upstream: dict[str, str]) -> list[str]:
+    """Return a list of human-readable mismatch messages (empty == OK)."""
+    errors: list[str] = []
+    for key, vendored in sorted(_ARCHIVE_SHA256.items()):
+        filename = archive_filename(key)
+        actual = upstream.get(filename)
+        if actual is None:
+            errors.append(f"{filename}: not present in upstream checksums.txt")
+        elif actual != vendored.lower():
+            errors.append(f"{filename}: vendored {vendored} != upstream {actual}")
+    return errors
+
+
+def main(argv: list[str]) -> int:
+    if len(argv) != 2:
+        print("usage: check_betterleaks_pin.py <checksums.txt>", file=sys.stderr)
+        return 2
+    try:
+        text = Path(argv[1]).read_text()
+    except OSError as exc:
+        print(f"could not read {argv[1]}: {exc}", file=sys.stderr)
+        return 2
+
+    errors = compare(parse_checksums(text))
+    if errors:
+        print(f"Betterleaks pin mismatch for v{PINNED_VERSION}:", file=sys.stderr)
+        for err in errors:
+            print(f"  {err}", file=sys.stderr)
+        print(
+            "\nIf you bumped PINNED_VERSION, refresh every _ARCHIVE_SHA256 row "
+            "from the new release's checksums.txt. A stale row fails closed.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"All {len(_ARCHIVE_SHA256)} vendored checksums match "
+        f"upstream Betterleaks v{PINNED_VERSION}."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,14 +6,17 @@ from clawjournal.redaction.anonymizer import Anonymizer
 
 
 @pytest.fixture(autouse=True)
-def _bypass_trufflehog_by_default(monkeypatch):
-    """TruffleHog is a mandatory share-time gate in production, but most
-    tests don't have the binary installed and shouldn't depend on it.
-    Default every test to the bypass path; tests that exercise the
-    gate itself do ``monkeypatch.delenv("CLAWJOURNAL_SKIP_TRUFFLEHOG",
-    raising=False)`` and mock the subprocess.
+def _bypass_secret_scanners_by_default(monkeypatch):
+    """TruffleHog and Betterleaks are mandatory share-time gates in
+    production, but most tests don't have the binaries installed and
+    shouldn't depend on them. Default every test to the bypass path;
+    tests that exercise a gate itself ``monkeypatch.delenv(...)`` the
+    relevant variable and mock the subprocess. Two separate variables
+    (not one unified switch) so each wrapper's ``is_bypassed`` stays
+    self-contained and the manifest records which scanner was bypassed.
     """
     monkeypatch.setenv("CLAWJOURNAL_SKIP_TRUFFLEHOG", "1")
+    monkeypatch.setenv("CLAWJOURNAL_SKIP_BETTERLEAKS", "1")
 
 
 @pytest.fixture

--- a/tests/redaction/fixtures/betterleaks_report.json
+++ b/tests/redaction/fixtures/betterleaks_report.json
@@ -1,0 +1,50 @@
+[
+    {
+        "RuleID": "private-key",
+        "Description": "Identified a Private Key, which may compromise cryptographic security and sensitive data encryption.",
+        "StartLine": 2,
+        "EndLine": 2,
+        "StartColumn": 64,
+        "EndColumn": 257,
+        "Match": "-----BEGIN RSA PRIVATE KEY-----\\nMIIEpAIBAAKCAQEA7ZkFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeF\\nakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFake2\\n-----END RSA PRIVATE KEY-----",
+        "Secret": "-----BEGIN RSA PRIVATE KEY-----\\nMIIEpAIBAAKCAQEA7ZkFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeF\\nakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFakeFake2\\n-----END RSA PRIVATE KEY-----",
+        "Attributes": {
+            "path": "sessions.jsonl",
+            "resource": "fs.content"
+        },
+        "Tags": [],
+        "Fingerprint": "sessions.jsonl:private-key:2",
+        "File": "sessions.jsonl",
+        "SymlinkFile": "",
+        "Commit": "",
+        "Entropy": 3.8576245,
+        "Author": "",
+        "Email": "",
+        "Date": "",
+        "Message": ""
+    },
+    {
+        "RuleID": "slack-bot-token",
+        "Description": "Identified a Slack Bot token, which may compromise bot integrations and communication channel security.",
+        "StartLine": 1,
+        "EndLine": 1,
+        "StartColumn": 70,
+        "EndColumn": 126,
+        "Match": "xoxb-FAKE0FAKE0FAKE-FIXTURE0TOKEN-AbCdEfGhIjKlMnOpQrStUvWx",
+        "Secret": "xoxb-FAKE0FAKE0FAKE-FIXTURE0TOKEN-AbCdEfGhIjKlMnOpQrStUvWx",
+        "Attributes": {
+            "path": "sessions.jsonl",
+            "resource": "fs.content"
+        },
+        "Tags": [],
+        "Fingerprint": "sessions.jsonl:slack-bot-token:1",
+        "File": "sessions.jsonl",
+        "SymlinkFile": "",
+        "Commit": "",
+        "Entropy": 4.972898,
+        "Author": "",
+        "Email": "",
+        "Date": "",
+        "Message": ""
+    }
+]

--- a/tests/redaction/test_betterleaks.py
+++ b/tests/redaction/test_betterleaks.py
@@ -1,0 +1,494 @@
+"""Tests for the Betterleaks scanner wrapper.
+
+The subprocess contract is faked by intercepting ``subprocess.run``,
+locating ``--report-path`` in the argv, and writing report JSON there —
+mirroring how the real binary communicates (verified against
+betterleaks 1.6.1; ``fixtures/betterleaks_report.json`` is a vendored
+real report from that binary).
+"""
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from clawjournal.redaction import betterleaks
+
+FIXTURE_REPORT = Path(__file__).parent / "fixtures" / "betterleaks_report.json"
+
+
+def _report_path_from(cmd: list[str]) -> Path:
+    return Path(cmd[cmd.index("--report-path") + 1])
+
+
+def _fake_run_writing(payload: str, returncode: int, capture: dict | None = None):
+    """A subprocess.run stand-in that writes ``payload`` to the argv's
+    --report-path, like the real binary does."""
+
+    def fake_run(cmd, **kwargs):
+        if capture is not None:
+            capture["argv"] = cmd
+            capture["kwargs"] = kwargs
+        _report_path_from(cmd).write_text(payload)
+        return subprocess.CompletedProcess(cmd, returncode, stdout=b"", stderr=b"")
+
+    return fake_run
+
+
+class TestPlaceholderForRule:
+    def test_normalizes_rule_id(self):
+        assert betterleaks.placeholder_for_rule("slack-bot-token") == (
+            "[REDACTED_SLACK_BOT_TOKEN]"
+        )
+        assert betterleaks.placeholder_for_rule("private-key") == "[REDACTED_PRIVATE_KEY]"
+
+    def test_empty_rule_falls_back(self):
+        assert betterleaks.placeholder_for_rule("--") == "[REDACTED_BETTERLEAKS]"
+
+    def test_placeholders_match_bundled_allowlist(self):
+        # The bundled TOML allowlists [REDACTED_*] so the redact-and-rescan
+        # loop converges; every placeholder this module emits must match it.
+        import re
+
+        allowlist_re = re.compile(r"\[REDACTED(?:_[A-Z0-9_]+)?\]")
+        for rule in ("slack-bot-token", "private-key", "aws-secret-access-key", "--"):
+            assert allowlist_re.fullmatch(betterleaks.placeholder_for_rule(rule))
+
+
+class TestParseFinding:
+    def _fixture_entries(self) -> list[dict]:
+        return json.loads(FIXTURE_REPORT.read_text())
+
+    def test_parses_real_report_entry(self):
+        entry = next(
+            e for e in self._fixture_entries() if e["RuleID"] == "slack-bot-token"
+        )
+        finding = betterleaks._parse_finding(entry)
+        assert finding is not None
+        assert finding.rule_id == "slack-bot-token"
+        assert finding.line == 1
+        assert finding.entropy == pytest.approx(4.97, abs=0.01)
+        assert finding.raw_sha256 is not None and finding.raw_sha256.startswith("sha256:")
+        # Masked keeps only edges of the secret.
+        assert entry["Secret"] not in finding.masked
+        assert finding.masked.startswith("xoxb")
+
+    def test_escaped_private_key_is_parsed_in_file_level_form(self):
+        # Betterleaks reports secrets as the bytes on disk: a key inside a
+        # JSONL string arrives with literal \n escape sequences intact.
+        entry = next(
+            e for e in self._fixture_entries() if e["RuleID"] == "private-key"
+        )
+        assert "\\n" in entry["Secret"] and "\n" not in entry["Secret"]
+        finding = betterleaks._parse_finding(entry)
+        assert finding is not None
+        assert finding.line == 2
+
+    def test_missing_rule_id_returns_none(self):
+        assert betterleaks._parse_finding({"Secret": "x"}) is None
+        assert betterleaks._parse_finding({"RuleID": "", "Secret": "x"}) is None
+
+    def test_missing_secret_still_reports_with_generic_mask(self):
+        finding = betterleaks._parse_finding({"RuleID": "some-rule", "StartLine": 3})
+        assert finding is not None
+        assert finding.masked == "[REDACTED]"
+        assert finding.raw_sha256 is None
+
+    def test_invalid_start_line_is_dropped(self):
+        finding = betterleaks._parse_finding({"RuleID": "r", "StartLine": 0})
+        assert finding is not None and finding.line is None
+
+
+class TestReadReportPayload:
+    def test_clean_scan_null_normalizes_to_empty(self, tmp_path):
+        report = tmp_path / "r.json"
+        report.write_text("null\n")
+        assert betterleaks._read_report_payload(report) == []
+
+    def test_findings_array_passes_through(self, tmp_path):
+        report = tmp_path / "r.json"
+        report.write_text('[{"RuleID": "x"}, "not-a-dict"]')
+        assert betterleaks._read_report_payload(report) == [{"RuleID": "x"}]
+
+    def test_missing_empty_or_malformed_is_none(self, tmp_path):
+        assert betterleaks._read_report_payload(tmp_path / "absent.json") is None
+        empty = tmp_path / "empty.json"
+        empty.write_text("")
+        assert betterleaks._read_report_payload(empty) is None
+        bad = tmp_path / "bad.json"
+        bad.write_text("{not json")
+        assert betterleaks._read_report_payload(bad) is None
+        scalar = tmp_path / "scalar.json"
+        scalar.write_text('"unexpected"')
+        assert betterleaks._read_report_payload(scalar) is None
+
+
+class TestScanFile:
+    def _enable_real_scan(self, monkeypatch):
+        monkeypatch.delenv(betterleaks.SKIP_ENV_VAR, raising=False)
+        monkeypatch.setattr(betterleaks, "is_available", lambda: True)
+        # Pin resolution so argv assertions don't depend on whether the
+        # machine running the tests has a real binary installed.
+        monkeypatch.setattr(betterleaks, "resolve_binary", lambda: "betterleaks")
+
+    def test_bypass_env_var_short_circuits(self, tmp_path, monkeypatch):
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("{}\n")
+        # Autouse fixture already sets SKIP_ENV_VAR=1; verify bypass path.
+
+        def fake_run(*args, **kwargs):
+            raise AssertionError("subprocess should not run under bypass")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        report = betterleaks.scan_file(target)
+        assert report.bypassed is True
+        assert report.findings == []
+
+    def test_missing_binary_is_reported(self, tmp_path, monkeypatch):
+        monkeypatch.delenv(betterleaks.SKIP_ENV_VAR, raising=False)
+        monkeypatch.setattr(betterleaks, "is_available", lambda: False)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("{}\n")
+
+        report = betterleaks.scan_file(target)
+        assert report.binary_missing is True
+        assert report.scan_error is None
+
+    def test_clean_scan_argv_contract(self, tmp_path, monkeypatch):
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text('{"hello":"world"}\n')
+        seen: dict = {}
+
+        monkeypatch.setattr(subprocess, "run", _fake_run_writing("null", 0, seen))
+        report = betterleaks.scan_file(target)
+
+        assert report.findings == []
+        assert report.binary_missing is False
+        assert report.scan_error is None
+        cmd = seen["argv"]
+        assert cmd[0] == "betterleaks"
+        assert cmd[1] == "dir"
+        assert cmd[2] == str(target)
+        assert "--report-format" in cmd and cmd[cmd.index("--report-format") + 1] == "json"
+        assert "--exit-code" in cmd and cmd[cmd.index("--exit-code") + 1] == "183"
+        assert "--no-banner" in cmd
+        # The bundled config ships in-repo, so every scan passes it.
+        assert "--config" in cmd
+        assert cmd[cmd.index("--config") + 1] == str(betterleaks.bundled_config_path())
+        # Live validation must NEVER be enabled: candidate secrets stay local.
+        assert all(not str(arg).startswith("--validation") for arg in cmd)
+        # Non-streaming scans get DEVNULL stdin; env is scrubbed, not inherited.
+        assert seen["kwargs"].get("stdin") is subprocess.DEVNULL
+        assert isinstance(seen["kwargs"].get("env"), dict)
+
+    def test_findings_parsed_from_real_report_fixture(self, tmp_path, monkeypatch):
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+        fixture_text = FIXTURE_REPORT.read_text()
+
+        monkeypatch.setattr(subprocess, "run", _fake_run_writing(fixture_text, 183))
+        report = betterleaks.scan_file(target)
+
+        assert [f.rule_id for f in report.findings] == ["slack-bot-token", "private-key"]
+        assert [f.line for f in report.findings] == [1, 2]  # sorted by line
+        assert report.top_rules == ["private-key", "slack-bot-token"]
+        # Raw secrets never appear in the summary or persisted report.
+        for secret in (f["Secret"] for f in json.loads(fixture_text)):
+            assert secret not in json.dumps(report.summary())
+        out = tmp_path / "betterleaks.json"
+        betterleaks.write_report(out, report)
+        persisted = out.read_text()
+        for secret in (f["Secret"] for f in json.loads(fixture_text)):
+            assert secret not in persisted
+        # Only the basename of the scanned path is persisted.
+        assert json.loads(persisted)["scanned_path"] == "sessions.jsonl"
+
+    def test_duplicate_findings_are_collapsed(self, tmp_path, monkeypatch):
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+        entry = json.loads(FIXTURE_REPORT.read_text())[0]
+        payload = json.dumps([entry, dict(entry)])
+
+        monkeypatch.setattr(subprocess, "run", _fake_run_writing(payload, 183))
+        report = betterleaks.scan_file(target)
+        assert len(report.findings) == 1
+
+    def test_unexpected_exit_status_is_scan_error(self, tmp_path, monkeypatch):
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+
+        monkeypatch.setattr(subprocess, "run", _fake_run_writing("null", 126))
+        report = betterleaks.scan_file(target)
+        assert report.scan_error == "unexpected exit status 126"
+
+    def test_timeout_is_scan_error(self, tmp_path, monkeypatch):
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+
+        def fake_run(cmd, **kwargs):
+            raise subprocess.TimeoutExpired(cmd=cmd, timeout=120)
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        report = betterleaks.scan_file(target)
+        assert "timed out" in (report.scan_error or "")
+
+    def test_spawn_failure_is_scan_error(self, tmp_path, monkeypatch):
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+
+        def fake_run(cmd, **kwargs):
+            raise OSError("exec format error")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        report = betterleaks.scan_file(target)
+        assert report.scan_error == "could not execute the betterleaks binary"
+
+    def test_missing_report_file_is_scan_error(self, tmp_path, monkeypatch):
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+
+        def fake_run(cmd, **kwargs):
+            # Simulate a binary that exited cleanly but wrote no report:
+            # unlink the mkstemp placeholder the wrapper created.
+            _report_path_from(cmd).unlink()
+            return subprocess.CompletedProcess(cmd, 0, stdout=b"", stderr=b"")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        report = betterleaks.scan_file(target)
+        assert report.scan_error == "scan produced no readable JSON report"
+
+    def test_unhashable_target_is_scan_error(self, tmp_path, monkeypatch):
+        self._enable_real_scan(monkeypatch)
+        report = betterleaks.scan_file(tmp_path / "does-not-exist.jsonl")
+        assert report.scan_error is not None
+        assert "could not hash scan target" in report.scan_error
+
+    def test_report_tempfile_is_always_unlinked(self, tmp_path, monkeypatch):
+        self._enable_real_scan(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+        seen: dict = {}
+
+        monkeypatch.setattr(
+            subprocess, "run", _fake_run_writing(FIXTURE_REPORT.read_text(), 183, seen)
+        )
+        betterleaks.scan_file(target)
+        # The raw-bearing report file must not outlive the call.
+        assert not _report_path_from(seen["argv"]).exists()
+
+
+class TestScanText:
+    def test_delegates_to_scan_file_and_cleans_up(self, monkeypatch):
+        captured: dict = {}
+
+        def fake_scan_file(path):
+            captured["path"] = Path(path)
+            captured["content"] = Path(path).read_text()
+            return betterleaks.BetterleaksReport(
+                scanned_path=str(path), scanned_sha256="sha256:x"
+            )
+
+        monkeypatch.setattr(betterleaks, "scan_file", fake_scan_file)
+        report = betterleaks.scan_text("some session text")
+        assert captured["content"] == "some session text"
+        assert not captured["path"].exists()  # temp file removed
+        assert report.scanned_sha256 == "sha256:x"
+
+
+class TestRawMatches:
+    def _enable(self, monkeypatch):
+        monkeypatch.delenv(betterleaks.SKIP_ENV_VAR, raising=False)
+        monkeypatch.setattr(betterleaks, "is_available", lambda: True)
+        monkeypatch.setattr(betterleaks, "resolve_binary", lambda: "betterleaks")
+
+    def test_file_scan_returns_raw_line_and_entropy(self, tmp_path, monkeypatch):
+        self._enable(monkeypatch)
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+
+        monkeypatch.setattr(
+            subprocess, "run", _fake_run_writing(FIXTURE_REPORT.read_text(), 183)
+        )
+        matches = betterleaks._scan_file_for_raw_matches(target)
+
+        by_rule = {m["rule_id"]: m for m in matches}
+        assert set(by_rule) == {"private-key", "slack-bot-token"}
+        slack = by_rule["slack-bot-token"]
+        assert slack["raw"].startswith("xoxb-")
+        assert slack["line"] == 1
+        assert slack["entropy"] == pytest.approx(4.97, abs=0.01)
+
+    def test_stdin_scan_streams_payload(self, monkeypatch):
+        self._enable(monkeypatch)
+        seen: dict = {}
+
+        monkeypatch.setattr(subprocess, "run", _fake_run_writing("null", 0, seen))
+        matches = betterleaks._scan_text_for_raw_matches("scan this text")
+
+        assert matches == []
+        assert seen["argv"][1] == "stdin"
+        assert seen["kwargs"]["input"] == b"scan this text"
+        assert "stdin" not in seen["kwargs"]  # input= replaces stdin=DEVNULL
+
+    def test_bypass_and_missing_binary_fail_soft(self, tmp_path, monkeypatch):
+        # Autouse fixture sets the bypass env var.
+        assert betterleaks._scan_text_for_raw_matches("text") == []
+        assert betterleaks._scan_file_for_raw_matches(tmp_path / "x") == []
+
+        monkeypatch.delenv(betterleaks.SKIP_ENV_VAR, raising=False)
+        monkeypatch.setattr(betterleaks, "is_available", lambda: False)
+        assert betterleaks._scan_text_for_raw_matches("text") == []
+
+    def test_scan_error_fails_soft_to_empty(self, tmp_path, monkeypatch):
+        self._enable(monkeypatch)
+
+        def fake_run(cmd, **kwargs):
+            raise OSError("boom")
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        assert betterleaks._scan_text_for_raw_matches("text") == []
+        target = tmp_path / "sessions.jsonl"
+        target.write_text("x\n")
+        assert betterleaks._scan_file_for_raw_matches(target) == []
+
+    def test_oversized_payload_is_skipped(self, monkeypatch):
+        self._enable(monkeypatch)
+        monkeypatch.setattr(betterleaks, "_MAX_SCAN_BYTES", 8)
+        assert betterleaks._scan_text_for_raw_matches("longer than eight") == []
+
+
+class TestSessionFindings:
+    def test_matches_are_relocated_per_field(self, monkeypatch):
+        raw = "xoxb-FAKE0FAKE0FAKE-FIXTURE0TOKEN-AbCdEfGhIjKlMnOpQrStUvWx"
+        monkeypatch.setattr(
+            betterleaks,
+            "_scan_text_for_raw_matches",
+            lambda text: [
+                {"raw": raw, "rule_id": "slack-bot-token", "entropy": 4.9, "line": 1}
+            ],
+        )
+        session = {
+            "display_title": f"token {raw} in title",
+            "messages": [
+                {"content": f"first {raw} second {raw}"},
+                {"tool_uses": [{"input": {"command": f"echo {raw}"}}]},
+            ],
+        }
+
+        findings = betterleaks.scan_session_for_betterleaks_findings(session)
+
+        assert len(findings) == 4  # 1 title + 2 content + 1 tool input
+        assert {f.engine for f in findings} == {betterleaks.BETTERLEAKS_ENGINE_ID}
+        assert {f.rule for f in findings} == {"slack-bot-token"}
+        title_hit = next(f for f in findings if f.field == "display_title")
+        assert title_hit.offset == len("token ")
+        assert title_hit.length == len(raw)
+        content_hits = [f for f in findings if f.field == "content"]
+        assert [f.offset for f in content_hits] == [
+            len("first "),
+            len(f"first {raw} second "),
+        ]
+
+    def test_short_raws_are_ignored(self, monkeypatch):
+        monkeypatch.setattr(
+            betterleaks,
+            "_scan_text_for_raw_matches",
+            lambda text: [{"raw": "ab", "rule_id": "r", "entropy": None, "line": None}],
+        )
+        session = {"messages": [{"content": "ab"}]}
+        assert betterleaks.scan_session_for_betterleaks_findings(session) == []
+
+    def test_no_matches_short_circuits(self, monkeypatch):
+        monkeypatch.setattr(betterleaks, "_scan_text_for_raw_matches", lambda text: [])
+        assert betterleaks.scan_session_for_betterleaks_findings({"messages": []}) == []
+
+
+class TestSecretMapFromBlob:
+    def test_maps_raw_to_rule_placeholder(self, monkeypatch):
+        raw = "xoxb-FAKE0FAKE0FAKE-FIXTURE0TOKEN-AbCdEfGhIjKlMnOpQrStUvWx"
+        monkeypatch.setattr(
+            betterleaks,
+            "_scan_text_for_raw_matches",
+            lambda text: [
+                {"raw": raw, "rule_id": "slack-bot-token", "entropy": 4.9, "line": 1}
+            ],
+        )
+        out = betterleaks.betterleaks_secret_map_from_blob({"messages": []}, {})
+        assert out == {raw: "[REDACTED_SLACK_BOT_TOKEN]"}
+
+    def test_ignored_decision_skips_raw(self, monkeypatch):
+        from clawjournal.findings import hash_entity
+
+        raw = "xoxb-FAKE0FAKE0FAKE-FIXTURE0TOKEN-AbCdEfGhIjKlMnOpQrStUvWx"
+        monkeypatch.setattr(
+            betterleaks,
+            "_scan_text_for_raw_matches",
+            lambda text: [
+                {"raw": raw, "rule_id": "slack-bot-token", "entropy": 4.9, "line": 1}
+            ],
+        )
+        decisions = {hash_entity(raw): "ignored"}
+        assert betterleaks.betterleaks_secret_map_from_blob({}, decisions) == {}
+
+    def test_overlapping_rules_pick_deterministic_placeholder(self, monkeypatch):
+        raw = "shared-raw-value-123456789"
+        monkeypatch.setattr(
+            betterleaks,
+            "_scan_text_for_raw_matches",
+            lambda text: [
+                {"raw": raw, "rule_id": "zzz-rule", "entropy": None, "line": 1},
+                {"raw": raw, "rule_id": "aaa-rule", "entropy": None, "line": 1},
+            ],
+        )
+        out = betterleaks.betterleaks_secret_map_from_blob({}, {})
+        # (rule_id, raw) ascending → "aaa-rule" wins regardless of scan order.
+        assert out == {raw: "[REDACTED_AAA_RULE]"}
+
+
+class TestEngineFingerprint:
+    def _fingerprint_with(self, monkeypatch, tmp_path, banner: str) -> str:
+        binary = tmp_path / "betterleaks"
+        binary.write_bytes(b"#!/bin/sh\n")
+        binary.chmod(0o755)
+        monkeypatch.setattr(betterleaks, "resolve_binary", lambda: str(binary))
+        betterleaks.reset_version_cache()
+
+        monkeypatch.setattr(
+            subprocess,
+            "run",
+            lambda cmd, **kwargs: subprocess.CompletedProcess(
+                cmd, 0, stdout=banner, stderr=""
+            ),
+        )
+        try:
+            return betterleaks.engine_fingerprint()
+        finally:
+            betterleaks.reset_version_cache()
+
+    def test_parses_version_flag_banner(self, monkeypatch, tmp_path):
+        # `betterleaks --version` prints "betterleaks version 1.6.1".
+        assert self._fingerprint_with(
+            monkeypatch, tmp_path, "betterleaks version 1.6.1\n"
+        ) == "betterleaks 1.6.1"
+
+    def test_parses_bare_semver_banner(self, monkeypatch, tmp_path):
+        # The `version` subcommand prints a bare "1.6.1".
+        assert self._fingerprint_with(monkeypatch, tmp_path, "1.6.1\n") == (
+            "betterleaks 1.6.1"
+        )
+
+    def test_missing_binary_reports_missing(self, monkeypatch):
+        monkeypatch.setattr(betterleaks, "resolve_binary", lambda: None)
+        betterleaks.reset_version_cache()
+        try:
+            assert betterleaks.engine_fingerprint() == "missing"
+        finally:
+            betterleaks.reset_version_cache()

--- a/tests/redaction/test_betterleaks_install.py
+++ b/tests/redaction/test_betterleaks_install.py
@@ -1,0 +1,563 @@
+"""Tests for the managed Betterleaks install (`clawjournal betterleaks install`).
+
+Everything runs offline: the download is served from an in-memory fake
+response, the platform key and vendored checksum table are patched per
+test, and the post-install `--version` sanity check is stubbed.
+"""
+
+import hashlib
+import io
+import os
+import tarfile
+import urllib.error
+import urllib.request
+import zipfile
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+from clawjournal.redaction import betterleaks, betterleaks_install
+
+
+def _tar_gz(members: dict[str, bytes]) -> bytes:
+    """Build a .tar.gz archive holding ``members`` (name → content)."""
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, content in members.items():
+            info = tarfile.TarInfo(name=name)
+            info.size = len(content)
+            info.mode = 0o755
+            tar.addfile(info, io.BytesIO(content))
+    return buf.getvalue()
+
+
+def _zip(members: dict[str, bytes]) -> bytes:
+    """Build a .zip archive holding ``members`` (name → content)."""
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, mode="w") as archive:
+        for name, content in members.items():
+            archive.writestr(name, content)
+    return buf.getvalue()
+
+
+class _FakeResponse:
+    """Minimal stand-in for the urlopen response context manager."""
+
+    def __init__(self, payload: bytes):
+        self._stream = io.BytesIO(payload)
+
+    def read(self, n: int = -1) -> bytes:
+        return self._stream.read(n)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc_info):
+        return False
+
+
+BINARY_CONTENT = b"#!/bin/sh\necho fake-betterleaks\n"
+
+PINNED = betterleaks_install.PINNED_VERSION
+
+
+@pytest.fixture
+def install_env(tmp_path, monkeypatch):
+    """Isolated CONFIG_DIR + deterministic platform + stubbed verify.
+
+    Returns a dict the test can tweak: ``serve(payload)`` swaps what the
+    fake network returns; ``pin_checksum(payload)`` pins the vendored
+    table to that payload; ``set_platform(key)`` switches the archive
+    flavor (zip for windows keys).
+    """
+    config_dir = tmp_path / ".clawjournal"
+    monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+    monkeypatch.setattr(betterleaks_install, "platform_key", lambda: "testos_x64")
+    monkeypatch.setattr(
+        betterleaks_install, "_verify_installed_binary", lambda path: PINNED
+    )
+
+    state = {"payload": b"", "urls": [], "key": "testos_x64"}
+
+    def fake_urlopen(request, timeout=None):
+        state["urls"].append(request.full_url)
+        return _FakeResponse(state["payload"])
+
+    monkeypatch.setattr(urllib.request, "urlopen", fake_urlopen)
+
+    def set_platform(key: str):
+        state["key"] = key
+        monkeypatch.setattr(betterleaks_install, "platform_key", lambda: key)
+
+    def pin_checksum(payload: bytes):
+        monkeypatch.setattr(
+            betterleaks_install,
+            "_ARCHIVE_SHA256",
+            {state["key"]: hashlib.sha256(payload).hexdigest()},
+        )
+
+    def serve(payload: bytes, *, pin: bool = True):
+        state["payload"] = payload
+        if pin:
+            pin_checksum(payload)
+
+    state["serve"] = serve
+    state["pin_checksum"] = pin_checksum
+    state["set_platform"] = set_platform
+    state["config_dir"] = config_dir
+    state["target"] = config_dir / "bin" / betterleaks.managed_binary_path().name
+    return state
+
+
+class TestInstall:
+    def test_happy_path_installs_executable_binary(self, install_env):
+        archive = _tar_gz({"betterleaks": BINARY_CONTENT, "LICENSE": b"MIT"})
+        install_env["serve"](archive)
+
+        result = betterleaks_install.install()
+
+        assert result["status"] == "installed"
+        assert result["version"] == PINNED
+        target = Path(result["path"])
+        assert target == install_env["target"]
+        assert target.read_bytes() == BINARY_CONTENT
+        if os.name != "nt":
+            assert os.access(target, os.X_OK)
+        # The pinned release URL was requested.
+        assert install_env["urls"] == [betterleaks_install.download_url("testos_x64")]
+
+    def test_zip_archive_for_windows_platform_key(self, install_env):
+        # Upstream ships .zip on Windows; the extractor must handle both
+        # flavors. (Member name stays this host's binary name — the flavor
+        # switch is what's under test.)
+        install_env["set_platform"]("windows_x64")
+        binary_name = install_env["target"].name
+        archive = _zip({binary_name: BINARY_CONTENT, "README.md": b"readme"})
+        install_env["serve"](archive)
+
+        result = betterleaks_install.install()
+
+        assert result["status"] == "installed"
+        assert install_env["target"].read_bytes() == BINARY_CONTENT
+        assert install_env["urls"] == [betterleaks_install.download_url("windows_x64")]
+        assert install_env["urls"][0].endswith(".zip")
+
+    def test_zip_without_binary_member_is_archive_invalid(self, install_env):
+        install_env["set_platform"]("windows_x64")
+        install_env["serve"](_zip({"README.md": b"not a binary"}))
+        result = betterleaks_install.install()
+        assert result["status"] == "archive-invalid"
+        assert not install_env["target"].exists()
+
+    def test_corrupt_zip_is_archive_invalid(self, install_env):
+        install_env["set_platform"]("windows_x64")
+        install_env["serve"](b"this is not a zip file")
+        result = betterleaks_install.install()
+        assert result["status"] == "archive-invalid"
+        assert not install_env["target"].exists()
+
+    def test_no_temp_files_left_behind(self, install_env):
+        install_env["serve"](_tar_gz({"betterleaks": BINARY_CONTENT}))
+        betterleaks_install.install()
+        leftovers = [
+            p for p in install_env["target"].parent.iterdir()
+            if p.name != install_env["target"].name
+        ]
+        assert leftovers == []
+
+    def test_checksum_mismatch_fails_closed(self, install_env):
+        archive = _tar_gz({"betterleaks": BINARY_CONTENT})
+        install_env["serve"](archive)
+        # Pin the table to different bytes than what the network serves.
+        install_env["pin_checksum"](b"something else entirely")
+
+        result = betterleaks_install.install()
+
+        assert result["status"] == "checksum-mismatch"
+        # Remediation guidance rides along for the CLI to print.
+        assert "proxy" in result["hint"]
+        assert not install_env["target"].exists()
+        bin_dir = install_env["target"].parent
+        assert not bin_dir.exists() or list(bin_dir.iterdir()) == []
+
+    def test_already_installed_without_force(self, install_env):
+        target = install_env["target"]
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"existing")
+        target.chmod(0o755)  # fixture's verify stub reports the pinned version
+
+        result = betterleaks_install.install()
+
+        assert result["status"] == "already-installed"
+        assert result["version"] == PINNED
+        assert target.read_bytes() == b"existing"
+        assert install_env["urls"] == []  # no network touch
+
+    def test_off_pin_existing_binary_is_upgraded(self, install_env, monkeypatch):
+        target = install_env["target"]
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"old pinned version")
+        target.chmod(0o755)
+        monkeypatch.setattr(
+            betterleaks_install,
+            "_verify_installed_binary",
+            lambda path: "1.0.0" if Path(path) == target else PINNED,
+        )
+        install_env["serve"](_tar_gz({"betterleaks": BINARY_CONTENT}))
+
+        result = betterleaks_install.install()
+
+        assert result["status"] == "installed"
+        assert result["version"] == PINNED
+        assert target.read_bytes() == BINARY_CONTENT
+
+    def test_force_reinstalls(self, install_env):
+        target = install_env["target"]
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"existing")
+        install_env["serve"](_tar_gz({"betterleaks": BINARY_CONTENT}))
+
+        result = betterleaks_install.install(force=True)
+
+        assert result["status"] == "installed"
+        assert target.read_bytes() == BINARY_CONTENT
+
+    def test_unsupported_platform(self, install_env, monkeypatch):
+        monkeypatch.setattr(betterleaks_install, "platform_key", lambda: None)
+        result = betterleaks_install.install()
+        assert result["status"] == "unsupported-platform"
+        assert "manually" in result["error"]
+
+    def test_download_failure_reported(self, install_env, monkeypatch):
+        def boom(request, timeout=None):
+            raise urllib.error.URLError("connection refused")
+
+        monkeypatch.setattr(urllib.request, "urlopen", boom)
+        install_env["pin_checksum"](b"irrelevant")
+
+        result = betterleaks_install.install()
+
+        assert result["status"] == "download-failed"
+        assert "proxy" in result["hint"]
+        assert not install_env["target"].exists()
+
+    def test_archive_without_binary_member(self, install_env):
+        install_env["serve"](_tar_gz({"README.md": b"not a binary"}))
+        result = betterleaks_install.install()
+        assert result["status"] == "archive-invalid"
+        assert not install_env["target"].exists()
+
+    def test_archive_with_traversal_member_is_rejected(self, install_env, tmp_path):
+        # A member trying to escape the bin dir must never be written; the
+        # exact-name match means it is simply not found.
+        install_env["serve"](_tar_gz({"../evil": BINARY_CONTENT}))
+        result = betterleaks_install.install()
+        assert result["status"] == "archive-invalid"
+        assert not (install_env["config_dir"] / "evil").exists()
+        assert not (tmp_path / "evil").exists()
+
+    def test_verify_failure_never_publishes(self, install_env, monkeypatch):
+        install_env["serve"](_tar_gz({"betterleaks": BINARY_CONTENT}))
+        monkeypatch.setattr(
+            betterleaks_install, "_verify_installed_binary", lambda path: None
+        )
+
+        result = betterleaks_install.install()
+
+        assert result["status"] == "verify-failed"
+        assert not install_env["target"].exists()
+        bin_dir = install_env["target"].parent
+        assert not bin_dir.exists() or list(bin_dir.iterdir()) == []
+
+    def test_verify_failure_leaves_existing_binary_untouched(self, install_env, monkeypatch):
+        # Verification happens BEFORE publish: a bad download (even under
+        # --force) must never displace a working managed binary.
+        target = install_env["target"]
+        target.parent.mkdir(parents=True)
+        target.write_bytes(b"known good binary")
+        target.chmod(0o755)
+        install_env["serve"](_tar_gz({"betterleaks": BINARY_CONTENT}))
+        monkeypatch.setattr(
+            betterleaks_install, "_verify_installed_binary", lambda path: None
+        )
+
+        result = betterleaks_install.install(force=True)
+
+        assert result["status"] == "verify-failed"
+        assert "left untouched" in result["error"]
+        assert target.read_bytes() == b"known good binary"
+
+    def test_oversized_decompressed_member_is_rejected(self, install_env, monkeypatch):
+        monkeypatch.setattr(betterleaks_install, "_MAX_BINARY_BYTES", 4)
+        install_env["serve"](_tar_gz({"betterleaks": BINARY_CONTENT}))
+
+        result = betterleaks_install.install()
+
+        assert result["status"] == "archive-invalid"
+        assert "size cap" in result["error"]
+        assert not install_env["target"].exists()
+
+    def test_install_never_raises_on_blocked_bin_dir(self, install_env):
+        # ~/.clawjournal/bin exists as a *file* → mkdir raises despite
+        # exist_ok=True; the backstop converts it to a status dict.
+        install_env["config_dir"].mkdir(parents=True)
+        (install_env["config_dir"] / "bin").write_bytes(b"not a directory")
+        install_env["serve"](_tar_gz({"betterleaks": BINARY_CONTENT}))
+
+        result = betterleaks_install.install()
+
+        assert result["status"] == "install-failed"
+        assert "FileExistsError" in result["error"]
+
+
+class TestPlatformKey:
+    def test_real_platform_resolves_or_is_unsupported(self):
+        key = betterleaks_install.platform_key()
+        assert key is None or key in betterleaks_install._ARCHIVE_SHA256
+
+    @pytest.mark.parametrize(
+        ("sys_platform", "os_name", "machine", "expected"),
+        [
+            ("darwin", "posix", "arm64", "darwin_arm64"),
+            ("darwin", "posix", "x86_64", "darwin_x64"),
+            ("linux", "posix", "x86_64", "linux_x64"),
+            ("linux", "posix", "aarch64", "linux_arm64"),
+            ("win32", "nt", "AMD64", "windows_x64"),
+            ("win32", "nt", "ARM64", "windows_arm64"),
+            ("linux", "posix", "riscv64", None),
+            ("sunos5", "posix", "x86_64", None),
+        ],
+    )
+    def test_os_arch_matrix(self, monkeypatch, sys_platform, os_name, machine, expected):
+        import os as os_mod
+        import sys as sys_mod
+
+        monkeypatch.setattr(sys_mod, "platform", sys_platform)
+        monkeypatch.setattr(os_mod, "name", os_name)
+        monkeypatch.setattr(
+            betterleaks_install.platform, "machine", lambda: machine
+        )
+        assert betterleaks_install.platform_key() == expected
+
+    def test_checksum_table_covers_release_matrix(self):
+        # Upstream naming: x64 (not amd64) — see the release asset list.
+        assert set(betterleaks_install._ARCHIVE_SHA256) == {
+            "darwin_x64", "darwin_arm64",
+            "linux_x64", "linux_arm64",
+            "windows_x64", "windows_arm64",
+        }
+        for value in betterleaks_install._ARCHIVE_SHA256.values():
+            assert len(value) == 64
+            int(value, 16)  # valid hex
+
+    def test_checksum_values_are_pairwise_distinct(self):
+        values = list(betterleaks_install._ARCHIVE_SHA256.values())
+        assert len(values) == len(set(values))
+
+    def test_archive_filename_flavors(self):
+        assert betterleaks_install.archive_filename("linux_x64") == (
+            f"betterleaks_{PINNED}_linux_x64.tar.gz"
+        )
+        assert betterleaks_install.archive_filename("windows_arm64") == (
+            f"betterleaks_{PINNED}_windows_arm64.zip"
+        )
+
+    def test_download_url_shape(self):
+        url = betterleaks_install.download_url("linux_x64")
+        assert url == (
+            "https://github.com/betterleaks/betterleaks/releases/download/"
+            f"v{PINNED}/betterleaks_{PINNED}_linux_x64.tar.gz"
+        )
+
+
+class TestBinaryResolution:
+    """resolve_binary(): managed install wins over PATH."""
+
+    def test_managed_binary_preferred_over_path(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / ".clawjournal"
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+        managed = betterleaks.managed_binary_path()
+        managed.parent.mkdir(parents=True)
+        managed.write_bytes(BINARY_CONTENT)
+        managed.chmod(0o755)
+        monkeypatch.setattr(
+            "clawjournal.redaction.betterleaks.shutil.which",
+            lambda name: "/usr/local/bin/betterleaks",
+        )
+
+        assert betterleaks.resolve_binary() == str(managed)
+        assert betterleaks.is_available()
+
+    def test_falls_back_to_path_when_no_managed_binary(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / ".clawjournal")
+        monkeypatch.setattr(
+            "clawjournal.redaction.betterleaks.shutil.which",
+            lambda name: "/usr/local/bin/betterleaks",
+        )
+        assert betterleaks.resolve_binary() == "/usr/local/bin/betterleaks"
+
+    def test_nothing_resolves(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / ".clawjournal")
+        monkeypatch.setattr(
+            "clawjournal.redaction.betterleaks.shutil.which", lambda name: None
+        )
+        assert betterleaks.resolve_binary() is None
+
+    def test_install_hint_mentions_managed_install(self):
+        assert "clawjournal betterleaks install" in betterleaks.INSTALL_HINT
+
+
+class TestManagedOffPin:
+    def _managed(self, tmp_path, monkeypatch):
+        config_dir = tmp_path / ".clawjournal"
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+        managed = betterleaks.managed_binary_path()
+        managed.parent.mkdir(parents=True)
+        managed.write_bytes(BINARY_CONTENT)
+        managed.chmod(0o755)
+        return managed
+
+    def test_none_for_path_resolved_binary(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / ".clawjournal")
+        monkeypatch.setattr(
+            "clawjournal.redaction.betterleaks.shutil.which",
+            lambda name: "/usr/local/bin/betterleaks",
+        )
+        monkeypatch.setattr(
+            betterleaks, "engine_fingerprint", lambda: "betterleaks 1.0.0"
+        )
+        assert betterleaks.managed_off_pin() is None
+
+    def test_none_when_managed_matches_pin(self, tmp_path, monkeypatch):
+        self._managed(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            betterleaks, "engine_fingerprint", lambda: f"betterleaks {PINNED}"
+        )
+        assert betterleaks.managed_off_pin() is None
+
+    def test_reports_drift_for_off_pin_managed_copy(self, tmp_path, monkeypatch):
+        self._managed(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            betterleaks, "engine_fingerprint", lambda: "betterleaks 1.0.0"
+        )
+        assert betterleaks.managed_off_pin() == ("1.0.0", PINNED)
+
+    def test_none_when_fingerprint_unparseable(self, tmp_path, monkeypatch):
+        self._managed(tmp_path, monkeypatch)
+        monkeypatch.setattr(betterleaks, "engine_fingerprint", lambda: "unknown")
+        assert betterleaks.managed_off_pin() is None
+
+
+class TestCliCommand:
+    def test_status_json_when_missing_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        import json as json_mod
+
+        from clawjournal.cli import _run_betterleaks_command
+
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / ".clawjournal")
+        monkeypatch.setattr(
+            "clawjournal.redaction.betterleaks.shutil.which", lambda name: None
+        )
+        args = Namespace(betterleaks_command="status", json=True)
+
+        with pytest.raises(SystemExit) as excinfo:
+            _run_betterleaks_command(args)
+
+        assert excinfo.value.code == 1
+        payload = json_mod.loads(capsys.readouterr().out)
+        assert payload["available"] is False
+        assert payload["resolved_path"] is None
+        assert payload["version"] is None
+        assert payload["fingerprint"] == "missing"
+        assert payload["pinned_version"] == PINNED
+
+    def test_install_dispatch_passes_force_and_exits_zero(self, monkeypatch, capsys):
+        from clawjournal import cli
+
+        calls = {}
+
+        def fake_install(*, force=False, progress=None):
+            calls["force"] = force
+            calls["progress"] = progress
+            return {"status": "installed", "path": "/x/betterleaks", "version": PINNED}
+
+        monkeypatch.setattr(
+            "clawjournal.redaction.betterleaks_install.install", fake_install
+        )
+        args = Namespace(betterleaks_command="install", force=True, json=False)
+
+        cli._run_betterleaks_command(args)
+
+        assert calls["force"] is True
+        assert calls["progress"] is not None  # human mode streams progress
+        assert f"Installed Betterleaks {PINNED}" in capsys.readouterr().out
+
+    def test_install_failure_exits_nonzero(self, monkeypatch, capsys):
+        from clawjournal import cli
+
+        monkeypatch.setattr(
+            "clawjournal.redaction.betterleaks_install.install",
+            lambda *, force=False, progress=None: {
+                "status": "download-failed",
+                "error": "offline",
+                "url": "https://example.invalid/archive.tar.gz",
+                "hint": "Check your network.",
+            },
+        )
+        args = Namespace(betterleaks_command="install", force=False, json=False)
+
+        with pytest.raises(SystemExit) as excinfo:
+            cli._run_betterleaks_command(args)
+
+        assert excinfo.value.code == 1
+        out = capsys.readouterr().out
+        assert "download-failed" in out
+        assert "https://example.invalid/archive.tar.gz" in out
+        assert "Check your network." in out
+
+    def test_status_warns_when_managed_copy_off_pin(self, tmp_path, monkeypatch, capsys):
+        from clawjournal.cli import _run_betterleaks_command
+
+        config_dir = tmp_path / ".clawjournal"
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+        managed = betterleaks.managed_binary_path()
+        managed.parent.mkdir(parents=True)
+        managed.write_bytes(BINARY_CONTENT)
+        managed.chmod(0o755)
+        monkeypatch.setattr(
+            "clawjournal.redaction.betterleaks.engine_fingerprint",
+            lambda: "betterleaks 1.0.0",
+        )
+        monkeypatch.setattr("shutil.which", lambda name: None)
+        args = Namespace(betterleaks_command="status", json=False)
+
+        # Warn, never block: off-pin status still exits 0.
+        _run_betterleaks_command(args)
+
+        out = capsys.readouterr().out
+        assert "Warning" in out
+        assert "v1.0.0" in out
+        assert f"pins v{PINNED}" in out
+        assert "clawjournal betterleaks install" in out
+
+    def test_parser_roundtrip_via_main(self, tmp_path, monkeypatch, capsys):
+        import sys as sys_mod
+
+        from clawjournal.cli import main
+
+        monkeypatch.setenv("CLAWJOURNAL_NO_AUTO_UPDATE", "1")
+        monkeypatch.setattr("clawjournal.config.CONFIG_DIR", tmp_path / ".clawjournal")
+        monkeypatch.setattr(
+            "clawjournal.redaction.betterleaks.shutil.which", lambda name: None
+        )
+        monkeypatch.setattr(
+            sys_mod, "argv", ["clawjournal", "betterleaks", "status", "--json"]
+        )
+
+        with pytest.raises(SystemExit) as excinfo:
+            main()
+
+        assert excinfo.value.code == 1
+        out = capsys.readouterr().out
+        assert '"available": false' in out

--- a/tests/test_check_betterleaks_pin.py
+++ b/tests/test_check_betterleaks_pin.py
@@ -1,0 +1,94 @@
+"""Hermetic tests for scripts/check_betterleaks_pin.py.
+
+The script's network fetch lives in the CI workflow; the comparison
+logic is pure and tested here without touching the network. A synthetic
+"upstream" is built from the vendored table so the matching case can
+never silently rot, and corruption cases prove the mismatch paths.
+"""
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "check_betterleaks_pin.py"
+_spec = importlib.util.spec_from_file_location("check_betterleaks_pin", _SCRIPT)
+pin = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(pin)
+
+
+def _upstream_text_matching_table() -> str:
+    """A checksums.txt whose rows match the vendored table exactly, plus
+    extra unrelated rows (sigstore bundle, other artifacts) that must be
+    ignored."""
+    lines = ["deadbeef" * 8 + "  betterleaks_extra_artifact.deb"]
+    for key, sha in pin._ARCHIVE_SHA256.items():
+        lines.append(f"{sha}  {pin.archive_filename(key)}")
+    return "\n".join(lines) + "\n"
+
+
+def test_parse_checksums_ignores_malformed_lines():
+    text = (
+        "abc123  file_a.tar.gz\n"
+        "\n"
+        "# a comment with spaces\n"
+        "onlyonefield\n"
+        "DEAD  file_b.zip\n"
+    )
+    parsed = pin.parse_checksums(text)
+    assert parsed == {"file_a.tar.gz": "abc123", "file_b.zip": "dead"}
+
+
+def test_compare_passes_when_table_matches_upstream():
+    upstream = pin.parse_checksums(_upstream_text_matching_table())
+    assert pin.compare(upstream) == []
+
+
+def test_compare_uses_upstream_archive_flavors():
+    # The vendored table's windows rows must be compared against .zip
+    # filenames — a .tar.gz-only comparison would report every windows
+    # row missing (or worse, silently pass on a stale name).
+    text = _upstream_text_matching_table()
+    assert f"betterleaks_{pin.PINNED_VERSION}_windows_x64.zip" in text
+    assert f"betterleaks_{pin.PINNED_VERSION}_linux_x64.tar.gz" in text
+
+
+def test_compare_flags_a_wrong_hash():
+    upstream = pin.parse_checksums(_upstream_text_matching_table())
+    target = pin.archive_filename("linux_x64")
+    upstream[target] = "0" * 64
+    errors = pin.compare(upstream)
+    assert len(errors) == 1
+    assert target in errors[0]
+    assert "vendored" in errors[0] and "upstream" in errors[0]
+
+
+def test_compare_flags_a_missing_row():
+    upstream = pin.parse_checksums(_upstream_text_matching_table())
+    target = pin.archive_filename("windows_arm64")
+    del upstream[target]
+    errors = pin.compare(upstream)
+    assert len(errors) == 1
+    assert "not present" in errors[0]
+
+
+def test_main_exit_codes(tmp_path, capsys):
+    good = tmp_path / "good.txt"
+    good.write_text(_upstream_text_matching_table())
+    assert pin.main(["prog", str(good)]) == 0
+    assert "match upstream" in capsys.readouterr().out
+
+    bad = tmp_path / "bad.txt"
+    bad.write_text("0000  betterleaks_0.0.0_linux_x64.tar.gz\n")
+    assert pin.main(["prog", str(bad)]) == 1
+
+    assert pin.main(["prog"]) == 2  # wrong arg count
+    assert pin.main(["prog", str(tmp_path / "nope.txt")]) == 2  # unreadable
+
+
+def test_compare_is_case_insensitive_on_hashes():
+    upstream = pin.parse_checksums(
+        "\n".join(
+            f"{sha.upper()}  {pin.archive_filename(key)}"
+            for key, sha in pin._ARCHIVE_SHA256.items()
+        )
+    )
+    assert pin.compare(upstream) == []


### PR DESCRIPTION
## Summary

First of four PRs replacing the all-or-nothing TruffleHog share gate with a tiered per-finding policy (**Betterleaks primary detection + TruffleHog verified-only secondary**). Context: on a real 33-session auto-upload pool, the current gate sent 17 sessions to `pending_review` because *any* finding (verified or not) blocks the whole bundle.

This PR is **pure addition — no behavior change**: nothing is wired into the share gate yet. It lands the scanner wrapper, managed install, bundled config, CLI verb, and tests.

- `clawjournal/redaction/betterleaks.py` — subprocess wrapper mirroring `trufflehog.py`'s surface: `scan_file`/`scan_text`, raw-match internals (`_scan_file_for_raw_matches` for the future gate redact-loop, `_scan_text_for_raw_matches` for the findings engine), `scan_session_for_betterleaks_findings` + `betterleaks_secret_map_from_blob` (the same two-function contract TruffleHog implements), managed-binary resolution, memoized `engine_fingerprint`, `managed_off_pin`.
- `clawjournal/redaction/betterleaks.toml` — bundled share-gate config: `[extend] useDefault = true` plus an allowlist for our own `[REDACTED_*]` placeholders (so the future redact-and-rescan loop converges). Shipped via `package-data`.
- `betterleaks_install.py` + `scripts/check_betterleaks_pin.py` + `.github/workflows/betterleaks-pin.yml` — managed install pinned to **v1.6.1** with vendored release checksums; mirrors the TruffleHog pin machinery. Upstream naming quirks handled: `x64` (not `amd64`) arch keys, `.zip` archives on Windows.
- `clawjournal betterleaks install|status` CLI verb (clone of the trufflehog one).
- `tests/conftest.py` — autouse `CLAWJOURNAL_SKIP_BETTERLEAKS=1` beside the TruffleHog bypass.

## Privacy posture

- Live validation (`--validation`) is **never** passed — candidate secrets must not leave the machine from the detection layer; verification remains TruffleHog's role (unchanged, and narrowed to verified-only in PR 2).
- `--redact` is not used because it also scrubs the report; instead the raw `Secret` is parsed transiently (0600 mkstemp report file, read + unlinked in `finally`) exactly like the TruffleHog wrapper parses `Raw` from stdout. Raw values never leave the module via public helpers; masked + salted-hash only.
- Subprocess env is scrubbed via the same `_scrubbed_subprocess_env` allowlist.

## Verified against the real binary (1.6.1)

- Report is a JSON **array** (`null` on clean scans); fields `RuleID`/`StartLine`/`Secret`/`Match`/`Entropy`/`Fingerprint` — a real report is vendored as `tests/redaction/fixtures/betterleaks_report.json` (Slack-token value defanged post-capture: GitHub push protection rightly rejects a realistic one).
- `--exit-code 183` honored → both wrappers share the `{0, 183}` = "scan ran" contract.
- `StartLine` is 1-based and aligns with `sessions.jsonl` line = session index (the mapping the gate uses).
- A `\n`-escaped private key inside a JSONL string **is** caught, and `Secret` arrives in file-level escaped form — this is why the PR 2 gate loop will string-replace on serialized lines rather than object-walk.
- `stdin` mode supports `--report-path` and line numbers; version banners parsed for both `--version` and `version` forms.

## Tests

87 new tests (wrapper subprocess contract driven by the vendored real report; install matrix incl. zip flavor, checksum fail-closed, traversal rejection; pin-check script; CLI dispatch). Full suite: **2858 passed**.

## Next PRs

2. `scan_policy.py` + `share_gate.py` redact-and-rescan loop + both gate call-site rewrites.
3. Findings-engine swap (config default, fingerprints, apply wiring, preview gates).
4. Auto-upload per-tier routing + docs (CLAUDE.md invariant rewrite, PRIVACY.md, README).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQ57fCxoLQQdtbYmdibkdE