### PR TITLE
fix(share): stop redaction stalling forever; back off the scanner

### DIFF
--- a/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
+++ b/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
@@ -150,7 +150,19 @@ assert.match(shareIndex, /isRedactionRetryActive\(redactionRetryRef\.current, id
 assert.match(shareIndex, /signal: run\.controller\.signal/);
 assert.match(shareIndex, /cancelRedactionRetries\(redactionRetryRef\.current\)/);
 assert.match(shareIndex, /if \(activeStep !== 'review'\) cancelAiRetries\(\)/);
-assert.match(shareIndex, /\[queuedSessions, aiPiiEnabled, cancelAiRetries\]/);
+// Cancel on a real queue change, not on a re-derived-but-equal array. Keying
+// these on `queuedSessions` identity aborted the run that had just started,
+// because `queueOrder` syncs to `eligibleQueueOrder` one render later.
+assert.match(shareIndex, /\[queuedSessionKey, aiPiiEnabled, cancelAiRetries\]/);
+assert.match(shareIndex, /\[queuedSessionKey, aiPiiEnabled, cancelRedaction\]/);
+assert.match(shareIndex, /const queuedSessionKey = useMemo\(/);
+// Staleness must be judged by the run's own abort signal, never by
+// `isActive()`. React applies updaters lazily, so an `isActive()` re-check
+// inside one runs after `finishRedactionRun` released the slot and would
+// discard a report that succeeded, pinning the trace at `loading` forever.
+assert.doesNotMatch(shareIndex, /setRedactedSessions\(\(prev\) => \{\s*if \(!isActive\(\)\) return prev;/);
+assert.match(shareIndex, /run\.controller\.signal\.aborted \? prev :/);
+assert.match(shareIndex, /settleFinishedRun\(/);
 assert.match(shareIndex, /\(\) => cancelRedactionRetries\(redactionRetryRef\.current\)/);
 assert.match(shareIndex, /const approvedSessions = useMemo\(/);
 assert.match(shareIndex, /approvedList=\{approvedSessions\}/);

--- a/clawjournal/web/frontend/src/views/Share/index.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.test.tsx
@@ -592,3 +592,35 @@ describe('Share selection defaults', () => {
     expect(onSubmittedShareChange).not.toHaveBeenCalledWith('second-share');
   });
 });
+
+describe('Redaction completion', () => {
+  it('settles every queued trace when reloading a locked redact deep link', async () => {
+    mockInitialLoad(readyStats(2));
+    const redactionSpy = vi.spyOn(api.sessions, 'redactionReport').mockImplementation(async (id) => ({
+      session_id: id,
+      redaction_count: 0,
+      redaction_log: [],
+      ai_pii_findings: [],
+      ai_coverage: 'full',
+      redacted_session: { messages: [] },
+    }) as unknown as Awaited<ReturnType<typeof api.sessions.redactionReport>>);
+
+    render(
+      <MemoryRouter initialEntries={['/share?step=redact&ids=s1,s2&selection=locked']}>
+        <ToastProvider><Share /></ToastProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByRole('heading', { name: 'Redacting your traces' })).toBeInTheDocument();
+
+    // The reports resolve, but the run releases its slot before React applies
+    // their state updates. Re-checking liveness inside the updater dropped
+    // them, pinning the trace at `loading` with no request left in flight.
+    await waitFor(() => {
+      expect(document.body.textContent || '').toContain('Redaction complete');
+    }, { timeout: 3000 });
+
+    // And it must settle without spinning: one report per queued trace.
+    expect(redactionSpy.mock.calls.map(([id]) => id)).toEqual(['s1', 's2']);
+  });
+});

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -44,6 +44,7 @@ import {
   beginRedactionRun,
   cancelRedactionRetries,
   cancelRedactionRun,
+  settleFinishedRun,
   finishRedactionRetry,
   finishRedactionRun,
   isRedactionRetryActive,
@@ -454,6 +455,15 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
     && (!lockedSelectionReady || largeBundleNeedsConfirmation)
     ? 'queue'
     : activeStep;
+  // Cancel redaction on a real queue change, never on a re-derived-but-equal
+  // one. `queuedSessions` is rebuilt whenever `queueOrder` syncs to
+  // `eligibleQueueOrder`, which happens one render after redaction starts — so
+  // keying the cancel effects on array identity aborted the run that had just
+  // begun and discarded the reports it had already fetched.
+  const queuedSessionKey = useMemo(
+    () => queuedSessions.map((s) => s.session_id).join(','),
+    [queuedSessions],
+  );
   const approvedSessions = useMemo(
     () => queuedSessions.filter((s) => approvedIds.has(s.session_id)),
     [queuedSessions, approvedIds],
@@ -706,7 +716,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
 
   useEffect(() => {
     cancelRedaction();
-  }, [queuedSessions, aiPiiEnabled, cancelRedaction]);
+  }, [queuedSessionKey, aiPiiEnabled, cancelRedaction]);
 
   useEffect(() => () => cancelRedaction(), [cancelRedaction]);
 
@@ -716,7 +726,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
 
   useEffect(() => {
     cancelAiRetries();
-  }, [queuedSessions, aiPiiEnabled, cancelAiRetries]);
+  }, [queuedSessionKey, aiPiiEnabled, cancelAiRetries]);
 
   useEffect(() => () => cancelRedactionRetries(redactionRetryRef.current), []);
 
@@ -732,9 +742,8 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
     });
 
     // mark missing ones as loading up-front so the per-trace list renders
-    if (missing.length > 0) {
+    if (missing.length > 0 && isActive()) {
       setRedactedSessions((prev) => {
-        if (!isActive()) return prev;
         const next = { ...prev };
         missing.forEach((s) => {
           if (!next[s.session_id]) next[s.session_id] = { messages: [], loading: true };
@@ -786,39 +795,40 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
         const trufflehogHits = (report.redaction_log || [])
           .filter((entry) => entry.type && entry.type.startsWith('trufflehog'))
           .length;
-        setRedactedSessions((prev) => {
-          if (!isActive()) return prev;
-          return {
-            ...prev,
-            [s.session_id]: {
-              messages: msgs, loading: false,
-              redactionCount: report.redaction_count,
-              aiPiiFindings: report.ai_pii_findings || [],
-              aiCoverage: report.ai_coverage || (aiPiiEnabled ? 'rules_only' : 'disabled'),
-              buckets,
-              trufflehogHits,
-            },
-          };
-        });
+        // Test the run's own abort signal, not `isActive()`. React applies
+        // updaters lazily at render time, by which point the run has usually
+        // finished and `finishRedactionRun` has released the slot — so
+        // `isActive()` reads false for a run that completed perfectly well and
+        // would discard its report, pinning the trace at `loading` with
+        // nothing left to fetch it again. The abort signal is scoped to this
+        // run, so it still rejects writes from a superseded one.
+        setRedactedSessions((prev) => (run.controller.signal.aborted ? prev : {
+          ...prev,
+          [s.session_id]: {
+            messages: msgs, loading: false,
+            redactionCount: report.redaction_count,
+            aiPiiFindings: report.ai_pii_findings || [],
+            aiCoverage: report.ai_coverage || (aiPiiEnabled ? 'rules_only' : 'disabled'),
+            buckets,
+            trufflehogHits,
+          },
+        }));
       } catch (error) {
         // A browser deadline is a queue-level stop condition. Let the outer
         // loop abort its sibling request and settle every unstarted trace
         // instead of spending another full deadline on each later batch.
         if (error instanceof ApiError && error.status === 408) throw error;
         if (!isActive()) return;
-        setRedactedSessions((prev) => {
-          if (!isActive()) return prev;
-          return {
-            ...prev,
-            [s.session_id]: {
-              messages: [{ role: 'system', content: '(unable to load redacted content)' }],
-              loading: false,
-              redactionCount: 0,
-              aiCoverage: aiPiiEnabled ? 'rules_only' : 'disabled',
-              buckets: emptyBuckets(),
-            },
-          };
-        });
+        setRedactedSessions((prev) => (run.controller.signal.aborted ? prev : {
+          ...prev,
+          [s.session_id]: {
+            messages: [{ role: 'system', content: '(unable to load redacted content)' }],
+            loading: false,
+            redactionCount: 0,
+            aiCoverage: aiPiiEnabled ? 'rules_only' : 'disabled',
+            buckets: emptyBuckets(),
+          },
+        }));
       }
     };
 
@@ -846,6 +856,15 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
       }
     } finally {
       finishRedactionRun(redactionRunRef, run);
+      // A canceled run abandons its reports without settling them. Hand those
+      // traces back as outstanding so the kick-off effect re-evaluates and
+      // refetches them instead of leaving them spinning with no request in
+      // flight — unless a successor run already owns the slot and is doing so.
+      setRedactedSessions((prev) => settleFinishedRun(
+        redactionRunRef,
+        prev,
+        missing.map((session) => session.session_id),
+      ));
     }
   }, [queuedSessions, redactedSessions, aiPiiEnabled, toast]);
 

--- a/clawjournal/web/frontend/src/views/Share/redactionRun.test.ts
+++ b/clawjournal/web/frontend/src/views/Share/redactionRun.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  beginRedactionRun,
+  cancelRedactionRun,
+  clearInterruptedRedactionEntries,
+  finishRedactionRun,
+  isRedactionRunActive,
+  settleFinishedRun,
+  settlePendingRedactionEntries,
+} from './redactionRun.ts';
+import type { RedactionRunSlot } from './redactionRun.ts';
+
+interface Entry {
+  loading: boolean;
+  tag?: string;
+}
+
+const loading = (): Entry => ({ loading: true });
+const done = (tag: string): Entry => ({ loading: false, tag });
+
+describe('clearInterruptedRedactionEntries', () => {
+  it('drops traces a canceled run left mid-flight so the next run refetches them', () => {
+    const entries: Record<string, Entry> = { s1: done('ok'), s2: loading() };
+
+    const next = clearInterruptedRedactionEntries(entries, ['s1', 's2']);
+
+    expect(next).not.toBe(entries);
+    expect(next.s1).toEqual(done('ok'));
+    expect('s2' in next).toBe(false);
+  });
+
+  it('returns the same map when nothing was left loading', () => {
+    const entries: Record<string, Entry> = { s1: done('ok'), s2: done('ok') };
+
+    // Identity matters: a fresh object here would re-trigger the kick-off
+    // effect on every completed run and refetch traces that already settled.
+    expect(clearInterruptedRedactionEntries(entries, ['s1', 's2'])).toBe(entries);
+  });
+
+  it('leaves traces outside the finished run untouched', () => {
+    const entries: Record<string, Entry> = { s1: loading(), s2: loading() };
+
+    const next = clearInterruptedRedactionEntries(entries, ['s1']);
+
+    expect('s1' in next).toBe(false);
+    expect(next.s2).toEqual(loading());
+  });
+
+  it('ignores ids with no entry', () => {
+    const entries: Record<string, Entry> = { s1: done('ok') };
+
+    expect(clearInterruptedRedactionEntries(entries, ['missing'])).toBe(entries);
+  });
+
+  it('hands back traces a canceled run abandoned, so the next run refetches', () => {
+    const slot: RedactionRunSlot = { current: null };
+    const run = beginRedactionRun(slot)!;
+    const entries: Record<string, Entry> = { s1: done('ok'), s2: loading() };
+
+    cancelRedactionRun(slot);
+    expect(isRedactionRunActive(slot, run)).toBe(false);
+    finishRedactionRun(slot, run);
+
+    const next = settleFinishedRun(slot, entries, ['s1', 's2']);
+
+    expect(next.s1).toEqual(done('ok'));
+    expect('s2' in next).toBe(false);
+    expect(Object.values(next).every((entry) => !entry.loading)).toBe(true);
+  });
+
+  it('leaves the map alone while a successor run owns the slot', () => {
+    // The successor is already refetching these traces; clearing them here
+    // would race it into a duplicate request.
+    const slot: RedactionRunSlot = { current: null };
+    const first = beginRedactionRun(slot)!;
+    const entries: Record<string, Entry> = { s1: done('ok'), s2: loading() };
+
+    cancelRedactionRun(slot);
+    const second = beginRedactionRun(slot);
+    finishRedactionRun(slot, first);
+
+    expect(slot.current).toBe(second);
+    expect(settleFinishedRun(slot, entries, ['s1', 's2'])).toBe(entries);
+  });
+
+  it('is a no-op for a run that completed normally', () => {
+    const slot: RedactionRunSlot = { current: null };
+    const run = beginRedactionRun(slot)!;
+    const entries: Record<string, Entry> = { s1: done('ok'), s2: done('ok') };
+
+    finishRedactionRun(slot, run);
+
+    expect(settleFinishedRun(slot, entries, ['s1', 's2'])).toBe(entries);
+  });
+});
+
+describe('settlePendingRedactionEntries', () => {
+  it('settles only entries that never finished', () => {
+    const entries: Record<string, Entry> = { s1: done('ok'), s2: loading() };
+
+    const next = settlePendingRedactionEntries(entries, ['s1', 's2'], done('timeout'));
+
+    expect(next.s1).toEqual(done('ok'));
+    expect(next.s2).toEqual(done('timeout'));
+  });
+});

