### PR TITLE
fix(scan): serialize scans across processes + honest store-failure labels

### DIFF
--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -3805,16 +3805,27 @@ def _run_cycle_impl(
                         list(enrollment["enrolled_sources"])
                     )
                     if not strict["ok"]:
+                        # Contention gets its own code, matching enable() and
+                        # preview(): "incomplete" invites diagnosing the logs.
+                        scan_code = (
+                            "scanner_busy"
+                            if strict.get("busy")
+                            else "strict_scan_incomplete"
+                        )
                         _record_cycle_result(
                             conn,
                             generation=generation,
-                            code="strict_scan_incomplete",
+                            code=scan_code,
                             retryable=True,
                         )
                         return {
                             "ok": False,
-                            "code": "strict_scan_incomplete",
-                            "message": "The enrolled source refresh was incomplete.",
+                            "code": scan_code,
+                            "message": (
+                                "Another scan is refreshing the index; the cycle will retry."
+                                if strict.get("busy")
+                                else "The enrolled source refresh was incomplete."
+                            ),
                             "retryable": True,
                             "scan": strict,
                         }
@@ -3905,16 +3916,27 @@ def _run_cycle_impl(
                         list(enrollment["enrolled_sources"])
                     )
                     if not strict["ok"]:
+                        # Contention gets its own code, matching enable() and
+                        # preview(): "incomplete" invites diagnosing the logs.
+                        scan_code = (
+                            "scanner_busy"
+                            if strict.get("busy")
+                            else "strict_scan_incomplete"
+                        )
                         _record_cycle_result(
                             conn,
                             generation=generation,
-                            code="strict_scan_incomplete",
+                            code=scan_code,
                             retryable=True,
                         )
                         return {
                             "ok": False,
-                            "code": "strict_scan_incomplete",
-                            "message": "The enrolled source refresh was incomplete.",
+                            "code": scan_code,
+                            "message": (
+                                "Another scan is refreshing the index; the cycle will retry."
+                                if strict.get("busy")
+                                else "The enrolled source refresh was incomplete."
+                            ),
                             "retryable": True,
                             "scan": strict,
                         }
@@ -3976,16 +3998,25 @@ def _run_cycle_impl(
                     list(enrollment["enrolled_sources"])
                 )
                 if not second_scan["ok"]:
+                    scan_code = (
+                        "scanner_busy"
+                        if second_scan.get("busy")
+                        else "strict_scan_incomplete"
+                    )
                     _record_cycle_result(
                         conn,
                         generation=generation,
-                        code="strict_scan_incomplete",
+                        code=scan_code,
                         retryable=True,
                     )
                     return {
                         "ok": False,
-                        "code": "strict_scan_incomplete",
-                        "message": "The final source refresh was incomplete.",
+                        "code": scan_code,
+                        "message": (
+                            "Another scan is refreshing the index; the cycle will retry."
+                            if second_scan.get("busy")
+                            else "The final source refresh was incomplete."
+                        ),
                         "retryable": True,
                         "scan": second_scan,
                     }

