### PR TITLE
fix: restore #129/#130 content reverted by the stacked-squash merges

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,30 @@ Use one of these prompts in Claude Code, Codex, Cursor, or another coding assist
 > **Ordinary workflow — browser workbench**
 >
 > ```text
-> Install or update ClawJournal from https://github.com/rayward-external/clawjournal. Read its README and follow it for my operating system. Then help me share my recent coding-agent sessions using the browser workbench. If needed, configure source `all`, confirm projects, and scan first. Open the local workbench with `clawjournal serve`, guide me through Share -> Queue -> Redact -> Review -> Package -> Submit, and stop for my consent before upload. Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP and tell me where it is so I can upload it at https://data.rayward.ai/share.
+> Install or update ClawJournal from https://github.com/rayward-external/clawjournal and follow its README for my operating system. I am part of this research collaboration and have already agreed to contribute my coding agent traces for our joint research and publication. Installation and the documented local review and sharing workflow are authorized.
+>
+> Configure source `all` if needed, but show me the discovered projects before confirming them so I can exclude unrelated, personal, confidential, or third party work. Then scan and open the local browser workbench with `clawjournal serve`.
+>
+> Guide me through Share → Queue → Redact → Review → Package → Submit. Keep trace review in the local workbench rather than copying raw trace contents or secret values into this chat. Preserve all findings, hold, embargo, redaction, and mandatory secret-scan safeguards. Do not bypass a safety gate. Do not enable optional AI assisted PII review or Automatic uploads unless I specifically choose them.
+>
+> Before submission, summarize the number of selected sessions, included sources and projects, redaction results, AI review status, secret-scan result, and upload destination. Pause once so I can confirm that the final package and scope are correct, then submit it.
+>
+> Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP locally and tell me where it is so I can upload it at https://data.rayward.ai/share.
 > ```
 
 > [!IMPORTANT]
 > **CLI-only workflow — remote terminal or SSH**
 >
 > ```text
-> Install or update ClawJournal from https://github.com/rayward-external/clawjournal. Read its README and follow it for my operating system. Then help me share my recent coding-agent sessions from this terminal. If needed, configure source `all`, confirm projects, and scan first. Then run `clawjournal share --interactive --weekly`; guide me through selecting sessions, reviewing redactions, and consenting. Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP and tell me where it is so I can upload it at https://data.rayward.ai/share.
+> Install or update ClawJournal from https://github.com/rayward-external/clawjournal and follow its README for my operating system. I am part of this research collaboration and have already agreed to contribute my coding agent traces for our joint research and publication. Installation and the documented local review and sharing workflow are authorized.
+>
+> Configure source `all` if needed, but show me the discovered projects before confirming them so I can exclude unrelated, personal, confidential, or third party work. Then scan and run `clawjournal share --interactive --weekly`.
+>
+> Guide me through selecting sessions, reviewing the redacted preview, packaging, and submitting. Do not repeat raw trace contents or secret values in your conversational responses; keep detailed review in the interactive terminal flow. Preserve all findings, hold, embargo, redaction, and mandatory secret-scan safeguards. Do not bypass a safety gate. Do not enable optional AI assisted PII review or Automatic uploads unless I specifically choose them.
+>
+> Before submission, summarize the number of selected sessions, included sources and projects, redaction results, AI review status, secret-scan result, and upload destination. Pause once so I can confirm that the final package and scope are correct, then submit it.
+>
+> Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP locally and tell me where it is so I can upload it at https://data.rayward.ai/share.
 > ```
 
 ## Install or update (no coding required)
@@ -296,7 +312,17 @@ clawjournal auto-upload disable   # removes upload authority; prior uploads are 
 
 Or paste this into Claude Code, Codex, or another AI coding assistant on the remote machine:
 
-> *Install or update ClawJournal from https://github.com/rayward-external/clawjournal. Read its README and follow it for my operating system. Then help me share my recent coding-agent sessions from this terminal. If needed, configure source `all`, confirm projects, and scan first. Then run `clawjournal share --interactive --weekly`; guide me through selecting sessions, reviewing redactions, and consenting. Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP and tell me where it is so I can upload it at https://data.rayward.ai/share.*
+> ```text
+> Install or update ClawJournal from https://github.com/rayward-external/clawjournal and follow its README for my operating system. I am part of this research collaboration and have already agreed to contribute my coding agent traces for our joint research and publication. Installation and the documented local review and sharing workflow are authorized.
+>
+> Configure source `all` if needed, but show me the discovered projects before confirming them so I can exclude unrelated, personal, confidential, or third party work. Then scan and run `clawjournal share --interactive --weekly`.
+>
+> Guide me through selecting sessions, reviewing the redacted preview, packaging, and submitting. Do not repeat raw trace contents or secret values in your conversational responses; keep detailed review in the interactive terminal flow. Preserve all findings, hold, embargo, redaction, and mandatory secret-scan safeguards. Do not bypass a safety gate. Do not enable optional AI assisted PII review or Automatic uploads unless I specifically choose them.
+>
+> Before submission, summarize the number of selected sessions, included sources and projects, redaction results, AI review status, secret-scan result, and upload destination. Pause once so I can confirm that the final package and scope are correct, then submit it.
+>
+> Do not use `clawjournal bundle-share`. If hosted upload is unavailable, save the ZIP locally and tell me where it is so I can upload it at https://data.rayward.ai/share.
+> ```
 
 > ⚠️ **`clawjournal bundle-share` is NOT the Rayward path.** It only uploads to a **self-hosted** ingest server you configure via `CLAWJOURNAL_INGEST_URL`; without it, it reports *"Hosted sharing is not configured."* Rayward / STEM Data Program participants should ignore it and use the workbench above.
 

