### PR TITLE
perf(share): avoid redundant TruffleHog scans

### DIFF
--- a/clawjournal/redaction/secrets.py
+++ b/clawjournal/redaction/secrets.py
@@ -36,6 +36,18 @@ class FindingsScannerProfile(str, Enum):
     LOCAL_SHARE = "local_share"
 
 
+def _normalize_findings_scanner_profile(
+    scanner_profile: FindingsScannerProfile | str,
+) -> FindingsScannerProfile:
+    """Accept serialized profiles and reject unknown values fail-closed."""
+    try:
+        return FindingsScannerProfile(scanner_profile)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(
+            f"Unknown findings scanner profile: {scanner_profile!r}"
+        ) from exc
+
+
 # Ordered from most specific to least specific
 SECRET_PATTERNS = [
     # JWT tokens — full 3-segment form
@@ -1107,7 +1119,7 @@ def apply_findings_to_blob(
     *,
     user_allowlist: list[dict] | None = None,
     max_passes: int = 3,
-    scanner_profile: FindingsScannerProfile = FindingsScannerProfile.COMPLETE,
+    scanner_profile: FindingsScannerProfile | str = FindingsScannerProfile.COMPLETE,
 ) -> tuple[dict, int]:
     """Re-scan the blob, apply decisions from the `findings` table.
 
@@ -1120,6 +1132,8 @@ def apply_findings_to_blob(
     revealed by earlier replacements. Byte-equivalent to `redact_session`
     when only secrets are present and every decision is open/accepted.
     """
+    scanner_profile = _normalize_findings_scanner_profile(scanner_profile)
+
     # Decisions are engine-agnostic at the apply step — same hash, same
     # answer. The pipeline guarantees that hashes are unique per
     # (session, entity), so collapsing to a single dict is safe.

--- a/clawjournal/redaction/secrets.py
+++ b/clawjournal/redaction/secrets.py
@@ -20,12 +20,21 @@ import math
 import re
 import sqlite3
 from collections.abc import Iterable
+from enum import Enum
 from typing import Any
 
 from ..findings import RawFinding, hash_entity
 from ..parsing.widened import iter_widened_text_locations
 
 REDACTED = "[REDACTED]"
+
+
+class FindingsScannerProfile(str, Enum):
+    """External scanner set used by findings-backed blob redaction."""
+
+    COMPLETE = "complete"
+    LOCAL_SHARE = "local_share"
+
 
 # Ordered from most specific to least specific
 SECRET_PATTERNS = [
@@ -1098,7 +1107,7 @@ def apply_findings_to_blob(
     *,
     user_allowlist: list[dict] | None = None,
     max_passes: int = 3,
-    include_trufflehog: bool = True,
+    scanner_profile: FindingsScannerProfile = FindingsScannerProfile.COMPLETE,
 ) -> tuple[dict, int]:
     """Re-scan the blob, apply decisions from the `findings` table.
 
@@ -1124,14 +1133,16 @@ def apply_findings_to_blob(
     from .betterleaks import betterleaks_secret_map_from_blob
     from .pii import pii_secret_map_from_text_decisions
 
-    # Betterleaks is always part of the local redaction pass. TruffleHog is
-    # optional here so the Share path can defer it to its mandatory final
-    # package gate. Each enabled engine runs once on the original blob rather
-    # than inside the per-pass loop.
+    # Betterleaks is the broad local detector. The Share path deliberately
+    # defers live credential verification to the mandatory merged-artifact
+    # gate; other callers retain the complete two-scanner behavior.
     trufflehog_map: dict[str, str] = {}
-    if include_trufflehog:
+    if scanner_profile is FindingsScannerProfile.COMPLETE:
         from .trufflehog import trufflehog_secret_map_from_blob
-        trufflehog_map = trufflehog_secret_map_from_blob(blob, decisions, user_allowlist)
+
+        trufflehog_map = trufflehog_secret_map_from_blob(
+            blob, decisions, user_allowlist
+        )
     betterleaks_map = betterleaks_secret_map_from_blob(blob, decisions, user_allowlist)
 
     total = 0
@@ -1158,7 +1169,7 @@ def apply_findings_to_blob(
         secret_map.update(_collect_infrastructure_secret_map(blob))
         secret_map.update(trufflehog_map)
         secret_map.update(betterleaks_map)
-        # Note on loop termination: once an engine map is non-empty the
+        # Note on loop termination: once an external scanner map is non-empty the
         # `not secret_map` guard never fires, so the pass loop now
         # relies on the `pass_count == 0 and pass_num > 0` guard below
         # to exit. That guard still works because the second pass's

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -14,7 +14,11 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-from ..redaction.secrets import FindingsScannerProfile, redact_text
+from ..redaction.secrets import (
+    FindingsScannerProfile,
+    _normalize_findings_scanner_profile,
+    redact_text,
+)
 from ..scoring.badges import compute_all_badges
 from ..config import (
     CONFIG_DIR,
@@ -1657,9 +1661,11 @@ def _build_deterministic_redaction_log(
     session: dict[str, Any],
     *,
     user_allowlist: list[dict[str, Any]] | None = None,
-    scanner_profile: FindingsScannerProfile = FindingsScannerProfile.COMPLETE,
+    scanner_profile: FindingsScannerProfile | str = FindingsScannerProfile.COMPLETE,
 ) -> list[dict[str, Any]]:
     """Build a metadata-only log from the findings-backed redaction substrate."""
+    scanner_profile = _normalize_findings_scanner_profile(scanner_profile)
+
     from ..findings import hash_entity
     from ..redaction.betterleaks import scan_session_for_betterleaks_findings
     from ..redaction.pii import _dedupe_overlapping_pii, scan_text_for_pii

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -14,7 +14,7 @@ from typing import Any
 
 logger = logging.getLogger(__name__)
 
-from ..redaction.secrets import redact_text
+from ..redaction.secrets import FindingsScannerProfile, redact_text
 from ..scoring.badges import compute_all_badges
 from ..config import (
     CONFIG_DIR,
@@ -1657,15 +1657,13 @@ def _build_deterministic_redaction_log(
     session: dict[str, Any],
     *,
     user_allowlist: list[dict[str, Any]] | None = None,
-    include_trufflehog: bool = True,
+    scanner_profile: FindingsScannerProfile = FindingsScannerProfile.COMPLETE,
 ) -> list[dict[str, Any]]:
     """Build a metadata-only log from the findings-backed redaction substrate."""
     from ..findings import hash_entity
     from ..redaction.betterleaks import scan_session_for_betterleaks_findings
     from ..redaction.pii import _dedupe_overlapping_pii, scan_text_for_pii
     from ..redaction.secrets import _dedupe_overlapping_matches, _iter_text_locations, scan_text
-    if include_trufflehog:
-        from ..redaction.trufflehog import scan_session_for_trufflehog_findings
 
     session_id = str(session.get("session_id") or "")
     if not session_id:
@@ -1702,7 +1700,9 @@ def _build_deterministic_redaction_log(
                 tool_field=tool_field,
             ))
 
-    if include_trufflehog:
+    if scanner_profile is FindingsScannerProfile.COMPLETE:
+        from ..redaction.trufflehog import scan_session_for_trufflehog_findings
+
         try:
             for finding in scan_session_for_trufflehog_findings(
                 session,
@@ -1995,7 +1995,7 @@ def apply_share_redactions(
             conn,
             session,
             user_allowlist=user_allowlist,
-            include_trufflehog=False,
+            scanner_profile=FindingsScannerProfile.LOCAL_SHARE,
         ),
     )
     session, deterministic_total = apply_findings_to_blob(
@@ -2003,10 +2003,9 @@ def apply_share_redactions(
         conn,
         session_id,
         user_allowlist=user_allowlist,
-        include_trufflehog=False,
+        scanner_profile=FindingsScannerProfile.LOCAL_SHARE,
     )
     total_redactions += deterministic_total
-
     # Known tradeoff: ``redaction_log`` is built from a single pre-apply
     # scan (see ``_build_deterministic_redaction_log``); the apply step
     # runs up to ``max_passes=3`` passes that can surface secrets

--- a/clawjournal/workbench/share_gate.py
+++ b/clawjournal/workbench/share_gate.py
@@ -2,10 +2,10 @@
 
 ``run_share_gate`` is the single chokepoint both export paths call on
 the merged ``sessions.jsonl`` (post-deterministic-redaction, and again
-post-PII-rewrite). Each pass:
+post-PII-rewrite). The gate:
 
-1. Betterleaks scans (broad detection, local-only) and TruffleHog
-   scans verified-only (live-credential check) — one subprocess each,
+1. Betterleaks scans (broad detection, local-only) and TruffleHog scans
+   verified-only (live-credential check) on the initial merged artifact,
    returning raw matches in *file-level* form (JSONL-escaped bytes as
    they appear on disk).
 2. Every finding is tiered by ``scan_policy.classify`` against the
@@ -16,8 +16,10 @@ post-PII-rewrite). Each pass:
    report the escaped on-disk form, not the decoded value. A
    replacement that breaks a line's JSON is rolled back and its
    finding escalated to review.
-4. The file is rescanned until a pass finds nothing left to redact
+4. Betterleaks alone rescans until no broad finding remains to redact
    (bounded by ``max_passes``; non-convergence escalates and blocks).
+5. If any bytes changed, TruffleHog performs one final verified-only
+   scan so a credential revealed by rewriting cannot leave the machine.
 
 Block/review findings accumulate across passes (their raws get
 redacted too — a best-effort scrub of the on-disk export dir that also
@@ -315,7 +317,7 @@ def _rewrite_sessions_file(
     return total, by_line, failed_pairs
 
 
-def _rawless_backstop_findings(bl_report, th_report) -> list[PolicyFinding]:
+def _rawless_backstop_findings(bl_report=None, th_report=None) -> list[PolicyFinding]:
     """Sticky findings for scanner hits that returned no usable raw.
 
     ``scan_file_with_raws`` only surfaces raw matches with a non-empty
@@ -327,39 +329,89 @@ def _rawless_backstop_findings(bl_report, th_report) -> list[PolicyFinding]:
     credential ship whenever TruffleHog omits ``Raw``.
     """
     out: list[PolicyFinding] = []
-    for f in th_report.findings:
-        if f.raw_sha256 is None:
-            out.append(
-                PolicyFinding(
-                    engine=trufflehog.TRUFFLEHOG_ENGINE_ID,
-                    rule=f.detector,
-                    status=f.status,
-                    line=f.line,
-                    masked=f.masked,
-                    raw_sha256=None,
-                    entropy=None,
-                    tier="block" if f.status == "verified" else "review",
-                    tier_reason="finding_without_raw",
-                    raw=None,
+    if th_report is not None:
+        for f in th_report.findings:
+            if f.raw_sha256 is None:
+                out.append(
+                    PolicyFinding(
+                        engine=trufflehog.TRUFFLEHOG_ENGINE_ID,
+                        rule=f.detector,
+                        status=f.status,
+                        line=f.line,
+                        masked=f.masked,
+                        raw_sha256=None,
+                        entropy=None,
+                        tier="block" if f.status == "verified" else "review",
+                        tier_reason="finding_without_raw",
+                        raw=None,
+                    )
                 )
-            )
-    for f in bl_report.findings:
-        if f.raw_sha256 is None:
-            out.append(
-                PolicyFinding(
-                    engine=betterleaks.BETTERLEAKS_ENGINE_ID,
-                    rule=f.rule_id,
-                    status="none",
-                    line=f.line,
-                    masked=f.masked,
-                    raw_sha256=None,
-                    entropy=f.entropy,
-                    tier="review",
-                    tier_reason="finding_without_raw",
-                    raw=None,
+    if bl_report is not None:
+        for f in bl_report.findings:
+            if f.raw_sha256 is None:
+                out.append(
+                    PolicyFinding(
+                        engine=betterleaks.BETTERLEAKS_ENGINE_ID,
+                        rule=f.rule_id,
+                        status="none",
+                        line=f.line,
+                        masked=f.masked,
+                        raw_sha256=None,
+                        entropy=f.entropy,
+                        tier="review",
+                        tier_reason="finding_without_raw",
+                        raw=None,
+                    )
                 )
-            )
     return out
+
+
+def _accumulate_policy_findings(
+    findings: list[PolicyFinding],
+    sticky: dict[tuple, PolicyFinding],
+    warns: dict[tuple, PolicyFinding],
+) -> None:
+    for finding in findings:
+        if finding.tier in ("block", "review"):
+            sticky.setdefault(_finding_key(finding), finding)
+        elif finding.tier == "warn":
+            warns.setdefault(_finding_key(finding), finding)
+
+
+def _rewrite_policy_findings(
+    sessions_file: Path,
+    findings: list[PolicyFinding],
+    *,
+    sticky: dict[tuple, PolicyFinding],
+    redacted_keys: set[tuple],
+) -> tuple[list[PolicyFinding], int, dict[int, int]]:
+    redactable = [
+        finding
+        for finding in findings
+        if finding.tier in ("redact", "review", "block")
+        and finding.raw is not None
+        and len(finding.raw) >= _MIN_RAW_LENGTH
+    ]
+    if not redactable:
+        return [], 0, {}
+
+    replaced, by_line, failed_pairs = _rewrite_sessions_file(
+        sessions_file, redactable
+    )
+    failed_raws = {raw for _line, raw in failed_pairs}
+    for finding in redactable:
+        failed_here = (
+            (finding.line, finding.raw) in failed_pairs
+            or (finding.line is None and finding.raw in failed_raws)
+        )
+        if failed_here and finding.tier not in ("block", "review"):
+            escalated = dataclasses.replace(
+                finding, tier="review", tier_reason="unredactable_span"
+            )
+            sticky.setdefault(_finding_key(escalated), escalated)
+        elif finding.tier == "redact" and not failed_here:
+            redacted_keys.add(_finding_key(finding))
+    return redactable, replaced, by_line
 
 
 def run_share_gate(
@@ -374,6 +426,9 @@ def run_share_gate(
     Never raises on scanner trouble — failures surface on the report
     (``binary_missing`` / ``scan_error``) so callers fail closed.
     """
+    if max_passes < 1:
+        raise ValueError("max_passes must be at least 1")
+
     bl_bypassed = betterleaks.is_bypassed()
     th_bypassed = trufflehog.is_bypassed()
     if bl_bypassed or th_bypassed:
@@ -416,14 +471,22 @@ def run_share_gate(
     while passes < max_passes:
         passes += 1
         bl_report, bl_raws = betterleaks.scan_file_with_raws(sessions_file)
-        th_report, th_raws = trufflehog.scan_file_with_raws(
-            sessions_file, results="verified"
-        )
+        th_raws = []
+        current_th_report = None
+        if passes == 1:
+            current_th_report, th_raws = trufflehog.scan_file_with_raws(
+                sessions_file, results="verified"
+            )
+            th_report = current_th_report
         error = (
             bl_report.scan_error
-            or th_report.scan_error
+            or (current_th_report.scan_error if current_th_report else None)
             or ("betterleaks binary disappeared mid-gate" if bl_report.binary_missing else None)
-            or ("trufflehog binary disappeared mid-gate" if th_report.binary_missing else None)
+            or (
+                "trufflehog binary disappeared mid-gate"
+                if current_th_report and current_th_report.binary_missing
+                else None
+            )
         )
         if error:
             return _finalize_report(
@@ -438,12 +501,8 @@ def run_share_gate(
             )
 
         findings = _policy_findings_for_pass(bl_raws, th_raws, decision_cache)
-        for f in findings:
-            if f.tier in ("block", "review"):
-                sticky.setdefault(_finding_key(f), f)
-            elif f.tier == "warn":
-                warns.setdefault(_finding_key(f), f)
-        for f in _rawless_backstop_findings(bl_report, th_report):
+        _accumulate_policy_findings(findings, sticky, warns)
+        for f in _rawless_backstop_findings(bl_report, current_th_report):
             sticky.setdefault(_finding_key(f), f)
 
         # Redact-tier raws are replaced so the share can proceed;
@@ -453,37 +512,19 @@ def run_share_gate(
         # span stays in the blocked export dir). Warn-tier values
         # are deliberately left alone — an ignored/allowlisted value is
         # the user's standing decision to keep it.
-        redactable = [
-            f for f in findings
-            if f.tier in ("redact", "review", "block")
-            and f.raw is not None and len(f.raw) >= _MIN_RAW_LENGTH
-        ]
+        redactable, replaced, by_line = _rewrite_policy_findings(
+            sessions_file,
+            findings,
+            sticky=sticky,
+            redacted_keys=redacted_keys,
+        )
         last_redactable = [f for f in redactable if f.tier == "redact"]
         if not redactable:
             converged = True
             break
-
-        replaced, by_line, failed_pairs = _rewrite_sessions_file(
-            sessions_file, redactable
-        )
         total_redactions += replaced
         for line_no, count in by_line.items():
             redactions_by_line[line_no] = redactions_by_line.get(line_no, 0) + count
-        failed_raws = {raw for _line, raw in failed_pairs}
-        for f in redactable:
-            failed_here = (
-                (f.line, f.raw) in failed_pairs
-                # A line-less finding was applied globally; a failure
-                # on any line is its failure.
-                or (f.line is None and f.raw in failed_raws)
-            )
-            if failed_here and f.tier not in ("block", "review"):
-                escalated = dataclasses.replace(
-                    f, tier="review", tier_reason="unredactable_span"
-                )
-                sticky.setdefault(_finding_key(escalated), escalated)
-            elif f.tier == "redact" and not failed_here:
-                redacted_keys.add(_finding_key(f))
 
     if not converged:
         # Pass budget exhausted with redactable findings still turning
@@ -495,6 +536,51 @@ def run_share_gate(
             )
             sticky.setdefault(_finding_key(escalated), escalated)
             redacted_keys.discard(_finding_key(f))
+
+    # Rewriting can reveal a credential hidden behind an earlier matched span.
+    # Verify the final bytes once, rather than repeating a network-backed
+    # TruffleHog pass during every Betterleaks convergence iteration.
+    if total_redactions:
+        th_report, final_th_raws = trufflehog.scan_file_with_raws(
+            sessions_file, results="verified"
+        )
+        error = (
+            th_report.scan_error
+            or (
+                "trufflehog binary disappeared mid-gate"
+                if th_report.binary_missing
+                else None
+            )
+        )
+        if error:
+            return _finalize_report(
+                GateReport(
+                    scanned_path=str(sessions_file),
+                    scanned_sha256=_hash_or_empty(sessions_file),
+                    scan_error=error,
+                    rescan_passes=passes,
+                ),
+                bl_report,
+                th_report,
+            )
+
+        final_findings = _policy_findings_for_pass(
+            [], final_th_raws, decision_cache
+        )
+        _accumulate_policy_findings(final_findings, sticky, warns)
+        for finding in _rawless_backstop_findings(th_report=th_report):
+            sticky.setdefault(_finding_key(finding), finding)
+        _final_redactable, replaced, by_line = _rewrite_policy_findings(
+            sessions_file,
+            final_findings,
+            sticky=sticky,
+            redacted_keys=redacted_keys,
+        )
+        total_redactions += replaced
+        for line_no, count in by_line.items():
+            redactions_by_line[line_no] = (
+                redactions_by_line.get(line_no, 0) + count
+            )
 
     all_findings = sorted(
         list(sticky.values()) + list(warns.values()),

--- a/tests/workbench/test_share_gates.py
+++ b/tests/workbench/test_share_gates.py
@@ -227,10 +227,35 @@ class TestExportManifestRedactions:
         assert "[REDACTED_JWT]" in body
         assert n >= 2
 
-    def test_apply_share_redactions_skips_trufflehog_in_local_data_step(self, conn, monkeypatch):
+    def test_complete_findings_profile_still_runs_trufflehog(
+        self, conn, monkeypatch
+    ):
+        from clawjournal.redaction import betterleaks, trufflehog
+        from clawjournal.redaction.secrets import apply_findings_to_blob
+
+        seen = []
+        monkeypatch.setattr(
+            betterleaks,
+            "betterleaks_secret_map_from_blob",
+            lambda *_args, **_kwargs: {},
+        )
+        monkeypatch.setattr(
+            trufflehog,
+            "trufflehog_secret_map_from_blob",
+            lambda *_args, **_kwargs: seen.append("trufflehog") or {},
+        )
+        sess = _settled_session("complete-profile", content="ordinary text")
+
+        apply_findings_to_blob(sess, conn, "complete-profile")
+
+        assert seen == ["trufflehog"]
+
+    def test_apply_share_redactions_defers_trufflehog_to_final_gate(
+        self, conn, monkeypatch
+    ):
         from clawjournal.redaction import trufflehog as trufflehog_scanner
 
-        raw = "trufflehog test sentinel"
+        raw = "trufflehog local share sentinel"
         sess = _settled_session("sess-th", content=f"leak {raw}")
         upsert_sessions(conn, [sess])
         conn.commit()
@@ -238,12 +263,16 @@ class TestExportManifestRedactions:
         monkeypatch.setattr(
             trufflehog_scanner,
             "scan_session_for_trufflehog_findings",
-            lambda *_args, **_kwargs: pytest.fail("local Share redaction must not scan with TruffleHog"),
+            lambda *_args, **_kwargs: pytest.fail(
+                "local Share logging must defer TruffleHog to the final gate"
+            ),
         )
         monkeypatch.setattr(
             trufflehog_scanner,
             "trufflehog_secret_map_from_blob",
-            lambda *_args, **_kwargs: pytest.fail("local Share redaction must not apply TruffleHog findings"),
+            lambda *_args, **_kwargs: pytest.fail(
+                "local Share redaction must defer TruffleHog to the final gate"
+            ),
         )
 
         redacted, n, log = apply_share_redactions(conn, sess)
@@ -301,10 +330,12 @@ class TestExportManifestRedactions:
         with pytest.raises(ValueError, match="session_id"):
             apply_share_redactions(conn, session)
 
-    def test_apply_share_redactions_skips_ignored_trufflehog_findings(self, conn, monkeypatch):
+    def test_apply_share_redactions_does_not_consult_trufflehog_decisions_locally(
+        self, conn, monkeypatch
+    ):
         from clawjournal.redaction import trufflehog as trufflehog_scanner
 
-        raw = "ignored trufflehog sentinel"
+        raw = "ignored trufflehog local sentinel"
         sess = _settled_session("sess-th-ignore", content=f"keep {raw}")
         upsert_sessions(conn, [sess])
         conn.execute(
@@ -323,12 +354,16 @@ class TestExportManifestRedactions:
         monkeypatch.setattr(
             trufflehog_scanner,
             "scan_session_for_trufflehog_findings",
-            lambda *_args, **_kwargs: pytest.fail("local Share redaction must not scan with TruffleHog"),
+            lambda *_args, **_kwargs: pytest.fail(
+                "local Share logging must not consult TruffleHog"
+            ),
         )
         monkeypatch.setattr(
             trufflehog_scanner,
             "trufflehog_secret_map_from_blob",
-            lambda *_args, **_kwargs: pytest.fail("local Share redaction must not apply TruffleHog findings"),
+            lambda *_args, **_kwargs: pytest.fail(
+                "local Share redaction must not consult TruffleHog"
+            ),
         )
 
         redacted, n, log = apply_share_redactions(conn, sess)
@@ -453,12 +488,10 @@ class TestAiTextRedaction:
 def _mock_gate_engines(monkeypatch, *, bl_passes=None, th_passes=None):
     """Enable a real (non-bypassed) share gate with both engines mocked.
 
-    ``bl_passes`` / ``th_passes`` are per-scan-pass lists of raw-match
-    dicts (betterleaks: ``{"raw","rule_id","entropy","line"}``;
-    trufflehog: ``{"raw","detector","status","line"}``). Passes beyond
-    the end of a list return no matches, which is how a redact loop
-    converges. The findings-engine hooks are stubbed empty so the
-    apply path never spawns a real subprocess.
+    ``bl_passes`` contains each broad convergence scan; ``th_passes``
+    contains the initial and optional final live-verification scans. Passes
+    beyond either list return no matches. The findings-engine hooks are
+    stubbed empty so the apply path never spawns a real subprocess.
     """
     from clawjournal.redaction import betterleaks, trufflehog
 
@@ -522,7 +555,7 @@ class TestSecretScanGate:
         ).fetchone()["status"]
 
     def test_clean_scan_advances_share_status(self, conn, monkeypatch):
-        _mock_gate_engines(monkeypatch)
+        calls = _mock_gate_engines(monkeypatch)
         share_id, share = self._share(conn)
         export_dir, manifest = export_share_to_disk(conn, share_id, share)
         assert export_dir is not None
@@ -532,6 +565,7 @@ class TestSecretScanGate:
         scan = manifest["redaction_summary"]["secret_scan"]
         assert scan["findings"] == 0
         assert scan["converged"] is True
+        assert calls == {"bl": 1, "th": 1}
         assert (export_dir / "trufflehog.json").exists()
         assert (export_dir / "secret-scan.json").exists()
 
@@ -654,7 +688,7 @@ class TestSecretScanGate:
         # The headline behavior change: a recognizable-but-unverified
         # token no longer rejects the session — the exact span is
         # replaced and the share ships.
-        _mock_gate_engines(
+        calls = _mock_gate_engines(
             monkeypatch,
             bl_passes=[[{
                 "raw": self.RAW, "rule_id": "slack-bot-token",
@@ -677,6 +711,7 @@ class TestSecretScanGate:
         assert scan["gate_redactions"] >= 1
         assert scan["tier_counts"].get("redact") == 1
         assert scan["converged"] is True
+        assert calls == {"bl": 2, "th": 2}
         # Folded into the manifest counters and the per-session entry.
         assert (
             manifest["redaction_summary"]["by_type"]["gate_secret_scan"]
@@ -687,7 +722,7 @@ class TestSecretScanGate:
         json.loads(body.splitlines()[0])
 
     def test_verified_credential_blocks_and_does_not_advance(self, conn, monkeypatch):
-        _mock_gate_engines(
+        calls = _mock_gate_engines(
             monkeypatch,
             th_passes=[[{
                 "raw": self.RAW, "detector": "GitHub",
@@ -712,8 +747,85 @@ class TestSecretScanGate:
         # Defense in depth: even a blocked export's on-disk artifact
         # has the live credential redacted.
         assert self.RAW not in (export_dir / "sessions.jsonl").read_text()
+        assert calls == {"bl": 2, "th": 2}
         disk = json.loads((export_dir / "manifest.json").read_text())
         assert disk["blocked"] is True
+
+    def test_final_verification_catches_credential_revealed_by_rewrite(
+        self, conn, monkeypatch
+    ):
+        prefix = "wrapper-prefix-"
+        calls = _mock_gate_engines(
+            monkeypatch,
+            bl_passes=[[
+                {
+                    "raw": prefix,
+                    "rule_id": "slack-bot-token",
+                    "entropy": 4.4,
+                    "line": 1,
+                }
+            ]],
+            th_passes=[[], [
+                {
+                    "raw": self.RAW,
+                    "detector": "GitHub",
+                    "status": "verified",
+                    "line": 1,
+                }
+            ]],
+        )
+        share_id, share = self._share(
+            conn, content=f"nested {prefix}{self.RAW}"
+        )
+
+        export_dir, manifest = export_share_to_disk(conn, share_id, share)
+
+        assert manifest["blocked"] is True
+        assert calls == {"bl": 2, "th": 2}
+        assert self.RAW not in (export_dir / "sessions.jsonl").read_text()
+        findings = manifest["blocked_sessions"][0]["findings"]
+        assert any(
+            finding["engine"] == "trufflehog" and finding["tier"] == "block"
+            for finding in findings
+        )
+
+    def test_final_verification_error_fails_closed(self, conn, monkeypatch):
+        from clawjournal.redaction import trufflehog
+
+        _mock_gate_engines(
+            monkeypatch,
+            bl_passes=[[
+                {
+                    "raw": self.RAW,
+                    "rule_id": "slack-bot-token",
+                    "entropy": 4.4,
+                    "line": 1,
+                }
+            ]],
+        )
+        th_calls = 0
+
+        def scan_trufflehog(path, *, results):
+            nonlocal th_calls
+            th_calls += 1
+            report = trufflehog.TruffleHogReport(
+                scanned_path=str(path),
+                scanned_sha256="sha256:0",
+                scan_error=(
+                    "verification transport failed" if th_calls == 2 else None
+                ),
+            )
+            return report, []
+
+        monkeypatch.setattr(trufflehog, "scan_file_with_raws", scan_trufflehog)
+        share_id, share = self._share(conn, content=f"leak {self.RAW}")
+
+        _export_dir, manifest = export_share_to_disk(conn, share_id, share)
+
+        assert th_calls == 2
+        assert manifest["blocked"] is True
+        assert manifest["block_reason"] == "scanner-error"
+        assert "verification transport failed" in manifest["block_message"]
 
     def test_private_key_rule_requires_review(self, conn, monkeypatch):
         fake_key = "-----BEGIN RSA PRIVATE KEY-----\\nFAKEFAKEFAKEFAKEFAKEFAKEFAKEFAKE\\n-----END RSA PRIVATE KEY-----"

--- a/tests/workbench/test_share_gates.py
+++ b/tests/workbench/test_share_gates.py
@@ -227,11 +227,15 @@ class TestExportManifestRedactions:
         assert "[REDACTED_JWT]" in body
         assert n >= 2
 
+    @pytest.mark.parametrize("serialized", [False, True])
     def test_complete_findings_profile_still_runs_trufflehog(
-        self, conn, monkeypatch
+        self, conn, monkeypatch, serialized
     ):
         from clawjournal.redaction import betterleaks, trufflehog
-        from clawjournal.redaction.secrets import apply_findings_to_blob
+        from clawjournal.redaction.secrets import (
+            FindingsScannerProfile,
+            apply_findings_to_blob,
+        )
 
         seen = []
         monkeypatch.setattr(
@@ -245,8 +249,57 @@ class TestExportManifestRedactions:
             lambda *_args, **_kwargs: seen.append("trufflehog") or {},
         )
         sess = _settled_session("complete-profile", content="ordinary text")
+        scanner_profile = FindingsScannerProfile.COMPLETE
+        if serialized:
+            scanner_profile = scanner_profile.value
 
-        apply_findings_to_blob(sess, conn, "complete-profile")
+        apply_findings_to_blob(
+            sess,
+            conn,
+            "complete-profile",
+            scanner_profile=scanner_profile,
+        )
+
+        assert seen == ["trufflehog"]
+
+    def test_unknown_findings_profile_is_rejected(self, conn):
+        from clawjournal.redaction.secrets import apply_findings_to_blob
+
+        sess = _settled_session("unknown-profile", content="ordinary text")
+
+        with pytest.raises(ValueError, match="Unknown findings scanner profile"):
+            apply_findings_to_blob(
+                sess,
+                conn,
+                "unknown-profile",
+                scanner_profile="typo",
+            )
+
+    def test_serialized_complete_log_profile_runs_trufflehog(
+        self, conn, monkeypatch
+    ):
+        from clawjournal.redaction import betterleaks, trufflehog
+        from clawjournal.redaction.secrets import FindingsScannerProfile
+        from clawjournal.workbench.index import _build_deterministic_redaction_log
+
+        seen = []
+        monkeypatch.setattr(
+            betterleaks,
+            "scan_session_for_betterleaks_findings",
+            lambda *_args, **_kwargs: [],
+        )
+        monkeypatch.setattr(
+            trufflehog,
+            "scan_session_for_trufflehog_findings",
+            lambda *_args, **_kwargs: seen.append("trufflehog") or [],
+        )
+        sess = _settled_session("serialized-log", content="ordinary text")
+
+        _build_deterministic_redaction_log(
+            conn,
+            sess,
+            scanner_profile=FindingsScannerProfile.COMPLETE.value,
+        )
 
         assert seen == ["trufflehog"]
 


### PR DESCRIPTION
## Summary

- Add explicit scanner profiles so complete findings scans keep Betterleaks + TruffleHog, while local Share redaction defers redundant TruffleHog work to the final artifact gate.
- Keep Betterleaks and deterministic redaction in the per-trace local path.
- Run TruffleHog once for a clean merged artifact, and at most once more after remediation changes artifact bytes.
- Preserve fail-closed final verification and sticky blocking findings across convergence passes.

## Why

Betterleaks is the broad, fast local detector, while TruffleHog remains valuable for verified credential detection at the egress boundary. Running TruffleHog once per trace and repeatedly during convergence adds substantial subprocess cost without improving the final sealed-artifact guarantee.

This keeps the defense-in-depth model while removing redundant scans from the interactive Share workflow.

## Safety invariants

- The exact outgoing merged artifact is still checked by Betterleaks and TruffleHog before egress.
- A final TruffleHog verification error fails closed.
- Verified findings discovered by any pass remain blocking even if remediation later removes the matching bytes.
- Non-Share callers retain the complete scanner profile by default.
- Serialized scanner profile values are normalized, and unknown profiles fail closed.
- The submission celebration changes already merged in #135 remain untouched.

## Validation

- `python -m pytest -q -p no:cacheprovider tests/workbench/test_share_gate.py tests/workbench/test_share_gates.py`
- `57 passed`
- `python -m pytest -q -p no:cacheprovider`
- `2995 passed`
- `python -m compileall -q clawjournal tests`
- `git diff --check`