### PR TITLE
fix(scan): surface preview lock waits

### DIFF
--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -757,7 +757,12 @@ def status(*, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
             db.close()
 
 
-def preview(*, refresh: bool = False, now: datetime | None = None) -> dict[str, Any]:
+def preview(
+    *,
+    refresh: bool = False,
+    now: datetime | None = None,
+    scan_wait_notice: Callable[[], None] | None = None,
+) -> dict[str, Any]:
     if not refresh:
         # GET preview is a read-only surface just like GET status: do not create
         # the index, run migrations, or repair state merely because Settings
@@ -802,7 +807,10 @@ def preview(*, refresh: bool = False, now: datetime | None = None) -> dict[str, 
                 return AutoUploadError("not_enrolled", "Automatic upload is not enabled.").as_result()
             from .workbench.daemon import Scanner
 
-            scan = Scanner().scan_once_strict(list(enrollment["enrolled_sources"]))
+            scan = Scanner().scan_once_strict(
+                list(enrollment["enrolled_sources"]),
+                on_wait=scan_wait_notice,
+            )
             if scan.get("busy"):
                 return AutoUploadError(
                     "scanner_busy",

--- a/clawjournal/cli_auto_upload.py
+++ b/clawjournal/cli_auto_upload.py
@@ -259,10 +259,24 @@ def run(args) -> None:
 
     command = args.auto_upload_command
     output_json = bool(getattr(args, "json", False))
+
+    def scan_wait_notice() -> None:
+        # Fires once when a strict refresh must wait for a scan in another
+        # process (usually the daemon's background pass).
+        if not output_json:
+            print(
+                "Waiting for another scan to finish before refreshing "
+                "(the background scanner may be mid-pass)…",
+                file=sys.stderr,
+            )
+
     if command == "status":
         result = auto_upload.status()
     elif command == "preview":
-        result = auto_upload.preview(refresh=bool(args.refresh))
+        result = auto_upload.preview(
+            refresh=bool(args.refresh),
+            scan_wait_notice=scan_wait_notice,
+        )
     elif command == "run":
         result = auto_upload.run_cycle(force=True)
     elif command == "pause":
@@ -307,16 +321,6 @@ def run(args) -> None:
                 print(
                     "Refreshing the enrolled source logs "
                     "(a large history can take a few minutes)…",
-                    file=sys.stderr,
-                )
-
-        def scan_wait_notice() -> None:
-            # Fires once when the strict refresh must wait for a scan in
-            # another process (usually the daemon's background pass).
-            if not output_json:
-                print(
-                    "Waiting for another scan to finish before refreshing "
-                    "(the background scanner may be mid-pass)…",
                     file=sys.stderr,
                 )
 

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -136,9 +136,9 @@ SCAN_LOCK_FILENAME = "scan.lock"
 # Longer than a full background pass on a large corpus, so a strict scan
 # waiting on the lock outlives the daemon tick that holds it.
 SCAN_LOCK_WAIT_SECONDS = 300.0
-# Normal scans proceed unlocked after the wait, so theirs is best-effort
-# politeness only — and their interactive callers (`clawjournal recent`,
-# the share preflight) have no wait feedback, so keep the ceiling short.
+# Normal scans fail closed after this wait instead of bypassing the lock.
+# Their interactive callers (`clawjournal recent`, the share preflight) have
+# limited wait feedback, so keep the ceiling short.
 SCAN_ONCE_LOCK_WAIT_SECONDS = 15.0
 _SCAN_LOCK_POLL_SECONDS = 0.5
 

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -248,7 +248,10 @@ def _patch_strict_scanner(
             index = len(calls) - 1
             if index < len(actions) and actions[index] is not None:
                 actions[index]()
-            return responses[min(index, len(responses) - 1)]
+            response = responses[min(index, len(responses) - 1)]
+            if response.get("busy") and on_wait is not None:
+                on_wait()
+            return response
 
     monkeypatch.setattr("clawjournal.workbench.daemon.Scanner", StrictScanner)
     return calls
@@ -3048,13 +3051,18 @@ def test_preview_refresh_surfaces_scanner_busy(
     scan_calls = _patch_strict_scanner(
         monkeypatch, results=[{"ok": False, "busy": True}]
     )
+    wait_notices = []
 
-    result = auto.preview(refresh=True)
+    result = auto.preview(
+        refresh=True,
+        scan_wait_notice=lambda: wait_notices.append("waiting"),
+    )
 
     assert result["ok"] is False
     assert result["code"] == "scanner_busy"
     assert result["retryable"] is True
     assert scan_calls == [["claude"]]
+    assert wait_notices == ["waiting"]
 
 
 def test_enable_never_backdates_cutoff_before_durable_local_intent(

--- a/tests/test_cli_auto_upload.py
+++ b/tests/test_cli_auto_upload.py
@@ -22,6 +22,37 @@ def test_auto_upload_status_json_is_pure_stdout(monkeypatch, capsys):
     assert captured.err == ""
 
 
+@pytest.mark.parametrize("output_json", [False, True])
+def test_preview_refresh_reports_lock_wait_without_breaking_json(
+    monkeypatch, capsys, output_json
+):
+    def preview(*, refresh, scan_wait_notice):
+        assert refresh is True
+        scan_wait_notice()
+        return {
+            "ok": True,
+            "selected": [],
+            "eligible_count": 0,
+            "selected_count": 0,
+            "deferred_by_cap": 0,
+        }
+
+    monkeypatch.setattr("clawjournal.auto_upload.preview", preview)
+    argv = ["clawjournal", "auto-upload", "preview", "--refresh"]
+    if output_json:
+        argv.append("--json")
+    monkeypatch.setattr(sys, "argv", argv)
+
+    main()
+
+    captured = capsys.readouterr()
+    if output_json:
+        assert json.loads(captured.out)["ok"] is True
+        assert captured.err == ""
+    else:
+        assert "Waiting for another scan to finish" in captured.err
+
+
 def test_noninteractive_enable_requires_exact_versions(monkeypatch, capsys):
     challenge = {
         "ok": False,


### PR DESCRIPTION
## Summary
- correct the scan-lock comment so it matches fail-closed normal-scan behavior
- surface the existing cross-process lock wait during `auto-upload preview --refresh`
- keep `--json` stdout/stderr clean while retaining the human-readable wait notice

## Validation
- `python -m pytest -q -p no:cacheprovider tests/test_auto_upload.py tests/test_cli_auto_upload.py` — **126 passed**
- `git diff --check`

Follow-up to #137.