### PR TITLE
Add workflow progress bar

### DIFF
--- a/clawjournal/web/frontend/src/App.tsx
+++ b/clawjournal/web/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { BrowserRouter, Routes, Route, NavLink, Navigate } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, NavLink, Navigate, useLocation } from 'react-router-dom';
 import { Inbox } from './views/Inbox.tsx';
 import { Search } from './views/Search.tsx';
 import SessionDetail from './views/SessionDetail.tsx';
@@ -12,6 +12,8 @@ import { Benchmark } from './views/Benchmark.tsx';
 import { Settings } from './views/Settings.tsx';
 import { ToastProvider } from './components/Toast.tsx';
 import { ConfirmDialog } from './components/ConfirmDialog.tsx';
+import { WorkflowProgress } from './components/WorkflowProgress.tsx';
+import { workflowProgressStageFor } from './components/workflowProgressStage.ts';
 import { colors, fontFamily } from './theme.ts';
 import { api, ApiError } from './api.ts';
 import type { Features } from './types.ts';
@@ -144,6 +146,13 @@ function Sidebar() {
   );
 }
 
+function WorkflowProgressTracker({ submittedShareId }: { submittedShareId: string | null }) {
+  const location = useLocation();
+  const stage = workflowProgressStageFor(location.pathname, location.search, submittedShareId);
+
+  return <WorkflowProgress stage={stage} />;
+}
+
 export default function App() {
   // Feature flags + the persisted auto-scorer decline come from /api/features.
   // benchmark_tab_enabled is initialised true so the common case never flashes;
@@ -153,6 +162,7 @@ export default function App() {
     scoring_warmup_declined: false,
   });
   const benchmarkEnabled = features.benchmark_tab_enabled;
+  const [submittedShareId, setSubmittedShareId] = useState<string | null>(null);
 
   // The same probe doubles as a connectivity check: the loopback daemon going
   // away (e.g. `clawjournal serve` stopped) otherwise just renders zero counts
@@ -236,31 +246,34 @@ export default function App() {
           )}
           <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
             <Sidebar />
-            <main style={{ flex: 1, overflow: 'auto', background: colors.white }}>
-              <Routes>
-                <Route path="/" element={<Inbox />} />
-                <Route path="/search" element={<Search />} />
-                <Route path="/session/:id" element={<SessionDetail />} />
-                {/* Analytics groups the three read-only "understand" views as sub-tabs. */}
-                <Route path="/analytics" element={<Analytics benchmarkEnabled={benchmarkEnabled} />}>
-                  <Route index element={<Dashboard />} />
-                  <Route path="insights" element={<Insights />} />
-                  <Route
-                    path="benchmark"
-                    element={benchmarkEnabled ? <Benchmark /> : <Navigate to="/analytics" replace />}
-                  />
-                </Route>
-                <Route path="/share" element={<Share />} />
-                <Route path="/share/rules" element={<Policies />} />
-                <Route path="/settings" element={<Settings />} />
-                {/* Back-compat redirects for the pre-regroup routes + bookmarks. */}
-                <Route path="/dashboard" element={<Navigate to="/analytics" replace />} />
-                <Route path="/insights" element={<Navigate to="/analytics/insights" replace />} />
-                <Route path="/benchmark" element={<Navigate to="/analytics/benchmark" replace />} />
-                <Route path="/bundles" element={<Navigate to="/share" replace />} />
-                <Route path="/policies" element={<Navigate to="/share/rules" replace />} />
-              </Routes>
-            </main>
+            <div style={{ display: 'flex', flex: 1, flexDirection: 'column', minWidth: 0, minHeight: 0 }}>
+              <main style={{ flex: 1, minHeight: 0, overflow: 'auto', background: colors.white }}>
+                <Routes>
+                  <Route path="/" element={<Inbox />} />
+                  <Route path="/search" element={<Search />} />
+                  <Route path="/session/:id" element={<SessionDetail />} />
+                  {/* Analytics groups the three read-only "understand" views as sub-tabs. */}
+                  <Route path="/analytics" element={<Analytics benchmarkEnabled={benchmarkEnabled} />}>
+                    <Route index element={<Dashboard />} />
+                    <Route path="insights" element={<Insights />} />
+                    <Route
+                      path="benchmark"
+                      element={benchmarkEnabled ? <Benchmark /> : <Navigate to="/analytics" replace />}
+                    />
+                  </Route>
+                  <Route path="/share" element={<Share onSubmittedShareChange={setSubmittedShareId} />} />
+                  <Route path="/share/rules" element={<Policies />} />
+                  <Route path="/settings" element={<Settings />} />
+                  {/* Back-compat redirects for the pre-regroup routes + bookmarks. */}
+                  <Route path="/dashboard" element={<Navigate to="/analytics" replace />} />
+                  <Route path="/insights" element={<Navigate to="/analytics/insights" replace />} />
+                  <Route path="/benchmark" element={<Navigate to="/analytics/benchmark" replace />} />
+                  <Route path="/bundles" element={<Navigate to="/share" replace />} />
+                  <Route path="/policies" element={<Navigate to="/share/rules" replace />} />
+                </Routes>
+              </main>
+              <WorkflowProgressTracker submittedShareId={submittedShareId} />
+            </div>
           </div>
         </div>
         <ConfirmDialog

