### PR TITLE
feat(auto-upload): streamline recurring enrollment and remove the UI rollout gate

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -31,7 +31,7 @@ tests/
 - `clawjournal/export/`: renders export formats such as JSONL and Markdown.
 - `clawjournal/prompts/`: canonical runtime prompt assets used by scoring and PII review.
 - `clawjournal/auto_upload.py`: SQLite-owned recurring authorization state, candidate selection, cadence, exact-artifact sealing, crash recovery, and the fail-closed runner.
-- `clawjournal/auto_upload_client.py` and `auto_upload_credentials.py`: the typed hosted v1 protocol and purpose-separated private credential boundary.
+- `clawjournal/auto_upload_client.py` and `auto_upload_credentials.py`: the typed hosted v2 protocol and purpose-separated private credential boundary.
 - `clawjournal/agent_hooks.py`: semantics-preserving Claude Code/Codex `SessionStart` configuration plus the bounded due-check adapter.
 
 ## Data Flow
@@ -82,6 +82,7 @@ Optional self-hosted path:
 Optional hosted recurring path:
 
 - It remains unavailable unless hosted discovery advertises protocol v2 and the participant has a successful manual receipt.
+- A successful manual share may return a short-lived, single-use enrollment grant bound to that receipt and participant. The client prefers that grant for immediate enrollment and falls back to fresh email verification when it is unavailable, expired, or rejected.
 - Enrollment sends the explicit (source, project) scope entries and requires two distinct affirmative acts: the versioned recurring authorization/retention acceptance and the versioned ownership certification. The server computes and owns the scope hash; the client pins the value read back at enrollment and fails closed on any drift.
 - The local SQLite singleton owns mode, generation, accepted exact scope/profile, cadence, health, and run overlay. Private files own active/recovery credentials; `config.json` never does.
 - The hosted service owns versioned recurring authorization, credential hashes, exact-byte idempotency, cross-enrollment duplicate-revision rejection, storage, and receipts.

