### PR TITLE
Auto-install managed scanners before sharing

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Use one of these prompts in Claude Code, Codex, Cursor, or another coding assist
 > **Ordinary workflow — browser workbench**
 >
 > ```text
-> Install or update ClawJournal from https://github.com/rayward-external/clawjournal and follow its README for my operating system. I am part of this research collaboration and have already agreed to contribute my coding agent traces for our joint research and publication. Installation and the documented local review and sharing workflow are authorized.
+> Install or update ClawJournal from https://github.com/rayward-external/clawjournal and follow its README for my operating system. Use the sharing-enabled installer so its managed secret scanners are installed automatically; do not ask me to install them with Homebrew. I am part of this research collaboration and have already agreed to contribute my coding agent traces for our joint research and publication. Installation and the documented local review and sharing workflow are authorized.
 >
 > Configure source `all` if needed, but show me the discovered projects before confirming them so I can exclude unrelated, personal, confidential, or third party work. Then scan and open the local browser workbench with `clawjournal serve`.
 >
@@ -25,7 +25,7 @@ Use one of these prompts in Claude Code, Codex, Cursor, or another coding assist
 > **CLI-only workflow — remote terminal or SSH**
 >
 > ```text
-> Install or update ClawJournal from https://github.com/rayward-external/clawjournal and follow its README for my operating system. I am part of this research collaboration and have already agreed to contribute my coding agent traces for our joint research and publication. Installation and the documented local review and sharing workflow are authorized.
+> Install or update ClawJournal from https://github.com/rayward-external/clawjournal and follow its README for my operating system. Use the sharing-enabled installer so its managed secret scanners are installed automatically; do not ask me to install them with Homebrew. I am part of this research collaboration and have already agreed to contribute my coding agent traces for our joint research and publication. Installation and the documented local review and sharing workflow are authorized.
 >
 > Configure source `all` if needed, but show me the discovered projects before confirming them so I can exclude unrelated, personal, confidential, or third party work. Then scan and run `clawjournal share --interactive --weekly`.
 >
@@ -42,7 +42,7 @@ The same prompt installs ClawJournal the first time and updates it later. Run it
 
 Open any AI coding assistant — **Claude Code**, **Codex**, **Cursor**, **OpenCode**, **Gemini CLI**, or similar — and paste this:
 
-> *Install or update ClawJournal from https://github.com/rayward-external/clawjournal. Read its README and follow it for my operating system. If it's already installed, pull the latest code from the public GitHub repo and rebuild the browser workbench. Install any missing prerequisites (git, Python 3.10+, Node.js). When you're done, run `clawjournal status` and tell me the version.*
+> *Install or update ClawJournal from https://github.com/rayward-external/clawjournal. Read its README and follow it for my operating system. Use the sharing-enabled installer so the managed Betterleaks and TruffleHog scanners are installed automatically. If ClawJournal is already installed, pull the latest code, rebuild the browser workbench, and repair any missing sharing dependencies. Install any missing prerequisites (git, Python 3.10+, Node.js). When you're done, run `clawjournal status` and tell me the version.*
 
 The AI detects your OS, installs what it needs (git, Python, Node.js), runs the installer, and confirms it works.
 
@@ -63,7 +63,7 @@ Research participants who are explicitly enrolled in OpenRefinery Agent Failure 
 clawjournal enroll openrefinery --agent all --ui auto
 ```
 
-The enrollment command first tries a safe `clawjournal selfupdate`, then writes a Stop hook into `~/.claude/settings.json` and `~/.codex/hooks.json`. The hook shows at most one gentle nudge per day asking whether to review recent agent failures with ClawJournal — answer **y** to open local review or **n** for later (preview the exact text any time with `clawjournal hooks run openrefinery-failures --client claude --dry-run`). Developers testing the hook can set `OPENREFINERY_SHARE_HOOK_TEST=1` to raise the cap to 10/day. If the participant accepts, run:
+The enrollment command first tries a safe `clawjournal selfupdate`, installs pinned and checksum-verified Betterleaks and TruffleHog copies under `~/.clawjournal/bin`, then writes a Stop hook into `~/.claude/settings.json` and `~/.codex/hooks.json`. The hook shows at most one gentle nudge per day asking whether to review recent agent failures with ClawJournal — answer **y** to open local review or **n** for later (preview the exact text any time with `clawjournal hooks run openrefinery-failures --client claude --dry-run`). Developers testing the hook can set `OPENREFINERY_SHARE_HOOK_TEST=1` to raise the cap to 10/day. If the participant accepts, run:
 
 ```bash
 clawjournal hooks launch openrefinery-failures