--- a/clawjournal/web/frontend/src/components/WorkflowProgress.test.tsx
+++ b/clawjournal/web/frontend/src/components/WorkflowProgress.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { WorkflowProgress } from './WorkflowProgress.tsx';
+import { workflowProgressStageFor } from './workflowProgressStage.ts';
+
+describe('WorkflowProgress', () => {
+  it.each([
+    { stage: 1 as const, percent: '33', text: 'Step 1 of 3: Review sessions', section: 'Sessions' },
+    { stage: 2 as const, percent: '67', text: 'Step 2 of 3: Prepare share', section: 'Share' },
+    { stage: 3 as const, percent: '100', text: 'Step 3 of 3: Submitted', section: 'Share' },
+  ])('renders stage $stage as $percent percent', ({ stage, percent, text, section }) => {
+    render(<WorkflowProgress stage={stage} />);
+
+    expect(screen.getByText(`Progress ${stage}/3: ${section}`)).toBeInTheDocument();
+    expect(screen.getByText('Done!')).toBeInTheDocument();
+    expect(screen.queryByText('Prepare share')).not.toBeInTheDocument();
+    expect(screen.queryByText('Submitted')).not.toBeInTheDocument();
+    expect(screen.getByRole('progressbar', { name: 'Overall workflow progress' })).toHaveAttribute(
+      'aria-valuenow',
+      percent,
+    );
+    expect(screen.getByRole('progressbar', { name: 'Overall workflow progress' })).toHaveAttribute(
+      'aria-valuetext',
+      text,
+    );
+  });
+
+  it('advances only a receipt-backed Done route to the submitted stage', () => {
+    expect(workflowProgressStageFor('/', '', null)).toBe(1);
+    expect(workflowProgressStageFor('/share', '', null)).toBe(2);
+    expect(workflowProgressStageFor('/share', '?step=done&share=local-only', null)).toBe(2);
+    expect(workflowProgressStageFor('/share', '?step=done&share=submitted', 'submitted')).toBe(3);
+    expect(workflowProgressStageFor('/share', '?step=done&share=other', 'submitted')).toBe(2);
+  });
+});

--- a/clawjournal/web/frontend/src/components/WorkflowProgress.tsx
+++ b/clawjournal/web/frontend/src/components/WorkflowProgress.tsx
@@ -1,0 +1,62 @@
+import { colors, fontFamily } from '../theme.ts';
+import type { WorkflowProgressStage } from './workflowProgressStage.ts';
+
+const WORKFLOW_STEPS = [
+  { stage: 1, label: 'Review sessions' },
+  { stage: 2, label: 'Prepare share' },
+  { stage: 3, label: 'Submitted' },
+] as const;
+
+export function WorkflowProgress({ stage }: { stage: WorkflowProgressStage }) {
+  const percent = Math.round((stage / WORKFLOW_STEPS.length) * 100);
+  const currentLabel = WORKFLOW_STEPS[stage - 1].label;
+  const sectionLabel = stage === 1 ? 'Sessions' : 'Share';
+
+  return (
+    <footer
+      aria-label="ClawJournal workflow progress"
+      style={{
+        flexShrink: 0,
+        padding: '5px 18px 6px',
+        background: colors.gray50,
+        borderTop: `1px solid ${colors.gray200}`,
+        fontFamily,
+      }}
+    >
+      <div style={{ display: 'flex', justifyContent: 'space-between', gap: 16, marginBottom: 4 }}>
+        <span style={{ fontSize: 11, fontWeight: 700, color: colors.gray700 }}>
+          Progress {stage}/3: {sectionLabel}
+        </span>
+        <span style={{
+          fontSize: 11,
+          fontWeight: stage === 3 ? 700 : 500,
+          color: stage === 3 ? colors.green700 : colors.gray400,
+        }}>
+          Done!
+        </span>
+      </div>
+      <div
+        role="progressbar"
+        aria-label="Overall workflow progress"
+        aria-valuemin={0}
+        aria-valuemax={100}
+        aria-valuenow={percent}
+        aria-valuetext={`Step ${stage} of 3: ${currentLabel}`}
+        style={{
+          height: 4,
+          overflow: 'hidden',
+          borderRadius: 999,
+          background: colors.gray200,
+        }}
+      >
+        <div style={{
+          width: `${percent}%`,
+          height: '100%',
+          borderRadius: 999,
+          background: stage === 3 ? colors.green500 : colors.primary500,
+          transition: 'width 280ms ease, background-color 280ms ease',
+        }} />
+      </div>
+    </footer>
+  );
+}

