### PR TITLE
feat(auto-upload): scan once per enrollment flow + refresh progress

### DIFF
--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -22,7 +22,7 @@ import uuid
 from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Iterator, Mapping, Sequence
+from typing import Any, Callable, Iterator, Mapping, Sequence
 
 from . import __version__, config as config_module
 from .agent_hooks import (
@@ -1023,6 +1023,51 @@ def _reconcile_explicit_pause_after_reauthorization(
         return True
 
 
+# An interactive enrollment invokes enable() up to three times (challenge,
+# post-acceptance, post-email-verification).  The index only has to be fresh
+# for the call that actually mutates, so a strict refresh that just completed
+# for the same index and a superset of the sources is reused instead of
+# re-parsing the whole history again.  Only enable() consults this; every run
+# cycle still performs its own strict scan before packaging.
+STRICT_SCAN_REUSE_SECONDS = 600.0
+_strict_scan_reuse_lock = threading.Lock()
+_strict_scan_reuse: dict[str, tuple[frozenset[str], float]] = {}
+
+
+def _reset_strict_scan_reuse() -> None:
+    with _strict_scan_reuse_lock:
+        _strict_scan_reuse.clear()
+
+
+def _strict_scan_for_enable(
+    sources: Sequence[str],
+    *,
+    progress: Callable[[str, int, int], None] | None = None,
+) -> dict[str, Any]:
+    from .workbench.daemon import Scanner
+    from .workbench.index import INDEX_DB
+
+    required = frozenset(sources)
+    key = str(INDEX_DB)
+    with _strict_scan_reuse_lock:
+        entry = _strict_scan_reuse.get(key)
+        if (
+            entry is not None
+            and required <= entry[0]
+            and time.monotonic() - entry[1] < STRICT_SCAN_REUSE_SECONDS
+        ):
+            return {
+                "ok": True,
+                "reused": True,
+                "required_sources": sorted(required),
+            }
+    scan = Scanner().scan_once_strict(sorted(required), progress=progress)
+    if scan.get("ok"):
+        with _strict_scan_reuse_lock:
+            _strict_scan_reuse[key] = (required, time.monotonic())
+    return scan
+
+
 def enable(
     *,
     agent: str = "all",
@@ -1031,6 +1076,7 @@ def enable(
     accepted_ownership_certification_version: str | None = None,
     accepted_authorization_profile_hash: str | None = None,
     challenge_only: bool = False,
+    scan_progress: Callable[[str, int, int], None] | None = None,
 ) -> dict[str, Any]:
     """Review or transactionally create/update a recurring enrollment.
 
@@ -1039,6 +1085,9 @@ def enable(
     are not depending on version mismatch to keep the call non-mutating.
     Protocol v2 requires the ownership certification to be accepted with the
     same exact-version discipline as the authorization and retention terms.
+    ``scan_progress`` is forwarded to the strict refresh (sources and
+    counters only), which runs only on a call whose acceptance matches the
+    displayed profile.
     """
 
     targets = _hook_targets(agent)
@@ -1069,18 +1118,44 @@ def enable(
                 "manual_share_required",
                 "Complete one successful hosted manual share before enabling automatic uploads.",
             ).as_result()
-        # Fail fast on the cheap network checks BEFORE the strict scan: the
-        # scan re-parses every enrolled source log (minutes of CPU on a large
-        # history), so an incompatible protocol, closed enrollment, or
-        # unreachable host must be surfaced without paying it. Later steps
-        # (server create/PATCH, the runner's enrollment gate) re-enforce
-        # capability freshness, so a closure during the scan still loses
-        # nothing.
+        # Only cheap work until acceptance is proven: the strict refresh
+        # re-parses every enrolled source log (minutes of CPU on a large
+        # history) and the interactive flow calls enable() up to three times
+        # (challenge, post-acceptance, post-email-verification), so the
+        # challenge is built from the current index and the refresh is
+        # deferred to the call whose acceptance matches. Network checks still
+        # run first so an incompatible protocol, closed enrollment, or
+        # unreachable host is surfaced immediately; later steps (server
+        # create/PATCH, the runner's enrollment gate) re-enforce capability
+        # freshness.
         capabilities = fetch_capabilities(force=True)
         terms = fetch_authorization(capabilities)
-        from .workbench.daemon import Scanner
+        ai_backend = _resolved_ai_backend(config)
 
-        scan = Scanner().scan_once_strict(list(scope["sources"]))
+        def _acceptance_matches(candidate: Mapping[str, Any]) -> bool:
+            return (
+                accepted_authorization_version
+                == candidate["authorization"]["version"]
+                and accepted_retention_version == candidate["retention"]["version"]
+                and accepted_ownership_certification_version
+                == candidate["ownership_certification"]["version"]
+                and accepted_authorization_profile_hash
+                == candidate["authorization_profile_hash"]
+            )
+
+        challenge = _authorization_challenge(
+            capabilities, terms, scope, ai_backend
+        )
+        if challenge_only or not _acceptance_matches(challenge):
+            # Non-mutating challenge response.  The HTTP adapter maps this to
+            # 409 so CLI/GUI cannot replace exact-version acceptance with --yes.
+            return challenge
+
+        # Acceptance matches the displayed profile, so this call intends to
+        # enroll: refresh the index now — a refresh that just completed for
+        # the same index and sources is reused, so one interactive flow pays
+        # for at most one full re-parse.
+        scan = _strict_scan_for_enable(scope["sources"], progress=scan_progress)
         if not scan["ok"]:
             return {
                 "ok": False,
@@ -1098,23 +1173,17 @@ def enable(
                 "message": "The refreshed source/project scope is not eligible.",
                 "scope_blockers": scope["blockers"],
             }
-        ai_backend = _resolved_ai_backend(config)
         challenge = _authorization_challenge(
             capabilities, terms, scope, ai_backend
         )
         expected_auth = challenge["authorization"]["version"]
         expected_retention = challenge["retention"]["version"]
         expected_ownership = challenge["ownership_certification"]["version"]
-        expected_profile = challenge["authorization_profile_hash"]
-        if (
-            challenge_only
-            or accepted_authorization_version != expected_auth
-            or accepted_retention_version != expected_retention
-            or accepted_ownership_certification_version != expected_ownership
-            or accepted_authorization_profile_hash != expected_profile
-        ):
-            # Non-mutating challenge response.  The HTTP adapter maps this to
-            # 409 so CLI/GUI cannot replace exact-version acceptance with --yes.
+        if not _acceptance_matches(challenge):
+            # The refresh changed the displayed profile (for example a new
+            # project appeared in an enrolled source): the exact-scope
+            # discipline requires accepting the refreshed challenge. The
+            # re-accepted call reuses this refresh instead of scanning again.
             return challenge
 
         # Serialize enrollment mutations with running cycles.  Controls still

--- a/clawjournal/cli_auto_upload.py
+++ b/clawjournal/cli_auto_upload.py
@@ -277,27 +277,59 @@ def run(args) -> None:
         ownership_version = args.accept_ownership_certification_version
         profile_hash = args.accept_authorization_profile_hash
 
-        def scan_notice() -> None:
-            # Every enable() call strict-refreshes the enrolled source logs
-            # after its fast hosted checks; on a large history that is minutes
-            # of silent CPU without this notice — including the re-runs after
-            # typing the acceptance versions and after email verification.
+        def hosted_notice() -> None:
             if not output_json:
                 print(
-                    "Checking the hosted service, then refreshing the enrolled "
-                    "source scope (a large history can take a few minutes)…",
+                    "Checking the hosted service and current terms…",
                     file=sys.stderr,
                 )
 
-        scan_notice()
-        result = auto_upload.enable(
-            agent=args.agent,
-            accepted_authorization_version=auth_version,
-            accepted_retention_version=retention_version,
-            accepted_ownership_certification_version=ownership_version,
-            accepted_authorization_profile_hash=profile_hash,
-        )
-        if result.get("code") == "authorization_required" and not output_json:
+        scan_started = False
+
+        def scan_progress(source: str, done: int, total: int) -> None:
+            # The strict refresh reports sources and counters only, never
+            # project names or paths; the values below are locally derived,
+            # not hosted-controlled. Only the call whose acceptance matches
+            # actually refreshes, so this appears at most once per flow.
+            nonlocal scan_started
+            if output_json:
+                return
+            if sys.stderr.isatty():
+                print(
+                    f"\rRefreshing source logs: {done}/{total} projects "
+                    f"({source})  ",
+                    end="\n" if done >= total else "",
+                    file=sys.stderr,
+                    flush=True,
+                )
+            elif not scan_started:
+                scan_started = True
+                print(
+                    "Refreshing the enrolled source logs "
+                    "(a large history can take a few minutes)…",
+                    file=sys.stderr,
+                )
+
+        def call_enable() -> dict[str, Any]:
+            hosted_notice()
+            return auto_upload.enable(
+                agent=args.agent,
+                accepted_authorization_version=auth_version,
+                accepted_retention_version=retention_version,
+                accepted_ownership_certification_version=ownership_version,
+                accepted_authorization_profile_hash=profile_hash,
+                scan_progress=scan_progress,
+            )
+
+        result = call_enable()
+        # The refresh on the accepting call can change the displayed scope
+        # (a project appeared since the challenge was shown), which bounces
+        # back with the refreshed challenge; one extra acceptance round
+        # covers it, and that call reuses the completed refresh instead of
+        # scanning again.
+        for _ in range(2):
+            if output_json or result.get("code") != "authorization_required":
+                break
             accepted = _interactive_accept(args, result)
             if accepted is None:
                 result = {
@@ -305,35 +337,22 @@ def run(args) -> None:
                     "code": "authorization_not_accepted",
                     "message": "Exact recurring authorization versions were not accepted.",
                 }
-            else:
-                (
-                    auth_version,
-                    retention_version,
-                    ownership_version,
-                    profile_hash,
-                ) = accepted
-                scan_notice()
-                result = auto_upload.enable(
-                    agent=args.agent,
-                    accepted_authorization_version=auth_version,
-                    accepted_retention_version=retention_version,
-                    accepted_ownership_certification_version=ownership_version,
-                    accepted_authorization_profile_hash=profile_hash,
-                )
+                break
+            (
+                auth_version,
+                retention_version,
+                ownership_version,
+                profile_hash,
+            ) = accepted
+            result = call_enable()
         if result.get("code") in {
             "email_verification_required",
             "enrollment_response_ambiguous",
         } and not output_json:
             if _fresh_email_verification():
-                # Re-fetching also catches terms changed while the code was in flight.
-                scan_notice()
-                result = auto_upload.enable(
-                    agent=args.agent,
-                    accepted_authorization_version=auth_version,
-                    accepted_retention_version=retention_version,
-                    accepted_ownership_certification_version=ownership_version,
-                    accepted_authorization_profile_hash=profile_hash,
-                )
+                # Re-fetching also catches terms changed while the code was
+                # in flight; the completed refresh is reused, not repeated.
+                result = call_enable()
             else:
                 result = {
                     "ok": False,

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -531,13 +531,20 @@ class Scanner:
         finally:
             self._scan_lock.release()
 
-    def scan_once_strict(self, required_sources: list[str]) -> dict[str, Any]:
+    def scan_once_strict(
+        self,
+        required_sources: list[str],
+        *,
+        progress: Callable[[str, int, int], None] | None = None,
+    ) -> dict[str, Any]:
         """Run a fail-closed refresh for an automatic-upload source scope.
 
         Unlike :meth:`scan_once`, this returns a structured report and never
         turns a partial parse/findings pass into success.  Project names,
         paths, session IDs, and exception text are intentionally omitted so
-        the report is safe to persist as scheduler telemetry.
+        the report is safe to persist as scheduler telemetry.  ``progress``
+        receives ``(source, position, total)`` per project under the same
+        discipline — sources and counters only, never names or paths.
         """
         required = sorted({source.strip() for source in required_sources if source.strip()})
         if not required:
@@ -558,22 +565,28 @@ class Scanner:
                 ],
             }
         with self._scan_lock:
-            return self._scan_once_report(required_sources=set(required))
+            return self._scan_once_report(
+                required_sources=set(required), progress=progress
+            )
 
     def _scan_once_report(
         self,
         *,
         required_sources: set[str] | None,
+        progress: Callable[[str, int, int], None] | None = None,
     ) -> dict[str, Any]:
         if required_sources is None:
             return self._scan_once_report_impl(required_sources=None)
         with _strict_scan_log_guard():
-            return self._scan_once_report_impl(required_sources=required_sources)
+            return self._scan_once_report_impl(
+                required_sources=required_sources, progress=progress
+            )
 
     def _scan_once_report_impl(
         self,
         *,
         required_sources: set[str] | None,
+        progress: Callable[[str, int, int], None] | None = None,
     ) -> dict[str, Any]:
         strict = required_sources is not None
         self.last_updated_count = 0
@@ -623,6 +636,7 @@ class Scanner:
                     {"source": "*", "stage": "discovery", "code": "discovery_failed"}
                 )
 
+            relevant_projects = []
             for project in projects:
                 source = project.get("source", "")
                 if source not in WORKBENCH_SOURCES:
@@ -631,7 +645,19 @@ class Scanner:
                     continue
                 if self.source_filter and source != self.source_filter:
                     continue
+                relevant_projects.append(project)
+
+            total_projects = len(relevant_projects)
+            for position, project in enumerate(relevant_projects, start=1):
+                source = project.get("source", "")
                 discovered_sources.add(source)
+                if progress is not None:
+                    try:
+                        progress(source, position, total_projects)
+                    except Exception:
+                        # A broken progress callback must not fail the
+                        # fail-closed scan or leak into its failure report.
+                        progress = None
 
                 try:
                     sessions = parse_project_sessions(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,8 +1,26 @@
 """Shared fixtures for clawjournal tests."""
 
+import sys
+
 import pytest
 
 from clawjournal.redaction.anonymizer import Anonymizer
+
+
+@pytest.fixture(autouse=True)
+def _reset_strict_scan_reuse():
+    """auto_upload.enable() memoizes a completed strict refresh at module
+    level so one interactive enrollment only re-parses the history once. A
+    test's refresh must never satisfy another test's, so clear the memo
+    around every test (lazily — most tests never import auto_upload).
+    """
+    auto_upload = sys.modules.get("clawjournal.auto_upload")
+    if auto_upload is not None:
+        auto_upload._reset_strict_scan_reuse()
+    yield
+    auto_upload = sys.modules.get("clawjournal.auto_upload")
+    if auto_upload is not None:
+        auto_upload._reset_strict_scan_reuse()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -7,6 +7,17 @@ import pytest
 from clawjournal.redaction.anonymizer import Anonymizer
 
 
+def _clear_strict_scan_reuse() -> None:
+    # getattr-guarded so a mixed setup (this conftest running against an
+    # older installed clawjournal without the memo, e.g. the editable
+    # install's console script inside a worktree) errors in the tests that
+    # actually exercise the new behavior instead of at every test's setup.
+    auto_upload = sys.modules.get("clawjournal.auto_upload")
+    reset = getattr(auto_upload, "_reset_strict_scan_reuse", None)
+    if reset is not None:
+        reset()
+
+
 @pytest.fixture(autouse=True)
 def _reset_strict_scan_reuse():
     """auto_upload.enable() memoizes a completed strict refresh at module
@@ -14,13 +25,9 @@ def _reset_strict_scan_reuse():
     test's refresh must never satisfy another test's, so clear the memo
     around every test (lazily — most tests never import auto_upload).
     """
-    auto_upload = sys.modules.get("clawjournal.auto_upload")
-    if auto_upload is not None:
-        auto_upload._reset_strict_scan_reuse()
+    _clear_strict_scan_reuse()
     yield
-    auto_upload = sys.modules.get("clawjournal.auto_upload")
-    if auto_upload is not None:
-        auto_upload._reset_strict_scan_reuse()
+    _clear_strict_scan_reuse()
 
 
 @pytest.fixture(autouse=True)

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -241,7 +241,7 @@ def _patch_strict_scanner(
     calls: list[list[str]] = []
 
     class StrictScanner:
-        def scan_once_strict(self, required_sources):
+        def scan_once_strict(self, required_sources, *, progress=None):
             calls.append(list(required_sources))
             index = len(calls) - 1
             if index < len(actions) and actions[index] is not None:
@@ -2775,6 +2775,182 @@ def test_enable_rejects_acceptance_when_displayed_scope_changes(
         assert get_auto_upload_enrollment(conn) is None
     finally:
         conn.close()
+
+
+def test_enable_defers_the_strict_scan_until_acceptance(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    """Displaying the challenge must not pay the full-history refresh (minutes
+    of CPU on a large history); only the call whose acceptance matches the
+    displayed profile scans, so one interactive enrollment re-parses the
+    history once, not once per step."""
+    _save_scope_config(upload_token="fresh-one-shot")
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    conn.close()
+    _patch_enable_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        auto, "create_enrollment", lambda _caps, **_kwargs: _enrollment_response()
+    )
+    scan_calls = _patch_strict_scanner(monkeypatch)
+
+    challenge = auto.enable(agent="claude")
+    assert challenge["code"] == "authorization_required"
+    assert scan_calls == []
+
+    displayed = auto.enable(agent="claude", challenge_only=True)
+    assert displayed["code"] == "authorization_required"
+    assert scan_calls == []
+
+    result = auto.enable(
+        agent="claude",
+        accepted_authorization_version=AUTH_VERSION,
+        accepted_retention_version=RETENTION_VERSION,
+        accepted_ownership_certification_version=OWNERSHIP_VERSION,
+        accepted_authorization_profile_hash=challenge["authorization_profile_hash"],
+    )
+    assert result["mode"] == "enabled"
+    assert scan_calls == [["claude"]]
+
+
+def test_enable_reuses_the_refresh_across_the_email_verification_retry(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    """The retry after fresh email verification replays the exact accepted
+    profile; the refresh that just completed is reused, not repeated."""
+    _save_scope_config()
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    conn.close()
+    _patch_enable_dependencies(monkeypatch)
+    create_calls: list[str] = []
+
+    def create(_capabilities, **_kwargs):
+        create_calls.append("create")
+        return _enrollment_response()
+
+    monkeypatch.setattr(auto, "create_enrollment", create)
+    scan_calls = _patch_strict_scanner(monkeypatch)
+    profile_hash = _current_authorization_profile_hash()
+    assert scan_calls == []
+    accepted = {
+        "agent": "claude",
+        "accepted_authorization_version": AUTH_VERSION,
+        "accepted_retention_version": RETENTION_VERSION,
+        "accepted_ownership_certification_version": OWNERSHIP_VERSION,
+        "accepted_authorization_profile_hash": profile_hash,
+    }
+
+    first = auto.enable(**accepted)
+
+    assert first["code"] == "email_verification_required"
+    assert create_calls == []
+    assert scan_calls == [["claude"]]
+
+    config = config_module.load_config()
+    config["verified_email_token"] = "fresh-one-shot"
+    config["verified_email_token_expires_at"] = "2099-01-01T00:00:00+00:00"
+    config_module.save_config(config)
+
+    second = auto.enable(**accepted)
+
+    assert second["mode"] == "enabled"
+    assert create_calls == ["create"]
+    assert scan_calls == [["claude"]]
+
+
+def test_enable_requires_reacceptance_when_the_refresh_changes_scope(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    """A project that only shows up during the accepting call's refresh must
+    bounce back for re-acceptance of the refreshed exact scope — and the
+    re-accepted call reuses the completed refresh instead of scanning again."""
+    _save_scope_config(upload_token="fresh-one-shot")
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    conn.close()
+    _patch_enable_dependencies(monkeypatch)
+    create_calls: list[str] = []
+
+    def create(_capabilities, **_kwargs):
+        create_calls.append("create")
+        return _enrollment_response()
+
+    monkeypatch.setattr(auto, "create_enrollment", create)
+
+    def reveal_project_two():
+        conn = open_index()
+        try:
+            session, _raw_path = _session(
+                isolated_auto_upload["root"], "session-two", project="project-two"
+            )
+            assert upsert_sessions(conn, [session]) == 1
+        finally:
+            conn.close()
+
+    scan_calls = _patch_strict_scanner(monkeypatch, callbacks=[reveal_project_two])
+
+    displayed = auto.enable(agent="claude", challenge_only=True)
+    assert displayed["scope"]["projects"] == ["project-one"]
+
+    bounced = auto.enable(
+        agent="claude",
+        accepted_authorization_version=AUTH_VERSION,
+        accepted_retention_version=RETENTION_VERSION,
+        accepted_ownership_certification_version=OWNERSHIP_VERSION,
+        accepted_authorization_profile_hash=displayed["authorization_profile_hash"],
+    )
+
+    assert bounced["code"] == "authorization_required"
+    assert bounced["scope"]["projects"] == ["project-one", "project-two"]
+    assert create_calls == []
+    assert scan_calls == [["claude"]]
+
+    final = auto.enable(
+        agent="claude",
+        accepted_authorization_version=AUTH_VERSION,
+        accepted_retention_version=RETENTION_VERSION,
+        accepted_ownership_certification_version=OWNERSHIP_VERSION,
+        accepted_authorization_profile_hash=bounced["authorization_profile_hash"],
+    )
+
+    assert final["mode"] == "enabled"
+    assert create_calls == ["create"]
+    assert scan_calls == [["claude"]]
+
+
+def test_strict_scan_reuse_window_scope_and_expiry(monkeypatch):
+    scan_calls = _patch_strict_scanner(monkeypatch)
+
+    assert auto._strict_scan_for_enable(["claude"])["ok"] is True
+    reused = auto._strict_scan_for_enable(["claude"])
+    assert reused == {"ok": True, "reused": True, "required_sources": ["claude"]}
+    assert scan_calls == [["claude"]]
+
+    # A superset requirement is not satisfied by the recorded subset...
+    assert auto._strict_scan_for_enable(["codex", "claude"])["ok"] is True
+    assert scan_calls == [["claude"], ["claude", "codex"]]
+    # ...but a subset is satisfied by the recorded superset.
+    assert auto._strict_scan_for_enable(["codex"])["reused"] is True
+    assert scan_calls == [["claude"], ["claude", "codex"]]
+
+    # Expiry forces a fresh refresh.
+    monkeypatch.setattr(auto, "STRICT_SCAN_REUSE_SECONDS", 0.0)
+    assert auto._strict_scan_for_enable(["claude"])["ok"] is True
+    assert scan_calls == [["claude"], ["claude", "codex"], ["claude"]]
+
+
+def test_strict_scan_reuse_ignores_failed_refreshes(monkeypatch):
+    scan_calls = _patch_strict_scanner(
+        monkeypatch, results=[{"ok": False}, {"ok": True, "sources": ["claude"]}]
+    )
+
+    assert auto._strict_scan_for_enable(["claude"])["ok"] is False
+    assert auto._strict_scan_for_enable(["claude"])["ok"] is True
+    assert scan_calls == [["claude"], ["claude"]]
 
 
 def test_enable_never_backdates_cutoff_before_durable_local_intent(

--- a/tests/test_cli_auto_upload.py
+++ b/tests/test_cli_auto_upload.py
@@ -231,6 +231,8 @@ def test_interactive_enable_replays_exact_profile_after_email_verification(
 
     main()
 
+    for call in calls:
+        assert callable(call.pop("scan_progress"))
     accepted = {
         "agent": "all",
         "accepted_authorization_version": "auth-v1",
@@ -250,6 +252,63 @@ def test_interactive_enable_replays_exact_profile_after_email_verification(
         accepted,
     ]
     assert "Automatic upload: enabled / ready" in capsys.readouterr().out
+
+
+def test_interactive_enable_reprompts_once_when_the_refresh_changes_scope(
+    monkeypatch, capsys
+):
+    """The accepting call's refresh can reveal a new project; the CLI must
+    re-display the refreshed challenge for one more acceptance round instead
+    of failing the enrollment."""
+
+    def challenge(profile_hash: str, projects: list[str]) -> dict:
+        return {
+            "ok": False,
+            "status": 409,
+            "code": "authorization_required",
+            "message": "review",
+            "authorization_profile_hash": profile_hash,
+            "authorization": {"version": "auth-v1", "text": "future uploads"},
+            "retention": {"version": "ret-v1", "text": "retention"},
+            "ownership_certification": {"version": "own-v1", "text": "ownership"},
+            "scope": {
+                "sources": ["codex"],
+                "projects": projects,
+                "entries": [["codex", project] for project in projects],
+            },
+            "ai": {"enabled": False, "backend": None},
+            "cap": 5,
+            "cadence_days": 1,
+            "maximum_bundle_size": 5_000_000,
+        }
+
+    calls = []
+
+    def enable(**kwargs):
+        kwargs.pop("scan_progress", None)
+        calls.append(kwargs)
+        if len(calls) == 1:
+            return challenge("profile-one", ["project"])
+        if len(calls) == 2:
+            return challenge("profile-two", ["project", "project-two"])
+        return {"ok": True, "mode": "enabled", "health": "ready"}
+
+    answers = iter(
+        ["auth-v1", "ret-v1", "own-v1", "auth-v1", "ret-v1", "own-v1"]
+    )
+    monkeypatch.setattr("clawjournal.auto_upload.enable", enable)
+    monkeypatch.setattr(sys, "stdin", _FakeStdin())
+    monkeypatch.setattr("builtins.input", lambda *_a, **_k: next(answers))
+    monkeypatch.setattr(sys, "argv", ["clawjournal", "auto-upload", "enable"])
+
+    main()
+
+    assert [
+        call["accepted_authorization_profile_hash"] for call in calls
+    ] == [None, "profile-one", "profile-two"]
+    out = capsys.readouterr().out
+    assert "project-two" in out
+    assert "Automatic upload: enabled / ready" in out
 
 
 def test_interactive_accept_handles_keyboard_interrupt(monkeypatch):

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -1182,6 +1182,79 @@ class TestScanner:
         assert "Traceback" not in caplog.text
         assert "parse_failed" in caplog.text
 
+    def _patch_progress_scan_environment(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db"
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs"
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.CONFIG_DIR", tmp_path / "clawjournal_config"
+        )
+        monkeypatch.setattr("clawjournal.workbench.daemon.load_config", lambda: {})
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.discover_projects",
+            lambda source_filter=None: [
+                {
+                    "source": "claude",
+                    "dir_name": "PRIVATE_PROJECT_ONE_SENTINEL",
+                    "locator": None,
+                },
+                {
+                    "source": "claude",
+                    "dir_name": "PRIVATE_PROJECT_TWO_SENTINEL",
+                    "locator": None,
+                },
+                {
+                    "source": "codex",
+                    "dir_name": "EXCLUDED_PROJECT_SENTINEL",
+                    "locator": None,
+                },
+            ],
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.parse_project_sessions",
+            lambda dir_name, **kwargs: [],
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.link_subagent_hierarchy", lambda conn: 0
+        )
+
+    def test_strict_scan_progress_reports_only_sources_and_counters(
+        self, tmp_path, monkeypatch
+    ):
+        """Excluded sources don't inflate the total, and each report carries
+        the source and counters only — never project names or paths."""
+        self._patch_progress_scan_environment(tmp_path, monkeypatch)
+        seen: list[tuple[str, int, int]] = []
+
+        report = Scanner().scan_once_strict(
+            ["claude"], progress=lambda *args: seen.append(args)
+        )
+
+        assert report["ok"] is True
+        assert seen == [("claude", 1, 2), ("claude", 2, 2)]
+
+    def test_strict_scan_survives_a_broken_progress_callback(
+        self, tmp_path, monkeypatch
+    ):
+        """A raising progress callback is dropped after its first failure and
+        must neither fail the fail-closed scan nor leak into its report."""
+        self._patch_progress_scan_environment(tmp_path, monkeypatch)
+        seen: list[tuple[str, int, int]] = []
+
+        def broken(source, position, total):
+            seen.append((source, position, total))
+            raise RuntimeError("PRIVATE_CALLBACK_SENTINEL")
+
+        report = Scanner().scan_once_strict(["claude"], progress=broken)
+
+        assert report["ok"] is True
+        assert report["failures"] == []
+        assert seen == [("claude", 1, 2)]
+        assert "PRIVATE_CALLBACK_SENTINEL" not in json.dumps(report)
+
     @pytest.mark.parametrize("source", ["claude", "codex"])
     def test_strict_scan_rejects_malformed_jsonl_without_partial_upsert(
         self, tmp_path, monkeypatch, source


### PR DESCRIPTION
## What

Enrollment UX items #1 and #2 from today's assessment: the interactive `auto-upload enable` flow previously re-ran the full-history strict scan on **every** `enable()` invocation — up to three times per flow (challenge → post-acceptance → post-email-verification), each ~3 silent minutes on a large corpus.

- **Scan once per flow.** `enable()` builds the authorization challenge from the current index and defers the strict refresh to the call whose acceptance matches the displayed profile. A refresh that just completed for the same index and a superset of the sources is reused (10-minute window, `_strict_scan_for_enable`), so one interactive flow pays for at most one full re-parse. If the refresh reveals a scope change (new project), the call bounces with the refreshed challenge and the CLI runs one extra acceptance round — which reuses the completed refresh instead of scanning again.
- **Refresh progress.** `Scanner.scan_once_strict()` gains an optional `progress(source, position, total)` callback; the CLI renders a live `Refreshing source logs: N/M projects (source)` counter on tty stderr (single fallback line on non-tty). Progress reports carry sources and counters only — never project names or paths — preserving the strict scan's safe-telemetry discipline, and a raising callback is dropped rather than failing the fail-closed scan.

## Invariants deliberately untouched

- Exact-scope acceptance: the mutating path re-verifies the accepted versions + profile hash against the **post-refresh** scope before any server call; server-owned scope-hash read-back unchanged.
- The distinct typed ownership certification and the three-prompt acceptance are unchanged.
- Only `enable()` consults the reuse window: run cycles and `preview --refresh` still strict-scan unconditionally (controls win before egress).
- Manual Share behavior unchanged.

## Tests

8 new tests: challenge display never scans; refresh reused across the email-verification retry; scope drift during the refresh bounces for re-acceptance then enrolls without a second scan; reuse-window subset/superset/expiry/failure semantics; scanner progress payload + broken-callback resilience; CLI re-prompt round. Full suite: **2989 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Dha7TpcKGpGTcFNEFWSTV