--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -44,6 +44,7 @@ from .auto_upload_client import (
     fetch_authorization,
     fetch_capabilities,
     get_enrollment,
+    grant_capability_version_supported,
     lookup_receipt,
     recovery_capabilities,
     revoke_enrollment,
@@ -58,7 +59,12 @@ from .auto_upload_credentials import (
     remove_active_token,
     write_credentials,
 )
-from .config import load_config, save_config, source_scope_sources
+from .config import (
+    RECURRING_ENROLLMENT_GRANT_CONFIG_KEYS,
+    load_config,
+    save_config,
+    source_scope_sources,
+)
 from .paths import atomic_write_text, ensure_hash_salt
 from .raw_sources import (
     RawFingerprint,
@@ -248,14 +254,6 @@ def _parse_expiry_time(value: Any) -> datetime | None:
         return None
 
 
-_RECURRING_ENROLLMENT_GRANT_CONFIG_KEYS = (
-    "recurring_enrollment_grant",
-    "recurring_enrollment_grant_expires_at",
-    "recurring_enrollment_grant_receipt_id",
-    "recurring_enrollment_grant_issuer",
-)
-
-
 def _available_recurring_enrollment_grant(
     config: Mapping[str, Any],
     *,
@@ -281,7 +279,7 @@ def _available_recurring_enrollment_grant(
         not grant
         or expires_at is None
         or expires_at <= _now() + timedelta(seconds=60)
-        or capability_version != MANUAL_SHARE_ENROLLMENT_GRANT_VERSION
+        or not grant_capability_version_supported(capability_version)
         or comparable_origin(issuer) != comparable_origin(origin)
     ):
         return None
@@ -289,13 +287,19 @@ def _available_recurring_enrollment_grant(
 
 
 def _configured_hosted_origin() -> str | None:
-    """The origin this install would enroll against, without a network call."""
+    """The origin this install would enroll against, without a network call.
+
+    The lazy import avoids a module-level cycle (daemon already imports this
+    module); RuntimeError is how ``_hosted_api_base`` reports a missing or
+    invalid share URL. Anything else should surface — a swallowed bug here
+    would silently report "no grant" forever.
+    """
 
     try:
         from .workbench.daemon import _hosted_api_base
 
         return _hosted_api_base()
-    except Exception:
+    except (ImportError, RuntimeError):
         return None
 
 
@@ -318,7 +322,7 @@ def _status_grant_available(config: Mapping[str, Any]) -> bool:
 
 
 def _remove_recurring_enrollment_grant(config: dict[str, Any]) -> None:
-    for key in _RECURRING_ENROLLMENT_GRANT_CONFIG_KEYS:
+    for key in RECURRING_ENROLLMENT_GRANT_CONFIG_KEYS:
         config.pop(key, None)
 
 
@@ -1554,10 +1558,17 @@ def enable(
                         "manual_share_enrollment_grant_version"
                     ),
                 )
-                if upload_token:
-                    sent_identity_kind = "upload_token"
-                elif enrollment_grant:
+                # Prefer the purpose-scoped enrollment grant: it exists only to
+                # authorize this enrollment, while verified_email_token is the
+                # manual-share credential — consuming the token here when a
+                # usable grant is idle would silently cost the user their next
+                # manual share and let the grant expire unused. If the server
+                # rejects the grant, the fallback below removes it and a retry
+                # finds the still-present token.
+                if enrollment_grant:
                     sent_identity_kind = "enrollment_grant"
+                elif upload_token:
+                    sent_identity_kind = "upload_token"
                 else:
                     raise AutoUploadError(
                         "email_verification_required",

--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -95,7 +95,6 @@ TELEMETRY_MAX_BYTES = 512 * 1024
 TELEMETRY_BACKUPS = 2
 SUPPORTED_HOOK_TARGETS = ("claude", "codex")
 HOOK_DB_BUSY_TIMEOUT_MS = 0
-AUTO_UPLOAD_UI_ENV = "CLAWJOURNAL_ENABLE_AUTO_UPLOAD_UI"
 _CONTROL_THREAD_LOCK = threading.Lock()
 
 # V1 supports only sources with both a SessionStart trigger and an audited,
@@ -611,35 +610,6 @@ def _has_successful_manual_receipt(conn: sqlite3.Connection) -> bool:
     )
 
 
-def _auto_upload_ui_visible(
-    config: Mapping[str, Any],
-    enrollment: Mapping[str, Any] | None = None,
-    *,
-    successful_manual_receipt: bool = False,
-) -> bool:
-    # A successful manual hosted share caches this non-authoritative offer bit
-    # only after the service advertises the current recurring-upload protocol.
-    # It is safe to use for visibility: Enable still revalidates the live
-    # capability document before granting any recurring authority.
-    hosted_offer_available = (
-        successful_manual_receipt
-        and config.get("auto_upload_capability_available") is True
-    )
-    explicitly_enabled = (
-        os.environ.get(AUTO_UPLOAD_UI_ENV) == "1"
-        or config.get("auto_upload_ui_enabled") is True
-    )
-    existing_authority = bool(
-        enrollment
-        and (
-            enrollment.get("mode") != "off"
-            or enrollment.get("server_enrollment_id")
-            or enrollment.get("revocation_pending")
-        )
-    )
-    return hosted_offer_available or explicitly_enabled or existing_authority
-
-
 def _off_status(config: Mapping[str, Any]) -> dict[str, Any]:
     hooks = []
     for target in SUPPORTED_HOOK_TARGETS:
@@ -653,7 +623,7 @@ def _off_status(config: Mapping[str, Any]) -> dict[str, Any]:
         "run_now_allowed": False,
         "overlay": None,
         "pending_submission_state": None,
-        "ui_visible": _auto_upload_ui_visible(config),
+        "ui_visible": True,
         "offer_available": False,
         "scope": {"sources": [], "projects": []},
         "cap": MAX_SESSIONS,
@@ -758,11 +728,7 @@ def status(*, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
             ),
             "overlay": overlay,
             "pending_submission_state": pending_submission_state,
-            "ui_visible": _auto_upload_ui_visible(
-                config,
-                enrollment,
-                successful_manual_receipt=successful_manual,
-            ),
+            "ui_visible": True,
             "offer_available": bool(
                 mode == "off"
                 and successful_manual

--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -259,9 +259,19 @@ _RECURRING_ENROLLMENT_GRANT_CONFIG_KEYS = (
 def _available_recurring_enrollment_grant(
     config: Mapping[str, Any],
     *,
-    origin: str | None = None,
+    origin: str,
     capability_version: Any = MANUAL_SHARE_ENROLLMENT_GRANT_VERSION,
 ) -> str | None:
+    """Return the cached grant only if it is usable against ``origin``.
+
+    ``origin`` is required rather than defaulted: a grant is authority to create
+    a recurring enrollment, and an optional binding is one a caller can forget.
+    ``capability_version`` does default to the supported version, because the
+    local status path has no discovery document to check it against and treats
+    ``enable`` as the authority; that default is permissive, so it must never
+    grow a second one beside it.
+    """
+
     grant = str(config.get("recurring_enrollment_grant") or "").strip()
     expires_at = _parse_expiry_time(
         config.get("recurring_enrollment_grant_expires_at")
@@ -272,10 +282,7 @@ def _available_recurring_enrollment_grant(
         or expires_at is None
         or expires_at <= _now() + timedelta(seconds=60)
         or capability_version != MANUAL_SHARE_ENROLLMENT_GRANT_VERSION
-        or (
-            origin is not None
-            and comparable_origin(issuer) != comparable_origin(origin)
-        )
+        or comparable_origin(issuer) != comparable_origin(origin)
     ):
         return None
     return grant

--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -225,6 +225,29 @@ def _parse_time(value: Any) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
+def _parse_expiry_time(value: Any) -> datetime | None:
+    """Parse config expiry values accepted by the manual-share boundary."""
+
+    parsed = _parse_time(value)
+    if parsed is not None:
+        return parsed
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, (int, float)):
+        timestamp = float(value)
+    elif isinstance(value, str) and value.strip():
+        try:
+            timestamp = float(value.strip())
+        except ValueError:
+            return None
+    else:
+        return None
+    try:
+        return datetime.fromtimestamp(timestamp, tz=timezone.utc)
+    except (OverflowError, OSError, ValueError):
+        return None
+
+
 _RECURRING_ENROLLMENT_GRANT_CONFIG_KEYS = (
     "recurring_enrollment_grant",
     "recurring_enrollment_grant_expires_at",
@@ -240,7 +263,9 @@ def _available_recurring_enrollment_grant(
     capability_version: Any = MANUAL_SHARE_ENROLLMENT_GRANT_VERSION,
 ) -> str | None:
     grant = str(config.get("recurring_enrollment_grant") or "").strip()
-    expires_at = _parse_time(config.get("recurring_enrollment_grant_expires_at"))
+    expires_at = _parse_expiry_time(
+        config.get("recurring_enrollment_grant_expires_at")
+    )
     issuer = str(config.get("recurring_enrollment_grant_issuer") or "").strip()
     if (
         not grant
@@ -1920,7 +1945,7 @@ def enable(
                     ambiguous=True,
                 )
             elif isinstance(exc, RecurringServiceError):
-                if (
+                enrollment_grant_rejected = (
                     sent_identity_kind == "enrollment_grant"
                     and not exc.ambiguous
                     and exc.code
@@ -1930,14 +1955,21 @@ def enable(
                         "credential_expired",
                         "credential_revoked",
                     }
-                ):
+                )
+                if enrollment_grant_rejected:
                     try:
                         failure_config = load_config()
                         _remove_recurring_enrollment_grant(failure_config)
                         save_config(failure_config)
                     except Exception:
                         pass
-                if updating and exc.code in {
+                if enrollment_grant_rejected:
+                    error = AutoUploadError(
+                        "email_verification_required",
+                        "The receipt-issued enrollment grant is unavailable. "
+                        "Verify your email to continue.",
+                    )
+                elif updating and exc.code in {
                     "credential_invalid",
                     "credential_expired",
                     "credential_revoked",

--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -34,6 +34,7 @@ from .agent_hooks import (
     uninstall_agent_hook,
 )
 from .auto_upload_client import (
+    MANUAL_SHARE_ENROLLMENT_GRANT_VERSION,
     MAX_SCOPE_ENTRIES,
     RECURRING_CADENCE_DAYS,
     CapabilityError,
@@ -222,6 +223,39 @@ def _parse_time(value: Any) -> datetime | None:
     if parsed.tzinfo is None:
         return None
     return parsed.astimezone(timezone.utc)
+
+
+_RECURRING_ENROLLMENT_GRANT_CONFIG_KEYS = (
+    "recurring_enrollment_grant",
+    "recurring_enrollment_grant_expires_at",
+    "recurring_enrollment_grant_receipt_id",
+    "recurring_enrollment_grant_issuer",
+)
+
+
+def _available_recurring_enrollment_grant(
+    config: Mapping[str, Any],
+    *,
+    origin: str | None = None,
+    capability_version: Any = MANUAL_SHARE_ENROLLMENT_GRANT_VERSION,
+) -> str | None:
+    grant = str(config.get("recurring_enrollment_grant") or "").strip()
+    expires_at = _parse_time(config.get("recurring_enrollment_grant_expires_at"))
+    issuer = str(config.get("recurring_enrollment_grant_issuer") or "").strip()
+    if (
+        not grant
+        or expires_at is None
+        or expires_at <= _now() + timedelta(seconds=60)
+        or capability_version != MANUAL_SHARE_ENROLLMENT_GRANT_VERSION
+        or (origin is not None and issuer != origin)
+    ):
+        return None
+    return grant
+
+
+def _remove_recurring_enrollment_grant(config: dict[str, Any]) -> None:
+    for key in _RECURRING_ENROLLMENT_GRANT_CONFIG_KEYS:
+        config.pop(key, None)
 
 
 def _due_at(enrollment: Mapping[str, Any]) -> datetime | None:
@@ -646,6 +680,9 @@ def _off_status(config: Mapping[str, Any]) -> dict[str, Any]:
         },
         "last_result": None,
         "generation": None,
+        "enrollment_grant_available": bool(
+            _available_recurring_enrollment_grant(config)
+        ),
     }
 
 
@@ -765,6 +802,9 @@ def status(*, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
             },
             "last_result": last_result,
             "generation": enrollment.get("generation") if enrollment else None,
+            "enrollment_grant_available": bool(
+                _available_recurring_enrollment_grant(config)
+            ),
         }
     finally:
         if own_connection:
@@ -937,8 +977,24 @@ def _authorization_challenge(
     return challenge
 
 
-def _hook_targets(agent: str) -> list[AgentName]:
+def _hook_targets(
+    agent: str,
+    *,
+    sources: Sequence[str] | None = None,
+) -> list[AgentName]:
     normalized = (agent or "all").strip().lower()
+    if normalized == "auto":
+        inferred = [
+            target
+            for target in SUPPORTED_HOOK_TARGETS
+            if target in set(sources or ())
+        ]
+        if inferred:
+            return inferred
+        raise AutoUploadError(
+            "invalid_hook_target",
+            "No supported SessionStart agent was found in the authorized scope.",
+        )
     if normalized == "all":
         return ["claude", "codex"]
     if normalized in SUPPORTED_HOOK_TARGETS:
@@ -1123,7 +1179,6 @@ def enable(
     to wait for a scan in another process.
     """
 
-    targets = _hook_targets(agent)
     lock_context: Any | None = None
     conn = open_index()
     try:
@@ -1146,6 +1201,7 @@ def enable(
                 "scope_blockers": scope["blockers"],
                 "unsupported_sources": scope["unsupported_sources"],
             }
+        targets = _hook_targets(agent, sources=scope["sources"])
         if not _has_successful_manual_receipt(conn):
             return AutoUploadError(
                 "manual_share_required",
@@ -1217,6 +1273,7 @@ def enable(
                 "message": "The refreshed source/project scope is not eligible.",
                 "scope_blockers": scope["blockers"],
             }
+        targets = _hook_targets(agent, sources=scope["sources"])
         challenge = _authorization_challenge(
             capabilities, terms, scope, ai_backend
         )
@@ -1404,9 +1461,11 @@ def enable(
         server_reauthorization_succeeded = False
         email_enrollment_may_have_committed = False
         recovery_only_written = False
+        create_identity_kind: str | None = None
         try:
             snapshots = _snapshot_hook_files(SUPPORTED_HOOK_TARGETS)
-            hook_results = install_hooks(agent=agent)
+            hook_agent = "all" if len(targets) > 1 else targets[0]
+            hook_results = install_hooks(agent=hook_agent)
             if not all(result.get("configured") for result in hook_results):
                 raise AutoUploadError(
                     "hook_install_failed",
@@ -1445,16 +1504,39 @@ def enable(
                         server_reauthorization_succeeded = True
                     raise
             else:
-                upload_token = str(config.get("verified_email_token") or "").strip()
-                if not upload_token:
+                identity_config = load_config()
+                upload_token = str(
+                    identity_config.get("verified_email_token") or ""
+                ).strip()
+                enrollment_grant = _available_recurring_enrollment_grant(
+                    identity_config,
+                    origin=str(capabilities["origin"]),
+                    capability_version=capabilities.get(
+                        "manual_share_enrollment_grant_version"
+                    ),
+                )
+                if upload_token:
+                    create_identity_kind = "upload_token"
+                elif enrollment_grant:
+                    create_identity_kind = "enrollment_grant"
+                else:
                     raise AutoUploadError(
                         "email_verification_required",
-                        "Verify your email again before creating a recurring enrollment.",
+                        "Verify your email before creating a recurring enrollment.",
                     )
                 try:
                     response = create_enrollment(
                         capabilities,
-                        upload_token=upload_token,
+                        upload_token=(
+                            upload_token
+                            if create_identity_kind == "upload_token"
+                            else None
+                        ),
+                        enrollment_grant=(
+                            enrollment_grant
+                            if create_identity_kind == "enrollment_grant"
+                            else None
+                        ),
                         client_enrollment_id=client_enrollment_id,
                         scope_entries=scope["entries"],
                         authorization_version=str(expected_auth),
@@ -1637,24 +1719,28 @@ def enable(
 
             config = load_config()
             config["auto_upload_capability_available"] = True
-            # Only the create / credential-rotation path sends the one-shot
-            # verified_email_token to the server; the non-rotating update path
-            # reuses the pinned active credential and never sends it. Deleting it
-            # there would silently destroy a still-valid manual-share credential
-            # the user just re-verified, so gate the removal to the paths that
-            # actually consumed it.
-            consumed_one_shot_token = not (updating and not rotating_credentials)
-            if consumed_one_shot_token:
+            # Remove only the purpose-scoped identity credential actually sent
+            # on create/rotation. A non-rotating PATCH uses the pinned active
+            # credential and must preserve any fresh manual-share token or
+            # receipt-issued enrollment grant.
+            if create_identity_kind == "upload_token":
                 config.pop("verified_email_token", None)
                 config.pop("verified_email_token_expires_at", None)
+            elif create_identity_kind == "enrollment_grant":
+                _remove_recurring_enrollment_grant(config)
             if save_config(config) is False:
                 raise AutoUploadError(
                     "config_persistence_failed",
                     "Recurring enrollment could not persist its local config safely.",
                 )
-            if consumed_one_shot_token:
+            if create_identity_kind is not None:
                 persisted_config = _load_config_readonly()
-                if persisted_config.get("verified_email_token"):
+                credential_still_present = (
+                    bool(persisted_config.get("verified_email_token"))
+                    if create_identity_kind == "upload_token"
+                    else bool(persisted_config.get("recurring_enrollment_grant"))
+                )
+                if credential_still_present:
                     raise AutoUploadError(
                         "config_persistence_failed",
                         "The consumed one-shot verification credential could not be removed durably.",
@@ -1810,8 +1896,11 @@ def enable(
                 # id to recover/reissue the hosted credentials.
                 try:
                     failure_config = load_config()
-                    failure_config.pop("verified_email_token", None)
-                    failure_config.pop("verified_email_token_expires_at", None)
+                    if create_identity_kind == "enrollment_grant":
+                        _remove_recurring_enrollment_grant(failure_config)
+                    else:
+                        failure_config.pop("verified_email_token", None)
+                        failure_config.pop("verified_email_token_expires_at", None)
                     save_config(failure_config)
                 except Exception:
                     pass
@@ -1824,6 +1913,23 @@ def enable(
                     ambiguous=True,
                 )
             elif isinstance(exc, RecurringServiceError):
+                if (
+                    create_identity_kind == "enrollment_grant"
+                    and not exc.ambiguous
+                    and exc.code
+                    in {
+                        "email_verification_required",
+                        "credential_invalid",
+                        "credential_expired",
+                        "credential_revoked",
+                    }
+                ):
+                    try:
+                        failure_config = load_config()
+                        _remove_recurring_enrollment_grant(failure_config)
+                        save_config(failure_config)
+                    except Exception:
+                        pass
                 if updating and exc.code in {
                     "credential_invalid",
                     "credential_expired",

--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -39,6 +39,7 @@ from .auto_upload_client import (
     RECURRING_CADENCE_DAYS,
     CapabilityError,
     RecurringServiceError,
+    comparable_origin,
     create_enrollment,
     fetch_authorization,
     fetch_capabilities,
@@ -246,10 +247,42 @@ def _available_recurring_enrollment_grant(
         or expires_at is None
         or expires_at <= _now() + timedelta(seconds=60)
         or capability_version != MANUAL_SHARE_ENROLLMENT_GRANT_VERSION
-        or (origin is not None and issuer != origin)
+        or (
+            origin is not None
+            and comparable_origin(issuer) != comparable_origin(origin)
+        )
     ):
         return None
     return grant
+
+
+def _configured_hosted_origin() -> str | None:
+    """The origin this install would enroll against, without a network call."""
+
+    try:
+        from .workbench.daemon import _hosted_api_base
+
+        return _hosted_api_base()
+    except Exception:
+        return None
+
+
+def _status_grant_available(config: Mapping[str, Any]) -> bool:
+    """Whether ``enable`` would actually accept the cached enrollment grant.
+
+    Mirrors the origin binding ``enable`` applies so the status field cannot
+    advertise a grant that enable will refuse — the UI reads this to decide
+    whether to skip the email-verification step, and a grant bound to a
+    different hosted origin must not send it down that path. An install with no
+    resolvable hosted origin can never enroll, so it reports no grant at all.
+    The hosted capability version is deliberately not checked here: that needs
+    discovery, and ``enable`` remains the authority on it.
+    """
+
+    origin = _configured_hosted_origin()
+    if origin is None:
+        return False
+    return bool(_available_recurring_enrollment_grant(config, origin=origin))
 
 
 def _remove_recurring_enrollment_grant(config: dict[str, Any]) -> None:
@@ -650,9 +683,7 @@ def _off_status(config: Mapping[str, Any]) -> dict[str, Any]:
         },
         "last_result": None,
         "generation": None,
-        "enrollment_grant_available": bool(
-            _available_recurring_enrollment_grant(config)
-        ),
+        "enrollment_grant_available": _status_grant_available(config),
     }
 
 
@@ -768,9 +799,7 @@ def status(*, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
             },
             "last_result": last_result,
             "generation": enrollment.get("generation") if enrollment else None,
-            "enrollment_grant_available": bool(
-                _available_recurring_enrollment_grant(config)
-            ),
+            "enrollment_grant_available": _status_grant_available(config),
         }
     finally:
         if own_connection:
@@ -957,6 +986,11 @@ def _hook_targets(
         ]
         if inferred:
             return inferred
+        # Defensive only: callers reach this after the scope blockers, which
+        # already reject an empty scope and any source outside COMPLETION_MODES
+        # (whose keys are exactly SUPPORTED_HOOK_TARGETS). It exists so a future
+        # source that gains a completion mode without a SessionStart hook fails
+        # loudly here instead of silently scheduling nothing.
         raise AutoUploadError(
             "invalid_hook_target",
             "No supported SessionStart agent was found in the authorized scope.",
@@ -1427,7 +1461,14 @@ def enable(
         server_reauthorization_succeeded = False
         email_enrollment_may_have_committed = False
         recovery_only_written = False
-        create_identity_kind: str | None = None
+        # Which one-shot identity credential this attempt actually put on the
+        # wire, or None when it sent neither. Set on both the create and the
+        # credential-rotation path — a non-rotating PATCH reuses the pinned
+        # active credential and consumes nothing. The cleanup below keys off
+        # this: removing a credential that was never sent destroys a still-valid
+        # one, and leaving a consumed one behind strands a spent single-use
+        # secret in config.
+        sent_identity_kind: str | None = None
         try:
             snapshots = _snapshot_hook_files(SUPPORTED_HOOK_TARGETS)
             hook_agent = "all" if len(targets) > 1 else targets[0]
@@ -1482,9 +1523,9 @@ def enable(
                     ),
                 )
                 if upload_token:
-                    create_identity_kind = "upload_token"
+                    sent_identity_kind = "upload_token"
                 elif enrollment_grant:
-                    create_identity_kind = "enrollment_grant"
+                    sent_identity_kind = "enrollment_grant"
                 else:
                     raise AutoUploadError(
                         "email_verification_required",
@@ -1495,12 +1536,12 @@ def enable(
                         capabilities,
                         upload_token=(
                             upload_token
-                            if create_identity_kind == "upload_token"
+                            if sent_identity_kind == "upload_token"
                             else None
                         ),
                         enrollment_grant=(
                             enrollment_grant
-                            if create_identity_kind == "enrollment_grant"
+                            if sent_identity_kind == "enrollment_grant"
                             else None
                         ),
                         client_enrollment_id=client_enrollment_id,
@@ -1689,21 +1730,21 @@ def enable(
             # on create/rotation. A non-rotating PATCH uses the pinned active
             # credential and must preserve any fresh manual-share token or
             # receipt-issued enrollment grant.
-            if create_identity_kind == "upload_token":
+            if sent_identity_kind == "upload_token":
                 config.pop("verified_email_token", None)
                 config.pop("verified_email_token_expires_at", None)
-            elif create_identity_kind == "enrollment_grant":
+            elif sent_identity_kind == "enrollment_grant":
                 _remove_recurring_enrollment_grant(config)
             if save_config(config) is False:
                 raise AutoUploadError(
                     "config_persistence_failed",
                     "Recurring enrollment could not persist its local config safely.",
                 )
-            if create_identity_kind is not None:
+            if sent_identity_kind is not None:
                 persisted_config = _load_config_readonly()
                 credential_still_present = (
                     bool(persisted_config.get("verified_email_token"))
-                    if create_identity_kind == "upload_token"
+                    if sent_identity_kind == "upload_token"
                     else bool(persisted_config.get("recurring_enrollment_grant"))
                 )
                 if credential_still_present:
@@ -1862,7 +1903,7 @@ def enable(
                 # id to recover/reissue the hosted credentials.
                 try:
                     failure_config = load_config()
-                    if create_identity_kind == "enrollment_grant":
+                    if sent_identity_kind == "enrollment_grant":
                         _remove_recurring_enrollment_grant(failure_config)
                     else:
                         failure_config.pop("verified_email_token", None)
@@ -1880,7 +1921,7 @@ def enable(
                 )
             elif isinstance(exc, RecurringServiceError):
                 if (
-                    create_identity_kind == "enrollment_grant"
+                    sent_identity_kind == "enrollment_grant"
                     and not exc.ambiguous
                     and exc.code
                     in {

--- a/clawjournal/auto_upload_client.py
+++ b/clawjournal/auto_upload_client.py
@@ -25,6 +25,24 @@ RECURRING_UPLOAD_API_VERSION = 2
 RECURRING_CLIENT_PROTOCOL_VERSION = "2"
 RECURRING_CADENCE_DAYS = 1
 MANUAL_SHARE_ENROLLMENT_GRANT_VERSION = 1
+
+
+def grant_capability_version_supported(value: Any) -> bool:
+    """Exact-integer check for the advertised enrollment-grant version.
+
+    The grant is an optional convenience on top of email verification, so an
+    unknown or malformed advertised version must only disable the grant path —
+    never fail the whole capability document, which would block enrollment for
+    every client until an upgrade. Strict typing matters here because Python
+    bools compare equal to ints: a server sending ``true`` must not pass as
+    version 1.
+    """
+
+    return (
+        isinstance(value, int)
+        and not isinstance(value, bool)
+        and value == MANUAL_SHARE_ENROLLMENT_GRANT_VERSION
+    )
 # Mirrors the hosted RECURRING_SCOPE_MAX_ENTRIES contract limit so oversized
 # scopes fail fast locally instead of as a server-worded enrollment rejection.
 MAX_SCOPE_ENTRIES = 200
@@ -189,16 +207,6 @@ def validate_capabilities(
                 "capability_incompatible",
                 f"Hosted recurring-upload capability {field} is unavailable or incompatible.",
             )
-    grant_version = capabilities.get("manual_share_enrollment_grant_version")
-    if grant_version is not None and (
-        not isinstance(grant_version, int)
-        or isinstance(grant_version, bool)
-        or grant_version != MANUAL_SHARE_ENROLLMENT_GRANT_VERSION
-    ):
-        raise CapabilityError(
-            "capability_incompatible",
-            "Hosted recurring-upload enrollment-grant capability is incompatible.",
-        )
     if require_enrollment_open and capabilities.get("recurring_enrollment_open") is not True:
         raise CapabilityError(
             "enrollment_closed",

--- a/clawjournal/auto_upload_client.py
+++ b/clawjournal/auto_upload_client.py
@@ -24,6 +24,7 @@ from . import __version__
 RECURRING_UPLOAD_API_VERSION = 2
 RECURRING_CLIENT_PROTOCOL_VERSION = "2"
 RECURRING_CADENCE_DAYS = 1
+MANUAL_SHARE_ENROLLMENT_GRANT_VERSION = 1
 # Mirrors the hosted RECURRING_SCOPE_MAX_ENTRIES contract limit so oversized
 # scopes fail fast locally instead of as a server-worded enrollment rejection.
 MAX_SCOPE_ENTRIES = 200
@@ -168,6 +169,12 @@ def validate_capabilities(
                 "capability_incompatible",
                 f"Hosted recurring-upload capability {field} is unavailable or incompatible.",
             )
+    grant_version = capabilities.get("manual_share_enrollment_grant_version")
+    if grant_version is not None and grant_version != MANUAL_SHARE_ENROLLMENT_GRANT_VERSION:
+        raise CapabilityError(
+            "capability_incompatible",
+            "Hosted recurring-upload enrollment-grant capability is incompatible.",
+        )
     if require_enrollment_open and capabilities.get("recurring_enrollment_open") is not True:
         raise CapabilityError(
             "enrollment_closed",
@@ -397,23 +404,36 @@ def _scope_payload(scope_entries: Any) -> list[dict[str, str]]:
 def create_enrollment(
     capabilities: Mapping[str, Any],
     *,
-    upload_token: str,
     client_enrollment_id: str,
     scope_entries: Any,
     authorization_version: str,
     retention_version: str,
     ownership_certification: bool,
+    upload_token: str | None = None,
+    enrollment_grant: str | None = None,
 ) -> dict[str, Any]:
     if ownership_certification is not True:
         raise CapabilityError(
             "ownership_certification_required",
             "Recurring enrollment requires the explicit ownership certification.",
         )
+    normalized_upload_token = (upload_token or "").strip()
+    normalized_enrollment_grant = (enrollment_grant or "").strip()
+    if bool(normalized_upload_token) == bool(normalized_enrollment_grant):
+        raise CapabilityError(
+            "email_verification_required",
+            "Recurring enrollment requires exactly one verified identity credential.",
+        )
+    identity_payload = (
+        {"enrollment_grant": normalized_enrollment_grant}
+        if normalized_enrollment_grant
+        else {"upload_token": normalized_upload_token}
+    )
     return _request_json(
         str(capabilities["recurring_enrollment_url"]),
         method="POST",
         payload={
-            "upload_token": upload_token,
+            **identity_payload,
             "client_enrollment_id": client_enrollment_id,
             "scope": _scope_payload(scope_entries),
             "authorization_version": authorization_version,

--- a/clawjournal/auto_upload_client.py
+++ b/clawjournal/auto_upload_client.py
@@ -190,7 +190,11 @@ def validate_capabilities(
                 f"Hosted recurring-upload capability {field} is unavailable or incompatible.",
             )
     grant_version = capabilities.get("manual_share_enrollment_grant_version")
-    if grant_version is not None and grant_version != MANUAL_SHARE_ENROLLMENT_GRANT_VERSION:
+    if grant_version is not None and (
+        not isinstance(grant_version, int)
+        or isinstance(grant_version, bool)
+        or grant_version != MANUAL_SHARE_ENROLLMENT_GRANT_VERSION
+    ):
         raise CapabilityError(
             "capability_incompatible",
             "Hosted recurring-upload enrollment-grant capability is incompatible.",

--- a/clawjournal/auto_upload_client.py
+++ b/clawjournal/auto_upload_client.py
@@ -114,6 +114,26 @@ def _normalized_origin(
     return f"{scheme}://{rendered_host}{port}"
 
 
+def comparable_origin(value: str) -> str:
+    """Render an origin so two spellings of the same host compare equal.
+
+    The enrollment-grant issuer is derived from the configured share URL, which
+    preserves whatever casing and explicit port the operator wrote, while
+    capability validation lowercases the host and re-renders the port. Comparing
+    those two spellings directly makes a perfectly valid grant silently
+    unusable, so both sides normalize through here first. A value this module
+    cannot parse as an origin is returned trimmed rather than raising: the
+    caller is comparing two strings for equality, not authorizing egress.
+    """
+
+    try:
+        return _normalized_origin(
+            value, allow_local_http=_allow_insecure_loopback_http()
+        )
+    except CapabilityError:
+        return value.strip().rstrip("/")
+
+
 def _endpoint(
     origin: str,
     value: Any,

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -159,6 +159,7 @@ def _mask_config_for_display(config: Mapping[str, Any]) -> dict[str, Any]:
         "token",
         "secret",
         "credential",
+        "grant",
         "password",
         "api_key",
         "access_key",

--- a/clawjournal/cli_auto_upload.py
+++ b/clawjournal/cli_auto_upload.py
@@ -194,29 +194,44 @@ def _interactive_accept(
         "AI-PII: "
         + (f"enabled via {ai.get('backend')}" if ai.get("enabled") else "disabled")
     ))
+    # Transcribing each version is the affirmative act itself, not decoration.
+    # A bare [y/N] can be answered without reading the text it is attached to,
+    # and it makes the accepted version a value the client echoes back from the
+    # challenge rather than one the participant attested to. Recurring sharing
+    # uploads future traces without per-bundle review, so its acceptance keeps
+    # the deliberate friction even though the web checkboxes are lighter.
     try:
-        accepted_scope = input(
-            "Authorize this exact scope and accept the displayed recurring "
-            "authorization and retention terms? [y/N] "
-        ).strip().lower()
-        if accepted_scope not in {"y", "yes"}:
+        entered_auth = input(
+            _sanitize_terminal_line(
+                f"Type authorization version {authorization['version']} to accept: "
+            )
+        ).strip()
+        if entered_auth != authorization["version"]:
             return None
-        accepted_ownership = input(
-            "Separately certify the displayed ownership statement? [y/N] "
-        ).strip().lower()
+        entered_retention = input(
+            _sanitize_terminal_line(
+                f"Type retention version {retention['version']} to accept: "
+            )
+        ).strip()
+        if entered_retention != retention["version"]:
+            return None
+        # The ownership certification is a distinct affirmative act, like the
+        # manual share's --certify-ownership: it is typed separately and never
+        # bundled into the terms acceptance above.
+        entered_ownership = input(
+            _sanitize_terminal_line(
+                f"Type ownership certification version {ownership['version']} "
+                "to certify: "
+            )
+        ).strip()
     except (EOFError, OSError, KeyboardInterrupt):
         return None
-    if accepted_ownership not in {"y", "yes"}:
+    if entered_ownership != ownership["version"]:
         return None
     profile_hash = challenge.get("authorization_profile_hash")
     if not isinstance(profile_hash, str) or not profile_hash:
         return None
-    return (
-        str(authorization["version"]),
-        str(retention["version"]),
-        str(ownership["version"]),
-        profile_hash,
-    )
+    return entered_auth, entered_retention, entered_ownership, profile_hash
 
 
 def _fresh_email_verification() -> bool:

--- a/clawjournal/cli_auto_upload.py
+++ b/clawjournal/cli_auto_upload.py
@@ -39,7 +39,12 @@ def add_auto_upload_parser(subparsers) -> argparse.ArgumentParser:
     commands = parser.add_subparsers(dest="auto_upload_command", required=True)
 
     enable = commands.add_parser("enable", help="Review terms and enable automatic sharing")
-    enable.add_argument("--agent", choices=["claude", "codex", "all"], default="all")
+    enable.add_argument(
+        "--agent",
+        choices=["auto", "claude", "codex", "all"],
+        default="auto",
+        help="SessionStart agent hook (default: infer from the accepted source scope)",
+    )
     enable.add_argument("--accept-authorization-version", default=None)
     enable.add_argument("--accept-retention-version", default=None)
     enable.add_argument("--accept-ownership-certification-version", default=None)
@@ -190,37 +195,28 @@ def _interactive_accept(
         + (f"enabled via {ai.get('backend')}" if ai.get("enabled") else "disabled")
     ))
     try:
-        entered_auth = input(
-            _sanitize_terminal_line(
-                f"Type authorization version {authorization['version']} to accept: "
-            )
-        ).strip()
-        if entered_auth != authorization["version"]:
+        accepted_scope = input(
+            "Authorize this exact scope and accept the displayed recurring "
+            "authorization and retention terms? [y/N] "
+        ).strip().lower()
+        if accepted_scope not in {"y", "yes"}:
             return None
-        entered_retention = input(
-            _sanitize_terminal_line(
-                f"Type retention version {retention['version']} to accept: "
-            )
-        ).strip()
-        if entered_retention != retention["version"]:
-            return None
-        # The ownership certification is a distinct affirmative act, like the
-        # manual share's --certify-ownership: it is typed separately and never
-        # bundled into the terms acceptance above.
-        entered_ownership = input(
-            _sanitize_terminal_line(
-                f"Type ownership certification version {ownership['version']} "
-                "to certify: "
-            )
-        ).strip()
+        accepted_ownership = input(
+            "Separately certify the displayed ownership statement? [y/N] "
+        ).strip().lower()
     except (EOFError, OSError, KeyboardInterrupt):
         return None
-    if entered_ownership != ownership["version"]:
+    if accepted_ownership not in {"y", "yes"}:
         return None
     profile_hash = challenge.get("authorization_profile_hash")
     if not isinstance(profile_hash, str) or not profile_hash:
         return None
-    return entered_auth, entered_retention, entered_ownership, profile_hash
+    return (
+        str(authorization["version"]),
+        str(retention["version"]),
+        str(ownership["version"]),
+        profile_hash,
+    )
 
 
 def _fresh_email_verification() -> bool:

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -154,6 +154,16 @@ DEFAULT_CONFIG: ClawJournalConfig = {
 _KNOWN_PREFIXES = ("claude:", "claude-science:", "codex:", "gemini:", "opencode:", "openclaw:", "kimi:", "cline:", "workbuddy:", "custom:")
 _BOTH_SOURCES = ("claude", "codex")
 
+# The receipt-issued recurring-enrollment grant travels as one unit: the
+# secret, its expiry, the receipt it is bound to, and the issuing origin.
+# Every writer that stores or clears it must touch all four keys.
+RECURRING_ENROLLMENT_GRANT_CONFIG_KEYS = (
+    "recurring_enrollment_grant",
+    "recurring_enrollment_grant_expires_at",
+    "recurring_enrollment_grant_receipt_id",
+    "recurring_enrollment_grant_issuer",
+)
+
 
 def load_config() -> ClawJournalConfig:
     if CONFIG_FILE.exists():

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -139,7 +139,6 @@ class ClawJournalConfig(TypedDict, total=False):
     benchmark_tab_enabled: bool  # show/hide the Benchmark tab in the workbench UI (default on)
     scoring_warmup_declined: bool  # user declined the background auto-scorer (suppresses prompt + server-side auto-start)
     auto_upload_capability_available: bool  # non-authoritative UI offer cache; Enable revalidates live
-    auto_upload_ui_enabled: bool  # internal override; a cached eligible offer also reveals the UI
 
 
 DEFAULT_CONFIG: ClawJournalConfig = {
@@ -149,7 +148,6 @@ DEFAULT_CONFIG: ClawJournalConfig = {
     "redact_strings": [],
     "allowlist_entries": [],
     "benchmark_tab_enabled": True,
-    "auto_upload_ui_enabled": False,
 }
 
 
@@ -165,6 +163,7 @@ def load_config() -> ClawJournalConfig:
             config = cast(ClawJournalConfig, {**DEFAULT_CONFIG, **stored})
             changed = _migrate_excluded_projects(config)
             changed |= _migrate_remove_device_credentials(config)
+            changed |= _migrate_remove_auto_upload_ui_flag(config)
             changed |= _migrate_findings_engines(config)
             if changed:
                 save_config(config)
@@ -230,6 +229,14 @@ def _migrate_remove_device_credentials(config: ClawJournalConfig) -> bool:
             del config[key]  # type: ignore[misc]
             changed = True
     return changed
+
+
+def _migrate_remove_auto_upload_ui_flag(config: ClawJournalConfig) -> bool:
+    """Remove the retired internal rollout flag from persisted config."""
+    if "auto_upload_ui_enabled" not in config:
+        return False
+    del config["auto_upload_ui_enabled"]  # type: ignore[misc]
+    return True
 
 
 def _migrate_findings_engines(config: ClawJournalConfig) -> bool:

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -123,6 +123,10 @@ class ClawJournalConfig(TypedDict, total=False):
     verified_email: str | None
     verified_email_token: str | None
     verified_email_token_expires_at: str | int | float | None
+    recurring_enrollment_grant: str | None
+    recurring_enrollment_grant_expires_at: str | int | float | None
+    recurring_enrollment_grant_receipt_id: str | None
+    recurring_enrollment_grant_issuer: str | None
     pending_verification_id: str | None
     pending_verification_email: str | None
     pending_verification_expires_at: str | int | None

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -120,6 +120,7 @@ function normalizeAutoUploadStatus(raw: Partial<AutoUploadStatus>): AutoUploadSt
       : null,
     ui_visible: raw.ui_visible === true,
     offer_available: raw.offer_available === true,
+    enrollment_grant_available: raw.enrollment_grant_available === true,
     scope: {
       sources: Array.isArray(scope.sources) ? scope.sources : [],
       projects: Array.isArray(scope.projects) ? scope.projects : [],

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
@@ -119,6 +119,7 @@ describe('AutoUploadOffer', () => {
     const dismissible = renderControl(<AutoUploadOffer manualReceiptId="receipt-2" />);
     expect(await screen.findByText('Share future traces automatically?')).toBeInTheDocument();
     expect(await screen.findByText(/exact source\/project pairs/i)).toBeInTheDocument();
+    expect(screen.getByText(/you will verify your email before enabling/i)).toBeInTheDocument();
     expect(screen.queryByRole('button', { name: 'Review and enable' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Not now' }));
@@ -170,6 +171,7 @@ describe('AutoUploadOffer', () => {
     renderControl(<AutoUploadOffer manualReceiptId="receipt-grant" />);
 
     expect(await screen.findByText('Share future traces automatically?')).toBeInTheDocument();
+    expect(screen.getByText(/without verifying your email again/i)).toBeInTheDocument();
     expect(await screen.findByText('Exact recurring scope · 1 source/project pair')).toBeInTheDocument();
     const boxes = screen.getAllByRole('checkbox');
     expect(boxes).toHaveLength(2);

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
@@ -287,6 +287,44 @@ describe('AutoUploadPanel authorization', () => {
     expect(screen.getByText('recurring-v2')).toBeInTheDocument();
     expect(screen.queryByText('recurring-v1')).not.toBeInTheDocument();
   });
+
+  it('never blames a receipt grant when rotating an active enrollment', async () => {
+    // Rotating credentials on a live enrollment returns email_verification_required
+    // and opens the same verification block the receipt offer uses. No grant was
+    // ever issued on this path, so it must not claim one expired.
+    const initial = status({
+      mode: 'enabled',
+      scope: { sources: ['claude'], projects: ['project-a'] },
+      hooks: [
+        { agent: 'claude', selected: true, configured: true, installed: true, last_observed_at: null },
+        { agent: 'codex', selected: false, configured: true, installed: true, last_observed_at: null },
+      ],
+    });
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValue(initial);
+    vi.spyOn(api.autoUpload, 'enable')
+      .mockRejectedValueOnce(authorizationRequired())
+      .mockRejectedValueOnce(new ApiError(409, 'Verify your email again to rotate recurring credentials.', {
+        code: 'email_verification_required',
+      }));
+    vi.spyOn(api.share, 'uploadStatus').mockResolvedValue({
+      verified_email: null,
+      token_valid: false,
+      expires_at: null,
+      pending_email: null,
+    });
+
+    renderControl(<AutoUploadPanel />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Review scope and terms' }));
+    await screen.findByRole('heading', { name: 'Authorize future automatic uploads' });
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Enable automatic upload' }));
+
+    expect(await screen.findByText(/single-use email verification/i)).toBeInTheDocument();
+    expect(screen.queryByText(/receipt-issued enrollment grant/i)).not.toBeInTheDocument();
+  });
 });
 
 describe('AutoUploadPanel status and controls', () => {

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
@@ -15,6 +15,7 @@ function status(overrides: Partial<AutoUploadStatus> = {}): AutoUploadStatus {
     pending_submission_state: null,
     ui_visible: true,
     offer_available: false,
+    enrollment_grant_available: false,
     scope: { sources: [], projects: [] },
     cap: 5,
     cadence_days: 1,
@@ -102,6 +103,7 @@ describe('AutoUploadOffer', () => {
 
   it('requires a manual receipt and server capability, then persists dismissal', async () => {
     const statusSpy = vi.spyOn(api.autoUpload, 'status');
+    vi.spyOn(api.autoUpload, 'enable').mockRejectedValue(authorizationRequired());
 
     const withoutReceipt = renderControl(<AutoUploadOffer manualReceiptId={null} />);
     expect(statusSpy).not.toHaveBeenCalled();
@@ -116,7 +118,8 @@ describe('AutoUploadOffer', () => {
     statusSpy.mockResolvedValueOnce(status({ offer_available: true }));
     const dismissible = renderControl(<AutoUploadOffer manualReceiptId="receipt-2" />);
     expect(await screen.findByText('Share future traces automatically?')).toBeInTheDocument();
-    expect(screen.getByText(/upload without individual review/i)).toBeInTheDocument();
+    expect(await screen.findByText(/exact source\/project pairs/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Review and enable' })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Not now' }));
 
@@ -136,6 +139,47 @@ describe('AutoUploadOffer', () => {
     statusSpy.mockResolvedValueOnce(status({ offer_available: true }));
     renderControl(<AutoUploadOffer manualReceiptId="receipt-3" />);
     expect(await screen.findByText('Share future traces automatically?')).toBeInTheDocument();
+  });
+
+  it('enables inline with the receipt grant and infers the only agent', async () => {
+    const initial = status({
+      offer_available: true,
+      enrollment_grant_available: true,
+      scope: { sources: ['codex'], projects: ['project-a'] },
+    });
+    const enabled = status({
+      mode: 'enabled',
+      scope: { sources: ['codex'], projects: ['project-a'] },
+    });
+    const grantChallenge = authorizationRequired();
+    (grantChallenge.body.scope as Record<string, unknown>).sources = ['codex'];
+    (grantChallenge.body.scope as Record<string, unknown>).entries = [
+      ['codex', 'project-a'],
+    ];
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValue(initial);
+    const enableSpy = vi.spyOn(api.autoUpload, 'enable')
+      .mockRejectedValueOnce(grantChallenge)
+      .mockResolvedValueOnce(enabled);
+    const uploadStatusSpy = vi.spyOn(api.share, 'uploadStatus').mockResolvedValue({
+      verified_email: null,
+      token_valid: false,
+      expires_at: null,
+      pending_email: null,
+    });
+
+    renderControl(<AutoUploadOffer manualReceiptId="receipt-grant" />);
+
+    expect(await screen.findByText('Share future traces automatically?')).toBeInTheDocument();
+    expect(await screen.findByText('Exact recurring scope · 1 source/project pair')).toBeInTheDocument();
+    const boxes = screen.getAllByRole('checkbox');
+    expect(boxes).toHaveLength(2);
+    fireEvent.click(boxes[0]);
+    fireEvent.click(boxes[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Enable automatic upload' }));
+
+    await waitFor(() => expect(enableSpy).toHaveBeenCalledTimes(2));
+    expect(enableSpy.mock.calls[1][0].agent).toBe('codex');
+    expect(uploadStatusSpy).not.toHaveBeenCalled();
   });
 });
 
@@ -199,10 +243,9 @@ describe('AutoUploadPanel authorization', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Refresh status' }));
     fireEvent.click(screen.getByRole('button', { name: 'Review scope and terms' }));
 
-    const agentSelect = await screen.findByLabelText('Run on agent sessions');
-    expect(agentSelect).toHaveValue('claude');
+    await screen.findByRole('heading', { name: 'Authorize future automatic uploads' });
+    expect(screen.queryByLabelText('Run on agent sessions')).not.toBeInTheDocument();
     expect(enableSpy).toHaveBeenNthCalledWith(1, { agent: 'claude', challenge_only: true });
-    expect(screen.getByRole('heading', { name: 'Authorize future automatic uploads' })).toBeInTheDocument();
     expect(screen.getByText(/separate from the consent you gave/i)).toBeInTheDocument();
     expect(screen.getByText('I authorize capped recurring uploads of eligible future traces.')).toBeInTheDocument();
     expect(screen.getByText('Hosted retention terms for recurring uploads.')).toBeInTheDocument();

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
@@ -698,9 +698,14 @@ function AuthorizationDialog({
             <div style={{ fontSize: 13, fontWeight: 650, color: colors.gray900 }}>
               Verify your email
             </div>
+            {/* This block is also reached from the settings panel while
+                rotating an active enrollment's credentials, where no grant was
+                ever issued. Naming one unconditionally would tell those users
+                a receipt grant expired when they never had one. */}
             <div style={{ fontSize: 12, lineHeight: 1.45, color: colors.gray600 }}>
-              The receipt-issued enrollment grant is unavailable or expired. Verify your email
-              to continue; your recurring terms selection above remains unchanged.
+              {initialStatus.enrollment_grant_available
+                ? 'The receipt-issued enrollment grant is unavailable or expired. Verify your email to continue; your recurring terms selection above remains unchanged.'
+                : 'Recurring enrollment needs its own single-use email verification. Verify to continue; your recurring terms selection above remains unchanged.'}
             </div>
             {tokenValid ? (
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
@@ -554,7 +554,11 @@ function AuthorizationDialog({
         </h3>
         <p style={{ margin: '0 0 18px', fontSize: 13, lineHeight: 1.55, color: colors.gray600 }}>
           {inline
-            ? `Enable up to ${cap} eligible future traces every ${cadence} day${cadence === 1 ? '' : 's'} from the exact scope below. The receipt from this share lets you enable it without verifying your email again.`
+            ? `Enable up to ${cap} eligible future traces every ${cadence} day${cadence === 1 ? '' : 's'} from the exact scope below. ${
+              initialStatus.enrollment_grant_available
+                ? 'The receipt from this share lets you enable it without verifying your email again.'
+                : 'If its receipt-issued enrollment grant is unavailable or expires, you will verify your email before enabling.'
+            }`
             : 'Future selected traces in this exact scope may be uploaded without you reviewing each bundle. This is separate from the consent you gave for the bundle you just reviewed.'}
         </p>
 

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
@@ -164,6 +164,13 @@ function selectedAgent(status: AutoUploadStatus): AutoUploadAgent {
   return 'all';
 }
 
+function inferredAgent(sources: string[], fallback: AutoUploadAgent): AutoUploadAgent {
+  const selected = new Set(sources);
+  if (selected.has('claude') && !selected.has('codex')) return 'claude';
+  if (selected.has('codex') && !selected.has('claude')) return 'codex';
+  return fallback;
+}
+
 function StatusChip({ children, tone = 'neutral' }: {
   children: React.ReactNode;
   tone?: 'neutral' | 'good' | 'warning' | 'danger' | 'info';
@@ -213,9 +220,16 @@ interface AuthorizationDialogProps {
   initialStatus: AutoUploadStatus;
   onClose: () => void;
   onEnabled: (status: AutoUploadStatus) => void;
+  inline?: boolean;
 }
 
-function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: AuthorizationDialogProps) {
+function AuthorizationDialog({
+  open,
+  initialStatus,
+  onClose,
+  onEnabled,
+  inline = false,
+}: AuthorizationDialogProps) {
   const { toast } = useToast();
   const titleId = useId();
   const requestedRef = useRef(false);
@@ -283,6 +297,7 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
       const next = challengeFromError(requestError);
       if (next) {
         setChallenge(next);
+        setAgent(current => inferredAgent(next.scope.sources, current));
       } else if (requiresEmailVerification(requestError)) {
         await showEmailVerification(
           'Verify your email before loading the recurring authorization.',
@@ -343,18 +358,18 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
   // focused element on close, so keyboard and screen-reader focus follow the
   // modal instead of staying on the background controls behind the overlay.
   useEffect(() => {
-    if (!open) return;
+    if (!open || inline) return;
     const previousFocus = document.activeElement as HTMLElement | null;
     dialogRef.current?.focus();
     return () => { previousFocus?.focus?.(); };
-  }, [open]);
+  }, [inline, open]);
 
   // Behave like a real modal: trap Tab within the dialog's focusables and
   // swallow every other page keystroke (capture phase) so background controls
   // can never be operated through the overlay. Escape dismisses unless a
   // mutating submit is in flight.
   useEffect(() => {
-    if (!open) return;
+    if (!open || inline) return;
     const onKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
         event.stopPropagation();
@@ -382,7 +397,7 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
     };
     window.addEventListener('keydown', onKeyDown, true);
     return () => window.removeEventListener('keydown', onKeyDown, true);
-  }, [dismissDialog, submitting, open]);
+  }, [dismissDialog, inline, submitting, open]);
 
   if (!open) return null;
 
@@ -431,7 +446,7 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
       // Updating an active enrollment uses its pinned active credential. Only
       // a new enrollment (or an explicit credential error returned below)
       // requires another one-shot email verification.
-      if (initialStatus.mode !== 'off') {
+      if (initialStatus.mode !== 'off' || initialStatus.enrollment_grant_available) {
         await enableWithAcceptedTerms();
         return;
       }
@@ -507,46 +522,62 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
 
   return (
     <div
-      role="presentation"
-      onMouseDown={event => { if (event.target === event.currentTarget && !submitting) dismissDialog(); }}
-      style={{
+      role={inline ? undefined : 'presentation'}
+      onMouseDown={event => {
+        if (!inline && event.target === event.currentTarget && !submitting) dismissDialog();
+      }}
+      style={inline ? {
+        margin: '20px auto', maxWidth: 680, padding: '18px 20px', textAlign: 'left',
+        border: `1px solid ${colors.primary200}`, borderRadius: 10,
+        background: colors.primary50,
+      } : {
         position: 'fixed', inset: 0, zIndex: 9998, padding: 20,
         display: 'grid', placeItems: 'center', background: 'rgba(27, 26, 23, 0.45)',
       }}
     >
       <section
         ref={dialogRef}
-        tabIndex={-1}
-        role="dialog"
-        aria-modal="true"
+        tabIndex={inline ? undefined : -1}
+        role={inline ? 'region' : 'dialog'}
+        aria-modal={inline ? undefined : 'true'}
         aria-labelledby={titleId}
-        style={{
+        style={inline ? {
+          width: '100%',
+        } : {
           width: 'min(680px, calc(100vw - 40px))', maxHeight: 'calc(100vh - 40px)',
           overflow: 'auto', background: colors.white, borderRadius: 12,
           boxShadow: '0 18px 50px rgba(0,0,0,0.22)', padding: '22px 24px',
         }}
       >
         <h3 id={titleId} style={{ margin: '0 0 6px', fontSize: 18, color: colors.gray900 }}>
-          Authorize future automatic uploads
+          {inline ? 'Share future traces automatically?' : 'Authorize future automatic uploads'}
         </h3>
         <p style={{ margin: '0 0 18px', fontSize: 13, lineHeight: 1.55, color: colors.gray600 }}>
-          Future selected traces in this exact scope may be uploaded without you reviewing each
-          bundle. This is separate from the consent you gave for the bundle you just reviewed.
+          {inline
+            ? `Enable up to ${cap} eligible future traces every ${cadence} day${cadence === 1 ? '' : 's'} from the exact scope below. The receipt from this share lets you enable it without verifying your email again.`
+            : 'Future selected traces in this exact scope may be uploaded without you reviewing each bundle. This is separate from the consent you gave for the bundle you just reviewed.'}
         </p>
 
-        <label style={{ display: 'block', marginBottom: 14, fontSize: 12.5, color: colors.gray700 }}>
-          Run on agent sessions
-          <select
-            value={agent}
-            disabled={loading}
-            onChange={event => setAgent(event.target.value as AutoUploadAgent)}
-            style={{ ...selectStyle, display: 'block', marginTop: 5, minWidth: 220 }}
-          >
-            <option value="all">Claude Code and Codex</option>
-            <option value="claude">Claude Code</option>
-            <option value="codex">Codex</option>
-          </select>
-        </label>
+        {new Set(scope.sources.filter(source => source === 'claude' || source === 'codex')).size === 1 ? (
+          <SummaryItem
+            label="Run on agent sessions"
+            value={scope.sources.includes('codex') ? 'Codex' : 'Claude Code'}
+          />
+        ) : (
+          <label style={{ display: 'block', marginBottom: 14, fontSize: 12.5, color: colors.gray700 }}>
+            Run on agent sessions
+            <select
+              value={agent}
+              disabled={loading}
+              onChange={event => setAgent(event.target.value as AutoUploadAgent)}
+              style={{ ...selectStyle, display: 'block', marginTop: 5, minWidth: 220 }}
+            >
+              <option value="all">Claude Code and Codex</option>
+              <option value="claude">Claude Code</option>
+              <option value="codex">Codex</option>
+            </select>
+          </label>
+        )}
 
         <div style={summaryGridStyle}>
           <SummaryItem label="Sources" value={compactList(scope.sources, 'No confirmed sources')} />
@@ -664,8 +695,8 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
               Verify your email
             </div>
             <div style={{ fontSize: 12, lineHeight: 1.45, color: colors.gray600 }}>
-              The token used for the manual upload is single-use. Verify again to authorize this
-              recurring enrollment; your recurring terms selection above remains unchanged.
+              The receipt-issued enrollment grant is unavailable or expired. Verify your email
+              to continue; your recurring terms selection above remains unchanged.
             </div>
             {tokenValid ? (
               <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8, flexWrap: 'wrap' }}>
@@ -745,7 +776,7 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
 
         <div style={{ display: 'flex', justifyContent: 'flex-end', gap: 8, marginTop: 20 }}>
           <button disabled={submitting} onClick={dismissDialog} style={{ ...btnSecondary, ...disabledStyle(submitting) }}>
-            Cancel
+            {inline ? 'Not now' : 'Cancel'}
           </button>
           {!verificationRequired && (
             <button
@@ -753,7 +784,11 @@ function AuthorizationDialog({ open, initialStatus, onClose, onEnabled }: Author
               onClick={() => void accept()}
               style={{ ...btnPrimary, ...disabledStyle(!challenge || !accepted || !ownershipCertified || loading) }}
             >
-              {loading && challenge ? 'Checking verification…' : 'Enable automatic upload'}
+              {submitting
+                ? 'Enabling…'
+                : loading && challenge
+                  ? 'Refreshing and enabling…'
+                  : 'Enable automatic upload'}
             </button>
           )}
         </div>
@@ -794,7 +829,6 @@ function SummaryItem({ label, value }: { label: string; value: string }) {
 
 export function AutoUploadOffer({ manualReceiptId }: { manualReceiptId: string | null }) {
   const [status, setStatus] = useState<AutoUploadStatus | null>(null);
-  const [dialogOpen, setDialogOpen] = useState(false);
   // Dismissal is scoped to the receipt it was shown for: "Not now" on one
   // share must not suppress the offer after every future manual share.
   const [dismissedReceipt, setDismissedReceipt] = useState<string | null>(() => {
@@ -824,33 +858,13 @@ export function AutoUploadOffer({ manualReceiptId }: { manualReceiptId: string |
   if (!status || !status.ui_visible || dismissed || status.mode !== 'off' || !status.offer_available) return null;
 
   return (
-    <>
-      <div style={{
-        margin: '20px auto', maxWidth: 520, padding: '16px 18px', textAlign: 'left',
-        border: `1px solid ${colors.primary200}`, borderRadius: 10, background: colors.primary50,
-      }}>
-        <div style={{ fontSize: 14, fontWeight: 650, color: colors.gray900 }}>
-          Share future traces automatically?
-        </div>
-        <p style={{ margin: '6px 0 14px', fontSize: 12.5, lineHeight: 1.55, color: colors.gray700 }}>
-          Once a week, ClawJournal can select and upload up to {status.cap} eligible future traces
-          from your approved scope. Those future bundles upload without individual review. You will
-          see the exact scope and recurring terms before anything is enabled.
-        </p>
-        <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
-          <button onClick={() => setDialogOpen(true)} style={btnPrimary}>
-            Review and enable
-          </button>
-          <button onClick={dismiss} style={btnGhost}>Not now</button>
-        </div>
-      </div>
-      <AuthorizationDialog
-        open={dialogOpen}
-        initialStatus={status}
-        onClose={() => setDialogOpen(false)}
-        onEnabled={next => { setStatus(next); dismiss(); }}
-      />
-    </>
+    <AuthorizationDialog
+      inline
+      open
+      initialStatus={status}
+      onClose={dismiss}
+      onEnabled={next => { setStatus(next); dismiss(); }}
+    />
   );
 }
 

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -258,6 +258,7 @@ export interface AutoUploadStatus {
   pending_submission_state: 'sealed' | 'submitting' | null;
   ui_visible: boolean;
   offer_available: boolean;
+  enrollment_grant_available: boolean;
   scope: {
     sources: string[];
     projects: string[];

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -50,7 +50,12 @@ from ..scoring.overrides import (
     normalize_failure_evidence,
     requires_failure_evidence,
 )
-from ..config import CONFIG_DIR, load_config, save_config
+from ..config import (
+    CONFIG_DIR,
+    RECURRING_ENROLLMENT_GRANT_CONFIG_KEYS,
+    load_config,
+    save_config,
+)
 from .findings_pipeline import (
     drain_findings_backfill,
     run_findings_pipeline,
@@ -1606,14 +1611,6 @@ def _clear_stored_upload_token() -> None:
             raise OSError("Stored upload authority could not be cleared safely.")
 
 
-_RECURRING_ENROLLMENT_GRANT_KEYS = (
-    "recurring_enrollment_grant",
-    "recurring_enrollment_grant_expires_at",
-    "recurring_enrollment_grant_receipt_id",
-    "recurring_enrollment_grant_issuer",
-)
-
-
 def _store_recurring_enrollment_grant(
     hosted_result: dict[str, Any],
     *,
@@ -1715,7 +1712,7 @@ def request_email_verification(email: str) -> dict:
             "verified_email",
             "verified_email_token",
             "verified_email_token_expires_at",
-            *_RECURRING_ENROLLMENT_GRANT_KEYS,
+            *RECURRING_ENROLLMENT_GRANT_CONFIG_KEYS,
         ):
             config.pop(key, None)
     config["pending_verification_id"] = verification_id

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -31,6 +31,7 @@ from .. import __version__
 from ..auto_upload_client import (
     RECURRING_CADENCE_DAYS,
     RECURRING_UPLOAD_API_VERSION,
+    comparable_origin,
 )
 from ..redaction.anonymizer import Anonymizer
 from ..scoring.badges import compute_all_badges
@@ -1646,7 +1647,12 @@ def _store_recurring_enrollment_grant(
         config["recurring_enrollment_grant"] = grant
         config["recurring_enrollment_grant_expires_at"] = expires_at
         config["recurring_enrollment_grant_receipt_id"] = receipt_id
-        config["recurring_enrollment_grant_issuer"] = _hosted_api_base()
+        # Store the issuer in the same normalized form the enrollment path
+        # compares against, so an operator's casing or explicit :443 in
+        # CLAWJOURNAL_SHARE_URL cannot make a valid grant permanently unusable.
+        config["recurring_enrollment_grant_issuer"] = comparable_origin(
+            _hosted_api_base()
+        )
         if save_config(config) is False:
             raise OSError("config save returned false")
     except (OSError, RuntimeError):

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -1614,19 +1614,6 @@ _RECURRING_ENROLLMENT_GRANT_KEYS = (
 )
 
 
-def _clear_stored_recurring_enrollment_grant() -> None:
-    config = load_config()
-    changed = False
-    for key in _RECURRING_ENROLLMENT_GRANT_KEYS:
-        if key in config:
-            del config[key]
-            changed = True
-    if changed and save_config(config) is False:
-        raise OSError(
-            "Stored recurring-enrollment convenience credential could not be cleared safely."
-        )
-
-
 def _store_recurring_enrollment_grant(
     hosted_result: dict[str, Any],
     *,

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -1605,6 +1605,59 @@ def _clear_stored_upload_token() -> None:
             raise OSError("Stored upload authority could not be cleared safely.")
 
 
+_RECURRING_ENROLLMENT_GRANT_KEYS = (
+    "recurring_enrollment_grant",
+    "recurring_enrollment_grant_expires_at",
+    "recurring_enrollment_grant_receipt_id",
+    "recurring_enrollment_grant_issuer",
+)
+
+
+def _clear_stored_recurring_enrollment_grant() -> None:
+    config = load_config()
+    changed = False
+    for key in _RECURRING_ENROLLMENT_GRANT_KEYS:
+        if key in config:
+            del config[key]
+            changed = True
+    if changed and save_config(config) is False:
+        raise OSError(
+            "Stored recurring-enrollment convenience credential could not be cleared safely."
+        )
+
+
+def _store_recurring_enrollment_grant(
+    hosted_result: dict[str, Any],
+    *,
+    receipt_id: str,
+) -> bool:
+    grant = hosted_result.get("recurring_enrollment_grant")
+    expires_at = hosted_result.get("recurring_enrollment_grant_expires_at")
+    grant_receipt_id = hosted_result.get("recurring_enrollment_grant_receipt_id")
+    if (
+        not isinstance(grant, str)
+        or not grant
+        or not _expiry_is_valid(expires_at, grace_seconds=0)
+        or grant_receipt_id != receipt_id
+    ):
+        return False
+    try:
+        config = load_config()
+        config["recurring_enrollment_grant"] = grant
+        config["recurring_enrollment_grant_expires_at"] = expires_at
+        config["recurring_enrollment_grant_receipt_id"] = receipt_id
+        config["recurring_enrollment_grant_issuer"] = _hosted_api_base()
+        if save_config(config) is False:
+            raise OSError("config save returned false")
+    except (OSError, RuntimeError):
+        logger.warning(
+            "Manual share succeeded, but its recurring-enrollment grant "
+            "could not be cached; email verification remains available."
+        )
+        return False
+    return True
+
+
 def _http_error_message(exc: urllib.error.HTTPError) -> str:
     body = exc.read().decode("utf-8", errors="replace")
     try:
@@ -1669,6 +1722,7 @@ def request_email_verification(email: str) -> dict:
             "verified_email",
             "verified_email_token",
             "verified_email_token_expires_at",
+            *_RECURRING_ENROLLMENT_GRANT_KEYS,
         ):
             config.pop(key, None)
     config["pending_verification_id"] = verification_id
@@ -2954,6 +3008,7 @@ def submit_share_to_hosted(
     )
     conn.commit()
 
+    _store_recurring_enrollment_grant(hosted_result, receipt_id=receipt_id)
     _clear_stored_upload_token()
     redaction_summary = manifest.get("redaction_summary", {}) if manifest else {}
     return {

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -2782,6 +2782,99 @@ def test_rejected_manual_share_grant_falls_back_to_email_verification(
     assert auto.status()["enrollment_grant_available"] is False
 
 
+@pytest.mark.parametrize(
+    "issuer",
+    [ORIGIN, "https://DATA.RAYWARD.AI", "https://data.rayward.ai/"],
+)
+def test_grant_issuer_survives_equivalent_origin_spellings(
+    isolated_auto_upload,
+    monkeypatch,
+    issuer,
+):
+    """A valid grant must not be lost to host casing or a trailing slash.
+
+    Both sides start from the same CLAWJOURNAL_SHARE_URL, but the issuer keeps
+    whatever the operator wrote while capability validation lowercases the host.
+    Comparing the raw spellings would silently force email verification forever
+    on an install that only differs cosmetically. Note this normalizes case, not
+    authority: a differing port is still a differing origin, as the port case in
+    ``test_grant_from_a_different_origin_is_never_offered_or_sent`` locks in.
+    """
+
+    _save_scope_config(enrollment_grant="cj_enroll_one-shot")
+    config = config_module.load_config()
+    config["recurring_enrollment_grant_issuer"] = issuer
+    config_module.save_config(config)
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    conn.close()
+    _patch_enable_dependencies(monkeypatch)
+    create_calls: list[dict[str, Any]] = []
+
+    def create(_capabilities, **kwargs):
+        create_calls.append(dict(kwargs))
+        return _enrollment_response()
+
+    monkeypatch.setattr(auto, "create_enrollment", create)
+
+    assert auto.status()["enrollment_grant_available"] is True
+
+    result = auto.enable(
+        agent="claude",
+        accepted_authorization_version=AUTH_VERSION,
+        accepted_retention_version=RETENTION_VERSION,
+        accepted_ownership_certification_version=OWNERSHIP_VERSION,
+        accepted_authorization_profile_hash=_current_authorization_profile_hash(),
+    )
+
+    assert result["mode"] == "enabled"
+    assert create_calls[0]["enrollment_grant"] == "cj_enroll_one-shot"
+
+
+@pytest.mark.parametrize(
+    "issuer",
+    ["https://evil.example.test", "https://data.rayward.ai:8443"],
+)
+def test_grant_from_a_different_origin_is_never_offered_or_sent(
+    isolated_auto_upload,
+    monkeypatch,
+    issuer,
+):
+    """A grant issued by another origin must not be advertised or put on the wire.
+
+    The workbench reads ``enrollment_grant_available`` to decide whether it can
+    skip email verification, so a status that ignores the issuer would send the
+    participant down a path enable is bound to refuse. A differing port is a
+    differing origin here, exactly as the capability endpoint pinning treats it.
+    """
+
+    _save_scope_config(enrollment_grant="cj_enroll_other-host")
+    config = config_module.load_config()
+    config["recurring_enrollment_grant_issuer"] = issuer
+    config_module.save_config(config)
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    conn.close()
+    _patch_enable_dependencies(monkeypatch)
+    monkeypatch.setattr(
+        auto,
+        "create_enrollment",
+        lambda *_a, **_k: pytest.fail("enrollment must not be attempted"),
+    )
+
+    assert auto.status()["enrollment_grant_available"] is False
+
+    result = auto.enable(
+        agent="claude",
+        accepted_authorization_version=AUTH_VERSION,
+        accepted_retention_version=RETENTION_VERSION,
+        accepted_ownership_certification_version=OWNERSHIP_VERSION,
+        accepted_authorization_profile_hash=_current_authorization_profile_hash(),
+    )
+
+    assert result["code"] == "email_verification_required"
+
+
 def test_enable_requires_exact_versions_then_commits_all_authority_transactionally(
     isolated_auto_upload,
     monkeypatch,

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -2749,9 +2749,19 @@ def test_enable_prefers_manual_share_grant_without_email_verification(
     assert "recurring_enrollment_grant_issuer" not in persisted
 
 
+@pytest.mark.parametrize(
+    "rejection_code",
+    [
+        "email_verification_required",
+        "credential_invalid",
+        "credential_expired",
+        "credential_revoked",
+    ],
+)
 def test_rejected_manual_share_grant_falls_back_to_email_verification(
     isolated_auto_upload,
     monkeypatch,
+    rejection_code,
 ):
     _save_scope_config(enrollment_grant="cj_enroll_expired")
     conn = open_index()
@@ -2761,7 +2771,7 @@ def test_rejected_manual_share_grant_falls_back_to_email_verification(
 
     def reject(_capabilities, **_kwargs):
         raise RecurringServiceError(
-            "email_verification_required",
+            rejection_code,
             "Fresh verified identity is required.",
         )
 
@@ -2780,6 +2790,32 @@ def test_rejected_manual_share_grant_falls_back_to_email_verification(
     persisted = config_module.load_config()
     assert "recurring_enrollment_grant" not in persisted
     assert auto.status()["enrollment_grant_available"] is False
+
+
+@pytest.mark.parametrize(
+    "expires_at",
+    [4102444800, 4102444800.0, "4102444800"],
+)
+def test_manual_share_grant_accepts_supported_epoch_expirations(
+    isolated_auto_upload,
+    monkeypatch,
+    expires_at,
+):
+    _save_scope_config(enrollment_grant="cj_enroll_epoch")
+    config = config_module.load_config()
+    config["recurring_enrollment_grant_expires_at"] = expires_at
+    config_module.save_config(config)
+    monkeypatch.setattr(auto, "_configured_hosted_origin", lambda: ORIGIN)
+
+    assert auto.status()["enrollment_grant_available"] is True
+    assert (
+        auto._available_recurring_enrollment_grant(
+            config_module.load_config(),
+            origin=ORIGIN,
+            capability_version=1,
+        )
+        == "cj_enroll_epoch"
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -2749,6 +2749,89 @@ def test_enable_prefers_manual_share_grant_without_email_verification(
     assert "recurring_enrollment_grant_issuer" not in persisted
 
 
+def test_enable_prefers_the_grant_over_a_live_manual_share_token(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    """A usable grant is consumed before the manual-share email token.
+
+    ``verified_email_token`` is the manual-share credential; burning it on
+    enrollment while the purpose-scoped grant idles to expiry would silently
+    cost the user their next manual share.
+    """
+
+    _save_scope_config(
+        upload_token="manual-share-token",
+        enrollment_grant="cj_enroll_one-shot",
+    )
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    conn.close()
+    _patch_enable_dependencies(monkeypatch)
+    create_calls: list[dict[str, Any]] = []
+
+    def create(_capabilities, **kwargs):
+        create_calls.append(dict(kwargs))
+        return _enrollment_response()
+
+    monkeypatch.setattr(auto, "create_enrollment", create)
+
+    result = auto.enable(
+        agent="claude",
+        accepted_authorization_version=AUTH_VERSION,
+        accepted_retention_version=RETENTION_VERSION,
+        accepted_ownership_certification_version=OWNERSHIP_VERSION,
+        accepted_authorization_profile_hash=_current_authorization_profile_hash(),
+    )
+
+    assert result["mode"] == "enabled"
+    assert create_calls[0]["enrollment_grant"] == "cj_enroll_one-shot"
+    assert create_calls[0]["upload_token"] is None
+    persisted = config_module.load_config()
+    # Only the grant was consumed; the manual-share token survives untouched.
+    assert "recurring_enrollment_grant" not in persisted
+    assert persisted["verified_email_token"] == "manual-share-token"
+
+
+def test_unsupported_server_grant_version_disables_only_the_grant_path(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    """A newer advertised grant version degrades to email verification.
+
+    It must not be sent to a server that no longer speaks this grant version,
+    and it must not be destroyed either — nothing consumed it.
+    """
+
+    _save_scope_config(enrollment_grant="cj_enroll_one-shot")
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    conn.close()
+    _patch_enable_dependencies(monkeypatch)
+    capabilities = _capabilities()
+    capabilities["manual_share_enrollment_grant_version"] = 2
+    monkeypatch.setattr(
+        auto, "fetch_capabilities", lambda **_kwargs: capabilities
+    )
+    monkeypatch.setattr(
+        auto,
+        "create_enrollment",
+        lambda *_a, **_k: pytest.fail("the grant must not be sent"),
+    )
+
+    result = auto.enable(
+        agent="claude",
+        accepted_authorization_version=AUTH_VERSION,
+        accepted_retention_version=RETENTION_VERSION,
+        accepted_ownership_certification_version=OWNERSHIP_VERSION,
+        accepted_authorization_profile_hash=_current_authorization_profile_hash(),
+    )
+
+    assert result["code"] == "email_verification_required"
+    persisted = config_module.load_config()
+    assert persisted["recurring_enrollment_grant"] == "cj_enroll_one-shot"
+
+
 @pytest.mark.parametrize(
     "rejection_code",
     [

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -374,29 +374,21 @@ def test_status_is_read_only_without_an_install(
     assert not isolated_auto_upload["install"].exists()
 
 
-def test_auto_upload_ui_is_hidden_unless_internal_rollout_is_enabled(
-    isolated_auto_upload,
-    monkeypatch,
-):
-    monkeypatch.delenv(auto.AUTO_UPLOAD_UI_ENV, raising=False)
-    assert auto.status()["ui_visible"] is False
-
-    monkeypatch.setenv(auto.AUTO_UPLOAD_UI_ENV, "1")
+def test_auto_upload_ui_is_visible_by_default(isolated_auto_upload):
     assert auto.status()["ui_visible"] is True
 
 
-def test_successful_manual_receipt_and_hosted_offer_reveal_auto_upload_ui(
+def test_hosted_offer_requires_the_receipt_database_not_just_config_cache(
     isolated_auto_upload,
-    monkeypatch,
 ):
-    monkeypatch.delenv(auto.AUTO_UPLOAD_UI_ENV, raising=False)
     config = _save_scope_config()
     config["auto_upload_capability_available"] = True
     assert config_module.save_config(config)
 
-    # A stale config cache without the receipt database must not reveal the
-    # controls after a partial reinstall.
-    assert auto.status()["ui_visible"] is False
+    # A stale config cache without the receipt database must not surface the
+    # offer after a partial reinstall. (The Settings panel itself is always
+    # visible now; only the receipt-page offer stays gated.)
+    assert auto.status()["offer_available"] is False
 
     conn = open_index()
     _seed_released_session(conn, isolated_auto_upload["root"])
@@ -422,9 +414,7 @@ def test_successful_manual_receipt_and_hosted_offer_reveal_auto_upload_ui(
 
 def test_existing_auto_upload_authority_keeps_controls_visible(
     isolated_auto_upload,
-    monkeypatch,
 ):
-    monkeypatch.delenv(auto.AUTO_UPLOAD_UI_ENV, raising=False)
     config = _save_scope_config()
     conn = open_index()
     _seed_released_session(conn, isolated_auto_upload["root"])

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -82,7 +82,11 @@ def isolated_auto_upload(tmp_path, monkeypatch):
     }
 
 
-def _save_scope_config(*, upload_token: str | None = None) -> dict[str, Any]:
+def _save_scope_config(
+    *,
+    upload_token: str | None = None,
+    enrollment_grant: str | None = None,
+) -> dict[str, Any]:
     config: dict[str, Any] = {
         **config_module.DEFAULT_CONFIG,
         "source": "claude",
@@ -92,6 +96,13 @@ def _save_scope_config(*, upload_token: str | None = None) -> dict[str, Any]:
     if upload_token is not None:
         config["verified_email_token"] = upload_token
         config["verified_email_token_expires_at"] = "2099-01-01T00:00:00+00:00"
+    if enrollment_grant is not None:
+        config["recurring_enrollment_grant"] = enrollment_grant
+        config["recurring_enrollment_grant_expires_at"] = (
+            "2099-01-01T00:00:00+00:00"
+        )
+        config["recurring_enrollment_grant_receipt_id"] = "manual-receipt-1"
+        config["recurring_enrollment_grant_issuer"] = ORIGIN
     config_module.save_config(config)
     return config
 
@@ -167,6 +178,7 @@ def _credentials(enrollment_id: str = "server-enrollment-1") -> dict[str, str]:
 def _capabilities(origin: str = ORIGIN) -> dict[str, Any]:
     return {
         "origin": origin,
+        "manual_share_enrollment_grant_version": 1,
         "maximum_bundle_size": 5_000_000,
         "recurring_cadence_days": 1,
         "recurring_enrollment_url": f"{origin}/api/recurring-enrollments",
@@ -2708,6 +2720,76 @@ def test_ambiguous_credential_rotation_never_uses_invalidated_old_recovery(
     disabled = auto.disable()
     assert disabled["mode"] == "off"
     assert revoke_calls == [("server-enrollment-1", "recovery-secret")]
+
+
+def test_enable_prefers_manual_share_grant_without_email_verification(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    _save_scope_config(enrollment_grant="cj_enroll_one-shot")
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    conn.close()
+    _patch_enable_dependencies(monkeypatch)
+    create_calls: list[dict[str, Any]] = []
+
+    def create(_capabilities, **kwargs):
+        create_calls.append(dict(kwargs))
+        return _enrollment_response()
+
+    monkeypatch.setattr(auto, "create_enrollment", create)
+    profile = _current_authorization_profile_hash()
+
+    result = auto.enable(
+        agent="claude",
+        accepted_authorization_version=AUTH_VERSION,
+        accepted_retention_version=RETENTION_VERSION,
+        accepted_ownership_certification_version=OWNERSHIP_VERSION,
+        accepted_authorization_profile_hash=profile,
+    )
+
+    assert result["mode"] == "enabled"
+    assert len(create_calls) == 1
+    assert create_calls[0]["enrollment_grant"] == "cj_enroll_one-shot"
+    assert create_calls[0]["upload_token"] is None
+    persisted = config_module.load_config()
+    assert "recurring_enrollment_grant" not in persisted
+    assert "recurring_enrollment_grant_expires_at" not in persisted
+    assert "recurring_enrollment_grant_receipt_id" not in persisted
+    assert "recurring_enrollment_grant_issuer" not in persisted
+
+
+def test_rejected_manual_share_grant_falls_back_to_email_verification(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    _save_scope_config(enrollment_grant="cj_enroll_expired")
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    conn.close()
+    _patch_enable_dependencies(monkeypatch)
+
+    def reject(_capabilities, **_kwargs):
+        raise RecurringServiceError(
+            "email_verification_required",
+            "Fresh verified identity is required.",
+        )
+
+    monkeypatch.setattr(auto, "create_enrollment", reject)
+    profile = _current_authorization_profile_hash()
+
+    result = auto.enable(
+        agent="claude",
+        accepted_authorization_version=AUTH_VERSION,
+        accepted_retention_version=RETENTION_VERSION,
+        accepted_ownership_certification_version=OWNERSHIP_VERSION,
+        accepted_authorization_profile_hash=profile,
+    )
+
+    assert result["code"] == "email_verification_required"
+    persisted = config_module.load_config()
+    assert "recurring_enrollment_grant" not in persisted
+    assert auto.status()["enrollment_grant_available"] is False
 
 
 def test_enable_requires_exact_versions_then_commits_all_authority_transactionally(

--- a/tests/test_auto_upload_client.py
+++ b/tests/test_auto_upload_client.py
@@ -59,14 +59,29 @@ def test_capabilities_require_every_safety_contract():
 
 @pytest.mark.parametrize(
     "grant_version",
-    [True, 1.0, "1", 2],
+    [True, 1.0, "1", 2, None],
 )
-def test_capabilities_require_an_exact_integer_grant_version(grant_version):
-    with pytest.raises(client.CapabilityError, match="enrollment-grant"):
-        client.validate_capabilities(
-            _caps(manual_share_enrollment_grant_version=grant_version),
-            origin="https://data.rayward.ai",
-        )
+def test_unknown_grant_version_never_fails_the_capability_document(grant_version):
+    """The grant is a convenience on top of email verification.
+
+    A server advertising a different (or malformed) grant version must only
+    disable the grant shortcut — failing validation here would block every
+    enrollment path, email verification included, until a client upgrade.
+    """
+
+    validated = client.validate_capabilities(
+        _caps(manual_share_enrollment_grant_version=grant_version),
+        origin="https://data.rayward.ai",
+    )
+
+    assert validated["recurring_enrollment_url"]
+    assert not client.grant_capability_version_supported(grant_version)
+
+
+def test_grant_version_support_requires_the_exact_integer():
+    assert client.grant_capability_version_supported(1) is True
+    # Python bools compare equal to ints; True must not pass as version 1.
+    assert client.grant_capability_version_supported(True) is False
 
 
 def test_capabilities_reject_cross_origin_endpoint():

--- a/tests/test_auto_upload_client.py
+++ b/tests/test_auto_upload_client.py
@@ -57,6 +57,18 @@ def test_capabilities_require_every_safety_contract():
         )
 
 
+@pytest.mark.parametrize(
+    "grant_version",
+    [True, 1.0, "1", 2],
+)
+def test_capabilities_require_an_exact_integer_grant_version(grant_version):
+    with pytest.raises(client.CapabilityError, match="enrollment-grant"):
+        client.validate_capabilities(
+            _caps(manual_share_enrollment_grant_version=grant_version),
+            origin="https://data.rayward.ai",
+        )
+
+
 def test_capabilities_reject_cross_origin_endpoint():
     with pytest.raises(client.CapabilityError, match="different origin"):
         client.validate_capabilities(

--- a/tests/test_auto_upload_client.py
+++ b/tests/test_auto_upload_client.py
@@ -11,6 +11,7 @@ from clawjournal import auto_upload_client as client
 def _caps(**overrides):
     caps = {
         "recurring_upload_api_version": 2,
+        "manual_share_enrollment_grant_version": 1,
         "recurring_cadence_days": 1,
         "recurring_enrollment_open": True,
         "maximum_recurring_sessions": 5,
@@ -207,6 +208,56 @@ def test_json_request_sends_bearer_without_following_redirect(monkeypatch):
     assert seen["body"]["ownership_certification"] is True
     assert seen["body"]["client_version"] == "2"
     assert "scope_hash" not in seen["body"]
+
+
+def test_create_enrollment_accepts_manual_share_grant_without_upload_token(
+    monkeypatch,
+):
+    seen = {}
+
+    def fake_open(request, *, timeout):
+        seen["body"] = json.loads(request.data)
+        return b'{"enrollment_id":"enrollment-1"}'
+
+    monkeypatch.setattr(client, "_open_request", fake_open)
+    result = client.create_enrollment(
+        client.validate_capabilities(_caps(), origin="https://data.rayward.ai"),
+        enrollment_grant="cj_enroll_one-shot",
+        client_enrollment_id="intent-1",
+        scope_entries=[("codex", "clawjournal")],
+        authorization_version="auth-v1",
+        retention_version="ret-v1",
+        ownership_certification=True,
+    )
+
+    assert result["enrollment_id"] == "enrollment-1"
+    assert seen["body"]["enrollment_grant"] == "cj_enroll_one-shot"
+    assert "upload_token" not in seen["body"]
+
+
+def test_create_enrollment_requires_exactly_one_identity_credential():
+    capabilities = client.validate_capabilities(
+        _caps(), origin="https://data.rayward.ai"
+    )
+    common = {
+        "client_enrollment_id": "intent-1",
+        "scope_entries": [("codex", "clawjournal")],
+        "authorization_version": "auth-v1",
+        "retention_version": "ret-v1",
+        "ownership_certification": True,
+    }
+    with pytest.raises(client.CapabilityError) as missing:
+        client.create_enrollment(capabilities, **common)
+    assert missing.value.code == "email_verification_required"
+
+    with pytest.raises(client.CapabilityError) as duplicate:
+        client.create_enrollment(
+            capabilities,
+            upload_token="upload",
+            enrollment_grant="grant",
+            **common,
+        )
+    assert duplicate.value.code == "email_verification_required"
 
 
 def test_typed_http_error_preserves_code_and_retryability():

--- a/tests/test_cli_auto_upload.py
+++ b/tests/test_cli_auto_upload.py
@@ -172,7 +172,7 @@ def test_interactive_challenge_sanitizes_versions_scope_and_backend(
 
     def answer(prompt):
         prompts.append(prompt)
-        return "yes"
+        return attack
 
     monkeypatch.setattr(cli.sys, "stdin", _FakeStdin())
     monkeypatch.setattr("builtins.input", answer)
@@ -245,7 +245,7 @@ def test_interactive_enable_replays_exact_profile_after_email_verification(
             }
         return {"ok": True, "mode": "enabled", "health": "ready"}
 
-    answers = iter(["yes", "yes", "student@uni.edu"])
+    answers = iter(["auth-v1", "ret-v1", "own-v1", "student@uni.edu"])
     monkeypatch.setattr("clawjournal.auto_upload.enable", enable)
     monkeypatch.setattr(sys, "stdin", _FakeStdin())
     monkeypatch.setattr("builtins.input", lambda *_a, **_k: next(answers))
@@ -326,7 +326,9 @@ def test_interactive_enable_reprompts_once_when_the_refresh_changes_scope(
             return challenge("profile-two", ["project", "project-two"])
         return {"ok": True, "mode": "enabled", "health": "ready"}
 
-    answers = iter(["yes", "yes", "yes", "yes"])
+    answers = iter(
+        ["auth-v1", "ret-v1", "own-v1", "auth-v1", "ret-v1", "own-v1"]
+    )
     monkeypatch.setattr("clawjournal.auto_upload.enable", enable)
     monkeypatch.setattr(sys, "stdin", _FakeStdin())
     monkeypatch.setattr("builtins.input", lambda *_a, **_k: next(answers))

--- a/tests/test_cli_auto_upload.py
+++ b/tests/test_cli_auto_upload.py
@@ -172,7 +172,7 @@ def test_interactive_challenge_sanitizes_versions_scope_and_backend(
 
     def answer(prompt):
         prompts.append(prompt)
-        return attack
+        return "yes"
 
     monkeypatch.setattr(cli.sys, "stdin", _FakeStdin())
     monkeypatch.setattr("builtins.input", answer)
@@ -245,7 +245,7 @@ def test_interactive_enable_replays_exact_profile_after_email_verification(
             }
         return {"ok": True, "mode": "enabled", "health": "ready"}
 
-    answers = iter(["auth-v1", "ret-v1", "own-v1", "student@uni.edu"])
+    answers = iter(["yes", "yes", "student@uni.edu"])
     monkeypatch.setattr("clawjournal.auto_upload.enable", enable)
     monkeypatch.setattr(sys, "stdin", _FakeStdin())
     monkeypatch.setattr("builtins.input", lambda *_a, **_k: next(answers))
@@ -266,7 +266,7 @@ def test_interactive_enable_replays_exact_profile_after_email_verification(
         assert callable(call.pop("scan_progress"))
         assert callable(call.pop("scan_wait_notice"))
     accepted = {
-        "agent": "all",
+        "agent": "auto",
         "accepted_authorization_version": "auth-v1",
         "accepted_retention_version": "ret-v1",
         "accepted_ownership_certification_version": "own-v1",
@@ -274,7 +274,7 @@ def test_interactive_enable_replays_exact_profile_after_email_verification(
     }
     assert calls == [
         {
-            "agent": "all",
+            "agent": "auto",
             "accepted_authorization_version": None,
             "accepted_retention_version": None,
             "accepted_ownership_certification_version": None,
@@ -326,9 +326,7 @@ def test_interactive_enable_reprompts_once_when_the_refresh_changes_scope(
             return challenge("profile-two", ["project", "project-two"])
         return {"ok": True, "mode": "enabled", "health": "ready"}
 
-    answers = iter(
-        ["auth-v1", "ret-v1", "own-v1", "auth-v1", "ret-v1", "own-v1"]
-    )
+    answers = iter(["yes", "yes", "yes", "yes"])
     monkeypatch.setattr("clawjournal.auto_upload.enable", enable)
     monkeypatch.setattr(sys, "stdin", _FakeStdin())
     monkeypatch.setattr("builtins.input", lambda *_a, **_k: next(answers))

--- a/tests/test_cli_config_masking.py
+++ b/tests/test_cli_config_masking.py
@@ -6,6 +6,7 @@ def test_config_display_masks_secret_keys_recursively():
         {
             "verified_email": "person@example.edu",
             "verified_email_token": "abcdefghijklmnop",
+            "recurring_enrollment_grant": "grant-abcdefghijklmnop",
             "nested": {
                 "api_key": "sk-super-secret-value",
                 "safe": "visible",
@@ -16,6 +17,7 @@ def test_config_display_masks_secret_keys_recursively():
 
     assert displayed["verified_email"] == "person@example.edu"
     assert displayed["verified_email_token"] == "abcd...mnop"
+    assert displayed["recurring_enrollment_grant"] == "gran...mnop"
     assert displayed["nested"] == {
         "api_key": "sk-s...alue",
         "safe": "visible",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -7,6 +7,7 @@ import pytest
 from clawjournal.config import (
     _migrate_excluded_projects,
     _migrate_findings_engines,
+    _migrate_remove_auto_upload_ui_flag,
     load_config,
     normalize_excluded_project_names,
     save_config,
@@ -168,3 +169,23 @@ class TestMigrateFindingsEngines:
         assert "betterleaks" in config["enabled_findings_engines"]
         data = json.loads(tmp_config.read_text())
         assert "betterleaks" in data["enabled_findings_engines"]
+
+
+class TestRemoveAutoUploadUiFlag:
+    def test_missing_key_is_unchanged(self):
+        config = {}
+        assert _migrate_remove_auto_upload_ui_flag(config) is False
+
+    def test_retired_rollout_flag_is_removed(self):
+        config = {"auto_upload_ui_enabled": False}
+        assert _migrate_remove_auto_upload_ui_flag(config) is True
+        assert "auto_upload_ui_enabled" not in config
+
+    def test_load_config_persists_removal(self, tmp_config):
+        tmp_config.parent.mkdir(parents=True, exist_ok=True)
+        tmp_config.write_text(json.dumps({"auto_upload_ui_enabled": True}))
+
+        config = load_config()
+
+        assert "auto_upload_ui_enabled" not in config
+        assert "auto_upload_ui_enabled" not in json.loads(tmp_config.read_text())

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -4092,6 +4092,61 @@ class TestShareAPI:
         assert "verified_email_token" not in persisted
         assert "verified_email_token_expires_at" not in persisted
 
+    def test_cached_grant_issuer_is_stored_normalized(self, server, monkeypatch):
+        """The issuer must be written in the form the enrollment path compares.
+
+        ``_hosted_api_base`` echoes the operator's CLAWJOURNAL_SHARE_URL casing,
+        while capability validation lowercases the host. Storing the raw spelling
+        would leave a valid grant permanently unusable on a mixed-case install.
+        """
+        WorkbenchHandler._last_share_time = 0.0
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon._HOSTED_SHARE_URL",
+            "https://Hosted.Example.TEST/share",
+        )
+        share_id = self._create_and_export_share(server)
+        config = _share_config()
+        snapshots: list[dict] = []
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(minutes=30)
+        ).isoformat()
+        upload_response = {
+            "receipt_id": "rcpt-test-456",
+            "status": "received",
+            "recurring_enrollment_grant": "cj_enroll_one-shot",
+            "recurring_enrollment_grant_expires_at": expires_at,
+            "recurring_enrollment_grant_receipt_id": "rcpt-test-456",
+        }
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config", lambda: config
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.save_config",
+            lambda updated: snapshots.append(dict(updated)) or True,
+        )
+
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                upload_response=upload_response,
+                capabilities={
+                    "recurring_upload_api_version": 2,
+                    "recurring_cadence_days": 1,
+                    "recurring_enrollment_open": True,
+                    "manual_share_enrollment_grant_version": 1,
+                },
+            ),
+        ):
+            status, _ = _post(
+                server, f"/api/shares/{share_id}/upload", self._consent_body()
+            )
+
+        assert status == 200
+        assert snapshots[-1]["recurring_enrollment_grant_issuer"] == (
+            "https://hosted.example.test"
+        )
+
     def test_share_rate_limiting(self, server, monkeypatch):
         """Two shares within cooldown → second gets 429."""
         WorkbenchHandler._last_share_time = 0.0

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -3595,6 +3595,42 @@ class TestVerifyEmailAPI:
         assert saved["pending_verification_id"] == "verify-123"
         assert saved["pending_verification_email"] == "test@university.edu"
 
+    def test_switching_identities_clears_the_enrollment_grant(self, monkeypatch):
+        """A grant issued to one verified email must not survive a new identity.
+
+        Re-verifying the same email keeps it: nothing about the grant's
+        authority changed, and destroying it would force the second email
+        verification the grant exists to avoid.
+        """
+        from clawjournal.workbench.daemon import request_email_verification
+
+        grant_state = {
+            "recurring_enrollment_grant": "cj_enroll_one-shot",
+            "recurring_enrollment_grant_expires_at": "2099-01-01T00:00:00+00:00",
+            "recurring_enrollment_grant_receipt_id": "rcpt-1",
+            "recurring_enrollment_grant_issuer": "https://hosted.example.test",
+        }
+        snapshots: list[dict] = []
+        monkeypatch.setattr("clawjournal.workbench.daemon._HOSTED_SHARE_URL", "https://hosted.example.test/share")
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: {"verified_email": "old@university.edu", **grant_state},
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.save_config",
+            lambda config: snapshots.append(dict(config)) or True,
+        )
+
+        with patch("clawjournal.workbench.daemon.urllib.request.urlopen", side_effect=_mock_urlopen_factory()):
+            request_email_verification("old@university.edu")
+            request_email_verification("new@university.edu")
+
+        same_identity, new_identity = snapshots
+        for key in grant_state:
+            assert same_identity[key] == grant_state[key]
+            assert key not in new_identity
+        assert "verified_email_token" not in new_identity
+
     def test_confirm_email_verification_persists_upload_token_and_expiry(self, monkeypatch):
         from clawjournal.workbench.daemon import confirm_email_verification
 

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -4039,6 +4039,59 @@ class TestShareAPI:
         assert "verified_email_token" not in saved
         assert "verified_email_token_expires_at" not in saved
 
+    def test_share_success_caches_recurring_enrollment_grant(self, server, monkeypatch):
+        WorkbenchHandler._last_share_time = 0.0
+        share_id = self._create_and_export_share(server)
+        config = _share_config()
+        snapshots: list[dict] = []
+        expires_at = (
+            datetime.now(timezone.utc) + timedelta(minutes=30)
+        ).isoformat()
+        upload_response = {
+            "receipt_id": "rcpt-test-123",
+            "status": "received",
+            "recurring_enrollment_grant": "cj_enroll_one-shot",
+            "recurring_enrollment_grant_expires_at": expires_at,
+            "recurring_enrollment_grant_receipt_id": "rcpt-test-123",
+        }
+        capabilities = {
+            "recurring_upload_api_version": 2,
+            "recurring_cadence_days": 1,
+            "recurring_enrollment_open": True,
+            "manual_share_enrollment_grant_version": 1,
+        }
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config", lambda: config
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.save_config",
+            lambda updated: snapshots.append(dict(updated)) or True,
+        )
+
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                upload_response=upload_response,
+                capabilities=capabilities,
+            ),
+        ):
+            status, data = _post(
+                server, f"/api/shares/{share_id}/upload", self._consent_body()
+            )
+
+        assert status == 200
+        assert data["ok"] is True
+        assert snapshots
+        persisted = snapshots[-1]
+        assert persisted["recurring_enrollment_grant"] == "cj_enroll_one-shot"
+        assert persisted["recurring_enrollment_grant_receipt_id"] == "rcpt-test-123"
+        assert persisted["recurring_enrollment_grant_issuer"] == (
+            "https://hosted.example.test"
+        )
+        assert "verified_email_token" not in persisted
+        assert "verified_email_token_expires_at" not in persisted
+
     def test_share_rate_limiting(self, server, monkeypatch):
         """Two shares within cooldown → second gets 429."""
         WorkbenchHandler._last_share_time = 0.0

--- a/tests/workbench/test_daemon_config.py
+++ b/tests/workbench/test_daemon_config.py
@@ -70,10 +70,18 @@ class TestGetConfig:
         assert "both" not in body["source_choices"]
 
     def test_never_exposes_secrets(self, api):
-        save_config({"verified_email_token": "SECRET", "publish_attestation": "X"})
+        save_config({
+            "verified_email_token": "SECRET",
+            "recurring_enrollment_grant": "ONE-TIME-GRANT",
+            "publish_attestation": "X",
+        })
         _, body = _get(api, "/api/config")
-        for secret in ("verified_email_token", "publish_attestation",
-                       "pending_verification_email"):
+        for secret in (
+            "verified_email_token",
+            "recurring_enrollment_grant",
+            "publish_attestation",
+            "pending_verification_email",
+        ):
             assert secret not in body
 
 


### PR DESCRIPTION
## Summary

- Cache the short-lived recurring-enrollment grant returned after a successful hosted manual share.
- Use that grant to create protocol-v2 recurring enrollment without asking the participant to verify the same email a second time.
- Present the exact recurring authorization, retention terms, scope, and distinct ownership certification directly on the successful receipt flow.
- Simplify CLI enrollment retries while preserving exact-version and post-refresh scope acceptance.
- Remove the internal `CLAWJOURNAL_ENABLE_AUTO_UPLOAD_UI` rollout gate so Automatic uploads is visible by default, and migrate away the retired config key.

## Safety invariants

- Recurring authorization remains separate from manual-share consent.
- Enrollment remains protocol-v2, future-only, exact-scope, ownership-certified, capped at five traces, and fail-closed on scope-hash drift.
- The receipt-issued grant is one-time, origin-bound, expiry-checked, removed after use, and falls back to normal email verification when unavailable or rejected.
- Manual Share review, redaction, secret scanning, and submission behavior remain unchanged.

## Validation

- Full Python suite: **3028 passed, 4 skipped**.
- Focused grant, client, config, CLI, and daemon suites: **215 passed**.
- Frontend tests: **50 passed**; production build completed successfully.
- Regression coverage includes ISO and epoch grant expirations, rejected-grant email fallback, strict integer capability versions, origin binding, credential cleanup, and conditional receipt copy.
- Local Docker E2E: manual hosted share → enrollment grant cached → recurring enrollment enabled without repeat email verification → post-enrollment trace selected → recurring artifact uploaded → matching receipt persisted by the hosted service.