--- a/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
@@ -28,6 +28,9 @@ export interface QueueStepProps {
   setAiPiiEnabled: (enabled: boolean) => void;
   onRemove: (id: string) => void;
   onAdd: (id: string) => void;
+  onClearAll: () => void;
+  onAddMany: (ids: string[]) => void;
+  onRemoveMany: (ids: string[]) => void;
   onReorder: (fromId: string, overId: string) => void;
   onHelp: () => void;
   onContinue: () => void;
@@ -163,6 +166,39 @@ export function QueueStep(p: QueueStepProps) {
           <option value="90d">Last 90 days</option>
         </select>
       </div>
+      {filteredSessions.length > 0 && (() => {
+        const filteredIds = filteredSessions.map(s => s.session_id);
+        const selectedInFilter = filteredIds.filter(id => selectedIds.has(id)).length;
+        const filterActive = !!(p.searchQuery || p.sourceFilter || p.projectFilter || p.scoreFilter > 0 || p.dateFilter);
+        const allSelected = selectedInFilter === filteredIds.length;
+        const batchBtn = {
+          ...btnGhost, fontSize: 12, padding: '5px 10px',
+          border: `1px solid ${colors.gray300}`, borderRadius: 6, background: colors.white,
+        };
+        return (
+          <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8, flexWrap: 'wrap' }}>
+            <button
+              type="button"
+              onClick={() => p.onAddMany(filteredIds)}
+              disabled={allSelected}
+              style={{ ...batchBtn, opacity: allSelected ? 0.45 : 1, cursor: allSelected ? 'not-allowed' : 'pointer' }}
+            >
+              {filterActive ? `Select ${filteredIds.length} filtered` : `Select all ${filteredIds.length}`}
+            </button>
+            <button
+              type="button"
+              onClick={() => filterActive ? p.onRemoveMany(filteredIds) : p.onClearAll()}
+              disabled={selectedInFilter === 0}
+              style={{ ...batchBtn, color: colors.red700, opacity: selectedInFilter === 0 ? 0.45 : 1, cursor: selectedInFilter === 0 ? 'not-allowed' : 'pointer' }}
+            >
+              {filterActive ? `Deselect ${selectedInFilter} filtered` : 'Deselect all'}
+            </button>
+            <span style={{ fontSize: 11.5, color: colors.gray500 }}>
+              {selectedInFilter} of {filteredIds.length}{filterActive ? ' filtered' : ''} selected
+            </span>
+          </div>
+        );
+      })()}
       <div style={{ maxHeight: '36vh', overflowY: 'auto', border: `1px solid ${colors.gray200}`, borderRadius: 6, background: colors.white }}>
         {filteredSessions.length === 0 ? (
           <div style={{ padding: 14, textAlign: 'center', color: colors.gray400, fontSize: 13 }}>
@@ -341,22 +377,36 @@ export function QueueStep(p: QueueStepProps) {
                 {uniqueProjects.length > 0 && ` · ${uniqueProjects.length} project${uniqueProjects.length !== 1 ? 's' : ''}`}
               </div>
             </div>
-            {p.showAddTraces ? (
-              <span style={{ color: colors.gray500, fontSize: 11.5 }}>
-                Use the checkboxes below to deselect traces
-              </span>
-            ) : (
-              <span
+            <div style={{ display: 'flex', alignItems: 'center', gap: 10 }}>
+              <button
+                type="button"
+                onClick={p.onClearAll}
+                title="Remove every trace from the bundle"
                 style={{
-                  display: 'inline-flex', alignItems: 'center', gap: 6,
-                  color: colors.gray500, fontSize: 11.5,
+                  ...btnGhost, fontSize: 11.5, color: colors.red700,
+                  padding: '4px 9px', border: `1px solid ${colors.gray300}`,
+                  borderRadius: 6, background: colors.white,
                 }}
-                title="Drag the handle on the left of each row to reorder"
               >
-                <Icon name="grip" size={12} />
-                Drag to reorder
-              </span>
-            )}
+                Deselect all
+              </button>
+              {p.showAddTraces ? (
+                <span style={{ color: colors.gray500, fontSize: 11.5 }}>
+                  Use the checkboxes below to deselect traces
+                </span>
+              ) : (
+                <span
+                  style={{
+                    display: 'inline-flex', alignItems: 'center', gap: 6,
+                    color: colors.gray500, fontSize: 11.5,
+                  }}
+                  title="Drag the handle on the left of each row to reorder"
+                >
+                  <Icon name="grip" size={12} />
+                  Drag to reorder
+                </span>
+              )}
+            </div>
             </div>
             <div style={{
               padding: '7px 14px 10px',

--- a/clawjournal/web/frontend/src/views/Share/index.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.test.tsx
@@ -109,6 +109,51 @@ describe('Share selection defaults', () => {
     });
   });
 
+  it('keeps a custom queue order when bulk-selecting filtered traces', async () => {
+    mockInitialLoad(readyStats(3));
+
+    render(
+      <MemoryRouter initialEntries={['/share?ids=s2,s1']}>
+        <ToastProvider><Share /></ToastProvider>
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('2 traces selected')).toBeInTheDocument();
+    fireEvent.change(screen.getByRole('textbox', { name: 'Search traces by title or project' }), {
+      target: { value: 's3' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Select 1 filtered' }));
+
+    expect(await screen.findByText('3 traces selected')).toBeInTheDocument();
+    await waitFor(() => {
+      const params = new URLSearchParams(screen.getByTestId('location-search').textContent || '');
+      expect(params.get('ids')).toBe('s2,s1,s3');
+      expect(params.has('selection')).toBe(false);
+    });
+  });
+
+  it('restores default queue order when bulk selection completes a default subset', async () => {
+    mockInitialLoad(readyStats(3));
+
+    render(
+      <MemoryRouter initialEntries={['/share?ids=s1,s3']}>
+        <ToastProvider><Share /></ToastProvider>
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('2 traces selected')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Select all 3' }));
+
+    expect(await screen.findByText('3 traces selected')).toBeInTheDocument();
+    await waitFor(() => {
+      const params = new URLSearchParams(screen.getByTestId('location-search').textContent || '');
+      expect(params.get('selection')).toBe('all');
+      expect(params.has('ids')).toBe(false);
+    });
+  });
+
   it('bounds large-history rendering while retaining and confirming the full selection', async () => {
     mockInitialLoad(readyStats(125));
 

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -521,6 +521,45 @@ export function Share() {
     });
   };
 
+  // Batch selection helpers. With 1000s of eligible sessions, unchecking traces
+  // one at a time is impractical, so the queue exposes select-all / deselect-all
+  // controls (scoped to whatever filters are active in the picker).
+  const clearQueue = () => {
+    cancelAiRetries();
+    setQueueOrder([]);
+  };
+
+  const addManyToQueue = (ids: string[]) => {
+    if (ids.length === 0) return;
+    cancelAiRetries();
+    setQueueOrder((prev) => {
+      const defaults = readyStats ? queueFromStats(readyStats) : [];
+      const defaultIds = new Set(defaults);
+      const selectedIds = new Set(prev);
+      const newIds = ids.filter((id) => !selectedIds.has(id));
+      if (newIds.length === 0) return prev;
+
+      // Keep the compact default order only while the user has not manually
+      // reordered the queue. Once the order is custom, batch additions must
+      // behave like single additions and leave the existing sequence intact.
+      const defaultOrderedSubset = defaults.filter((id) => selectedIds.has(id));
+      const followsDefaultOrder = defaultOrderedSubset.length === prev.length
+        && defaultOrderedSubset.every((id, index) => id === prev[index]);
+      if (followsDefaultOrder && newIds.every((id) => defaultIds.has(id))) {
+        newIds.forEach((id) => selectedIds.add(id));
+        return defaults.filter((id) => selectedIds.has(id));
+      }
+      return [...prev, ...newIds];
+    });
+  };
+
+  const removeManyFromQueue = (ids: string[]) => {
+    if (ids.length === 0) return;
+    cancelAiRetries();
+    const drop = new Set(ids);
+    setQueueOrder((prev) => prev.filter((id) => !drop.has(id)));
+  };
+
   const updateAiPiiEnabled = (enabled: boolean) => {
     cancelRedaction();
     cancelAiRetries();
@@ -1184,6 +1223,9 @@ export function Share() {
         setAiPiiEnabled={updateAiPiiEnabled}
         onRemove={removeFromQueue}
         onAdd={addToQueue}
+        onClearAll={clearQueue}
+        onAddMany={addManyToQueue}
+        onRemoveMany={removeManyFromQueue}
         onReorder={reorderQueue}
         onHelp={() => setShowHelp(true)}
         onContinue={handleStartRedaction}


### PR DESCRIPTION
While merging the betterleaks stack (#125–#128, squash merges of stacked branches), the squash diffs were computed against a main that had since gained #129 and #130 — and reverted them:

- **#129 (batch queue selection)**: `QueueStep.tsx`, `Share/index.tsx`, `Share/index.test.tsx` went back to their pre-#129 versions. Restored verbatim from 270b115; frontend build + all 36 vitest tests pass against the stack's `types.ts`/`PackageStep.tsx` changes.
- **#130 (research trace sharing prompts)**: the two README prompt blocks disappeared. Re-applied, with "mandatory TruffleHog safeguards" / "TruffleHog result" updated to the tiered secret-scan wording #128 introduced (the stack deliberately rewrote those phrases everywhere else).

No Python changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MQ57fCxoLQQdtbYmdibkdE