### PR TITLE
fix(share): ignore stale receipt responses

### DIFF
--- a/clawjournal/web/frontend/src/views/Share/index.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, useLocation, useNavigate } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { api } from '../../api.ts';
@@ -478,5 +478,59 @@ describe('Share selection defaults', () => {
       expect(onSubmittedShareChange).toHaveBeenLastCalledWith('submitted-share');
     });
     expect(await screen.findByRole('heading', { name: 'Submitted' })).toBeInTheDocument();
+  });
+
+  it('ignores a stale receipt response after navigating to another share', async () => {
+    mockInitialLoad(readyStats(1));
+    type ShareResult = Awaited<ReturnType<typeof api.shares.get>>;
+    let resolveFirst!: (share: ShareResult) => void;
+    const firstRequest = new Promise<ShareResult>((resolve) => { resolveFirst = resolve; });
+    const shareResult = (shareId: string, receiptId: string | null): ShareResult => ({
+      share_id: shareId,
+      created_at: '2026-07-22T12:00:00Z',
+      session_count: 1,
+      status: receiptId ? 'shared' : 'draft',
+      attestation: null,
+      submission_note: null,
+      bundle_hash: 'bundle-hash',
+      manifest: {},
+      shared_at: receiptId ? '2026-07-22T12:01:00Z' : null,
+      hosted_receipt_id: receiptId,
+      hosted_status: receiptId ? 'accepted' : null,
+    });
+    vi.spyOn(api.shares, 'get').mockImplementation((shareId) => (
+      shareId === 'first-share'
+        ? firstRequest
+        : Promise.resolve(shareResult('second-share', null))
+    ));
+    const onSubmittedShareChange = vi.fn();
+
+    render(
+      <MemoryRouter initialEntries={['/share?step=done&share=first-share']}>
+        <ToastProvider>
+          <Share onSubmittedShareChange={onSubmittedShareChange} />
+        </ToastProvider>
+        <NavigationProbe to="/share?step=done&share=second-share" />
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    await waitFor(() => expect(api.shares.get).toHaveBeenCalledWith('first-share'));
+    expect(await screen.findByRole('heading', { name: 'Your bundle is ready' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Navigate' }));
+    await waitFor(() => expect(api.shares.get).toHaveBeenCalledWith('second-share'));
+    await waitFor(() => {
+      const params = new URLSearchParams(screen.getByTestId('location-search').textContent || '');
+      expect(params.get('share')).toBe('second-share');
+    });
+
+    await act(async () => {
+      resolveFirst(shareResult('first-share', 'receipt-first'));
+      await firstRequest;
+    });
+
+    expect(screen.getByRole('heading', { name: 'Your bundle is ready' })).toBeInTheDocument();
+    expect(screen.queryByRole('heading', { name: 'Submitted' })).not.toBeInTheDocument();
+    expect(onSubmittedShareChange).not.toHaveBeenCalledWith('second-share');
   });
 });

--- a/clawjournal/web/frontend/src/views/Share/index.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.test.tsx
@@ -517,6 +517,11 @@ describe('Share selection defaults', () => {
 
     await waitFor(() => expect(api.shares.get).toHaveBeenCalledWith('first-share'));
     expect(await screen.findByRole('heading', { name: 'Your bundle is ready' })).toBeInTheDocument();
+    // Let initial queue hydration finish so this test isolates the receipt race.
+    await waitFor(() => {
+      const params = new URLSearchParams(screen.getByTestId('location-search').textContent || '');
+      expect(params.get('selection')).toBe('all');
+    });
     fireEvent.click(screen.getByRole('button', { name: 'Navigate' }));
     await waitFor(() => expect(api.shares.get).toHaveBeenCalledWith('second-share'));
     await waitFor(() => {

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -483,7 +483,9 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
 
   useEffect(() => {
     if (!packagedShareId) return;
+    let cancelled = false;
     api.shares.get(packagedShareId).then((share) => {
+      if (cancelled) return;
       const piiReview = (share.manifest?.redaction_summary as { pii_review?: { ai_enabled?: unknown } } | undefined)?.pii_review;
       if (!searchParams.get('ai_pii') && typeof piiReview?.ai_enabled === 'boolean') {
         setAiPiiEnabled(piiReview.ai_enabled);
@@ -502,6 +504,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
         });
       }
     }).catch(() => { });
+    return () => { cancelled = true; };
   }, [packagedShareId, searchParams]);
 
   // =================================================


### PR DESCRIPTION
## Summary

- Ignore stale share-detail responses after navigation changes the active share.
- Prevent a late receipt from Share A being attributed to Share B and incorrectly advancing the workflow footer to Submitted / 3 of 3.
- Add a regression test that delays the first receipt response, navigates to a second local-only share, and verifies the second share remains unsubmitted.

## Root cause

The receipt state was stored separately from the share ID. The existing asynchronous `api.shares.get()` effect did not invalidate an in-flight request when its dependencies changed, so an older response could update receipt state after a newer share became active.

## Fix

The effect now marks itself cancelled during cleanup and ignores responses from invalidated requests. This also protects the other share metadata hydrated by the same request.

## Validation

- Focused stale-response regression test passed.
- `npm test` — 46 tests passed.
- `npm run build` — production build passed.
- Targeted ESLint checks passed.
- `git diff --check` passed.