### PR TITLE
fix(sharing): cap share queue at 50 traces

### DIFF
--- a/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
@@ -283,7 +283,7 @@ export function QueueStep(p: QueueStepProps) {
       </div>
       {filteredSessions.length > TRACE_RENDER_BATCH && (
         <div style={{ marginTop: 7, fontSize: 11.5, color: colors.gray500 }}>
-          Showing {visiblePickerSessions.length} of {filteredSessions.length} matching traces. All eligible traces remain selected unless you uncheck them.
+          Showing {visiblePickerSessions.length} of {filteredSessions.length} matching traces. Only selected traces are in this bundle ({MAX_SHARE_QUEUE_SIZE} maximum); unselected matches remain available to swap in.
         </div>
       )}
     </div>

--- a/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
@@ -6,7 +6,7 @@ import { colors } from '../../theme.ts';
 import { ConfirmDialog } from '../../components/ConfirmDialog.tsx';
 import { SessionDrawer } from '../../components/SessionDrawer.tsx';
 import { TraceCard } from '../../components/TraceCard.tsx';
-import { LARGE_BUNDLE_CONFIRM_THRESHOLD } from './types.ts';
+import { LARGE_BUNDLE_CONFIRM_THRESHOLD, MAX_SHARE_QUEUE_SIZE } from './types.ts';
 import type { ReadySession, ShareReadyStats } from './types.ts';
 import { autoDescription, formatDate, formatTokens, outcomeBadge, outcomeTooltip, sessionTotalTokens, sourceFullLabel } from './helpers.ts';
 import { SHARE_SHELL_WIDTH, btnGhost, btnPrimary, btnSecondary } from './styles.tsx';
@@ -77,6 +77,7 @@ export function QueueStep(p: QueueStepProps) {
 
   const allSessions = p.readyStats?.sessions || [];
   const selectedIds = new Set(p.queueOrder);
+  const selectionLimitReached = p.queueOrder.length >= MAX_SHARE_QUEUE_SIZE;
   // `total_approved` counts every approved session; `allSessions` only holds the
   // ones actually eligible to share. When approved > 0 but eligible == 0, the
   // sessions exist but are all held/embargoed/excluded/already-shared — say so
@@ -171,6 +172,20 @@ export function QueueStep(p: QueueStepProps) {
         const selectedInFilter = filteredIds.filter(id => selectedIds.has(id)).length;
         const filterActive = !!(p.searchQuery || p.sourceFilter || p.projectFilter || p.scoreFilter > 0 || p.dateFilter);
         const allSelected = selectedInFilter === filteredIds.length;
+        const batchDisabled = allSelected || selectionLimitReached;
+        const remainingSlots = Math.max(0, MAX_SHARE_QUEUE_SIZE - p.queueOrder.length);
+        const unselectedInFilter = filteredIds.length - selectedInFilter;
+        const batchSelectionWouldBeCapped = unselectedInFilter > remainingSlots;
+        let batchLabel = filterActive
+          ? `Select ${filteredIds.length} filtered`
+          : `Select all ${filteredIds.length}`;
+        if (selectionLimitReached && !allSelected) {
+          batchLabel = `${MAX_SHARE_QUEUE_SIZE} trace limit reached`;
+        } else if (batchSelectionWouldBeCapped) {
+          batchLabel = filterActive
+            ? `Select ${remainingSlots} more filtered (${MAX_SHARE_QUEUE_SIZE} max)`
+            : `Select first ${remainingSlots} (${MAX_SHARE_QUEUE_SIZE} max)`;
+        }
         const batchBtn = {
           ...btnGhost, fontSize: 12, padding: '5px 10px',
           border: `1px solid ${colors.gray300}`, borderRadius: 6, background: colors.white,
@@ -180,10 +195,10 @@ export function QueueStep(p: QueueStepProps) {
             <button
               type="button"
               onClick={() => p.onAddMany(filteredIds)}
-              disabled={allSelected}
-              style={{ ...batchBtn, opacity: allSelected ? 0.45 : 1, cursor: allSelected ? 'not-allowed' : 'pointer' }}
+              disabled={batchDisabled}
+              style={{ ...batchBtn, opacity: batchDisabled ? 0.45 : 1, cursor: batchDisabled ? 'not-allowed' : 'pointer' }}
             >
-              {filterActive ? `Select ${filteredIds.length} filtered` : `Select all ${filteredIds.length}`}
+              {batchLabel}
             </button>
             <button
               type="button"
@@ -195,6 +210,7 @@ export function QueueStep(p: QueueStepProps) {
             </button>
             <span style={{ fontSize: 11.5, color: colors.gray500 }}>
               {selectedInFilter} of {filteredIds.length}{filterActive ? ' filtered' : ''} selected
+              {' · '}{MAX_SHARE_QUEUE_SIZE} trace maximum
             </span>
           </div>
         );
@@ -204,43 +220,52 @@ export function QueueStep(p: QueueStepProps) {
           <div style={{ padding: 14, textAlign: 'center', color: colors.gray400, fontSize: 13 }}>
             No sessions match your filters.
           </div>
-        ) : visiblePickerSessions.map((s, i) => (
-          <label key={s.session_id} style={{
-            display: 'grid', gridTemplateColumns: 'auto 1fr', gap: 10,
-            alignItems: 'center', padding: '8px 12px',
-            borderBottom: i < visiblePickerSessions.length - 1 ? `1px solid ${colors.gray100}` : 'none',
-            cursor: 'pointer',
-          }}>
-            <input
-              type="checkbox"
-              checked={selectedIds.has(s.session_id)}
-              aria-label={`Include trace: ${s.display_title || 'Untitled'}`}
-              onChange={(e) => e.target.checked ? p.onAdd(s.session_id) : p.onRemove(s.session_id)}
-              style={{ width: 15, height: 15, accentColor: colors.gray900 }}
-            />
-            <div style={{ minWidth: 0 }}>
-              <div style={{ display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }}>
-                <span style={{
-                  minWidth: 0, fontSize: 13, color: colors.gray900, fontWeight: 500,
-                  whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
-                }}>
-                  {s.display_title || 'Untitled'}
-                </span>
-                <UpdatedSinceShareBadge session={s} />
-              </div>
-              <div style={{ fontSize: 11, color: colors.gray500, marginTop: 2, display: 'flex', gap: 8, alignItems: 'center' }}>
-                <SourceBadge s={s} />
-                <span>{s.project}</span>
-                <span style={{ opacity: 0.5 }}>&middot;</span>
-                <span>{formatTokens(sessionTotalTokens(s))} tokens</span>
-                {s.review_status && s.review_status !== 'approved' && (<>
+        ) : visiblePickerSessions.map((s, i) => {
+          const selected = selectedIds.has(s.session_id);
+          const blockedByLimit = selectionLimitReached && !selected;
+          return (
+            <label
+              key={s.session_id}
+              title={blockedByLimit ? 'Remove a selected trace before adding another.' : undefined}
+              style={{
+                display: 'grid', gridTemplateColumns: 'auto 1fr', gap: 10,
+                alignItems: 'center', padding: '8px 12px',
+                borderBottom: i < visiblePickerSessions.length - 1 ? `1px solid ${colors.gray100}` : 'none',
+                cursor: blockedByLimit ? 'not-allowed' : 'pointer',
+                opacity: blockedByLimit ? 0.55 : 1,
+              }}>
+              <input
+                type="checkbox"
+                checked={selected}
+                disabled={blockedByLimit}
+                aria-label={`Include trace: ${s.display_title || 'Untitled'}`}
+                onChange={(e) => e.target.checked ? p.onAdd(s.session_id) : p.onRemove(s.session_id)}
+                style={{ width: 15, height: 15, accentColor: colors.gray900 }}
+              />
+              <div style={{ minWidth: 0 }}>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 7, minWidth: 0 }}>
+                  <span style={{
+                    minWidth: 0, fontSize: 13, color: colors.gray900, fontWeight: 500,
+                    whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis',
+                  }}>
+                    {s.display_title || 'Untitled'}
+                  </span>
+                  <UpdatedSinceShareBadge session={s} />
+                </div>
+                <div style={{ fontSize: 11, color: colors.gray500, marginTop: 2, display: 'flex', gap: 8, alignItems: 'center' }}>
+                  <SourceBadge s={s} />
+                  <span>{s.project}</span>
                   <span style={{ opacity: 0.5 }}>&middot;</span>
-                  <span style={{ color: colors.gray400, fontStyle: 'italic' }}>{s.review_status}</span>
-                </>)}
+                  <span>{formatTokens(sessionTotalTokens(s))} tokens</span>
+                  {s.review_status && s.review_status !== 'approved' && (<>
+                    <span style={{ opacity: 0.5 }}>&middot;</span>
+                    <span style={{ color: colors.gray400, fontStyle: 'italic' }}>{s.review_status}</span>
+                  </>)}
+                </div>
               </div>
-            </div>
-          </label>
-        ))}
+            </label>
+          );
+        })}
         {filteredSessions.length > visiblePickerSessions.length && (
           <button
             onClick={() => setPickerRenderLimit((current) => current + TRACE_RENDER_BATCH)}

--- a/clawjournal/web/frontend/src/views/Share/helpers.test.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.test.ts
@@ -44,10 +44,11 @@ export function readyStats(count = 12): ShareReadyStats {
 }
 
 describe('Share queue selection encoding', () => {
-  it('defaults to every eligible trace, including queues larger than the old cap', () => {
-    const stats = readyStats();
-    expect(queueFromStats(stats)).toEqual(stats.sessions.map((session) => session.session_id));
-    expect(queueFromSelectionParams(stats, new URLSearchParams())).toHaveLength(12);
+  it('defaults to the first 50 ranked eligible traces', () => {
+    const stats = readyStats(75);
+    const expected = stats.sessions.slice(0, 50).map((session) => session.session_id);
+    expect(queueFromStats(stats)).toEqual(expected);
+    expect(queueFromSelectionParams(stats, new URLSearchParams())).toEqual(expected);
   });
 
   it('keeps default and exclusion URLs compact while preserving explicit empty and ordered subsets', () => {
@@ -79,6 +80,15 @@ describe('Share queue selection encoding', () => {
     const params = new URLSearchParams('ids=s2,blocked,s2,s1,missing');
 
     expect(queueFromSelectionParams(stats, params)).toEqual(['s2', 's1']);
+  });
+
+  it('caps explicit selections at 50 while retaining eligible traces outside the default queue', () => {
+    const stats = readyStats(75);
+    const reversed = stats.sessions.map((session) => session.session_id).reverse();
+    const params = new URLSearchParams({ ids: reversed.join(',') });
+
+    expect(queueFromSelectionParams(stats, params)).toEqual(reversed.slice(0, 50));
+    expect(queueFromSelectionParams(stats, params)[0]).toBe('s75');
   });
 
   it('materializes and marks an exact downstream snapshot', () => {

--- a/clawjournal/web/frontend/src/views/Share/helpers.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.ts
@@ -1,6 +1,7 @@
 import type { Share as ShareType } from '../../types.ts';
 import {
   CONFIDENCE_THRESHOLD,
+  MAX_SHARE_QUEUE_SIZE,
   STEPS,
 } from './types.ts';
 import type {
@@ -141,13 +142,14 @@ export function queueFromStats(stats: ShareReadyStats): string[] {
   const recommended = (stats.recommended_session_ids || [])
     .filter((id) => validIds.has(id));
 
-  // Start with the server's highest-value recommendations, then include every
-  // other eligible trace. Share is opt-out: users remove traces they do not
-  // want in the bundle instead of adding a hidden pool one at a time.
+  // Start with the server's highest-value recommendations, then fill the
+  // bounded queue from the remaining eligible traces. The complete eligible
+  // pool stays available in the picker, but a share never starts with the
+  // user's entire local history selected.
   return [...new Set([
     ...recommended,
     ...stats.sessions.map((s) => s.session_id).filter(Boolean),
-  ])];
+  ])].slice(0, MAX_SHARE_QUEUE_SIZE);
 }
 
 function csvParam(params: URLSearchParams, name: string): string[] | null {
@@ -177,13 +179,16 @@ export function sanitizeQueueSelection(
   stats: ShareReadyStats,
   selection: string[],
 ): string[] {
-  const eligibleIds = new Set(queueFromStats(stats));
+  const eligibleIds = new Set(stats.sessions.map((session) => session.session_id));
   const seen = new Set<string>();
-  return selection.filter((id) => {
-    if (!eligibleIds.has(id) || seen.has(id)) return false;
+  const sanitized: string[] = [];
+  for (const id of selection) {
+    if (!eligibleIds.has(id) || seen.has(id)) continue;
     seen.add(id);
-    return true;
-  });
+    sanitized.push(id);
+    if (sanitized.length >= MAX_SHARE_QUEUE_SIZE) break;
+  }
+  return sanitized;
 }
 
 export function hasLockedQueueSelection(params: URLSearchParams): boolean {

--- a/clawjournal/web/frontend/src/views/Share/index.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.test.tsx
@@ -168,6 +168,7 @@ describe('Share selection defaults', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Select first 50 (50 max)' }));
 
     expect(await screen.findByText('50 traces selected')).toBeInTheDocument();
+    expect(screen.queryByText(/Added 50 traces/)).not.toBeInTheDocument();
     await waitFor(() => {
       const params = new URLSearchParams(screen.getByTestId('location-search').textContent || '');
       expect(params.get('selection')).toBe('all');
@@ -187,6 +188,7 @@ describe('Share selection defaults', () => {
     expect(await screen.findByText('50 traces selected')).toBeInTheDocument();
     expect(screen.getAllByRole('checkbox', { name: /Include trace:/ })).toHaveLength(50);
     expect(screen.getByText(/Showing 50 of 125 matching traces/)).toBeInTheDocument();
+    expect(screen.getByText(/Only selected traces are in this bundle \(50 maximum\)/)).toBeInTheDocument();
     expect(screen.getByRole('button', { name: '50 trace limit reached' })).toBeDisabled();
 
     fireEvent.click(screen.getByRole('button', { name: /Show 50 more/ }));
@@ -200,6 +202,40 @@ describe('Share selection defaults', () => {
     fireEvent.click(screen.getByRole('checkbox', { name: 'Include trace: Trace s51' }));
     expect(await screen.findByText('50 traces selected')).toBeInTheDocument();
     expect(screen.getByRole('checkbox', { name: 'Include trace: Trace s51' })).toBeChecked();
+  });
+
+  it('prunes stale queue ids when eligibility refreshes after a completed bundle', async () => {
+    const initialStats = readyStats(50);
+    const refreshedSessions = ['s51', 's52', 's53'].map(readySession);
+    const refreshedStats: ShareReadyStats = {
+      ...readyStats(0),
+      count: refreshedSessions.length,
+      total_approved: refreshedSessions.length,
+      recommended_session_ids: ['s51'],
+      sessions: refreshedSessions,
+    };
+    mockInitialLoad(initialStats);
+    vi.mocked(api.shareReady)
+      .mockResolvedValueOnce(initialStats as Awaited<ReturnType<typeof api.shareReady>>)
+      .mockResolvedValueOnce(refreshedStats as Awaited<ReturnType<typeof api.shareReady>>);
+
+    render(
+      <MemoryRouter initialEntries={['/share?step=done&share=completed-share']}>
+        <ToastProvider><Share /></ToastProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Your bundle is ready' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Start a new bundle' }));
+
+    await waitFor(() => expect(api.shareReady).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText(/Nothing is preselected/)).toBeInTheDocument();
+    const replacement = screen.getByRole('checkbox', { name: 'Include trace: Trace s51' });
+    expect(replacement).toBeEnabled();
+
+    fireEvent.click(replacement);
+    expect(await screen.findByText('1 trace selected')).toBeInTheDocument();
+    expect(replacement).toBeChecked();
   });
 
   it('sanitizes duplicate and ineligible ids from deep links after ready state loads', async () => {

--- a/clawjournal/web/frontend/src/views/Share/index.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.test.tsx
@@ -154,7 +154,28 @@ describe('Share selection defaults', () => {
     });
   });
 
-  it('bounds large-history rendering while retaining and confirming the full selection', async () => {
+  it('caps bulk selection at 50 traces', async () => {
+    mockInitialLoad(readyStats(75));
+
+    render(
+      <MemoryRouter initialEntries={['/share?ids=']}>
+        <ToastProvider><Share /></ToastProvider>
+        <LocationProbe />
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Nothing is preselected/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Select first 50 (50 max)' }));
+
+    expect(await screen.findByText('50 traces selected')).toBeInTheDocument();
+    await waitFor(() => {
+      const params = new URLSearchParams(screen.getByTestId('location-search').textContent || '');
+      expect(params.get('selection')).toBe('all');
+      expect(params.has('ids')).toBe(false);
+    });
+  });
+
+  it('caps a large eligible history at 50 selected traces while keeping the rest browsable', async () => {
     mockInitialLoad(readyStats(125));
 
     render(
@@ -163,16 +184,22 @@ describe('Share selection defaults', () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText('125 traces selected')).toBeInTheDocument();
+    expect(await screen.findByText('50 traces selected')).toBeInTheDocument();
     expect(screen.getAllByRole('checkbox', { name: /Include trace:/ })).toHaveLength(50);
     expect(screen.getByText(/Showing 50 of 125 matching traces/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: '50 trace limit reached' })).toBeDisabled();
 
     fireEvent.click(screen.getByRole('button', { name: /Show 50 more/ }));
     expect(screen.getAllByRole('checkbox', { name: /Include trace:/ })).toHaveLength(100);
+    expect(screen.getByRole('checkbox', { name: 'Include trace: Trace s51' })).toBeDisabled();
 
-    fireEvent.click(screen.getByRole('button', { name: 'Redact & review' }));
-    expect(screen.getByRole('dialog', { name: 'Review large bundle?' })).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: 'Redact 125 traces' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Include trace: Trace s1' }));
+    await waitFor(() => {
+      expect(screen.getByRole('checkbox', { name: 'Include trace: Trace s51' })).toBeEnabled();
+    });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Include trace: Trace s51' }));
+    expect(await screen.findByText('50 traces selected')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Include trace: Trace s51' })).toBeChecked();
   });
 
   it('sanitizes duplicate and ineligible ids from deep links after ready state loads', async () => {
@@ -221,7 +248,7 @@ describe('Share selection defaults', () => {
     await waitFor(() => expect(screen.getByTestId('location-search')).toHaveTextContent('ids=s1'));
   });
 
-  it('gates a large Redact deep link before any redaction or AI review starts', async () => {
+  it('caps the default queue before rejecting an unlocked Redact deep link', async () => {
     mockInitialLoad(readyStats(125));
     const redactionSpy = vi.spyOn(api.sessions, 'redactionReport');
 
@@ -231,12 +258,8 @@ describe('Share selection defaults', () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText('125 traces selected')).toBeInTheDocument();
+    expect(await screen.findByText('50 traces selected')).toBeInTheDocument();
     expect(screen.getByRole('heading', { name: 'What would you like to share?' })).toBeInTheDocument();
-    expect(redactionSpy).not.toHaveBeenCalled();
-
-    fireEvent.click(screen.getByRole('button', { name: 'Redact & review' }));
-    expect(screen.getByRole('dialog', { name: 'Review large bundle?' })).toBeInTheDocument();
     expect(redactionSpy).not.toHaveBeenCalled();
   });
 
@@ -312,11 +335,8 @@ describe('Share selection defaults', () => {
     expect(redactionSpy.mock.calls.every(([, options]) => options?.aiPii === true)).toBe(true);
   });
 
-  it('stores a large locked snapshot by reference without adding a newly eligible trace', async () => {
-    const ids = Array.from(
-      { length: 800 },
-      (_, index) => `session-${index.toString().padStart(4, '0')}-${'x'.repeat(64)}`,
-    );
+  it('locks only the capped 50-trace snapshot without adding a newly eligible trace', async () => {
+    const ids = Array.from({ length: 80 }, (_, index) => `session-${index.toString().padStart(4, '0')}`);
     const stats: ShareReadyStats = {
       ...readyStats(0),
       count: ids.length,
@@ -336,22 +356,19 @@ describe('Share selection defaults', () => {
       </MemoryRouter>,
     );
 
-    expect(await screen.findByText('800 traces selected')).toBeInTheDocument();
+    expect(await screen.findByText('50 traces selected')).toBeInTheDocument();
     fireEvent.click(screen.getByRole('button', { name: 'Redact & review' }));
-    fireEvent.click(screen.getByRole('button', { name: 'Redact 800 traces' }));
 
     let lockedSearch = '';
-    let lockedRef = '';
     await waitFor(() => {
       lockedSearch = screen.getByTestId('location-search').textContent || '';
       const params = new URLSearchParams(lockedSearch);
       expect(params.get('step')).toBe('redact');
       expect(params.get('selection')).toBe('locked');
-      lockedRef = params.get('queue_ref') || '';
-      expect(lockedRef).not.toBe('');
-      expect(params.has('ids')).toBe(false);
+      expect((params.get('ids') || '').split(',')).toEqual(ids.slice(0, 50));
+      expect(params.has('queue_ref')).toBe(false);
     });
-    expect(JSON.parse(window.localStorage.getItem(`clawjournal.share.queue.${lockedRef}`) || '[]')).toEqual(ids);
+    await waitFor(() => expect(redactionSpy).toHaveBeenCalledTimes(2));
 
     firstView.unmount();
     const newlyEligible = 'newly-eligible-trace';

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -146,7 +146,21 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
       ? new Set(queueSelectionFromSearchParams(searchParams, [], queueStorage) || [])
       : null
   ));
-  const queueSet = useMemo(() => new Set(queueOrder), [queueOrder]);
+  const eligibleQueueOrder = useMemo(
+    () => readyStats
+      ? sanitizeQueueSelection(readyStats, queueOrder)
+      : [...new Set(queueOrder)].slice(0, MAX_SHARE_QUEUE_SIZE),
+    [readyStats, queueOrder],
+  );
+  const queueSet = useMemo(() => new Set(eligibleQueueOrder), [eligibleQueueOrder]);
+
+  // Eligibility can shrink after a successful share or a hold/config refresh.
+  // Keep the stored queue canonical so stale IDs never consume the 50 slots.
+  useEffect(() => {
+    const unchanged = queueOrder.length === eligibleQueueOrder.length
+      && queueOrder.every((id, index) => id === eligibleQueueOrder[index]);
+    if (!unchanged) setQueueOrder(eligibleQueueOrder);
+  }, [eligibleQueueOrder, queueOrder]);
 
   const [note, setNote] = useState(() => searchParams.get('note') || '');
   const [aiPiiEnabled, setAiPiiEnabled] = useState(() => searchParams.get('ai_pii') === '1');
@@ -367,7 +381,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
       else next.set('step', activeStep);
       if (selectionInitialized) {
         const defaultQueue = !locked && readyStats ? queueFromStats(readyStats) : null;
-        syncQueueSelectionToSearchParams(next, queueOrder, defaultQueue, queueStorage);
+        syncQueueSelectionToSearchParams(next, eligibleQueueOrder, defaultQueue, queueStorage);
         if (locked) next.set('selection', 'locked');
       }
       if (note) next.set('note', note); else next.delete('note');
@@ -376,7 +390,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
       internalSearchRef.current = next.toString();
       return next;
     }, { replace: true });
-  }, [activeStep, queueOrder, selectionInitialized, selectionLocked, readyStats, queueStorage, note, aiPiiEnabled, packagedShareId, setSearchParams]);
+  }, [activeStep, eligibleQueueOrder, selectionInitialized, selectionLocked, readyStats, queueStorage, note, aiPiiEnabled, packagedShareId, setSearchParams]);
 
   // Drop cached redacted entries when sessions leave the queue.
   useEffect(() => {
@@ -421,11 +435,11 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
   }, [readyStats]);
 
   const queuedSessions = useMemo(
-    () => queueOrder.map((id) => sessionById[id]).filter((s): s is ReadySession => !!s),
-    [queueOrder, sessionById],
+    () => eligibleQueueOrder.map((id) => sessionById[id]).filter((s): s is ReadySession => !!s),
+    [eligibleQueueOrder, sessionById],
   );
   const confirmedLargeQueueCoversCurrent = confirmedLargeQueueIds !== null
-    && queueOrder.every((id) => confirmedLargeQueueIds.has(id));
+    && eligibleQueueOrder.every((id) => confirmedLargeQueueIds.has(id));
   const largeBundleNeedsConfirmation = queuedSessions.length > LARGE_BUNDLE_CONFIRM_THRESHOLD
     && !confirmedLargeQueueCoversCurrent;
   // Only a locked exact-ID snapshot can restore an unpackaged downstream step.
@@ -514,29 +528,32 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
 
   const removeFromQueue = (id: string) => {
     cancelAiRetries();
-    const next = queueOrder.filter((x) => x !== id);
+    const next = eligibleQueueOrder.filter((x) => x !== id);
     setQueueOrder(next);
   };
 
   const addToQueue = (id: string) => {
-    if (!queueOrder.includes(id) && queueOrder.length >= MAX_SHARE_QUEUE_SIZE) {
+    if (!eligibleQueueOrder.includes(id) && eligibleQueueOrder.length >= MAX_SHARE_QUEUE_SIZE) {
       toast(`A share can include at most ${MAX_SHARE_QUEUE_SIZE} traces. Remove one before adding another.`, 'error');
       return;
     }
     cancelAiRetries();
     setQueueOrder((prev) => {
-      if (prev.includes(id)) return prev;
-      if (prev.length >= MAX_SHARE_QUEUE_SIZE) return prev;
+      const current = readyStats
+        ? sanitizeQueueSelection(readyStats, prev)
+        : [...new Set(prev)].slice(0, MAX_SHARE_QUEUE_SIZE);
+      if (current.includes(id)) return current;
+      if (current.length >= MAX_SHARE_QUEUE_SIZE) return current;
       const defaults = readyStats ? queueFromStats(readyStats) : [];
-      const previousIds = new Set(prev);
+      const previousIds = new Set(current);
       const defaultOrderedSubset = defaults.filter((sessionId) => previousIds.has(sessionId));
-      const followsDefaultOrder = defaultOrderedSubset.length === prev.length
-        && defaultOrderedSubset.every((sessionId, index) => sessionId === prev[index]);
+      const followsDefaultOrder = defaultOrderedSubset.length === current.length
+        && defaultOrderedSubset.every((sessionId, index) => sessionId === current[index]);
       if (followsDefaultOrder && defaults.includes(id)) {
         previousIds.add(id);
         return defaults.filter((sessionId) => previousIds.has(sessionId));
       }
-      return [...prev, id];
+      return [...current, id];
     });
   };
 
@@ -550,39 +567,31 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
 
   const addManyToQueue = (ids: string[]) => {
     if (ids.length === 0) return;
-    const currentIds = new Set(queueOrder);
-    const uniqueNewIds = [...new Set(ids)].filter((id) => !currentIds.has(id));
-    const remainingSlots = Math.max(0, MAX_SHARE_QUEUE_SIZE - queueOrder.length);
-    if (uniqueNewIds.length > remainingSlots) {
-      toast(
-        remainingSlots > 0
-          ? `Added ${remainingSlots} traces. A share can include at most ${MAX_SHARE_QUEUE_SIZE}.`
-          : `A share can include at most ${MAX_SHARE_QUEUE_SIZE} traces. Remove one before adding another.`,
-        'error',
-      );
-    }
     cancelAiRetries();
     setQueueOrder((prev) => {
+      const current = readyStats
+        ? sanitizeQueueSelection(readyStats, prev)
+        : [...new Set(prev)].slice(0, MAX_SHARE_QUEUE_SIZE);
       const defaults = readyStats ? queueFromStats(readyStats) : [];
       const defaultIds = new Set(defaults);
-      const selectedIds = new Set(prev);
-      const availableSlots = Math.max(0, MAX_SHARE_QUEUE_SIZE - prev.length);
+      const selectedIds = new Set(current);
+      const availableSlots = Math.max(0, MAX_SHARE_QUEUE_SIZE - current.length);
       const newIds = [...new Set(ids)]
         .filter((id) => !selectedIds.has(id))
         .slice(0, availableSlots);
-      if (newIds.length === 0) return prev;
+      if (newIds.length === 0) return current;
 
       // Keep the compact default order only while the user has not manually
       // reordered the queue. Once the order is custom, batch additions must
       // behave like single additions and leave the existing sequence intact.
       const defaultOrderedSubset = defaults.filter((id) => selectedIds.has(id));
-      const followsDefaultOrder = defaultOrderedSubset.length === prev.length
-        && defaultOrderedSubset.every((id, index) => id === prev[index]);
+      const followsDefaultOrder = defaultOrderedSubset.length === current.length
+        && defaultOrderedSubset.every((id, index) => id === current[index]);
       if (followsDefaultOrder && newIds.every((id) => defaultIds.has(id))) {
         newIds.forEach((id) => selectedIds.add(id));
         return defaults.filter((id) => selectedIds.has(id));
       }
-      return [...prev, ...newIds];
+      return [...current, ...newIds];
     });
   };
 
@@ -843,7 +852,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
   const handleStartRedaction = () => {
     // Confirmation covers this exact set and any later subset (for example,
     // removing a blocked trace during review), but never newly added traces.
-    setConfirmedLargeQueueIds(new Set(queueOrder));
+    setConfirmedLargeQueueIds(new Set(eligibleQueueOrder));
     lockQueueSelection();
     setCompletedKeys((prev) => new Set([...prev, 'queue']));
     setActiveStep('redact');
@@ -1272,7 +1281,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
         shares={shares}
         candidates={candidates}
         scoringBackend={scoringBackend}
-        queueOrder={queueOrder}
+        queueOrder={eligibleQueueOrder}
         queuedSessions={queuedSessions}
         note={note}
         setNote={setNote}

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -7,6 +7,7 @@ import { Spinner } from '../../components/Spinner.tsx';
 import { Stepper } from '../../components/Stepper.tsx';
 import {
   LARGE_BUNDLE_CONFIRM_THRESHOLD,
+  MAX_SHARE_QUEUE_SIZE,
   STEPS,
 } from './types.ts';
 import type {
@@ -518,9 +519,14 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
   };
 
   const addToQueue = (id: string) => {
+    if (!queueOrder.includes(id) && queueOrder.length >= MAX_SHARE_QUEUE_SIZE) {
+      toast(`A share can include at most ${MAX_SHARE_QUEUE_SIZE} traces. Remove one before adding another.`, 'error');
+      return;
+    }
     cancelAiRetries();
     setQueueOrder((prev) => {
       if (prev.includes(id)) return prev;
+      if (prev.length >= MAX_SHARE_QUEUE_SIZE) return prev;
       const defaults = readyStats ? queueFromStats(readyStats) : [];
       const previousIds = new Set(prev);
       const defaultOrderedSubset = defaults.filter((sessionId) => previousIds.has(sessionId));
@@ -534,9 +540,9 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
     });
   };
 
-  // Batch selection helpers. With 1000s of eligible sessions, unchecking traces
-  // one at a time is impractical, so the queue exposes select-all / deselect-all
-  // controls (scoped to whatever filters are active in the picker).
+  // Batch selection helpers fill only the remaining slots in the bounded
+  // queue. Filters still make it practical to swap among 1000s of eligible
+  // sessions without ever selecting the full local corpus.
   const clearQueue = () => {
     cancelAiRetries();
     setQueueOrder([]);
@@ -544,12 +550,26 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
 
   const addManyToQueue = (ids: string[]) => {
     if (ids.length === 0) return;
+    const currentIds = new Set(queueOrder);
+    const uniqueNewIds = [...new Set(ids)].filter((id) => !currentIds.has(id));
+    const remainingSlots = Math.max(0, MAX_SHARE_QUEUE_SIZE - queueOrder.length);
+    if (uniqueNewIds.length > remainingSlots) {
+      toast(
+        remainingSlots > 0
+          ? `Added ${remainingSlots} traces. A share can include at most ${MAX_SHARE_QUEUE_SIZE}.`
+          : `A share can include at most ${MAX_SHARE_QUEUE_SIZE} traces. Remove one before adding another.`,
+        'error',
+      );
+    }
     cancelAiRetries();
     setQueueOrder((prev) => {
       const defaults = readyStats ? queueFromStats(readyStats) : [];
       const defaultIds = new Set(defaults);
       const selectedIds = new Set(prev);
-      const newIds = ids.filter((id) => !selectedIds.has(id));
+      const availableSlots = Math.max(0, MAX_SHARE_QUEUE_SIZE - prev.length);
+      const newIds = [...new Set(ids)]
+        .filter((id) => !selectedIds.has(id))
+        .slice(0, availableSlots);
       if (newIds.length === 0) return prev;
 
       // Keep the compact default order only while the user has not manually

--- a/clawjournal/web/frontend/src/views/Share/types.ts
+++ b/clawjournal/web/frontend/src/views/Share/types.ts
@@ -136,4 +136,5 @@ export interface RedactedSessionData {
 }
 
 export const CONFIDENCE_THRESHOLD = 0.85;
+export const MAX_SHARE_QUEUE_SIZE = 50;
 export const LARGE_BUNDLE_CONFIRM_THRESHOLD = 100;


### PR DESCRIPTION
## Summary

Cap the Share workbench queue at 50 traces while keeping the full eligible session pool browsable.

## Root cause

The Share queue defaulted to every eligible local trace. For users with thousands of indexed sessions, opening Share immediately selected the entire corpus and made review, redaction, and packaging impractical.

## Changes

* preselect only the top 50 ranked eligible traces
* cap restored URL selections, individual additions, and batch additions at 50
* keep remaining eligible traces visible in the picker so users can remove one selected trace and add another
* prune stale queue IDs whenever eligibility refreshes so completed shares do not consume slots in the next bundle
* treat the advertised capped bulk action as normal behavior without an error toast
* show accurate picker guidance about selected and swappable traces
* add regression coverage for defaults, explicit URLs, bulk selection, eligibility refreshes, limit state, swapping traces, and locked snapshots

## Validation

* `npm run test` — 52 tests passed
* focused ESLint on the changed Share files — passed
* `npm run build` — TypeScript and Vite production build passed
* Share queue state prebuild check — passed
