### PR TITLE
feat(sharing): add batch queue selection

### DIFF
--- a/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
@@ -28,6 +28,9 @@ export interface QueueStepProps {
   setAiPiiEnabled: (enabled: boolean) => void;
   onRemove: (id: string) => void;
   onAdd: (id: string) => void;
+  onClearAll: () => void;
+  onAddMany: (ids: string[]) => void;
+  onRemoveMany: (ids: string[]) => void;
   onReorder: (fromId: string, overId: string) => void;
   onHelp: () => void;
   onContinue: () => void;
@@ -163,6 +166,39 @@ export function QueueStep(p: QueueStepProps) {
           <option value="90d">Last 90 days</option>
         </select>
       </div>
+      {filteredSessions.length > 0 && (() => {
+        const filteredIds = filteredSessions.map(s => s.session_id);
+        const selectedInFilter = filteredIds.filter(id => selectedIds.has(id)).length;
+        const filterActive = !!(p.searchQuery || p.sourceFilter || p.projectFilter || p.scoreFilter > 0 || p.dateFilter);
+        const allSelected = selectedInFilter === filteredIds.length;
+        const batchBtn = {
+          ...btnGhost, fontSize: 12, padding: '5px 10px',
+          border: `1px solid ${colors.gray300}`, borderRadius: 6, background: colors.white,
+        };
+        return (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8, flexWrap: 'wrap' }}>
+            <button
+              type="button"
+              onClick={() => p.onAddMany(filteredIds)}
+              disabled={allSelected}
+              style={{ ...batchBtn, opacity: allSelected ? 0.45 : 1, cursor: allSelected ? 'not-allowed' : 'pointer' }}
+            >
+              {filterActive ? `Select ${filteredIds.length} filtered` : `Select all ${filteredIds.length}`}
+            </button>
+            <button
+              type="button"
+              onClick={() => filterActive ? p.onRemoveMany(filteredIds) : p.onClearAll()}
+              disabled={selectedInFilter === 0}
+              style={{ ...batchBtn, color: colors.red700, opacity: selectedInFilter === 0 ? 0.45 : 1, cursor: selectedInFilter === 0 ? 'not-allowed' : 'pointer' }}
+            >
+              {filterActive ? `Deselect ${selectedInFilter} filtered` : 'Deselect all'}
+            </button>
+            <span style={{ fontSize: 11.5, color: colors.gray500 }}>
+              {selectedInFilter} of {filteredIds.length}{filterActive ? ' filtered' : ''} selected
+            </span>
+          </div>
+        );
+      })()}
       <div style={{ maxHeight: '36vh', overflowY: 'auto', border: `1px solid ${colors.gray200}`, borderRadius: 6, background: colors.white }}>
         {filteredSessions.length === 0 ? (
           <div style={{ padding: 14, textAlign: 'center', color: colors.gray400, fontSize: 13 }}>
@@ -341,22 +377,36 @@ export function QueueStep(p: QueueStepProps) {
                 {uniqueProjects.length > 0 && ` · ${uniqueProjects.length} project${uniqueProjects.length !== 1 ? 's' : ''}`}
               </div>
             </div>
-            {p.showAddTraces ? (
-              <span style={{ color: colors.gray500, fontSize: 11.5 }}>
-                Use the checkboxes below to deselect traces
-              </span>
-            ) : (
-              <span
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <button
+                type="button"
+                onClick={p.onClearAll}
+                title="Remove every trace from the bundle"
                 style={{
-                  display: 'inline-flex', alignItems: 'center', gap: 6,
-                  color: colors.gray500, fontSize: 11.5,
+                  ...btnGhost, fontSize: 11.5, color: colors.red700,
+                  padding: '4px 9px', border: `1px solid ${colors.gray300}`,
+                  borderRadius: 6, background: colors.white,
                 }}
-                title="Drag the handle on the left of each row to reorder"
               >
-                <Icon name="grip" size={12} />
-                Drag to reorder
-              </span>
-            )}
+                Deselect all
+              </button>
+              {p.showAddTraces ? (
+                <span style={{ color: colors.gray500, fontSize: 11.5 }}>
+                  Use the checkboxes below to deselect traces
+                </span>
+              ) : (
+                <span
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 6,
+                    color: colors.gray500, fontSize: 11.5,
+                  }}
+                  title="Drag the handle on the left of each row to reorder"
+                >
+                  <Icon name="grip" size={12} />
+                  Drag to reorder
+                </span>
+              )}
+            </div>
             </div>
             <div style={{
               padding: '7px 14px 10px',

--- a/clawjournal/web/frontend/src/views/Share/index.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.test.tsx
@@ -109,6 +109,51 @@ describe('Share selection defaults', () => {
     });
   });
 
+  it('keeps a custom queue order when bulk-selecting filtered traces', async () => {
+    mockInitialLoad(readyStats(3));
+
+    render(
+      <MemoryRouter initialEntries={['/share?ids=s2,s1']}>
+        <ToastProvider><Share /></ToastProvider>
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('2 traces selected')).toBeInTheDocument();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search traces by title or project' }), {
+      target: { value: 's3' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Select 1 filtered' }));
+
+    expect(await screen.findByText('3 traces selected')).toBeInTheDocument();
+    await waitFor(() => {
+      const params = new URLSearchParams(screen.getByTestId('location-search').textContent || '');
+      expect(params.get('ids')).toBe('s2,s1,s3');
+      expect(params.has('selection')).toBe(false);
+    });
+  });
+
+  it('restores default queue order when bulk selection completes a default subset', async () => {
+    mockInitialLoad(readyStats(3));
+
+    render(
+      <MemoryRouter initialEntries={['/share?ids=s1,s3']}>
+        <ToastProvider><Share /></ToastProvider>
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('2 traces selected')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Select all 3' }));
+
+    expect(await screen.findByText('3 traces selected')).toBeInTheDocument();
+    await waitFor(() => {
+      const params = new URLSearchParams(screen.getByTestId('location-search').textContent || '');
+      expect(params.get('selection')).toBe('all');
+      expect(params.has('ids')).toBe(false);
+    });
+  });
+
   it('bounds large-history rendering while retaining and confirming the full selection', async () => {
     mockInitialLoad(readyStats(125));
 

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -533,14 +533,23 @@ export function Share() {
     if (ids.length === 0) return;
     cancelAiRetries();
     setQueueOrder((prev) => {
-      const merged = new Set(prev);
-      ids.forEach((id) => merged.add(id));
-      // Preserve the default ordering for any default sessions, then append the
-      // rest (already-added extras and newly-added non-default ids) in place.
       const defaults = readyStats ? queueFromStats(readyStats) : [];
-      const ordered = defaults.filter((id) => merged.has(id));
-      const remaining = [...merged].filter((id) => !defaults.includes(id));
-      return [...ordered, ...remaining];
+      const defaultIds = new Set(defaults);
+      const selectedIds = new Set(prev);
+      const newIds = ids.filter((id) => !selectedIds.has(id));
+      if (newIds.length === 0) return prev;
+
+      // Keep the compact default order only while the user has not manually
+      // reordered the queue. Once the order is custom, batch additions must
+      // behave like single additions and leave the existing sequence intact.
+      const defaultOrderedSubset = defaults.filter((id) => selectedIds.has(id));
+      const followsDefaultOrder = defaultOrderedSubset.length === prev.length
+        && defaultOrderedSubset.every((id, index) => id === prev[index]);
+      if (followsDefaultOrder && newIds.every((id) => defaultIds.has(id))) {
+        newIds.forEach((id) => selectedIds.add(id));
+        return defaults.filter((id) => selectedIds.has(id));
+      }
+      return [...prev, ...newIds];
     });
   };
 

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -521,6 +521,36 @@ export function Share() {
     });
   };
 
+  // Batch selection helpers. With 1000s of eligible sessions, unchecking traces
+  // one at a time is impractical, so the queue exposes select-all / deselect-all
+  // controls (scoped to whatever filters are active in the picker).
+  const clearQueue = () => {
+    cancelAiRetries();
+    setQueueOrder([]);
+  };
+
+  const addManyToQueue = (ids: string[]) => {
+    if (ids.length === 0) return;
+    cancelAiRetries();
+    setQueueOrder((prev) => {
+      const merged = new Set(prev);
+      ids.forEach((id) => merged.add(id));
+      // Preserve the default ordering for any default sessions, then append the
+      // rest (already-added extras and newly-added non-default ids) in place.
+      const defaults = readyStats ? queueFromStats(readyStats) : [];
+      const ordered = defaults.filter((id) => merged.has(id));
+      const remaining = [...merged].filter((id) => !defaults.includes(id));
+      return [...ordered, ...remaining];
+    });
+  };
+
+  const removeManyFromQueue = (ids: string[]) => {
+    if (ids.length === 0) return;
+    cancelAiRetries();
+    const drop = new Set(ids);
+    setQueueOrder((prev) => prev.filter((id) => !drop.has(id)));
+  };
+
   const updateAiPiiEnabled = (enabled: boolean) => {
     cancelRedaction();
     cancelAiRetries();
@@ -1184,6 +1214,9 @@ export function Share() {
         setAiPiiEnabled={updateAiPiiEnabled}
         onRemove={removeFromQueue}
         onAdd={addToQueue}
+        onClearAll={clearQueue}
+        onAddMany={addManyToQueue}
+        onRemoveMany={removeManyFromQueue}
         onReorder={reorderQueue}
         onHelp={() => setShowHelp(true)}
         onContinue={handleStartRedaction}


### PR DESCRIPTION
## Summary

Adds bulk selection controls to the Share queue picker and a clear queue action.

Filtered views can select or deselect every visible trace at once. Batch selection preserves a custom drag order and restores the compact default order only for default ordered queues.

## Why

Selecting or removing a large set of eligible traces one at a time is impractical.

## User impact

Users can rapidly curate a share bundle without losing a deliberate queue order.

## Validation

- `npm run test` — 36 tests passed
- `npm run build` — passed, including the Share queue state check
- `npx eslint src/views/Share/QueueStep.tsx src/views/Share/index.tsx src/views/Share/index.test.tsx` — passed
- GitHub Actions test matrix for Python 3.10 through 3.13 and smoke — passed

Repository-wide `npm run lint` still reports six pre-existing errors outside this change.