--- a/clawjournal/web/frontend/src/views/Share/redactionRun.ts
+++ b/clawjournal/web/frontend/src/views/Share/redactionRun.ts
@@ -66,6 +66,46 @@ export function finishRedactionRetry(
   if (slot.current.get(sessionId) === run) slot.current.delete(sessionId);
 }
 
+/** Drop entries a canceled run left mid-flight so the next run refetches them.
+ *
+ * A canceled run abandons its in-flight reports without settling them, which
+ * pins those traces at `loading: true` forever: the kick-off effect still sees
+ * them as outstanding, but nothing it depends on has changed, so it never
+ * re-evaluates and no request is ever issued again. Removing the entries both
+ * changes the map's identity (waking that effect) and marks the traces as
+ * missing (so the next run fetches them) — a run that ends must never leave a
+ * trace stuck loading.
+ */
+export function clearInterruptedRedactionEntries<T extends { loading: boolean }>(
+  entries: Record<string, T>,
+  sessionIds: readonly string[],
+): Record<string, T> {
+  let changed = false;
+  const next = { ...entries };
+  for (const sessionId of sessionIds) {
+    if (next[sessionId]?.loading) {
+      delete next[sessionId];
+      changed = true;
+    }
+  }
+  return changed ? next : entries;
+}
+
+/** Reconcile the entry map when a run ends, from that run's point of view.
+ *
+ * A successor run holding the slot is already refetching these traces, so the
+ * map is left untouched rather than raced into a duplicate request. Otherwise
+ * anything this run abandoned mid-flight is handed back as outstanding.
+ */
+export function settleFinishedRun<T extends { loading: boolean }>(
+  slot: RedactionRunSlot,
+  entries: Record<string, T>,
+  sessionIds: readonly string[],
+): Record<string, T> {
+  if (slot.current) return entries;
+  return clearInterruptedRedactionEntries(entries, sessionIds);
+}
+
 export function settlePendingRedactionEntries<T extends { loading: boolean }>(
   entries: Record<string, T>,
   sessionIds: readonly string[],

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -284,6 +284,15 @@ def _log_strict_scan_failure(*, source: str, stage: str, code: str) -> None:
 
 DEFAULT_PORT = 8384
 SCAN_INTERVAL = 60  # seconds
+# A scan pass over a large corpus can take longer than SCAN_INTERVAL. Waiting a
+# flat interval after such a tick leaves the scanner running nearly
+# back-to-back, which pins a core and churns the session list the workbench is
+# rendering. Back off to at least the tick's own duration, which holds scanning
+# to half the loop's wall-clock for any pass up to MAX_SCAN_BACKOFF. Past that
+# the cap wins and the duty cycle climbs again — a deliberate trade so a
+# pathologically slow corpus still gets rechecked a few times an hour rather
+# than falling arbitrarily far behind.
+MAX_SCAN_BACKOFF = 900  # seconds
 AUTO_SCORE_BATCH_SIZE = 20
 _NO_MATCHING_WARMUP_SOURCE = "__clawjournal_no_matching_warmup_source__"
 SCORING_DISPLAY_NAMES = {
@@ -579,6 +588,19 @@ def _maybe_create_trace_note(conn: sqlite3.Connection, session_id: str) -> None:
             logger.debug("created trace note at %s", created)
     except Exception:
         logger.exception("Failed to create trace note for %s", session_id)
+
+
+def _next_scan_delay(elapsed_seconds: float) -> float:
+    """Return how long the background scanner should idle after a pass.
+
+    A pass that finishes within ``SCAN_INTERVAL`` keeps the normal cadence. A
+    slower pass — large corpora routinely exceed a minute — idles for at least
+    its own duration so scanning never occupies more than half the loop's
+    wall-clock, bounded by ``MAX_SCAN_BACKOFF``.
+    """
+    if not elapsed_seconds or elapsed_seconds <= SCAN_INTERVAL:
+        return SCAN_INTERVAL
+    return min(elapsed_seconds, MAX_SCAN_BACKOFF)
 
 
 class Scanner:
@@ -1113,10 +1135,13 @@ class Scanner:
 
     def _run(self) -> None:
         while not self._stop_event.is_set():
+            tick_started = time.monotonic()
             try:
                 results = self._scan_tick()
                 if results is None:
-                    self._stop_event.wait(SCAN_INTERVAL)
+                    self._stop_event.wait(
+                        _next_scan_delay(time.monotonic() - tick_started)
+                    )
                     continue
                 trigger_scoring_warmup(self)
                 total_new = sum(results.values())
@@ -1136,7 +1161,17 @@ class Scanner:
                     )
             except Exception:
                 logger.exception("Scanner error")
-            self._stop_event.wait(SCAN_INTERVAL)
+            elapsed = time.monotonic() - tick_started
+            delay = _next_scan_delay(elapsed)
+            if delay > SCAN_INTERVAL:
+                logger.info(
+                    "Scan pass took %.0fs (longer than the %ds interval); "
+                    "waiting %.0fs before the next pass",
+                    elapsed,
+                    SCAN_INTERVAL,
+                    delay,
+                )
+            self._stop_event.wait(delay)
 
 
 _LOCALHOST_ORIGINS = re.compile(r"^https?://(localhost|127\.0\.0\.1)(:\d+)?$")

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -27,11 +27,52 @@ from clawjournal.workbench.daemon import (
     _build_share_zip,
     _reload_child_command,
     _missing_ingest_url_error,
+    _next_scan_delay,
     _recurring_offer_available,
     _warn_if_frontend_stale,
     trigger_scoring_warmup,
 )
+from clawjournal.workbench.daemon import MAX_SCAN_BACKOFF, SCAN_INTERVAL
 from clawjournal.workbench.index import add_policy, open_index, set_hold_state, upsert_sessions
+
+
+@pytest.mark.parametrize(
+    "elapsed,expected",
+    [
+        (0.0, SCAN_INTERVAL),
+        (1.0, SCAN_INTERVAL),
+        (SCAN_INTERVAL, SCAN_INTERVAL),
+        (SCAN_INTERVAL + 0.5, SCAN_INTERVAL + 0.5),
+        (123.0, 123.0),
+        (MAX_SCAN_BACKOFF * 2, MAX_SCAN_BACKOFF),
+    ],
+)
+def test_next_scan_delay_backs_off_for_slow_passes(elapsed, expected):
+    """A pass slower than the interval idles at least as long as it ran."""
+    assert _next_scan_delay(elapsed) == expected
+
+
+def test_next_scan_delay_halves_duty_cycle_up_to_the_backoff_cap():
+    """Scanning stays at or below half the loop's wall-clock, up to the cap.
+
+    A 123s pass on a 60s interval previously idled a flat 60s, leaving the
+    daemon scanning ~67% of the time — enough to pin a core indefinitely.
+    """
+    for elapsed in (30.0, 60.0, 123.0, 400.0, float(MAX_SCAN_BACKOFF)):
+        cycle = elapsed + _next_scan_delay(elapsed)
+        assert elapsed / cycle <= 0.5
+
+
+def test_next_scan_delay_lets_duty_cycle_rise_past_the_backoff_cap():
+    """Past the cap the duty cycle climbs again, by design.
+
+    Idling proportionally forever would let a pathologically slow corpus fall
+    arbitrarily far behind, so the cap deliberately wins over the duty-cycle
+    target. This pins that trade so it is not mistaken for the guarantee above.
+    """
+    elapsed = float(MAX_SCAN_BACKOFF) * 3
+    assert _next_scan_delay(elapsed) == MAX_SCAN_BACKOFF
+    assert elapsed / (elapsed + _next_scan_delay(elapsed)) > 0.5
 
 
 def test_recurring_offer_uses_current_protocol_version():


### PR DESCRIPTION
Two independent bugs surfaced while redacting a 2-trace bundle: the Redact step sat at 50% indefinitely, and the daemon pinned a core.

## Redaction never completes

`processOne` judged staleness with `isActive()` **inside** the `setRedactedSessions` updater. React applies updaters lazily at render time, by which point the run's `finally` has called `finishRedactionRun` and released the slot — so `isActive()` read false for a run that had completed perfectly well, and its successfully fetched report was silently discarded.

The trace then stayed pinned at `loading: true` with no request in flight and nothing to issue another: the kick-off effect only re-runs when one of its dependencies changes, and the dropped write changed none of them. The UI spun forever while the browser made **zero** requests.

Staleness is now judged by the run's own `controller.signal.aborted`, which is scoped to the run rather than to slot ownership. It still rejects writes from a genuinely superseded run — the reason the guard exists, e.g. a mid-run AI-PII toggle must not have its old result land — without discarding the results of one that simply finished.

The backend was never implicated. Measured against the reported bundle:

| Measurement | Result |
|---|---|
| `apply_share_redactions` in-process (92k-token trace) | 0.22s |
| Same session via the live daemon's `/redaction-report` | 0.16s, HTTP 200 |
| Established TCP connections from the browser | 0 |

Two adjacent holes are closed alongside it, since either could stall the step on its own:

- The cancel effects keyed on `queuedSessions` **identity**, which is rebuilt one render after redaction starts when `queueOrder` syncs to `eligibleQueueOrder`. That aborted the run that had just begun. They now key on queue **contents** via `queuedSessionKey`.
- A canceled run abandoned its reports without settling them. `settleFinishedRun` hands those traces back as outstanding so the next run refetches them, unless a successor run already owns the slot and is doing so itself.

## Scanner pins a core

A scan pass over a large corpus (~1.4 GB locally) takes ~123s, but the loop always slept a flat `SCAN_INTERVAL` of 60s afterwards, leaving the daemon scanning ~67% of the time — observed as CPU alternating 0% → 98% with no idle gap.

`_next_scan_delay` now idles for at least the pass's own duration, holding scanning to half the loop's wall-clock for any pass up to `MAX_SCAN_BACKOFF`. Past that the cap wins and the duty cycle climbs again — a deliberate trade so a pathologically slow corpus still gets rechecked a few times an hour rather than falling arbitrarily far behind.

This also reduces churn in the session list the workbench renders, which is what kept re-arming the cancel path above.

## Tests

- A regression test reproduces the stall deterministically — on the previous code it issues both requests, both resolve, and the step still never reports complete.
- Unit tests cover `settleFinishedRun` / `clearInterruptedRedactionEntries`, including the successor-run case and the no-op-on-normal-completion case.
- Both sides of the backoff curve are pinned: the ≤50% duty cycle up to the cap, and the intentional rise past it.
- The share-queue guard script pins the new invariants, including a `doesNotMatch` so the `isActive()`-inside-updater regression can't return.

Full suite: 3,012 Python tests, 61 frontend tests, eslint clean, `npm run build` green.

## Reviewer notes

- `queuedSessionKey` is order-sensitive, so drag-reordering the queue still cancels redaction. Wasteful but not incorrect, and it matches prior behavior — with this fix the cancelled traces recover rather than stranding. A sorted key would avoid it; left alone as out of scope.
- The `doesNotMatch` guard is a whitespace-sensitive regex and pins today's formatting. The vitest regression test is the real protection.
- The scanner backoff treats a symptom. ~123s to scan 1.4 GB is worth investigating separately; this stops it pinning a core but doesn't make scanning faster.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TQVbXjz8rQaaodfeLV21Qx