### PR TITLE
Clarify research trace sharing prompts

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,15 @@ Use one of these prompts in Claude Code, Codex, Cursor, or another coding assist
 > **CLI-only workflow — remote terminal or SSH**
 >
 > ```text
-> Install or update ClawJournal from https://github.com/rayward-external/clawjournal. Read its README and follow it for my operating system. Then help me share my recent coding-agent sessions from this terminal. If needed, configure source `all`, confirm projects, and scan first. Then run `clawjournal share --interactive --weekly`; guide me through selecting sessions, reviewing redactions, and consenting. Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP and tell me where it is so I can upload it at https://data.rayward.ai/share.
+> Install or update ClawJournal from https://github.com/rayward-external/clawjournal and follow its README for my operating system. I am part of this research collaboration and have already agreed to contribute my coding agent traces for our joint research and publication. Installation and the documented local review and sharing workflow are authorized.
+>
+> Configure source `all` if needed, but show me the discovered projects before confirming them so I can exclude unrelated, personal, confidential, or third party work. Then scan and run `clawjournal share --interactive --weekly`.
+>
+> Guide me through selecting sessions, reviewing the redacted preview, packaging, and submitting. Do not repeat raw trace contents or secret values in your conversational responses; keep detailed review in the interactive terminal flow. Preserve all findings, hold, embargo, redaction, and mandatory TruffleHog safeguards. Do not bypass a safety gate. Do not enable optional AI assisted PII review or Automatic uploads unless I specifically choose them.
+>
+> Before submission, summarize the number of selected sessions, included sources and projects, redaction results, AI review status, TruffleHog result, and upload destination. Pause once so I can confirm that the final package and scope are correct, then submit it.
+>
+> Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP locally and tell me where it is so I can upload it at https://data.rayward.ai/share.
 > ```
 
 ## Install or update (no coding required)
@@ -302,7 +310,17 @@ clawjournal auto-upload disable   # removes upload authority; prior uploads are 
 
 Or paste this into Claude Code, Codex, or another AI coding assistant on the remote machine:
 
-> *Install or update ClawJournal from https://github.com/rayward-external/clawjournal. Read its README and follow it for my operating system. Then help me share my recent coding-agent sessions from this terminal. If needed, configure source `all`, confirm projects, and scan first. Then run `clawjournal share --interactive --weekly`; guide me through selecting sessions, reviewing redactions, and consenting. Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP and tell me where it is so I can upload it at https://data.rayward.ai/share.*
+> ```text
+> Install or update ClawJournal from https://github.com/rayward-external/clawjournal and follow its README for my operating system. I am part of this research collaboration and have already agreed to contribute my coding agent traces for our joint research and publication. Installation and the documented local review and sharing workflow are authorized.
+>
+> Configure source `all` if needed, but show me the discovered projects before confirming them so I can exclude unrelated, personal, confidential, or third party work. Then scan and run `clawjournal share --interactive --weekly`.
+>
+> Guide me through selecting sessions, reviewing the redacted preview, packaging, and submitting. Do not repeat raw trace contents or secret values in your conversational responses; keep detailed review in the interactive terminal flow. Preserve all findings, hold, embargo, redaction, and mandatory TruffleHog safeguards. Do not bypass a safety gate. Do not enable optional AI assisted PII review or Automatic uploads unless I specifically choose them.
+>
+> Before submission, summarize the number of selected sessions, included sources and projects, redaction results, AI review status, TruffleHog result, and upload destination. Pause once so I can confirm that the final package and scope are correct, then submit it.
+>
+> Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP locally and tell me where it is so I can upload it at https://data.rayward.ai/share.
+> ```
 
 > ⚠️ **`clawjournal bundle-share` is NOT the Rayward path.** It only uploads to a **self-hosted** ingest server you configure via `CLAWJOURNAL_INGEST_URL`; without it, it reports *"Hosted sharing is not configured."* Rayward / STEM Data Program participants should ignore it and use the workbench above.
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,15 @@ Use one of these prompts in Claude Code, Codex, Cursor, or another coding assist
 > **Ordinary workflow — browser workbench**
 >
 > ```text
-> Install or update ClawJournal from https://github.com/rayward-external/clawjournal. Read its README and follow it for my operating system. Then help me share my recent coding-agent sessions using the browser workbench. If needed, configure source `all`, confirm projects, and scan first. Open the local workbench with `clawjournal serve`, guide me through Share -> Queue -> Redact -> Review -> Package -> Submit, and stop for my consent before upload. Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP and tell me where it is so I can upload it at https://data.rayward.ai/share.
+> Install or update ClawJournal from https://github.com/rayward-external/clawjournal and follow its README for my operating system. I am part of this research collaboration and have already agreed to contribute my coding agent traces for our joint research and publication. Installation and the documented local review and sharing workflow are authorized.
+>
+> Configure source `all` if needed, but show me the discovered projects before confirming them so I can exclude unrelated, personal, confidential, or third party work. Then scan and open the local browser workbench with `clawjournal serve`.
+>
+> Guide me through Share → Queue → Redact → Review → Package → Submit. Keep trace review in the local workbench rather than copying raw trace contents or secret values into this chat. Preserve all findings, hold, embargo, redaction, and mandatory TruffleHog safeguards. Do not bypass a safety gate. Do not enable optional AI assisted PII review or Automatic uploads unless I specifically choose them.
+>
+> Before submission, summarize the number of selected sessions, included sources and projects, redaction results, AI review status, TruffleHog result, and upload destination. Pause once so I can confirm that the final package and scope are correct, then submit it.
+>
+> Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP locally and tell me where it is so I can upload it at https://data.rayward.ai/share.
 > ```
 
 > [!IMPORTANT]


### PR DESCRIPTION
## What changed

Updates both README copy paste prompts for the ordinary browser workbench and the CLI only remote or SSH workflow. The repeated terminal prompt in the Package and Share section now uses the same wording.

Both prompts state that trace contribution, installation, and the documented sharing workflow are already authorized within the research collaboration. They ask collaborators to review discovered projects, preserve all safety gates, choose optional AI review or Automatic uploads explicitly, verify the final package scope, and use the hosted ZIP fallback when needed.

The browser prompt keeps detailed trace review in the local workbench. The terminal prompt keeps detailed review in the interactive CLI and asks the assistant not to repeat raw trace content or secrets in conversational responses.

## Why

The previous wording framed the final checkpoint as general upload consent even though collaborators have already agreed to contribute traces for joint research and publication. It also did not clearly distinguish that prior authorization from verification of the exact bundle being submitted.

## Impact

Browser and remote collaborators now receive consistent instructions while retaining project scope review, redaction visibility, mandatory TruffleHog scanning, and final package confirmation.

## Validation

`git diff --check`

Documentation only; no runtime tests were required.