--- a/clawjournal/web/frontend/src/components/workflowProgressStage.ts
+++ b/clawjournal/web/frontend/src/components/workflowProgressStage.ts
@@ -1,0 +1,17 @@
+export type WorkflowProgressStage = 1 | 2 | 3;
+
+export function workflowProgressStageFor(
+  pathname: string,
+  search: string,
+  submittedShareId: string | null,
+): WorkflowProgressStage {
+  const inShare = pathname === '/share' || pathname.startsWith('/share/');
+  if (!inShare) return 1;
+
+  const params = new URLSearchParams(search);
+  return params.get('step') === 'done'
+    && params.get('share') !== null
+    && params.get('share') === submittedShareId
+    ? 3
+    : 2;
+}

--- a/clawjournal/web/frontend/src/views/Share/index.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { api } from '../../api.ts';
@@ -478,5 +478,64 @@ describe('Share selection defaults', () => {
       expect(onSubmittedShareChange).toHaveBeenLastCalledWith('submitted-share');
     });
     expect(await screen.findByRole('heading', { name: 'Submitted' })).toBeInTheDocument();
+  });
+
+  it('ignores a stale receipt response after navigating to another share', async () => {
+    mockInitialLoad(readyStats(1));
+    type ShareResult = Awaited<ReturnType<typeof api.shares.get>>;
+    let resolveFirst!: (share: ShareResult) => void;
+    const firstRequest = new Promise<ShareResult>((resolve) => { resolveFirst = resolve; });
+    const shareResult = (shareId: string, receiptId: string | null): ShareResult => ({
+      share_id: shareId,
+      created_at: '2026-07-22T12:00:00Z',
+      session_count: 1,
+      status: receiptId ? 'shared' : 'draft',
+      attestation: null,
+      submission_note: null,
+      bundle_hash: 'bundle-hash',
+      manifest: {},
+      shared_at: receiptId ? '2026-07-22T12:01:00Z' : null,
+      hosted_receipt_id: receiptId,
+      hosted_status: receiptId ? 'accepted' : null,
+    });
+    vi.spyOn(api.shares, 'get').mockImplementation((shareId) => (
+      shareId === 'first-share'
+        ? firstRequest
+        : Promise.resolve(shareResult('second-share', null))
+    ));
+    const onSubmittedShareChange = vi.fn();
+
+    render(
+      <MemoryRouter initialEntries={['/share?step=done&share=first-share']}>
+        <ToastProvider>
+          <Share onSubmittedShareChange={onSubmittedShareChange} />
+        </ToastProvider>
+        <NavigationProbe to="/share?step=done&share=second-share" />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(api.shares.get).toHaveBeenCalledWith('first-share'));
+    expect(await screen.findByRole('heading', { name: 'Your bundle is ready' })).toBeInTheDocument();
+    // Let initial queue hydration finish so this test isolates the receipt race.
+    await waitFor(() => {
+      const params = new URLSearchParams(screen.getByTestId('location-search').textContent || '');
+      expect(params.get('selection')).toBe('all');
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Navigate' }));
+    await waitFor(() => expect(api.shares.get).toHaveBeenCalledWith('second-share'));
+    await waitFor(() => {
+      const params = new URLSearchParams(screen.getByTestId('location-search').textContent || '');
+      expect(params.get('share')).toBe('second-share');
+    });
+
+    await act(async () => {
+      resolveFirst(shareResult('first-share', 'receipt-first'));
+      await firstRequest;
+    });
+
+    expect(screen.getByRole('heading', { name: 'Your bundle is ready' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Submitted' })).not.toBeInTheDocument();
+    expect(onSubmittedShareChange).not.toHaveBeenCalledWith('second-share');
   });
 });

--- a/clawjournal/web/frontend/src/views/Share/index.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.test.tsx
@@ -448,4 +448,35 @@ describe('Share selection defaults', () => {
     expect(screen.queryByRole('heading', { name: 'What would you like to share?' })).not.toBeInTheDocument();
     expect(redactionSpy).not.toHaveBeenCalled();
   });
+
+  it('reports a hosted submission only after its receipt is restored', async () => {
+    mockInitialLoad(readyStats(1));
+    vi.spyOn(api.shares, 'get').mockResolvedValue({
+      share_id: 'submitted-share',
+      created_at: '2026-07-22T12:00:00Z',
+      session_count: 1,
+      status: 'shared',
+      attestation: null,
+      submission_note: null,
+      bundle_hash: 'bundle-hash',
+      manifest: {},
+      shared_at: '2026-07-22T12:01:00Z',
+      hosted_receipt_id: 'receipt-123',
+      hosted_status: 'accepted',
+    });
+    const onSubmittedShareChange = vi.fn();
+
+    render(
+      <MemoryRouter initialEntries={['/share?step=done&share=submitted-share']}>
+        <ToastProvider>
+          <Share onSubmittedShareChange={onSubmittedShareChange} />
+        </ToastProvider>
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => {
+      expect(onSubmittedShareChange).toHaveBeenLastCalledWith('submitted-share');
+    });
+    expect(await screen.findByRole('heading', { name: 'Submitted' })).toBeInTheDocument();
+  });
 });

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -483,7 +483,9 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
 
   useEffect(() => {
     if (!packagedShareId) return;
+    let cancelled = false;
     api.shares.get(packagedShareId).then((share) => {
+      if (cancelled) return;
       const piiReview = (share.manifest?.redaction_summary as { pii_review?: { ai_enabled?: unknown } } | undefined)?.pii_review;
       if (!searchParams.get('ai_pii') && typeof piiReview?.ai_enabled === 'boolean') {
         setAiPiiEnabled(piiReview.ai_enabled);
@@ -502,6 +504,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
         });
       }
     }).catch(() => { });
+    return () => { cancelled = true; };
   }, [packagedShareId, searchParams]);
 
   // =================================================

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -96,7 +96,11 @@ function restoredQueueFromParams(
 const PACKAGE_LOG_TRACE_LIMIT = 20;
 const PACKAGE_ANIMATION_MAX_MS = 10_000;
 
-export function Share() {
+export interface ShareProps {
+  onSubmittedShareChange?: (shareId: string | null) => void;
+}
+
+export function Share({ onSubmittedShareChange }: ShareProps = {}) {
   const { toast } = useToast();
   const location = useLocation();
   const [searchParams, setSearchParams] = useSearchParams();
@@ -211,6 +215,10 @@ export function Share() {
   const [receiptId, setReceiptId] = useState<string | null>(null);
   const [hostedStatus, setHostedStatus] = useState<string | null>(null);
   const [supportContact, setSupportContact] = useState<string | null>(null);
+
+  useEffect(() => {
+    onSubmittedShareChange?.(receiptId ? packagedShareId : null);
+  }, [onSubmittedShareChange, packagedShareId, receiptId]);
 
   // Candidates (empty queue hint)
   const [candidates, setCandidates] = useState<Session[]>([]);


### PR DESCRIPTION
## Summary

- add a compact, persistent three-stage progress bar beneath the main content area
- keep the left sidebar unobstructed by scoping the footer to the right-hand content column
- show `Progress 1/3: Sessions`, `Progress 2/3: Share`, and `Progress 3/3: Share`
- advance to 100% only after a hosted submission receipt is present
- keep a concise `Done!` endpoint label and accessible progress metadata

## Why

The workbench did not provide a simple top-level indicator connecting session review, the Share workflow, and successful submission. This makes that journey visible without interfering with the existing Share stepper or sidebar.

## User impact

Users can see their overall workflow position from every workbench screen. Local packaging without submission remains at 2/3; only a receipt-backed hosted submission reaches 3/3.

## Validation

- `npm test` — 44 frontend tests passed
- focused workflow progress and Share tests — 20 tests passed
- final progress-label tests — 4 tests passed
- changed-file ESLint checks passed
- `npm run build` passed and rebuilt the production frontend
- live workbench verification confirmed sidebar clearance, a 34px footer, route labels, and a clean browser console