--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -757,7 +757,12 @@ def status(*, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
             db.close()
 
 
-def preview(*, refresh: bool = False, now: datetime | None = None) -> dict[str, Any]:
+def preview(
+    *,
+    refresh: bool = False,
+    now: datetime | None = None,
+    scan_wait_notice: Callable[[], None] | None = None,
+) -> dict[str, Any]:
     if not refresh:
         # GET preview is a read-only surface just like GET status: do not create
         # the index, run migrations, or repair state merely because Settings
@@ -802,7 +807,10 @@ def preview(*, refresh: bool = False, now: datetime | None = None) -> dict[str, 
                 return AutoUploadError("not_enrolled", "Automatic upload is not enabled.").as_result()
             from .workbench.daemon import Scanner
 
-            scan = Scanner().scan_once_strict(list(enrollment["enrolled_sources"]))
+            scan = Scanner().scan_once_strict(
+                list(enrollment["enrolled_sources"]),
+                on_wait=scan_wait_notice,
+            )
             if scan.get("busy"):
                 return AutoUploadError(
                     "scanner_busy",

--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -803,6 +803,12 @@ def preview(*, refresh: bool = False, now: datetime | None = None) -> dict[str, 
             from .workbench.daemon import Scanner
 
             scan = Scanner().scan_once_strict(list(enrollment["enrolled_sources"]))
+            if scan.get("busy"):
+                return AutoUploadError(
+                    "scanner_busy",
+                    "Another scan is refreshing the index; try again in a few minutes.",
+                    retryable=True,
+                ).as_result()
             if not scan["ok"]:
                 return {
                     "ok": False,
@@ -1043,6 +1049,7 @@ def _strict_scan_for_enable(
     sources: Sequence[str],
     *,
     progress: Callable[[str, int, int], None] | None = None,
+    on_wait: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
     from .workbench.daemon import Scanner
     from .workbench.index import INDEX_DB
@@ -1061,7 +1068,9 @@ def _strict_scan_for_enable(
                 "reused": True,
                 "required_sources": sorted(required),
             }
-    scan = Scanner().scan_once_strict(sorted(required), progress=progress)
+    scan = Scanner().scan_once_strict(
+        sorted(required), progress=progress, on_wait=on_wait
+    )
     if scan.get("ok"):
         with _strict_scan_reuse_lock:
             _strict_scan_reuse[key] = (required, time.monotonic())
@@ -1077,6 +1086,7 @@ def enable(
     accepted_authorization_profile_hash: str | None = None,
     challenge_only: bool = False,
     scan_progress: Callable[[str, int, int], None] | None = None,
+    scan_wait_notice: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
     """Review or transactionally create/update a recurring enrollment.
 
@@ -1087,7 +1097,8 @@ def enable(
     same exact-version discipline as the authorization and retention terms.
     ``scan_progress`` is forwarded to the strict refresh (sources and
     counters only), which runs only on a call whose acceptance matches the
-    displayed profile.
+    displayed profile; ``scan_wait_notice`` fires once if that refresh has
+    to wait for a scan in another process.
     """
 
     targets = _hook_targets(agent)
@@ -1155,7 +1166,18 @@ def enable(
         # enroll: refresh the index now — a refresh that just completed for
         # the same index and sources is reused, so one interactive flow pays
         # for at most one full re-parse.
-        scan = _strict_scan_for_enable(scope["sources"], progress=scan_progress)
+        scan = _strict_scan_for_enable(
+            scope["sources"], progress=scan_progress, on_wait=scan_wait_notice
+        )
+        if scan.get("busy"):
+            # Fail closed with an honest code: another process held the scan
+            # lock past the bounded wait, so nothing was refreshed and there
+            # is nothing to diagnose in the source logs.
+            return AutoUploadError(
+                "scanner_busy",
+                "Another scan is refreshing the index; try again in a few minutes.",
+                retryable=True,
+            ).as_result()
         if not scan["ok"]:
             return {
                 "ok": False,

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -1261,14 +1261,18 @@ def prep(source_filter: str = "auto") -> None:
 
 def _run_scan(source_filter: str | None = None) -> None:
     """One-shot scan: index sessions into the workbench database."""
-    from .workbench.daemon import Scanner
+    from .workbench.daemon import ScanBusyError, Scanner
     from .workbench.index import get_stats, open_index
     from .pricing import ensure_pricing_fresh
 
     ensure_pricing_fresh()
     scanner = Scanner(source_filter=source_filter)
     print("Scanning sessions...")
-    results = scanner.scan_once()
+    try:
+        results = scanner.scan_once()
+    except ScanBusyError as exc:
+        print(f"Scan not run: {exc}", file=sys.stderr)
+        raise SystemExit(1) from None
 
     total_new = sum(results.values())
     total_updated = scanner.last_updated_count
@@ -3467,7 +3471,7 @@ def _run_segment(args: argparse.Namespace) -> None:
 
 def _run_recent(args: argparse.Namespace) -> None:
     """Show recent sessions, auto-scanning if the index is stale."""
-    from .workbench.daemon import Scanner
+    from .workbench.daemon import ScanBusyError, Scanner
     from .workbench.index import open_index, query_sessions
 
     conn = open_index()
@@ -3489,8 +3493,14 @@ def _run_recent(args: argparse.Namespace) -> None:
     if stale:
         conn.close()
         scanner = Scanner(source_filter=args.source)
-        scanner.scan_once()
-        auto_scanned = True
+        try:
+            scanner.scan_once()
+            auto_scanned = True
+        except ScanBusyError:
+            print(
+                "Another scan is refreshing the index; showing current results.",
+                file=sys.stderr,
+            )
         conn = open_index()
 
     # Query recent sessions

--- a/clawjournal/cli_auto_upload.py
+++ b/clawjournal/cli_auto_upload.py
@@ -259,10 +259,24 @@ def run(args) -> None:
 
     command = args.auto_upload_command
     output_json = bool(getattr(args, "json", False))
+
+    def scan_wait_notice() -> None:
+        # Fires once when a strict refresh must wait for a scan in another
+        # process (usually the daemon's background pass).
+        if not output_json:
+            print(
+                "Waiting for another scan to finish before refreshing "
+                "(the background scanner may be mid-pass)…",
+                file=sys.stderr,
+            )
+
     if command == "status":
         result = auto_upload.status()
     elif command == "preview":
-        result = auto_upload.preview(refresh=bool(args.refresh))
+        result = auto_upload.preview(
+            refresh=bool(args.refresh),
+            scan_wait_notice=scan_wait_notice,
+        )
     elif command == "run":
         result = auto_upload.run_cycle(force=True)
     elif command == "pause":
@@ -307,16 +321,6 @@ def run(args) -> None:
                 print(
                     "Refreshing the enrolled source logs "
                     "(a large history can take a few minutes)…",
-                    file=sys.stderr,
-                )
-
-        def scan_wait_notice() -> None:
-            # Fires once when the strict refresh must wait for a scan in
-            # another process (usually the daemon's background pass).
-            if not output_json:
-                print(
-                    "Waiting for another scan to finish before refreshing "
-                    "(the background scanner may be mid-pass)…",
                     file=sys.stderr,
                 )
 

--- a/clawjournal/cli_auto_upload.py
+++ b/clawjournal/cli_auto_upload.py
@@ -310,6 +310,16 @@ def run(args) -> None:
                     file=sys.stderr,
                 )
 
+        def scan_wait_notice() -> None:
+            # Fires once when the strict refresh must wait for a scan in
+            # another process (usually the daemon's background pass).
+            if not output_json:
+                print(
+                    "Waiting for another scan to finish before refreshing "
+                    "(the background scanner may be mid-pass)…",
+                    file=sys.stderr,
+                )
+
         def call_enable() -> dict[str, Any]:
             hosted_notice()
             return auto_upload.enable(
@@ -319,6 +329,7 @@ def run(args) -> None:
                 accepted_ownership_certification_version=ownership_version,
                 accepted_authorization_profile_hash=profile_hash,
                 scan_progress=scan_progress,
+                scan_wait_notice=scan_wait_notice,
             )
 
         result = call_enable()

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -143,6 +143,10 @@ SCAN_ONCE_LOCK_WAIT_SECONDS = 15.0
 _SCAN_LOCK_POLL_SECONDS = 0.5
 
 
+class ScanBusyError(RuntimeError):
+    """Raised when a normal scan cannot acquire the cross-process scan lock."""
+
+
 @contextmanager
 def _scan_process_lock(
     *,
@@ -616,16 +620,15 @@ class Scanner:
         whose content changed (or remained unchanged) are exposed on the
         ``last_updated_*`` and ``last_unchanged_*`` attributes. Waits
         briefly for a scan in another process to finish; if the wait
-        expires, the scan proceeds unlocked — the normal scan is per-project
-        resilient, so that matches pre-lock correctness, and the short
-        ceiling keeps interactive callers (which have no wait feedback)
-        from hanging. Only strict scans fail closed on contention.
+        expires, raises :class:`ScanBusyError` without touching the index.
+        Normal scans must never bypass the process lock because doing so
+        could disrupt a strict scan that already holds it.
         """
         with self._scan_lock:
             with _scan_process_lock(wait_seconds=lock_wait_seconds) as acquired:
                 if not acquired:
-                    logger.warning(
-                        "Scan lock wait expired; scanning alongside another process"
+                    raise ScanBusyError(
+                        "Another scan is still refreshing the index; try again shortly."
                     )
                 return self._scan_once_report(required_sources=None)["new_by_source"]
 
@@ -5581,16 +5584,23 @@ def run_server(
     # Run initial scan in background, then start periodic scanner
     def _initial_scan() -> None:
         logger.info("Running initial scan...")
-        results = scanner.scan_once()
-        trigger_scoring_warmup(scanner)
-        total = sum(results.values())
-        logger.info(
-            "Initial scan complete: %d new sessions indexed, %d existing traces updated, "
-            "%d subagent relationships linked",
-            total,
-            scanner.last_updated_count,
-            scanner.last_linked_count,
-        )
+        try:
+            results = scanner.scan_once()
+        except ScanBusyError:
+            logger.info(
+                "Initial scan skipped: another process is refreshing the index"
+            )
+        else:
+            trigger_scoring_warmup(scanner)
+            total = sum(results.values())
+            logger.info(
+                "Initial scan complete: %d new sessions indexed, "
+                "%d existing traces updated, "
+                "%d subagent relationships linked",
+                total,
+                scanner.last_updated_count,
+                scanner.last_linked_count,
+            )
         scanner.start()
         logger.info("Background scanner started (interval: %ds)", SCAN_INTERVAL)
 

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -136,6 +136,10 @@ SCAN_LOCK_FILENAME = "scan.lock"
 # Longer than a full background pass on a large corpus, so a strict scan
 # waiting on the lock outlives the daemon tick that holds it.
 SCAN_LOCK_WAIT_SECONDS = 300.0
+# Normal scans proceed unlocked after the wait, so theirs is best-effort
+# politeness only — and their interactive callers (`clawjournal recent`,
+# the share preflight) have no wait feedback, so keep the ceiling short.
+SCAN_ONCE_LOCK_WAIT_SECONDS = 15.0
 _SCAN_LOCK_POLL_SECONDS = 0.5
 
 
@@ -190,7 +194,12 @@ def _scan_process_lock(
         acquired = _try_acquire()
         if not acquired and wait_seconds is not None:
             if on_wait is not None:
-                on_wait()
+                try:
+                    on_wait()
+                except Exception:
+                    # A broken wait notice (e.g. a closed stderr pipe) must
+                    # not abort the scan it merely narrates.
+                    pass
             deadline = time.monotonic() + wait_seconds
             while time.monotonic() < deadline:
                 time.sleep(_SCAN_LOCK_POLL_SECONDS)
@@ -599,17 +608,18 @@ class Scanner:
     def scan_once(
         self,
         *,
-        lock_wait_seconds: float | None = SCAN_LOCK_WAIT_SECONDS,
+        lock_wait_seconds: float | None = SCAN_ONCE_LOCK_WAIT_SECONDS,
     ) -> dict[str, int]:
         """Run a scan pass and return ``{source: new_session_count}``.
 
         The return shape is retained for existing callers. Counts for traces
         whose content changed (or remained unchanged) are exposed on the
-        ``last_updated_*`` and ``last_unchanged_*`` attributes. Waits up to
-        ``lock_wait_seconds`` for a scan in another process to finish; if
-        the wait expires, the scan proceeds unlocked — the normal scan is
-        per-project resilient and this can never be worse than the pre-lock
-        behavior. Only strict scans fail closed on contention.
+        ``last_updated_*`` and ``last_unchanged_*`` attributes. Waits
+        briefly for a scan in another process to finish; if the wait
+        expires, the scan proceeds unlocked — the normal scan is per-project
+        resilient, so that matches pre-lock correctness, and the short
+        ceiling keeps interactive callers (which have no wait feedback)
+        from hanging. Only strict scans fail closed on contention.
         """
         with self._scan_lock:
             with _scan_process_lock(wait_seconds=lock_wait_seconds) as acquired:
@@ -865,12 +875,17 @@ class Scanner:
                 except Exception as store_error:
                     # Not a parse problem: the sessions parsed cleanly and the
                     # index write failed. A lock timeout gets its own code so
-                    # contention is diagnosable as contention.
-                    code = (
-                        "index_busy"
-                        if isinstance(store_error, sqlite3.OperationalError)
-                        else "store_failed"
+                    # contention is diagnosable as contention — but only a
+                    # locked/busy OperationalError: the same exception type
+                    # also covers corruption and full disks, which must not
+                    # masquerade as transient contention.
+                    contention = isinstance(
+                        store_error, sqlite3.OperationalError
+                    ) and any(
+                        marker in str(store_error).lower()
+                        for marker in ("locked", "busy")
                     )
+                    code = "index_busy" if contention else "store_failed"
                     if strict:
                         _log_strict_scan_failure(
                             source=source, stage="store", code=code

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -126,6 +126,95 @@ class _StrictScanLogFilter(logging.Filter):
         )
 
 
+# Serializes scan passes ACROSS processes (CLI commands vs the serve daemon):
+# SQLite allows one writer at a time, and a daemon background pass can hold
+# write transactions long enough that a concurrent CLI scan's upserts blow
+# through the busy timeout and fail. The lock file lives next to the index
+# database — the contended resource — which also isolates monkeypatched test
+# indexes from each other.
+SCAN_LOCK_FILENAME = "scan.lock"
+# Longer than a full background pass on a large corpus, so a strict scan
+# waiting on the lock outlives the daemon tick that holds it.
+SCAN_LOCK_WAIT_SECONDS = 300.0
+_SCAN_LOCK_POLL_SECONDS = 0.5
+
+
+@contextmanager
+def _scan_process_lock(
+    *,
+    wait_seconds: float | None,
+    on_wait: Callable[[], None] | None = None,
+) -> Iterator[bool]:
+    """Acquire the cross-process scan lock; yields whether it was acquired.
+
+    Mirrors ``auto_upload.whole_run_lock``: an OS-level lock the kernel
+    releases on process death, so a crashed scan can never wedge future
+    scans. ``wait_seconds=None`` makes a single non-blocking attempt;
+    otherwise attempts are polled until the deadline passes. ``on_wait``
+    fires once if the first attempt fails, before any waiting starts.
+    """
+
+    from .index import INDEX_DB
+
+    path = Path(str(INDEX_DB)).parent / SCAN_LOCK_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    file = path.open("a+b")
+    acquired = False
+
+    def _try_acquire() -> bool:
+        if os.name == "nt":
+            import msvcrt
+
+            try:
+                # Byte-range locking needs at least one byte; unlike the
+                # single-attempt whole_run_lock this is retried in a poll
+                # loop, so guard on the real size instead of appending a
+                # byte per attempt.
+                if os.fstat(file.fileno()).st_size == 0:
+                    file.write(b"0")
+                    file.flush()
+                file.seek(0)
+                msvcrt.locking(file.fileno(), msvcrt.LK_NBLCK, 1)
+                return True
+            except OSError:
+                return False
+        import fcntl
+
+        try:
+            fcntl.flock(file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return True
+        except BlockingIOError:
+            return False
+
+    try:
+        acquired = _try_acquire()
+        if not acquired and wait_seconds is not None:
+            if on_wait is not None:
+                on_wait()
+            deadline = time.monotonic() + wait_seconds
+            while time.monotonic() < deadline:
+                time.sleep(_SCAN_LOCK_POLL_SECONDS)
+                acquired = _try_acquire()
+                if acquired:
+                    break
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                if os.name == "nt":
+                    import msvcrt
+
+                    file.seek(0)
+                    msvcrt.locking(file.fileno(), msvcrt.LK_UNLCK, 1)
+                else:
+                    import fcntl
+
+                    fcntl.flock(file.fileno(), fcntl.LOCK_UN)
+            except OSError:
+                pass
+        file.close()
+
+
 @contextmanager
 def _strict_scan_log_guard() -> Iterator[None]:
     """Allow only explicitly bounded logs from the current strict scan.
@@ -507,27 +596,59 @@ class Scanner:
         if self._thread:
             self._thread.join(timeout=5)
 
-    def scan_once(self) -> dict[str, int]:
+    def scan_once(
+        self,
+        *,
+        lock_wait_seconds: float | None = SCAN_LOCK_WAIT_SECONDS,
+    ) -> dict[str, int]:
         """Run a scan pass and return ``{source: new_session_count}``.
 
         The return shape is retained for existing callers. Counts for traces
         whose content changed (or remained unchanged) are exposed on the
-        ``last_updated_*`` and ``last_unchanged_*`` attributes.
+        ``last_updated_*`` and ``last_unchanged_*`` attributes. Waits up to
+        ``lock_wait_seconds`` for a scan in another process to finish; if
+        the wait expires, the scan proceeds unlocked — the normal scan is
+        per-project resilient and this can never be worse than the pre-lock
+        behavior. Only strict scans fail closed on contention.
         """
         with self._scan_lock:
-            return self._scan_once_report(required_sources=None)["new_by_source"]
+            with _scan_process_lock(wait_seconds=lock_wait_seconds) as acquired:
+                if not acquired:
+                    logger.warning(
+                        "Scan lock wait expired; scanning alongside another process"
+                    )
+                return self._scan_once_report(required_sources=None)["new_by_source"]
+
+    def _scan_tick(self) -> dict[str, int] | None:
+        """One background-loop pass; skips when another process is scanning.
+
+        The loop reruns within a minute, so a skipped tick just catches up on
+        the next one instead of contending with a CLI scan for SQLite writes.
+        """
+        with self._scan_lock:
+            with _scan_process_lock(wait_seconds=None) as acquired:
+                if not acquired:
+                    logger.info(
+                        "Skipping background scan: another process holds the scan lock"
+                    )
+                    return None
+                return self._scan_once_report(required_sources=None)["new_by_source"]
 
     def scan_once_if_idle(self) -> dict[str, int] | None:
         """Run a normal scan only when no scan is already active.
 
         HTTP refresh requests use this non-blocking entry point so repeated
         desktop launches coalesce instead of running concurrent SQLite and
-        findings passes on the same Scanner instance.
+        findings passes on the same Scanner instance — or against a scan in
+        another process.
         """
         if not self._scan_lock.acquire(blocking=False):
             return None
         try:
-            return self._scan_once_report(required_sources=None)["new_by_source"]
+            with _scan_process_lock(wait_seconds=None) as acquired:
+                if not acquired:
+                    return None
+                return self._scan_once_report(required_sources=None)["new_by_source"]
         finally:
             self._scan_lock.release()
 
@@ -536,6 +657,8 @@ class Scanner:
         required_sources: list[str],
         *,
         progress: Callable[[str, int, int], None] | None = None,
+        on_wait: Callable[[], None] | None = None,
+        lock_wait_seconds: float | None = SCAN_LOCK_WAIT_SECONDS,
     ) -> dict[str, Any]:
         """Run a fail-closed refresh for an automatic-upload source scope.
 
@@ -545,6 +668,10 @@ class Scanner:
         the report is safe to persist as scheduler telemetry.  ``progress``
         receives ``(source, position, total)`` per project under the same
         discipline — sources and counters only, never names or paths.
+        ``on_wait`` fires once if a scan in another process holds the lock;
+        if the lock is still held after ``lock_wait_seconds``, the refresh
+        fails closed with a ``busy`` report instead of contending for SQLite
+        writes it would lose.
         """
         required = sorted({source.strip() for source in required_sources if source.strip()})
         if not required:
@@ -565,9 +692,26 @@ class Scanner:
                 ],
             }
         with self._scan_lock:
-            return self._scan_once_report(
-                required_sources=set(required), progress=progress
-            )
+            with _scan_process_lock(
+                wait_seconds=lock_wait_seconds, on_wait=on_wait
+            ) as acquired:
+                if not acquired:
+                    return {
+                        "ok": False,
+                        "busy": True,
+                        "required_sources": required,
+                        "discovered_sources": [],
+                        "missing_sources": [],
+                        "new_by_source": {},
+                        "updated_by_source": {},
+                        "unchanged_by_source": {},
+                        "failures": [
+                            {"source": "*", "stage": "lock", "code": "scanner_busy"}
+                        ],
+                    }
+                return self._scan_once_report(
+                    required_sources=set(required), progress=progress
+                )
 
     def _scan_once_report(
         self,
@@ -668,74 +812,26 @@ class Scanner:
                         locator=project.get("locator"),
                         strict_jsonl=strict,
                     )
-                    if sessions:
-                        if strict:
-                            for session in sessions:
-                                snapshot = session.pop(
-                                    "_raw_source_fingerprint", None
-                                )
-                                session_id = session.get("session_id")
-                                if (
-                                    source in {"claude", "codex"}
-                                    and (
-                                        not session_id
-                                        or not isinstance(snapshot, tuple)
-                                        or len(snapshot) != 5
-                                    )
-                                ):
-                                    raise ValueError(
-                                        "strict parser did not return a raw-source snapshot"
-                                    )
-                                if session_id and snapshot is not None:
-                                    strict_raw_fingerprints[str(session_id)] = list(
-                                        snapshot
-                                    )
-                        upsert_stats: dict[str, int] = {}
-                        new_count = upsert_sessions(conn, sessions, stats=upsert_stats)
-                        results[source] = results.get(source, 0) + new_count
-                        updated_count = upsert_stats.get("updated", 0)
-                        unchanged_count = upsert_stats.get("unchanged", 0)
-                        self.last_updated_count += updated_count
-                        self.last_unchanged_count += unchanged_count
-                        self.last_updated_by_source[source] = (
-                            self.last_updated_by_source.get(source, 0) + updated_count
-                        )
-                        self.last_unchanged_by_source[source] = (
-                            self.last_unchanged_by_source.get(source, 0) + unchanged_count
-                        )
-                        # Drive each freshly-upserted session through the
-                        # findings pipeline. Settle-threshold + revision
-                        # check inside the driver keep this cheap on steady
-                        # state; errors per session don't abort the loop.
+                    if sessions and strict:
                         for session in sessions:
-                            sid = session.get("session_id")
-                            if not sid:
-                                continue
-                            try:
-                                run_findings_pipeline(
-                                    conn,
-                                    sid,
-                                    session,
-                                    config=config,
-                                    safe_logging=strict,
+                            snapshot = session.pop(
+                                "_raw_source_fingerprint", None
+                            )
+                            session_id = session.get("session_id")
+                            if (
+                                source in {"claude", "codex"}
+                                and (
+                                    not session_id
+                                    or not isinstance(snapshot, tuple)
+                                    or len(snapshot) != 5
                                 )
-                            except Exception:
-                                if strict:
-                                    _log_strict_scan_failure(
-                                        source=source,
-                                        stage="findings",
-                                        code="findings_failed",
-                                    )
-                                else:
-                                    logger.exception(
-                                        "Findings pipeline failed for %s", sid
-                                    )
-                                failures.append(
-                                    {
-                                        "source": source,
-                                        "stage": "findings",
-                                        "code": "findings_failed",
-                                    }
+                            ):
+                                raise ValueError(
+                                    "strict parser did not return a raw-source snapshot"
+                                )
+                            if session_id and snapshot is not None:
+                                strict_raw_fingerprints[str(session_id)] = list(
+                                    snapshot
                                 )
                 except Exception:
                     if strict:
@@ -749,6 +845,78 @@ class Scanner:
                     failures.append(
                         {"source": source, "stage": "parse", "code": "parse_failed"}
                     )
+                    continue
+                if not sessions:
+                    continue
+                try:
+                    upsert_stats: dict[str, int] = {}
+                    new_count = upsert_sessions(conn, sessions, stats=upsert_stats)
+                    results[source] = results.get(source, 0) + new_count
+                    updated_count = upsert_stats.get("updated", 0)
+                    unchanged_count = upsert_stats.get("unchanged", 0)
+                    self.last_updated_count += updated_count
+                    self.last_unchanged_count += unchanged_count
+                    self.last_updated_by_source[source] = (
+                        self.last_updated_by_source.get(source, 0) + updated_count
+                    )
+                    self.last_unchanged_by_source[source] = (
+                        self.last_unchanged_by_source.get(source, 0) + unchanged_count
+                    )
+                except Exception as store_error:
+                    # Not a parse problem: the sessions parsed cleanly and the
+                    # index write failed. A lock timeout gets its own code so
+                    # contention is diagnosable as contention.
+                    code = (
+                        "index_busy"
+                        if isinstance(store_error, sqlite3.OperationalError)
+                        else "store_failed"
+                    )
+                    if strict:
+                        _log_strict_scan_failure(
+                            source=source, stage="store", code=code
+                        )
+                    else:
+                        logger.exception(
+                            "Error storing project %s", project["dir_name"]
+                        )
+                    failures.append(
+                        {"source": source, "stage": "store", "code": code}
+                    )
+                    continue
+                # Drive each freshly-upserted session through the findings
+                # pipeline. Settle-threshold + revision check inside the
+                # driver keep this cheap on steady state; errors per session
+                # don't abort the loop.
+                for session in sessions:
+                    sid = session.get("session_id")
+                    if not sid:
+                        continue
+                    try:
+                        run_findings_pipeline(
+                            conn,
+                            sid,
+                            session,
+                            config=config,
+                            safe_logging=strict,
+                        )
+                    except Exception:
+                        if strict:
+                            _log_strict_scan_failure(
+                                source=source,
+                                stage="findings",
+                                code="findings_failed",
+                            )
+                        else:
+                            logger.exception(
+                                "Findings pipeline failed for %s", sid
+                            )
+                        failures.append(
+                            {
+                                "source": source,
+                                "stage": "findings",
+                                "code": "findings_failed",
+                            }
+                        )
 
             try:
                 self.last_linked_count = link_subagent_hierarchy(conn)
@@ -928,7 +1096,10 @@ class Scanner:
     def _run(self) -> None:
         while not self._stop_event.is_set():
             try:
-                results = self.scan_once()
+                results = self._scan_tick()
+                if results is None:
+                    self._stop_event.wait(SCAN_INTERVAL)
+                    continue
                 trigger_scoring_warmup(self)
                 total_new = sum(results.values())
                 if (

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -136,9 +136,9 @@ SCAN_LOCK_FILENAME = "scan.lock"
 # Longer than a full background pass on a large corpus, so a strict scan
 # waiting on the lock outlives the daemon tick that holds it.
 SCAN_LOCK_WAIT_SECONDS = 300.0
-# Normal scans proceed unlocked after the wait, so theirs is best-effort
-# politeness only — and their interactive callers (`clawjournal recent`,
-# the share preflight) have no wait feedback, so keep the ceiling short.
+# Normal scans fail closed after this wait instead of bypassing the lock.
+# Their interactive callers (`clawjournal recent`, the share preflight) have
+# limited wait feedback, so keep the ceiling short.
 SCAN_ONCE_LOCK_WAIT_SECONDS = 15.0
 _SCAN_LOCK_POLL_SECONDS = 0.5
 

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -241,7 +241,9 @@ def _patch_strict_scanner(
     calls: list[list[str]] = []
 
     class StrictScanner:
-        def scan_once_strict(self, required_sources, *, progress=None):
+        def scan_once_strict(
+            self, required_sources, *, progress=None, on_wait=None
+        ):
             calls.append(list(required_sources))
             index = len(calls) - 1
             if index < len(actions) and actions[index] is not None:
@@ -409,7 +411,7 @@ def test_enable_requires_a_successful_hosted_manual_receipt_before_network(
     forbidden_calls: list[str] = []
 
     class ScannerForbidden:
-        def scan_once_strict(self, _required_sources):
+        def scan_once_strict(self, _required_sources, **_kwargs):
             forbidden_calls.append("scan")
             raise AssertionError("manual-receipt gate must run before strict scan")
 
@@ -2951,6 +2953,75 @@ def test_strict_scan_reuse_ignores_failed_refreshes(monkeypatch):
     assert auto._strict_scan_for_enable(["claude"])["ok"] is False
     assert auto._strict_scan_for_enable(["claude"])["ok"] is True
     assert scan_calls == [["claude"], ["claude"]]
+
+
+def test_enable_surfaces_scanner_busy_and_does_not_memoize_it(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    """A lock-timeout refresh must fail closed with its own retryable code —
+    not the log-diagnosis-inviting strict_scan_incomplete — and must not
+    poison the reuse window: the retry scans for real."""
+    _save_scope_config(upload_token="fresh-one-shot")
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    conn.close()
+    _patch_enable_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        auto, "create_enrollment", lambda _caps, **_kwargs: _enrollment_response()
+    )
+    scan_calls = _patch_strict_scanner(
+        monkeypatch,
+        results=[
+            {"ok": False, "busy": True},
+            {"ok": True, "sources": ["claude"]},
+        ],
+    )
+    profile_hash = _current_authorization_profile_hash()
+    accepted = {
+        "agent": "claude",
+        "accepted_authorization_version": AUTH_VERSION,
+        "accepted_retention_version": RETENTION_VERSION,
+        "accepted_ownership_certification_version": OWNERSHIP_VERSION,
+        "accepted_authorization_profile_hash": profile_hash,
+    }
+
+    busy = auto.enable(**accepted)
+
+    assert busy["ok"] is False
+    assert busy["code"] == "scanner_busy"
+    assert busy["retryable"] is True
+    conn = open_index()
+    try:
+        assert get_auto_upload_enrollment(conn) is None
+    finally:
+        conn.close()
+
+    retry = auto.enable(**accepted)
+
+    assert retry["mode"] == "enabled"
+    assert scan_calls == [["claude"], ["claude"]]
+
+
+def test_preview_refresh_surfaces_scanner_busy(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    config = _save_scope_config()
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    _save_enabled_enrollment(conn, config)
+    conn.close()
+    scan_calls = _patch_strict_scanner(
+        monkeypatch, results=[{"ok": False, "busy": True}]
+    )
+
+    result = auto.preview(refresh=True)
+
+    assert result["ok"] is False
+    assert result["code"] == "scanner_busy"
+    assert result["retryable"] is True
+    assert scan_calls == [["claude"]]
 
 
 def test_enable_never_backdates_cutoff_before_durable_local_intent(

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -1677,6 +1677,39 @@ def test_stale_sealed_recovery_is_discarded_so_later_revision_can_progress(
         conn.close()
 
 
+def test_run_cycle_reports_scanner_busy_distinctly(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    """A lock-timeout refresh in a run cycle surfaces as scanner_busy (still
+    retryable) — matching enable()/preview() — instead of the incompleteness
+    code that invites diagnosing healthy source logs."""
+    config = _save_scope_config()
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    _save_enabled_enrollment(conn, config)
+    conn.close()
+    monkeypatch.setattr(auto, "load_credentials", lambda **_kwargs: _credentials())
+    _patch_runner_host(monkeypatch)
+    scan_calls = _patch_strict_scanner(
+        monkeypatch, results=[{"ok": False, "busy": True}]
+    )
+
+    result = auto.run_cycle(force=True)
+
+    assert result["ok"] is False
+    assert result["code"] == "scanner_busy"
+    assert result["retryable"] is True
+    assert scan_calls == [["claude"]]
+    conn = open_index()
+    try:
+        enrollment = get_auto_upload_enrollment(conn)
+        assert enrollment["last_result_code"] == "scanner_busy"
+        assert enrollment["mode"] == "enabled"
+    finally:
+        conn.close()
+
+
 def test_pending_recovery_requires_a_fresh_strict_scan(
     isolated_auto_upload,
     monkeypatch,

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -248,7 +248,10 @@ def _patch_strict_scanner(
             index = len(calls) - 1
             if index < len(actions) and actions[index] is not None:
                 actions[index]()
-            return responses[min(index, len(responses) - 1)]
+            response = responses[min(index, len(responses) - 1)]
+            if response.get("busy") and on_wait is not None:
+                on_wait()
+            return response
 
     monkeypatch.setattr("clawjournal.workbench.daemon.Scanner", StrictScanner)
     return calls
@@ -3048,13 +3051,18 @@ def test_preview_refresh_surfaces_scanner_busy(
     scan_calls = _patch_strict_scanner(
         monkeypatch, results=[{"ok": False, "busy": True}]
     )
+    wait_notices = []
 
-    result = auto.preview(refresh=True)
+    result = auto.preview(
+        refresh=True,
+        scan_wait_notice=lambda: wait_notices.append("waiting"),
+    )
 
     assert result["ok"] is False
     assert result["code"] == "scanner_busy"
     assert result["retryable"] is True
     assert scan_calls == [["claude"]]
+    assert wait_notices == ["waiting"]
 
 
 def test_enable_never_backdates_cutoff_before_durable_local_intent(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1468,6 +1468,29 @@ class TestScanOutput:
 
         assert "No new or updated sessions found." in output
 
+    def test_reports_busy_scan_without_a_traceback(self, monkeypatch, capsys):
+        from clawjournal.workbench.daemon import ScanBusyError
+
+        class FakeScanner:
+            def __init__(self, source_filter=None):
+                pass
+
+            def scan_once(self):
+                raise ScanBusyError("Another scan is still refreshing the index.")
+
+        self._patch_scan_dependencies(monkeypatch, FakeScanner)
+
+        from clawjournal.cli import _run_scan
+
+        with pytest.raises(SystemExit) as exc_info:
+            _run_scan()
+
+        assert exc_info.value.code == 1
+        assert (
+            "Scan not run: Another scan is still refreshing the index."
+            in capsys.readouterr().err
+        )
+
 
 class TestWorkbenchSourceChoices:
     def test_scan_accepts_cursor_source(self, monkeypatch):
@@ -1536,6 +1559,39 @@ class TestRecentOutput:
         out = capsys.readouterr().out
         assert "FV 4/5" in out
         assert "1/5" not in out
+
+    def test_recent_shows_current_index_when_refresh_is_busy(
+        self, monkeypatch, capsys
+    ):
+        from clawjournal.cli import _run_recent
+        from clawjournal.workbench.daemon import ScanBusyError
+
+        conn = MagicMock()
+
+        class BusyScanner:
+            def __init__(self, source_filter=None):
+                pass
+
+            def scan_once(self):
+                raise ScanBusyError("busy")
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.Scanner", BusyScanner
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.open_index", lambda: conn
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.query_sessions",
+            lambda _conn, **_kwargs: [],
+        )
+
+        _run_recent(MagicMock(source=None, since=None, limit=5, json=False))
+
+        assert (
+            "Another scan is refreshing the index; showing current results."
+            in capsys.readouterr().err
+        )
 
 
 class TestEventsCLI:

--- a/tests/test_cli_auto_upload.py
+++ b/tests/test_cli_auto_upload.py
@@ -22,6 +22,37 @@ def test_auto_upload_status_json_is_pure_stdout(monkeypatch, capsys):
     assert captured.err == ""
 
 
+@pytest.mark.parametrize("output_json", [False, True])
+def test_preview_refresh_reports_lock_wait_without_breaking_json(
+    monkeypatch, capsys, output_json
+):
+    def preview(*, refresh, scan_wait_notice):
+        assert refresh is True
+        scan_wait_notice()
+        return {
+            "ok": True,
+            "selected": [],
+            "eligible_count": 0,
+            "selected_count": 0,
+            "deferred_by_cap": 0,
+        }
+
+    monkeypatch.setattr("clawjournal.auto_upload.preview", preview)
+    argv = ["clawjournal", "auto-upload", "preview", "--refresh"]
+    if output_json:
+        argv.append("--json")
+    monkeypatch.setattr(sys, "argv", argv)
+
+    main()
+
+    captured = capsys.readouterr()
+    if output_json:
+        assert json.loads(captured.out)["ok"] is True
+        assert captured.err == ""
+    else:
+        assert "Waiting for another scan to finish" in captured.err
+
+
 def test_noninteractive_enable_requires_exact_versions(monkeypatch, capsys):
     challenge = {
         "ok": False,

--- a/tests/test_cli_auto_upload.py
+++ b/tests/test_cli_auto_upload.py
@@ -233,6 +233,7 @@ def test_interactive_enable_replays_exact_profile_after_email_verification(
 
     for call in calls:
         assert callable(call.pop("scan_progress"))
+        assert callable(call.pop("scan_wait_notice"))
     accepted = {
         "agent": "all",
         "accepted_authorization_version": "auth-v1",
@@ -286,6 +287,7 @@ def test_interactive_enable_reprompts_once_when_the_refresh_changes_scope(
 
     def enable(**kwargs):
         kwargs.pop("scan_progress", None)
+        kwargs.pop("scan_wait_notice", None)
         calls.append(kwargs)
         if len(calls) == 1:
             return challenge("profile-one", ["project"])

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import sqlite3
 import time
 import urllib.error
 import zipfile
@@ -18,6 +19,7 @@ import pytest
 from clawjournal.workbench.daemon import (
     Scanner,
     WorkbenchHandler,
+    _scan_process_lock,
     run_server,
     _SHARE_COOLDOWN_SECONDS,
     _apply_upload_pii_redactions,
@@ -1254,6 +1256,98 @@ class TestScanner:
         assert report["failures"] == []
         assert seen == [("claude", 1, 2)]
         assert "PRIVATE_CALLBACK_SENTINEL" not in json.dumps(report)
+
+    @pytest.mark.parametrize(
+        ("store_error", "expected_code"),
+        [
+            (RuntimeError("PRIVATE_STORE_SENTINEL"), "store_failed"),
+            (sqlite3.OperationalError("database is locked"), "index_busy"),
+        ],
+    )
+    def test_strict_scan_labels_store_failures_distinctly(
+        self, tmp_path, monkeypatch, store_error, expected_code
+    ):
+        """A failed index write is not a parse problem: it gets stage=store,
+        and a lock timeout gets its own code so cross-process contention is
+        diagnosable as contention instead of sending someone at the logs."""
+        self._patch_progress_scan_environment(tmp_path, monkeypatch)
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.parse_project_sessions",
+            lambda dir_name, **kwargs: [
+                {
+                    "session_id": f"session-{dir_name[-12:]}",
+                    "_raw_source_fingerprint": ("a", "b", "c", "d", "e"),
+                }
+            ],
+        )
+
+        def failing_upsert(_conn, _sessions, stats=None):
+            raise store_error
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.upsert_sessions", failing_upsert
+        )
+
+        report = Scanner().scan_once_strict(["claude"])
+
+        assert report["ok"] is False
+        assert report["failures"] == [
+            {"source": "claude", "stage": "store", "code": expected_code},
+            {"source": "claude", "stage": "store", "code": expected_code},
+        ]
+        assert "PRIVATE_STORE_SENTINEL" not in json.dumps(report)
+
+    def test_strict_scan_fails_closed_busy_when_lock_held(
+        self, tmp_path, monkeypatch
+    ):
+        """A refresh that cannot get the cross-process scan lock within its
+        wait fails closed with a busy report — it must not contend for
+        SQLite writes it would lose — and fires on_wait exactly once."""
+        self._patch_progress_scan_environment(tmp_path, monkeypatch)
+        waits: list[str] = []
+
+        with _scan_process_lock(wait_seconds=None) as held:
+            assert held is True
+            report = Scanner().scan_once_strict(
+                ["claude"],
+                on_wait=lambda: waits.append("waited"),
+                lock_wait_seconds=0.0,
+            )
+
+        assert report["ok"] is False
+        assert report["busy"] is True
+        assert report["failures"] == [
+            {"source": "*", "stage": "lock", "code": "scanner_busy"}
+        ]
+        assert waits == ["waited"]
+        # With the lock free again the same call succeeds.
+        clean = Scanner().scan_once_strict(["claude"])
+        assert clean["ok"] is True
+
+    def test_background_tick_skips_while_another_process_scans(
+        self, tmp_path, monkeypatch
+    ):
+        """The background loop must yield to a CLI scan, not contend with it;
+        the next tick catches up."""
+        self._patch_progress_scan_environment(tmp_path, monkeypatch)
+
+        with _scan_process_lock(wait_seconds=None) as held:
+            assert held is True
+            assert Scanner()._scan_tick() is None
+
+        assert Scanner()._scan_tick() == {}
+
+    def test_scan_once_proceeds_unlocked_after_wait_expires(
+        self, tmp_path, monkeypatch
+    ):
+        """Normal scans degrade to pre-lock behavior after the bounded wait:
+        per-project resilience makes proceeding strictly better than failing,
+        and only strict scans must fail closed."""
+        self._patch_progress_scan_environment(tmp_path, monkeypatch)
+
+        with _scan_process_lock(wait_seconds=None) as held:
+            assert held is True
+            assert Scanner().scan_once(lock_wait_seconds=0.0) == {}
 
     @pytest.mark.parametrize("source", ["claude", "codex"])
     def test_strict_scan_rejects_malformed_jsonl_without_partial_upsert(

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -17,6 +17,7 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 from clawjournal.workbench.daemon import (
+    ScanBusyError,
     Scanner,
     WorkbenchHandler,
     _scan_process_lock,
@@ -1343,17 +1344,22 @@ class TestScanner:
 
         assert Scanner()._scan_tick() == {}
 
-    def test_scan_once_proceeds_unlocked_after_wait_expires(
+    def test_scan_once_fails_closed_when_lock_wait_expires(
         self, tmp_path, monkeypatch
     ):
-        """Normal scans degrade to pre-lock behavior after the bounded wait:
-        per-project resilience makes proceeding strictly better than failing,
-        and only strict scans must fail closed."""
+        """A normal scan must not bypass a lock held by a strict scan."""
         self._patch_progress_scan_environment(tmp_path, monkeypatch)
+        scanner = Scanner()
+        monkeypatch.setattr(
+            scanner,
+            "_scan_once_report",
+            lambda **_kwargs: pytest.fail("a busy scan must not touch the index"),
+        )
 
         with _scan_process_lock(wait_seconds=None) as held:
             assert held is True
-            assert Scanner().scan_once(lock_wait_seconds=0.0) == {}
+            with pytest.raises(ScanBusyError, match="Another scan"):
+                scanner.scan_once(lock_wait_seconds=0.0)
 
     @pytest.mark.parametrize("source", ["claude", "codex"])
     def test_strict_scan_rejects_malformed_jsonl_without_partial_upsert(
@@ -1988,8 +1994,11 @@ class TestScanner:
 
 class TestScanAPI:
     def test_scanner_coalesces_a_scan_request_while_another_scan_is_active(
-        self, monkeypatch
+        self, tmp_path, monkeypatch
     ):
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db"
+        )
         scanner = Scanner()
         entered = Event()
         release = Event()

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -1262,6 +1262,12 @@ class TestScanner:
         [
             (RuntimeError("PRIVATE_STORE_SENTINEL"), "store_failed"),
             (sqlite3.OperationalError("database is locked"), "index_busy"),
+            # OperationalError also covers corruption and full disks, which
+            # must not masquerade as transient contention.
+            (
+                sqlite3.OperationalError("database disk image is malformed"),
+                "store_failed",
+            ),
         ],
     )
     def test_strict_scan_labels_store_failures_distinctly(


### PR DESCRIPTION
## What

The contention fix from last night's enrollment incident: the CLI's strict refresh ran while the serve daemon's background scanner held long SQLite write transactions, the CLI's upserts blew through the 30s busy timeout, and the failures were mislabeled `stage=parse code=parse_failed` — sending diagnosis at the (perfectly healthy) codex logs, and fail-closing enrollment with `strict_scan_incomplete` until the daemon was manually stopped.

### Part 1 — take turns instead of colliding
`_scan_process_lock`: a cross-process scan lock (lock file next to the index DB), mirroring `whole_run_lock` — an OS-level lock the kernel releases on process death, so a crashed scan can never wedge future scans. Wait behavior is matched to the caller:

| entry point | on contention |
|---|---|
| `scan_once_strict` (enable, preview --refresh, run cycles) | wait up to 300s (longer than a full background pass), then **fail closed** with a distinct `busy` report |
| `scan_once` (CLI `clawjournal scan`, serve initial scan) | wait up to 15s, then **fail without touching the index** with an explicit busy error |
| background tick (`_scan_tick`), `scan_once_if_idle` (HTTP refresh) | **skip**; the next tick/refresh catches up |

`enable()` and `preview(refresh=True)` map the busy report to a retryable `scanner_busy` result instead of `strict_scan_incomplete`, the CLI prints a one-line wait notice when the refresh has to wait, and a busy result is never memoized into #136's reuse window.

### Part 2 — honest failure labels
The scanner's per-project handler previously wrapped parse **and** `upsert_sessions` in one `try` labeled `parse_failed`. Now: parse failures keep `stage=parse`; index-write failures get `stage=store` (`store_failed`), with `sqlite3.OperationalError` specifically reported as `index_busy` — so contention is diagnosable as contention.

## Safety notes

- Lock ordering is consistent (instance thread-lock → file lock, never nested, never held while taking `whole_run_lock`: enable's scan releases the file lock before the run lock is acquired; run cycles take the run lock first and their scan wait is bounded) — no circular wait.
- Normal scans never bypass the process lock after their bounded wait, so they cannot disrupt a strict scan that already holds it.
- Busy reports carry `ok: false`, so every existing `strict["ok"]` guard (run cycles, fingerprint binding) handles them; run cycles route busy into their existing retry/backoff.
- The posix path catches `BlockingIOError` only, matching `whole_run_lock`'s exposure profile on exotic filesystems.

## Tests

9 new: store-failure labeling (generic → `store_failed`, lock timeout → `index_busy`, sentinel never leaks into the report), strict-scan busy fail-closed + `on_wait` fired exactly once, background tick skips while another process scans, normal `scan_once` fails without touching the index after wait expiry, manual CLI scan reports busy without a traceback, `recent` falls back to the current index, `enable` surfaces `scanner_busy` without memoizing it (retry really scans), and `preview --refresh` surfaces `scanner_busy`. Focused scanner, CLI, and automatic-upload validation: **314 passed**. Full CI matrix on Python 3.10–3.13: **3006 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014Dha7TpcKGpGTcFNEFWSTV