@@ -116,7 +116,7 @@ $env:Path = [Environment]::GetEnvironmentVariable('Path','Machine') + ';' + [Env
 ```bash
 git clone https://github.com/rayward-external/clawjournal.git ~/clawjournal
 cd ~/clawjournal
-./scripts/install.sh --with-frontend       # or: sh scripts/install.sh --with-frontend
+./scripts/install.sh --with-frontend --with-sharing
 ```
 
 **Install — native Windows PowerShell** (use `powershell` if `pwsh` isn't installed):
@@ -124,10 +124,10 @@ cd ~/clawjournal
 ```powershell
 git clone https://github.com/rayward-external/clawjournal.git "$HOME\clawjournal"
 Set-Location "$HOME\clawjournal"
-pwsh -ExecutionPolicy Bypass -File .\scripts\install.ps1 -WithFrontend
+pwsh -ExecutionPolicy Bypass -File .\scripts\install.ps1 -WithFrontend -WithSharing
 ```
 
-`--with-frontend` / `-WithFrontend` builds the workbench at `localhost:8384`. Without Node.js the script warns and continues CLI-only (`serve` will 404 until you install Node and re-run). The script prints `[ok] ClawJournal <version> installed.` on success.
+`--with-frontend` / `-WithFrontend` builds the workbench at `localhost:8384`. `--with-sharing` / `-WithSharing` installs pinned, checksum-verified Betterleaks and TruffleHog copies without root access. Omit the sharing flag for a local-review-only install. Without Node.js the script warns and continues CLI-only (`serve` will 404 until you install Node and re-run). The script prints `[ok] ClawJournal <version> installed.` on success.
 
 **Verify** — the CLI lives at `~/.clawjournal-venv/bin/clawjournal` (POSIX) or `$HOME\.clawjournal-venv\Scripts\clawjournal.exe` (Windows); `status` prints JSON with `"stage"` and `"stage_number"`:
 
@@ -160,23 +160,21 @@ Optionally, `npx skills add rayward-external/clawjournal` installs three skills 
 
 ### 1. Install
 
-Use [Quickstart](#quickstart) above (or the install prompt at the top). The secret scanners (Betterleaks + TruffleHog) are **not** required for local use — they're only needed at Stage 6, where every export runs an independent secret scan; verified credentials block, recognizable tokens are auto-redacted, and a missing scanner blocks the export. Your AI installs them when you reach Stage 6.
+Use [Quickstart](#quickstart) above (or the install prompt at the top). The secret scanners (Betterleaks + TruffleHog) are **not** required for local use. The sharing-enabled installer installs them up front; existing installations repair a missing scanner automatically during enrollment or the first packaging preflight. Every export still runs an independent secret scan: verified credentials block, recognizable tokens are auto-redacted, and a scanner that cannot be installed or resolved blocks the export.
 
 <details>
-<summary><b>Show scanner install commands</b></summary>
+<summary><b>Show scanner recovery commands</b></summary>
 
 ```bash
 # macOS / Linux / Windows (x86-64 and ARM64) — pinned versions, sha256-verified,
 # installed to ~/.clawjournal/bin, no root needed:
 clawjournal betterleaks install
 clawjournal trufflehog install
-
-# Or install them yourself:
-brew install betterleaks trufflehog                        # macOS
-curl -sSfL https://raw.githubusercontent.com/trufflesecurity/trufflehog/main/scripts/install.sh | sh -s -- -b /usr/local/bin   # Linux (TruffleHog)
-# Betterleaks Linux/Windows: https://github.com/betterleaks/betterleaks#installation
-# Windows: download release binaries from each project's releases page
 ```
+
+Normal participants do not need these commands: enrollment and packaging run
+the same managed installers automatically. They are included only for retrying
+a failed download or diagnosing an offline machine.
 
 </details>
 
@@ -313,7 +311,7 @@ clawjournal auto-upload disable   # removes upload authority; prior uploads are 
 Or paste this into Claude Code, Codex, or another AI coding assistant on the remote machine:
 
 > ```text
-> Install or update ClawJournal from https://github.com/rayward-external/clawjournal and follow its README for my operating system. I am part of this research collaboration and have already agreed to contribute my coding agent traces for our joint research and publication. Installation and the documented local review and sharing workflow are authorized.
+> Install or update ClawJournal from https://github.com/rayward-external/clawjournal and follow its README for my operating system. Use the sharing-enabled installer so its managed secret scanners are installed automatically; do not ask me to install them with Homebrew. I am part of this research collaboration and have already agreed to contribute my coding agent traces for our joint research and publication. Installation and the documented local review and sharing workflow are authorized.
 >
 > Configure source `all` if needed, but show me the discovered projects before confirming them so I can exclude unrelated, personal, confidential, or third party work. Then scan and run `clawjournal share --interactive --weekly`.
 >

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -1682,6 +1682,7 @@ def _write_bundle_zip(export_dir: Path) -> Path:
 
 def _run_bundle_export(args) -> None:
     """Export a bundle to disk as JSONL + manifest."""
+    from .redaction.scanner_install import ensure_share_scanners
     from .workbench.index import (
         export_share_to_disk,
         get_effective_share_settings,
@@ -1691,6 +1692,20 @@ def _run_bundle_export(args) -> None:
     )
 
     config = load_config()
+
+    scanner_setup = ensure_share_scanners(
+        progress=None if getattr(args, "json", False) else print,
+    )
+    if not scanner_setup["ok"]:
+        if getattr(args, "json", False):
+            print(json.dumps({
+                "error": scanner_setup.get("error"),
+                "block_reason": "scanner-not-installed",
+                "scanner_install": scanner_setup,
+            }, indent=2))
+        else:
+            print(scanner_setup.get("error") or "Required secret scanners are not installed.")
+        sys.exit(2)
 
     # AI-PII review only runs inside the uploadable-zip finalize pass, so the
     # flag is a no-op for a plain on-disk export. Warn instead of silently
@@ -5001,6 +5016,14 @@ def main() -> None:
             update_status = update.get("status") if isinstance(update, dict) else None
             if update_status:
                 print(f"ClawJournal update status: {update_status}")
+            scanners = result.get("scanners") or {}
+            scanner_states = scanners.get("scanners", {}) if isinstance(scanners, dict) else {}
+            if scanner_states:
+                summary = ", ".join(
+                    f"{name} ({state.get('status', 'unknown')})"
+                    for name, state in scanner_states.items()
+                )
+                print(f"Local secret scanners ready: {summary}.")
             install = result["install"]
             installed = install.get("installed", [])
             agents = ", ".join(item.get("agent", "?") for item in installed)

--- a/clawjournal/openrefinery_hooks.py
+++ b/clawjournal/openrefinery_hooks.py
@@ -801,6 +801,11 @@ def enroll_openrefinery(
         from .selfupdate import selfupdate_sync
 
         update_result = dict(selfupdate_sync())
+    from .redaction.scanner_install import ensure_share_scanners
+
+    scanner_result = ensure_share_scanners(prefer_managed=True)
+    if not scanner_result["ok"]:
+        raise HookError(scanner_result.get("error") or "Secret scanner installation failed.")
     install_result = install_profile(
         profile=PROFILE_NAME,
         agent=agent,
@@ -811,6 +816,7 @@ def enroll_openrefinery(
     return {
         "profile": PROFILE_NAME,
         "update": update_result,
+        "scanners": scanner_result,
         "install": install_result,
         "next": {
             "review": f"clawjournal hooks launch {PROFILE_NAME}",

--- a/clawjournal/redaction/scanner_install.py
+++ b/clawjournal/redaction/scanner_install.py
@@ -9,7 +9,6 @@ checksum-verified installers.
 
 from __future__ import annotations
 
-import os
 import threading
 from collections.abc import Callable
 from typing import Any
@@ -17,10 +16,6 @@ from typing import Any
 
 _INSTALL_LOCK = threading.Lock()
 _INSTALL_OK = frozenset({"installed", "already-installed"})
-
-
-def _truthy(value: str | None) -> bool:
-    return bool(value) and value.strip().lower() not in {"", "0", "false", "no", "off"}
 
 
 def ensure_share_scanners(
@@ -55,7 +50,11 @@ def ensure_share_scanners(
         for name, scanner, installer in scanners:
             before = scanner.resolve_binary()
             available_before = scanner.is_available()
-            if _truthy(os.environ.get(scanner.SKIP_ENV_VAR)):
+            # Keep preflight and gate semantics identical.  The scanners own
+            # their development-bypass contract (currently the exact value
+            # ``"1"``); accepting broader truthy spellings here would skip an
+            # install that the gate still requires and strand recovery retries.
+            if scanner.is_bypassed():
                 outcomes[name] = {
                     "ok": True,
                     "status": "bypassed",

--- a/clawjournal/redaction/scanner_install.py
+++ b/clawjournal/redaction/scanner_install.py
@@ -1,0 +1,122 @@
+"""Managed share-scanner readiness and installation.
+
+The share gate must remain fail-closed, but a ClawJournal update can add a new
+required scanner before an existing participant has installed its binary.  This
+module is the single preflight used by enrollment, CLI sharing, and the
+workbench to repair that dependency gap with the existing pinned,
+checksum-verified installers.
+"""
+
+from __future__ import annotations
+
+import os
+import threading
+from collections.abc import Callable
+from typing import Any
+
+
+_INSTALL_LOCK = threading.Lock()
+_INSTALL_OK = frozenset({"installed", "already-installed"})
+
+
+def _truthy(value: str | None) -> bool:
+    return bool(value) and value.strip().lower() not in {"", "0", "false", "no", "off"}
+
+
+def ensure_share_scanners(
+    *,
+    prefer_managed: bool = False,
+    progress: Callable[[str], None] | None = None,
+) -> dict[str, Any]:
+    """Ensure Betterleaks and TruffleHog are usable for sharing.
+
+    Missing scanners are installed into ``~/.clawjournal/bin`` using the
+    pinned, checksum-verified managed installers.  ``prefer_managed`` also
+    installs a managed copy when a PATH binary is already usable; enrollment
+    and explicit workbench recovery use this for reproducible participant
+    setup, while routine share preflight only repairs missing dependencies.
+
+    The test/development bypass variables remain authoritative: a bypassed
+    scanner is not installed here, and the existing upload gate still refuses
+    to ship bypassed bundles.
+    """
+    from . import betterleaks, betterleaks_install, trufflehog, trufflehog_install
+
+    scanners = (
+        ("betterleaks", betterleaks, betterleaks_install),
+        ("trufflehog", trufflehog, trufflehog_install),
+    )
+    outcomes: dict[str, dict[str, Any]] = {}
+
+    # A daemon can receive concurrent package/retry requests.  The individual
+    # installers publish atomically, and this lock also avoids duplicate
+    # downloads and confusing interleaved progress within one process.
+    with _INSTALL_LOCK:
+        for name, scanner, installer in scanners:
+            before = scanner.resolve_binary()
+            available_before = scanner.is_available()
+            if _truthy(os.environ.get(scanner.SKIP_ENV_VAR)):
+                outcomes[name] = {
+                    "ok": True,
+                    "status": "bypassed",
+                    "install_attempted": False,
+                    "available": available_before,
+                    "managed": before == str(scanner.managed_binary_path()),
+                }
+                continue
+
+            already_managed = before == str(scanner.managed_binary_path())
+            should_install = not available_before or (
+                prefer_managed and not already_managed
+            )
+            if not should_install:
+                outcomes[name] = {
+                    "ok": True,
+                    "status": "available",
+                    "install_attempted": False,
+                    "available": True,
+                    "managed": already_managed,
+                    "resolved_path": before,
+                }
+                continue
+
+            if progress is not None:
+                progress(f"Installing the managed {name} scanner…")
+            install_result = installer.install(progress=progress)
+            after = scanner.resolve_binary()
+            usable = scanner.is_available()
+            outcome = {
+                "ok": usable,
+                "status": install_result.get("status", "install-failed"),
+                "install_attempted": True,
+                "available": usable,
+                "managed": after == str(scanner.managed_binary_path()),
+                "resolved_path": after,
+            }
+            for key in ("version", "error", "hint"):
+                if install_result.get(key) is not None:
+                    outcome[key] = install_result[key]
+            # A working PATH copy is a safe fallback when the explicit managed
+            # install failed.  Preserve the failure status for diagnostics but
+            # do not strand a share whose required scanner is still usable.
+            if install_result.get("status") in _INSTALL_OK and after is None:
+                outcome["error"] = "The managed install completed but the scanner could not be resolved."
+            outcomes[name] = outcome
+
+    missing = [name for name, outcome in outcomes.items() if not outcome["ok"]]
+    result: dict[str, Any] = {
+        "ok": not missing,
+        "scanners": outcomes,
+        "missing": missing,
+    }
+    if missing:
+        details = []
+        for name in missing:
+            outcome = outcomes[name]
+            detail = outcome.get("error") or outcome.get("status") or "not available"
+            details.append(f"{name}: {detail}")
+        result["error"] = (
+            "Could not install the required local secret scanner"
+            f"{'s' if len(missing) != 1 else ''}: " + "; ".join(details)
+        )
+    return result

--- a/clawjournal/web/frontend/src/api.test.ts
+++ b/clawjournal/web/frontend/src/api.test.ts
@@ -58,3 +58,38 @@ describe('automatic-upload API normalization', () => {
     ]);
   });
 });
+
+describe('share scanner recovery API', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('requests installation of the pinned managed scanners', async () => {
+    const payload = {
+      ok: true,
+      missing: [],
+      scanners: {
+        betterleaks: {
+          ok: true,
+          status: 'installed',
+          install_attempted: true,
+          available: true,
+          managed: true,
+        },
+      },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.share.installScanners()).resolves.toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith('/api/share/scanners/install', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+  });
+});

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -463,6 +463,24 @@ export const api = {
     }> {
       return request('/share/upload-status');
     },
+
+    installScanners(): Promise<{
+      ok: boolean;
+      missing: string[];
+      scanners: Record<string, {
+        ok: boolean;
+        status: string;
+        install_attempted: boolean;
+        available: boolean;
+        managed: boolean;
+      }>;
+    }> {
+      return request('/share/scanners/install', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({}),
+      });
+    },
   },
 
   quickShare(sessionIds: string[], note?: string, opts?: { aiPii?: boolean }): Promise<{

--- a/clawjournal/web/frontend/src/views/Share/PackageStep.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/PackageStep.test.tsx
@@ -1,0 +1,46 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PackageStep } from './PackageStep.tsx';
+
+function renderMissingScanners(overrides: Partial<React.ComponentProps<typeof PackageStep>> = {}) {
+  const onInstallScannersAndRetry = vi.fn();
+  render(
+    <PackageStep
+      stepperHeader={null}
+      approvedCount={1}
+      approvedList={[]}
+      progress={46}
+      log="Failed: required scanner missing"
+      failed="Betterleaks is required"
+      missingScanners
+      installingScanners={false}
+      blockedSessions={[]}
+      onInstallScannersAndRetry={onInstallScannersAndRetry}
+      onRetry={vi.fn()}
+      onRemoveBlockedAndRetry={vi.fn()}
+      onBack={vi.fn()}
+      globalStyles={null}
+      {...overrides}
+    />,
+  );
+  return { onInstallScannersAndRetry };
+}
+
+describe('PackageStep scanner recovery', () => {
+  it('offers a local managed install and retry when preflight reports a missing scanner', () => {
+    const { onInstallScannersAndRetry } = renderMissingScanners();
+
+    expect(screen.getByRole('heading', { name: 'Packaging failed' })).toBeInTheDocument();
+    expect(screen.getByText('Local scanners required')).toBeInTheDocument();
+    expect(screen.getByText(/Betterleaks and TruffleHog scan the redacted bundle on this computer/)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Install secure scanners & retry' }));
+    expect(onInstallScannersAndRetry).toHaveBeenCalledOnce();
+  });
+
+  it('disables the repair action while the managed installers are running', () => {
+    renderMissingScanners({ installingScanners: true });
+
+    expect(screen.getByRole('button', { name: 'Installing secure scanners…' })).toBeDisabled();
+  });
+});

--- a/clawjournal/web/frontend/src/views/Share/PackageStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/PackageStep.tsx
@@ -13,7 +13,10 @@ export interface PackageStepProps {
   progress: number;
   log: string;
   failed: string | null;
+  missingScanners: boolean;
+  installingScanners: boolean;
   blockedSessions: BlockedShareSession[];
+  onInstallScannersAndRetry: () => void;
   onRetry: () => void;
   onRemoveBlockedAndRetry: () => void;
   onBack: () => void;
@@ -102,7 +105,9 @@ export function PackageStep(p: PackageStepProps) {
           {p.failed && blockedCount > 0
             ? `${blockedCount} trace${blockedCount === 1 ? '' : 's'} triggered the final secret scan.`
             : p.failed
-            ? p.failed
+            ? p.missingScanners
+              ? 'A required local secret scanner is missing.'
+              : p.failed
             : <>Compressing {p.approvedCount} approved trace{p.approvedCount === 1 ? '' : 's'} into a single redacted zip.</>}
         </p>
         <div style={{
@@ -124,6 +129,20 @@ export function PackageStep(p: PackageStepProps) {
         </div>
         {p.failed && (
           <>
+            {p.missingScanners && (
+              <div style={{
+                margin: '20px auto 0', maxWidth: 560, textAlign: 'left',
+                border: '1px solid #D4AB73', background: '#E9DEC9',
+                borderRadius: 12, padding: '14px 16px', color: '#362815',
+              }}>
+                <div style={{ fontSize: 13, fontWeight: 600, marginBottom: 5 }}>
+                  Local scanners required
+                </div>
+                <div style={{ fontSize: 12.5, lineHeight: 1.5, color: '#725E47' }}>
+                  Betterleaks and TruffleHog scan the redacted bundle on this computer before a ZIP is created. Install the pinned, verified copies and retry packaging.
+                </div>
+              </div>
+            )}
             {blockedCount > 0 && (
               <div style={{
                 margin: '20px auto 0', maxWidth: 560, textAlign: 'left',
@@ -168,6 +187,26 @@ export function PackageStep(p: PackageStepProps) {
             )}
             <div style={{ marginTop: 20, display: 'flex', gap: 10, justifyContent: 'center', flexWrap: 'wrap' }}>
               <button onClick={p.onBack} style={btnSecondary}>Back to review</button>
+              {p.missingScanners && (
+                <button
+                  onClick={p.onInstallScannersAndRetry}
+                  disabled={p.installingScanners}
+                  style={{
+                    ...btnPrimary,
+                    background: '#EDE2CC', color: '#362815', border: '1px solid #45392C',
+                    cursor: p.installingScanners ? 'wait' : 'pointer',
+                    opacity: p.installingScanners ? 0.7 : 1,
+                  }}
+                >
+                  <span style={{
+                    display: 'inline-flex',
+                    animation: p.installingScanners ? 'clawSpin 900ms linear infinite' : undefined,
+                  }}>
+                    <Icon name={p.installingScanners ? 'retry' : 'lock'} size={13} />
+                  </span>
+                  {p.installingScanners ? 'Installing secure scanners…' : 'Install secure scanners & retry'}
+                </button>
+              )}
               {blockedCount > 0 && (
                 <button onClick={p.onRemoveBlockedAndRetry} style={btnPrimary}>
                   Remove and retry

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -202,6 +202,8 @@ export function Share() {
   const [packageProgress, setPackageProgress] = useState(0);
   const [packageLog, setPackageLog] = useState('');
   const [packagingFailed, setPackagingFailed] = useState<string | null>(null);
+  const [packageBlockReason, setPackageBlockReason] = useState<string | null>(null);
+  const [installingScanners, setInstallingScanners] = useState(false);
   const [blockedPackageSessions, setBlockedPackageSessions] = useState<BlockedShareSession[]>([]);
 
   // Done state
@@ -962,6 +964,7 @@ export function Share() {
     if (packagingStartedRef.current) return;
     packagingStartedRef.current = true;
     setPackagingFailed(null);
+    setPackageBlockReason(null);
     setBlockedPackageSessions([]);
     setPackageProgress(0);
     setPackageLog('Allocating bundle...');
@@ -1060,7 +1063,11 @@ export function Share() {
     } catch (err: unknown) {
       clearAllTimers();
       const msg = err instanceof Error ? err.message : 'Package failed';
+      const blockReason = err instanceof ApiError && typeof err.body.block_reason === 'string'
+        ? err.body.block_reason
+        : null;
       setBlockedPackageSessions(blockedSessionsFromError(err));
+      setPackageBlockReason(blockReason);
       setPackagingFailed(msg);
       setPackageLog(`Failed: ${msg}`);
       toast(msg, 'error');
@@ -1068,6 +1075,25 @@ export function Share() {
       packagingStartedRef.current = false;
     }
   }, [approvedSessions, note, toast, aiPiiEnabled]);
+
+  const installScannersAndRetry = useCallback(async () => {
+    if (installingScanners) return;
+    setInstallingScanners(true);
+    setPackageLog('Installing pinned local scanners...');
+    try {
+      await api.share.installScanners();
+      toast('Local secret scanners installed', 'success');
+      await runPackage();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Scanner installation failed';
+      setPackageBlockReason('scanner-not-installed');
+      setPackagingFailed(msg);
+      setPackageLog(`Failed: ${msg}`);
+      toast(msg, 'error');
+    } finally {
+      setInstallingScanners(false);
+    }
+  }, [installingScanners, runPackage, toast]);
 
   const handleStartPackage = () => {
     if (queuedSessions.length === 0) return;
@@ -1313,7 +1339,10 @@ export function Share() {
         progress={packageProgress}
         log={packageLog}
         failed={packagingFailed}
+        missingScanners={packageBlockReason === 'scanner-not-installed'}
+        installingScanners={installingScanners}
         blockedSessions={blockedPackageSessions}
+        onInstallScannersAndRetry={installScannersAndRetry}
         onRetry={runPackage}
         onRemoveBlockedAndRetry={removeBlockedAndRetry}
         onBack={() => setActiveStep('review')}

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -2096,6 +2096,20 @@ def _prepare_share_export_for_upload(
     ai_pii_backend: str = "auto",
     before_ai_call: Callable[[], None] | None = None,
 ) -> tuple[Path | None, dict[str, Any], dict[str, Any] | None]:
+    # Existing participants can receive a new required scanner through a
+    # ClawJournal fast-forward without re-running the installer.  Repair that
+    # dependency gap before any export or AI work; failures stay fail-closed and
+    # carry a stable reason the workbench can recover from explicitly.
+    from ..redaction.scanner_install import ensure_share_scanners
+
+    scanner_setup = ensure_share_scanners()
+    if not scanner_setup["ok"]:
+        return None, {}, {
+            "error": scanner_setup.get("error") or "Required secret scanners are not installed.",
+            "block_reason": "scanner-not-installed",
+            "scanner_install": scanner_setup,
+            "status": 503,
+        }
     effective_ai_pii = (
         bool(settings.get("ai_pii_review_enabled", False))
         if ai_pii_review_enabled is None
@@ -2893,6 +2907,8 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             self._handle_share_verify_email()
         elif path == "/api/share/verify-confirm":
             self._handle_share_verify_confirm()
+        elif path == "/api/share/scanners/install":
+            self._handle_install_share_scanners()
         elif path == "/api/auto-upload/preview":
             self._handle_auto_upload_preview(refresh=True)
         elif path == "/api/auto-upload/enable":
@@ -3984,6 +4000,16 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
     def _handle_share_upload_status(self) -> None:
         _json_response(self, hosted_upload_status())
 
+    def _handle_install_share_scanners(self) -> None:
+        """Install pinned local scanner binaries and report readiness."""
+        from ..redaction.scanner_install import ensure_share_scanners
+
+        result = ensure_share_scanners(prefer_managed=True)
+        if result["ok"]:
+            _json_response(self, result)
+            return
+        _json_response(self, result, 503)
+
     @staticmethod
     def _auto_upload_http_status(result: dict[str, Any]) -> int:
         if result.get("ok") is not False:
@@ -4467,6 +4493,17 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
     def _handle_export_share(self, share_id: str) -> None:
         body = _read_body(self)
         output_path = body.get("output_path")
+
+        from ..redaction.scanner_install import ensure_share_scanners
+
+        scanner_setup = ensure_share_scanners()
+        if not scanner_setup["ok"]:
+            _json_response(self, {
+                "error": scanner_setup.get("error") or "Required secret scanners are not installed.",
+                "block_reason": "scanner-not-installed",
+                "scanner_install": scanner_setup,
+            }, 503)
+            return
 
         conn = open_index()
         try:

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -2096,20 +2096,6 @@ def _prepare_share_export_for_upload(
     ai_pii_backend: str = "auto",
     before_ai_call: Callable[[], None] | None = None,
 ) -> tuple[Path | None, dict[str, Any], dict[str, Any] | None]:
-    # Existing participants can receive a new required scanner through a
-    # ClawJournal fast-forward without re-running the installer.  Repair that
-    # dependency gap before any export or AI work; failures stay fail-closed and
-    # carry a stable reason the workbench can recover from explicitly.
-    from ..redaction.scanner_install import ensure_share_scanners
-
-    scanner_setup = ensure_share_scanners()
-    if not scanner_setup["ok"]:
-        return None, {}, {
-            "error": scanner_setup.get("error") or "Required secret scanners are not installed.",
-            "block_reason": "scanner-not-installed",
-            "scanner_install": scanner_setup,
-            "status": 503,
-        }
     effective_ai_pii = (
         bool(settings.get("ai_pii_review_enabled", False))
         if ai_pii_review_enabled is None
@@ -2142,6 +2128,23 @@ def _prepare_share_export_for_upload(
         if cached is not None:
             export_dir, manifest = cached
             return export_dir, manifest, None
+
+    # Existing participants can receive a new required scanner through a
+    # ClawJournal fast-forward without re-running the installer. Repair that
+    # dependency gap only when building a new artifact: a finalized cached
+    # export has already passed the current gate and is reused byte-for-byte.
+    # Failures stay fail-closed before any export or AI work and carry a stable
+    # reason the workbench can recover from explicitly.
+    from ..redaction.scanner_install import ensure_share_scanners
+
+    scanner_setup = ensure_share_scanners()
+    if not scanner_setup["ok"]:
+        return None, {}, {
+            "error": scanner_setup.get("error") or "Required secret scanners are not installed.",
+            "block_reason": "scanner-not-installed",
+            "scanner_install": scanner_setup,
+            "status": 503,
+        }
 
     export_dir, manifest = export_share_to_disk(
         conn,

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -11,6 +11,10 @@
 .PARAMETER WithFrontend
     Also build the browser workbench (requires Node.js / npm).
 
+.PARAMETER WithSharing
+    Also install the pinned, checksum-verified Betterleaks and TruffleHog
+    binaries used by the share gate.
+
 .PARAMETER VenvPath
     Where to create the venv. Default: $HOME\.clawjournal-venv (or the
     CLAWJOURNAL_VENV environment variable, if set).
@@ -20,10 +24,14 @@
 
 .EXAMPLE
     .\scripts\install.ps1 -WithFrontend
+
+.EXAMPLE
+    .\scripts\install.ps1 -WithFrontend -WithSharing
 #>
 [CmdletBinding()]
 param(
     [switch]$WithFrontend,
+    [switch]$WithSharing,
     [string]$VenvPath
 )
 
@@ -128,7 +136,27 @@ if ($WithFrontend) {
     }
 }
 
-# 5) Report.
+# 5) Optional sharing dependencies. Keep auto-update disabled while the
+# installer is already operating on a freshly synchronized checkout.
+if ($WithSharing) {
+    Write-Host "-> Installing managed secret scanners"
+    $previousNoAutoUpdate = $env:CLAWJOURNAL_NO_AUTO_UPDATE
+    $env:CLAWJOURNAL_NO_AUTO_UPDATE = '1'
+    try {
+        & $ClawJournalExe betterleaks install
+        if ($LASTEXITCODE -ne 0) { throw "Betterleaks installation failed (exit $LASTEXITCODE)." }
+        & $ClawJournalExe trufflehog install
+        if ($LASTEXITCODE -ne 0) { throw "TruffleHog installation failed (exit $LASTEXITCODE)." }
+    } finally {
+        if ($null -eq $previousNoAutoUpdate) {
+            Remove-Item Env:CLAWJOURNAL_NO_AUTO_UPDATE -ErrorAction SilentlyContinue
+        } else {
+            $env:CLAWJOURNAL_NO_AUTO_UPDATE = $previousNoAutoUpdate
+        }
+    }
+}
+
+# 6) Report.
 $InstalledVersion = & $VenvPy -c "import clawjournal; print(clawjournal.__version__)" 2>$null
 if (-not $InstalledVersion) { $InstalledVersion = '?' }
 Write-Host ""
@@ -141,7 +169,7 @@ Write-Host ""
 Write-Host "Or add the venv to PATH for this session:"
 Write-Host "        `$env:Path = `"$VenvBin;`" + `$env:Path"
 
-# 6) Soft hints for optional runtime deps.
+# 7) Soft hints for optional runtime deps.
 $DistHtml = Join-Path $RepoDir 'clawjournal\web\frontend\dist\index.html'
 $FeSrcDir = Join-Path $RepoDir 'clawjournal\web\frontend\src'
 $frontendBuilt = Test-Path $DistHtml
@@ -165,10 +193,18 @@ elseif (Test-Path $FeSrcDir) {
     }
 }
 
+$managedBetterleaks = Join-Path $HOME ".clawjournal\bin\betterleaks.exe"
+if (-not $WithSharing -and -not (Get-Command betterleaks -ErrorAction SilentlyContinue) -and -not (Test-Path $managedBetterleaks)) {
+    Write-Host ""
+    Write-Host "[i] Betterleaks is required when sharing exports."
+    Write-Host "    Install a pinned, checksum-verified copy: $ClawJournalExe betterleaks install"
+    Write-Host "    Or re-run: .\scripts\install.ps1 -WithSharing"
+}
+
 $managedTrufflehog = Join-Path $HOME ".clawjournal\bin\trufflehog.exe"
-if (-not (Get-Command trufflehog -ErrorAction SilentlyContinue) -and -not (Test-Path $managedTrufflehog)) {
+if (-not $WithSharing -and -not (Get-Command trufflehog -ErrorAction SilentlyContinue) -and -not (Test-Path $managedTrufflehog)) {
     Write-Host ""
     Write-Host "[i] TruffleHog is required when sharing exports."
     Write-Host "    Install a pinned, checksum-verified copy: $ClawJournalExe trufflehog install"
-    Write-Host "    Or download a release binary: https://github.com/trufflesecurity/trufflehog/releases"
+    Write-Host "    Or re-run: .\scripts\install.ps1 -WithSharing"
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -8,6 +8,8 @@
 # Usage:
 #   ./scripts/install.sh                # CLI install (recommended for first run)
 #   ./scripts/install.sh --with-frontend  # also build the browser workbench
+#   ./scripts/install.sh --with-sharing   # also install the managed secret scanners
+#   ./scripts/install.sh --with-frontend --with-sharing
 #   ./scripts/install.sh --help
 #
 # Environment:
@@ -23,11 +25,13 @@ ERR_LOG="$(mktemp 2>/dev/null || echo "/tmp/clawjournal-venv.$$.err")"
 trap 'rm -f "$ERR_LOG"' EXIT INT TERM
 
 WITH_FRONTEND=0
+WITH_SHARING=0
 while [ $# -gt 0 ]; do
   case "$1" in
     --with-frontend) WITH_FRONTEND=1 ;;
+    --with-sharing) WITH_SHARING=1 ;;
     -h|--help)
-      sed -n '2,16p' "$0" | sed 's/^# \{0,1\}//'
+      sed -n '2,18p' "$0" | sed 's/^# \{0,1\}//'
       exit 0 ;;
     *)
       echo "Unknown option: $1" >&2
@@ -126,7 +130,15 @@ EOF
   fi
 fi
 
-# 5) Report.
+# 5) Optional sharing dependencies. These are pinned, checksum-verified, and
+# installed under ~/.clawjournal/bin without root access.
+if [ "$WITH_SHARING" -eq 1 ]; then
+  echo "-> Installing managed secret scanners"
+  CLAWJOURNAL_NO_AUTO_UPDATE=1 "$VENV_BIN/clawjournal" betterleaks install
+  CLAWJOURNAL_NO_AUTO_UPDATE=1 "$VENV_BIN/clawjournal" trufflehog install
+fi
+
+# 6) Report.
 echo
 INSTALLED_VERSION="$("$VENV_PY" -c 'import clawjournal; print(clawjournal.__version__)' 2>/dev/null || echo "?")"
 echo "[ok] ClawJournal $INSTALLED_VERSION installed."
@@ -140,7 +152,7 @@ Or add the venv to your PATH:
         export PATH="$VENV_BIN:\$PATH"
 EOF
 
-# 6) Soft hints for optional runtime deps.
+# 7) Soft hints for optional runtime deps.
 FE_DIST_HTML="$REPO_DIR/clawjournal/web/frontend/dist/index.html"
 FE_SRC_DIR="$REPO_DIR/clawjournal/web/frontend/src"
 if [ ! -f "$FE_DIST_HTML" ]; then
@@ -160,11 +172,20 @@ elif [ -d "$FE_SRC_DIR" ] && [ -n "$(find "$FE_SRC_DIR" -type f -newer "$FE_DIST
 EOF
 fi
 
-if ! command -v trufflehog >/dev/null 2>&1 && [ ! -x "$HOME/.clawjournal/bin/trufflehog" ]; then
+if [ "$WITH_SHARING" -eq 0 ] && ! CLAWJOURNAL_NO_AUTO_UPDATE=1 "$VENV_BIN/clawjournal" betterleaks status --json >/dev/null 2>&1; then
+  cat <<EOF
+
+[i] Betterleaks is required when sharing exports. Install it with:
+    $VENV_BIN/clawjournal betterleaks install      (pinned version, sha256-verified, no root needed)
+    Or re-run: ./scripts/install.sh --with-sharing
+EOF
+fi
+
+if [ "$WITH_SHARING" -eq 0 ] && ! CLAWJOURNAL_NO_AUTO_UPDATE=1 "$VENV_BIN/clawjournal" trufflehog status --json >/dev/null 2>&1; then
   cat <<EOF
 
 [i] TruffleHog is required when sharing exports. Install it before 'bundle-export':
     $VENV_BIN/clawjournal trufflehog install      (pinned version, sha256-verified, no root needed)
-    Or: brew install trufflehog (macOS) / https://github.com/trufflesecurity/trufflehog/releases
+    Or re-run: ./scripts/install.sh --with-sharing
 EOF
 fi

--- a/skills/clawjournal-setup/SKILL.md
+++ b/skills/clawjournal-setup/SKILL.md
@@ -23,7 +23,7 @@ Check if `clawjournal` is already installed:
 
 Use the bundled installer scripts. They detect a Python 3.10+ interpreter, create an isolated venv at `~/.clawjournal-venv`, and `pip install -e` the repo. Idempotent — safe to re-run.
 
-First, ask: "Do you want the browser workbench? (Recommended — it's the primary review surface. Otherwise the CLI works alone.)" Use the answer to pick whether to pass the frontend flag below.
+First, ask: "Do you want the browser workbench? (Recommended — it's the primary review surface. Otherwise the CLI works alone.)" Use the answer to pick whether to pass the frontend flag below. If the user intends to share traces or enroll in OpenRefinery, also pass the sharing flag so the managed secret scanners are ready before packaging. Do not use Homebrew for those scanners.
 
 **macOS / Linux / WSL / Git Bash on Windows:**
 
@@ -37,6 +37,7 @@ fi
 # Pick ONE based on the user's answer above:
 ~/clawjournal/scripts/install.sh                    # CLI only
 ~/clawjournal/scripts/install.sh --with-frontend    # also build the browser workbench (needs Node.js)
+# Add --with-sharing to either command for sharing or OpenRefinery enrollment.
 ```
 
 **Native Windows PowerShell** (no WSL / Git Bash):
@@ -51,6 +52,7 @@ if (Test-Path "$HOME\clawjournal\.git") {
 # Pick ONE based on the user's answer above:
 powershell -ExecutionPolicy Bypass -File "$HOME\clawjournal\scripts\install.ps1"                # CLI only
 powershell -ExecutionPolicy Bypass -File "$HOME\clawjournal\scripts\install.ps1" -WithFrontend  # also build the browser workbench (needs Node.js)
+# Add -WithSharing to either command for sharing or OpenRefinery enrollment.
 ```
 
 The script's exit code and printed output tell you exactly what to do next. Common failure modes the script surfaces directly:
@@ -58,6 +60,7 @@ The script's exit code and printed output tell you exactly what to do next. Comm
 - **Python 3.10+ not found** — install via the platform hint the script prints, then re-run. macOS users may also need `xcode-select --install` to get a working `python3`.
 - **`python3 -m venv` fails on Debian/Ubuntu** — run `sudo apt install -y python3-venv python3-full`, then re-run the script.
 - **`node` / `npm` missing** when `--with-frontend` was requested — the script skips the frontend with a warning. Install Node.js (macOS: `brew install node`, Linux: `sudo apt-get install -y nodejs npm`, Windows: nodejs.org) and re-run with the flag.
+- **A managed secret scanner download fails** when `--with-sharing` / `-WithSharing` was requested — check the printed network or checksum diagnostic and re-run the same installer. Do not bypass the sharing gate.
 
 Verify (POSIX):
 

--- a/skills/clawjournal/SKILL.md
+++ b/skills/clawjournal/SKILL.md
@@ -151,9 +151,13 @@ If user says "looks good" / "share" / "yes" — proceed to Step 4.
 Only after explicit user confirmation:
 
 ```bash
+clawjournal betterleaks status --json >/dev/null 2>&1 || clawjournal betterleaks install
+clawjournal trufflehog status --json >/dev/null 2>&1 || clawjournal trufflehog install
 clawjournal bundle-create --status approved --note "<user's comment>" --json
 clawjournal bundle-export <bundle_id> --zip --json
 ```
+
+Run the scanner checks yourself. The packaging preflight also repairs missing managed scanners, but this explicit check gives the user a clear installation result before the final package step. Never ask the user to install Betterleaks or TruffleHog with Homebrew.
 
 Parse the export result and **always report the redaction summary to the user** (see Communication Guidelines above). For hosted research submission, do not ask the user for `CLAWJOURNAL_INGEST_URL`; use the workbench Share tab's Submit step so email verification, consent, and receipt handling happen in the UI. If the destination is not configured, tell the user the redacted zip is ready on their computer.
 

--- a/tests/redaction/test_scanner_install.py
+++ b/tests/redaction/test_scanner_install.py
@@ -153,3 +153,27 @@ def test_bypassed_scanner_is_never_installed(monkeypatch, tmp_path):
 
     assert result["ok"] is True
     assert result["scanners"]["betterleaks"]["status"] == "bypassed"
+
+
+def test_noncanonical_skip_value_does_not_bypass_install(monkeypatch, tmp_path):
+    state, _managed = _scanner_state(
+        monkeypatch,
+        tmp_path,
+        better=False,
+        truffle=True,
+    )
+    monkeypatch.setenv(betterleaks.SKIP_ENV_VAR, "true")
+    installs: list[str] = []
+
+    def install_betterleaks(**_kwargs):
+        installs.append("betterleaks")
+        state["betterleaks"] = True
+        return {"status": "installed", "version": "1.6.1"}
+
+    monkeypatch.setattr(betterleaks_install, "install", install_betterleaks)
+
+    result = scanner_install.ensure_share_scanners()
+
+    assert result["ok"] is True
+    assert installs == ["betterleaks"]
+    assert result["scanners"]["betterleaks"]["status"] == "installed"

--- a/tests/redaction/test_scanner_install.py
+++ b/tests/redaction/test_scanner_install.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from clawjournal.redaction import (
+    betterleaks,
+    betterleaks_install,
+    scanner_install,
+    trufflehog,
+    trufflehog_install,
+)
+
+
+def _scanner_state(monkeypatch, tmp_path: Path, *, better: bool, truffle: bool):
+    state = {"betterleaks": better, "trufflehog": truffle}
+    managed = {
+        "betterleaks": tmp_path / "bin" / "betterleaks",
+        "trufflehog": tmp_path / "bin" / "trufflehog",
+    }
+    for name, scanner in (("betterleaks", betterleaks), ("trufflehog", trufflehog)):
+        monkeypatch.delenv(scanner.SKIP_ENV_VAR, raising=False)
+        monkeypatch.setattr(scanner, "managed_binary_path", lambda name=name: managed[name])
+        monkeypatch.setattr(scanner, "is_available", lambda name=name: state[name])
+        monkeypatch.setattr(
+            scanner,
+            "resolve_binary",
+            lambda name=name: str(managed[name]) if state[name] else None,
+        )
+    return state, managed
+
+
+def test_available_scanners_do_not_run_installers(monkeypatch, tmp_path):
+    _scanner_state(monkeypatch, tmp_path, better=True, truffle=True)
+
+    def unexpected_install(**_kwargs):
+        raise AssertionError("installer should not run")
+
+    monkeypatch.setattr(betterleaks_install, "install", unexpected_install)
+    monkeypatch.setattr(trufflehog_install, "install", unexpected_install)
+
+    result = scanner_install.ensure_share_scanners()
+
+    assert result["ok"] is True
+    assert result["missing"] == []
+    assert all(
+        row["install_attempted"] is False
+        for row in result["scanners"].values()
+    )
+
+
+def test_first_share_repairs_scanners_added_by_an_update(monkeypatch, tmp_path):
+    state, _managed = _scanner_state(
+        monkeypatch,
+        tmp_path,
+        better=False,
+        truffle=True,
+    )
+    installs: list[str] = []
+
+    def install_betterleaks(**_kwargs):
+        installs.append("betterleaks")
+        state["betterleaks"] = True
+        return {"status": "installed", "version": "1.6.1"}
+
+    monkeypatch.setattr(betterleaks_install, "install", install_betterleaks)
+    monkeypatch.setattr(
+        trufflehog_install,
+        "install",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("existing scanner should not be reinstalled")
+        ),
+    )
+
+    result = scanner_install.ensure_share_scanners()
+
+    assert result["ok"] is True
+    assert installs == ["betterleaks"]
+    assert result["scanners"]["betterleaks"] == {
+        "ok": True,
+        "status": "installed",
+        "install_attempted": True,
+        "available": True,
+        "managed": True,
+        "resolved_path": str(tmp_path / "bin" / "betterleaks"),
+        "version": "1.6.1",
+    }
+
+
+def test_prefer_managed_installs_over_path_copy(monkeypatch, tmp_path):
+    state, managed = _scanner_state(monkeypatch, tmp_path, better=True, truffle=True)
+    paths = {
+        "betterleaks": "/usr/local/bin/betterleaks",
+        "trufflehog": "/usr/local/bin/trufflehog",
+    }
+    monkeypatch.setattr(betterleaks, "resolve_binary", lambda: paths["betterleaks"])
+    monkeypatch.setattr(trufflehog, "resolve_binary", lambda: paths["trufflehog"])
+
+    def managed_install(name: str):
+        paths[name] = str(managed[name])
+        state[name] = True
+        return {"status": "installed"}
+
+    monkeypatch.setattr(
+        betterleaks_install,
+        "install",
+        lambda **_kwargs: managed_install("betterleaks"),
+    )
+    monkeypatch.setattr(
+        trufflehog_install,
+        "install",
+        lambda **_kwargs: managed_install("trufflehog"),
+    )
+
+    result = scanner_install.ensure_share_scanners(prefer_managed=True)
+
+    assert result["ok"] is True
+    assert all(row["managed"] for row in result["scanners"].values())
+    assert all(row["install_attempted"] for row in result["scanners"].values())
+
+
+def test_install_failure_is_structured_and_fail_closed(monkeypatch, tmp_path):
+    _scanner_state(monkeypatch, tmp_path, better=False, truffle=True)
+    monkeypatch.setattr(
+        betterleaks_install,
+        "install",
+        lambda **_kwargs: {
+            "status": "download-failed",
+            "error": "network unavailable",
+            "hint": "check proxy settings",
+        },
+    )
+
+    result = scanner_install.ensure_share_scanners()
+
+    assert result["ok"] is False
+    assert result["missing"] == ["betterleaks"]
+    assert "network unavailable" in result["error"]
+    assert result["scanners"]["betterleaks"]["hint"] == "check proxy settings"
+
+
+def test_bypassed_scanner_is_never_installed(monkeypatch, tmp_path):
+    _scanner_state(monkeypatch, tmp_path, better=False, truffle=True)
+    monkeypatch.setenv(betterleaks.SKIP_ENV_VAR, "1")
+    monkeypatch.setattr(
+        betterleaks_install,
+        "install",
+        lambda **_kwargs: (_ for _ in ()).throw(
+            AssertionError("bypassed scanner should not be installed")
+        ),
+    )
+
+    result = scanner_install.ensure_share_scanners()
+
+    assert result["ok"] is True
+    assert result["scanners"]["betterleaks"]["status"] == "bypassed"

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_posix_installer_supports_managed_sharing_dependencies():
+    script = (ROOT / "scripts" / "install.sh").read_text()
+
+    assert "--with-sharing" in script
+    assert '"$VENV_BIN/clawjournal" betterleaks install' in script
+    assert '"$VENV_BIN/clawjournal" trufflehog install' in script
+
+    help_result = subprocess.run(
+        ["sh", str(ROOT / "scripts" / "install.sh"), "--help"],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+    assert help_result.returncode == 0
+    assert "--with-sharing" in help_result.stdout
+
+
+def test_powershell_installer_supports_managed_sharing_dependencies():
+    script = (ROOT / "scripts" / "install.ps1").read_text()
+
+    assert "[switch]$WithSharing" in script
+    assert "& $ClawJournalExe betterleaks install" in script
+    assert "& $ClawJournalExe trufflehog install" in script

--- a/tests/test_openrefinery_hooks.py
+++ b/tests/test_openrefinery_hooks.py
@@ -27,6 +27,52 @@ def _read(path: Path) -> dict:
     return json.loads(path.read_text())
 
 
+def test_enroll_installs_managed_share_scanners(isolated_hook_env, monkeypatch):
+    calls = []
+    scanner_result = {
+        "ok": True,
+        "missing": [],
+        "scanners": {
+            "betterleaks": {"ok": True, "status": "installed"},
+            "trufflehog": {"ok": True, "status": "installed"},
+        },
+    }
+    monkeypatch.setattr(
+        "clawjournal.redaction.scanner_install.ensure_share_scanners",
+        lambda **kwargs: calls.append(kwargs) or scanner_result,
+    )
+
+    result = hooks.enroll_openrefinery(
+        agent="codex",
+        skip_selfupdate=True,
+        home=isolated_hook_env / "home",
+    )
+
+    assert calls == [{"prefer_managed": True}]
+    assert result["scanners"] == scanner_result
+    assert result["install"]["enabled"] is True
+
+
+def test_enroll_stops_when_share_scanners_cannot_be_installed(
+    isolated_hook_env,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        "clawjournal.redaction.scanner_install.ensure_share_scanners",
+        lambda **_kwargs: {
+            "ok": False,
+            "error": "betterleaks: network unavailable",
+        },
+    )
+
+    with pytest.raises(hooks.HookError, match="betterleaks: network unavailable"):
+        hooks.enroll_openrefinery(
+            agent="codex",
+            skip_selfupdate=True,
+            home=isolated_hook_env / "home",
+        )
+
+
 def test_install_profile_writes_claude_and_codex_hooks(isolated_hook_env):
     home = isolated_hook_env / "home"
     claude_settings = home / ".claude" / "settings.json"

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -211,6 +211,52 @@ def _write_with_mtime(path, content, mtime):
     os.utime(path, (mtime, mtime))
 
 
+@pytest.mark.parametrize(
+    ("result", "expected_status"),
+    [
+        (
+            {
+                "ok": True,
+                "missing": [],
+                "scanners": {
+                    "betterleaks": {"ok": True, "status": "installed"},
+                    "trufflehog": {"ok": True, "status": "already-installed"},
+                },
+            },
+            200,
+        ),
+        (
+            {
+                "ok": False,
+                "missing": ["betterleaks"],
+                "error": "betterleaks: download failed",
+                "scanners": {
+                    "betterleaks": {"ok": False, "status": "download-failed"},
+                },
+            },
+            503,
+        ),
+    ],
+)
+def test_install_share_scanners_endpoint(
+    server,
+    monkeypatch,
+    result,
+    expected_status,
+):
+    calls = []
+    monkeypatch.setattr(
+        "clawjournal.redaction.scanner_install.ensure_share_scanners",
+        lambda **kwargs: calls.append(kwargs) or result,
+    )
+
+    status, body = _post(server, "/api/share/scanners/install")
+
+    assert status == expected_status
+    assert body == result
+    assert calls == [{"prefer_managed": True}]
+
+
 def _patch(port, path, data=None, *, skip_auth=False):
     conn = HTTPConnection("127.0.0.1", port, timeout=5)
     body = json.dumps(data or {}).encode()

--- a/tests/workbench/test_share_gates.py
+++ b/tests/workbench/test_share_gates.py
@@ -530,6 +530,68 @@ class TestSecretScanGate:
         assert (export_dir / "trufflehog.json").exists()
         assert (export_dir / "secret-scan.json").exists()
 
+    def test_first_share_after_update_auto_installs_new_scanner(
+        self,
+        conn,
+        monkeypatch,
+        tmp_path,
+    ):
+        """An existing install must recover when an update adds Betterleaks.
+
+        This models a participant whose ClawJournal checkout fast-forwarded to
+        the mandatory Betterleaks gate, but whose old installer had only put
+        TruffleHog on the machine.  The first package preflight installs the
+        newly required managed scanner and then completes the same share.
+        """
+        from clawjournal.redaction import betterleaks, betterleaks_install
+        from clawjournal.workbench.daemon import _prepare_share_export_for_upload
+
+        _mock_gate_engines(monkeypatch)
+        managed = tmp_path / "managed-bin" / "betterleaks"
+        scanner_state = {"available": False}
+        installs = []
+        monkeypatch.setattr(
+            betterleaks,
+            "is_available",
+            lambda: scanner_state["available"],
+        )
+        monkeypatch.setattr(betterleaks, "managed_binary_path", lambda: managed)
+        monkeypatch.setattr(
+            betterleaks,
+            "resolve_binary",
+            lambda: str(managed) if scanner_state["available"] else None,
+        )
+
+        def install_betterleaks(**_kwargs):
+            installs.append("betterleaks")
+            scanner_state["available"] = True
+            return {"status": "installed", "version": "1.6.1"}
+
+        monkeypatch.setattr(betterleaks_install, "install", install_betterleaks)
+        share_id, share = self._share(conn, content="ordinary trace content")
+        settings = {
+            "custom_strings": [],
+            "extra_usernames": [],
+            "excluded_projects": [],
+            "blocked_domains": [],
+            "allowlist_entries": [],
+            "source_filter": None,
+            "ai_pii_review_enabled": False,
+        }
+
+        export_dir, manifest, error = _prepare_share_export_for_upload(
+            conn,
+            share_id,
+            share,
+            settings,
+        )
+
+        assert error is None
+        assert installs == ["betterleaks"]
+        assert export_dir is not None
+        assert manifest.get("blocked") is not True
+        assert (export_dir / "manifest.json").exists()
+
     def test_unverified_token_is_redacted_and_share_advances(self, conn, monkeypatch):
         # The headline behavior change: a recognizable-but-unverified
         # token no longer rejects the session — the exact span is

--- a/tests/workbench/test_share_gates.py
+++ b/tests/workbench/test_share_gates.py
@@ -592,6 +592,59 @@ class TestSecretScanGate:
         assert manifest.get("blocked") is not True
         assert (export_dir / "manifest.json").exists()
 
+    def test_finalized_export_reuse_does_not_require_live_scanners(
+        self,
+        conn,
+        monkeypatch,
+        tmp_path,
+    ):
+        from clawjournal.workbench import daemon as daemon_module
+        from clawjournal.workbench.daemon import _prepare_share_export_for_upload
+
+        monkeypatch.setattr(daemon_module, "CONFIG_DIR", tmp_path)
+        _mock_gate_engines(monkeypatch)
+        share_id, share = self._share(conn, content="ordinary trace content")
+        settings = {
+            "custom_strings": [],
+            "extra_usernames": [],
+            "excluded_projects": [],
+            "blocked_domains": [],
+            "allowlist_entries": [],
+            "source_filter": None,
+            "ai_pii_review_enabled": False,
+        }
+
+        export_dir, manifest, error = _prepare_share_export_for_upload(
+            conn,
+            share_id,
+            share,
+            settings,
+            reuse_finalized=True,
+        )
+        assert error is None
+        assert export_dir is not None
+        assert manifest.get("blocked") is not True
+
+        def unexpected_preflight(**_kwargs):
+            raise AssertionError("finalized export reuse must not require scanners")
+
+        monkeypatch.setattr(
+            "clawjournal.redaction.scanner_install.ensure_share_scanners",
+            unexpected_preflight,
+        )
+
+        cached_dir, cached_manifest, cached_error = _prepare_share_export_for_upload(
+            conn,
+            share_id,
+            share,
+            settings,
+            reuse_finalized=True,
+        )
+
+        assert cached_error is None
+        assert cached_dir == export_dir
+        assert cached_manifest == manifest
+
     def test_unverified_token_is_redacted_and_share_advances(self, conn, monkeypatch):
         # The headline behavior change: a recognizable-but-unverified
         # token no longer rejects the session — the exact span is


### PR DESCRIPTION
## Summary

- add one managed scanner preflight that installs pinned, checksum-verified Betterleaks and TruffleHog copies before enrollment, CLI packaging, and Workbench packaging
- add a Workbench recovery endpoint and **Install secure scanners & retry** action when an install cannot complete
- add `--with-sharing` / `-WithSharing` to participant installers and make sharing prompts/skills use it
- cover the existing-user upgrade case where Betterleaks becomes mandatory before their first share
- keep development bypass parsing aligned with the actual scanner gate and reuse finalized, already-scanned artifacts without requiring live scanner binaries

## Why

PR #126 made Betterleaks a mandatory fail-closed share gate. Existing participants can fast-forward to that code without re-running the installer, so their first package attempt could be blocked even though ClawJournal can safely install the pinned binary itself.

With this change, normal participants do not need to run pip or Homebrew for Betterleaks. Missing scanners are repaired locally at enrollment or package preflight; a failed download remains fail-closed. Previously finalized artifacts continue to reuse their exact scanned bytes without an unnecessary reinstall.

## Validation

- `python -m pytest -q --import-mode=importlib` — full suite passed locally after review fixes (`2938 passed, 4 skipped` on macOS)
- regression coverage for exact bypass semantics and finalized-export cache reuse
- `npm test` — 39 passed
- changed frontend files pass ESLint
- `npm run build` — production build succeeded
- wheel smoke check confirms `scanner_install.py` and `dist/index.html` are packaged
- visually checked the missing-scanner recovery state against the current OpenRefinery brand guide

## Known unrelated baseline

The repository-wide `npm run lint` still reports six pre-existing errors in untouched frontend files; none are introduced by this PR.
