### PR TITLE
Show Auto Upload after an eligible hosted share

### DIFF
--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -580,13 +580,16 @@ def _has_successful_manual_receipt(conn: sqlite3.Connection) -> bool:
 def _auto_upload_ui_visible(
     config: Mapping[str, Any],
     enrollment: Mapping[str, Any] | None = None,
+    *,
+    successful_manual_receipt: bool = False,
 ) -> bool:
     # A successful manual hosted share caches this non-authoritative offer bit
     # only after the service advertises the current recurring-upload protocol.
     # It is safe to use for visibility: Enable still revalidates the live
     # capability document before granting any recurring authority.
     hosted_offer_available = (
-        config.get("auto_upload_capability_available") is True
+        successful_manual_receipt
+        and config.get("auto_upload_capability_available") is True
     )
     explicitly_enabled = (
         os.environ.get(AUTO_UPLOAD_UI_ENV) == "1"
@@ -718,7 +721,11 @@ def status(*, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
             ),
             "overlay": overlay,
             "pending_submission_state": pending_submission_state,
-            "ui_visible": _auto_upload_ui_visible(config, enrollment),
+            "ui_visible": _auto_upload_ui_visible(
+                config,
+                enrollment,
+                successful_manual_receipt=successful_manual,
+            ),
             "offer_available": bool(
                 mode == "off"
                 and successful_manual

--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -581,6 +581,13 @@ def _auto_upload_ui_visible(
     config: Mapping[str, Any],
     enrollment: Mapping[str, Any] | None = None,
 ) -> bool:
+    # A successful manual hosted share caches this non-authoritative offer bit
+    # only after the service advertises the current recurring-upload protocol.
+    # It is safe to use for visibility: Enable still revalidates the live
+    # capability document before granting any recurring authority.
+    hosted_offer_available = (
+        config.get("auto_upload_capability_available") is True
+    )
     explicitly_enabled = (
         os.environ.get(AUTO_UPLOAD_UI_ENV) == "1"
         or config.get("auto_upload_ui_enabled") is True
@@ -593,7 +600,7 @@ def _auto_upload_ui_visible(
             or enrollment.get("revocation_pending")
         )
     )
-    return explicitly_enabled or existing_authority
+    return hosted_offer_available or explicitly_enabled or existing_authority
 
 
 def _off_status(config: Mapping[str, Any]) -> dict[str, Any]:

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -135,7 +135,7 @@ class ClawJournalConfig(TypedDict, total=False):
     benchmark_tab_enabled: bool  # show/hide the Benchmark tab in the workbench UI (default on)
     scoring_warmup_declined: bool  # user declined the background auto-scorer (suppresses prompt + server-side auto-start)
     auto_upload_capability_available: bool  # non-authoritative UI offer cache; Enable revalidates live
-    auto_upload_ui_enabled: bool  # internal rollout flag; default hidden
+    auto_upload_ui_enabled: bool  # internal override; a cached eligible offer also reveals the UI
 
 
 DEFAULT_CONFIG: ClawJournalConfig = {

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -362,7 +362,7 @@ def test_status_is_read_only_without_an_install(
     assert not isolated_auto_upload["install"].exists()
 
 
-def test_auto_upload_ui_is_hidden_unless_internal_rollout_is_enabled(
+def test_auto_upload_ui_is_hidden_until_rollout_or_hosted_offer_is_available(
     isolated_auto_upload,
     monkeypatch,
 ):
@@ -370,6 +370,13 @@ def test_auto_upload_ui_is_hidden_unless_internal_rollout_is_enabled(
     assert auto.status()["ui_visible"] is False
 
     monkeypatch.setenv(auto.AUTO_UPLOAD_UI_ENV, "1")
+    assert auto.status()["ui_visible"] is True
+
+    monkeypatch.delenv(auto.AUTO_UPLOAD_UI_ENV)
+    config = _save_scope_config()
+    config["auto_upload_capability_available"] = True
+    assert config_module.save_config(config)
+
     assert auto.status()["ui_visible"] is True
 
 

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -362,7 +362,7 @@ def test_status_is_read_only_without_an_install(
     assert not isolated_auto_upload["install"].exists()
 
 
-def test_auto_upload_ui_is_hidden_until_rollout_or_hosted_offer_is_available(
+def test_auto_upload_ui_is_hidden_unless_internal_rollout_is_enabled(
     isolated_auto_upload,
     monkeypatch,
 ):
@@ -372,12 +372,40 @@ def test_auto_upload_ui_is_hidden_until_rollout_or_hosted_offer_is_available(
     monkeypatch.setenv(auto.AUTO_UPLOAD_UI_ENV, "1")
     assert auto.status()["ui_visible"] is True
 
-    monkeypatch.delenv(auto.AUTO_UPLOAD_UI_ENV)
+
+def test_successful_manual_receipt_and_hosted_offer_reveal_auto_upload_ui(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    monkeypatch.delenv(auto.AUTO_UPLOAD_UI_ENV, raising=False)
     config = _save_scope_config()
     config["auto_upload_capability_available"] = True
     assert config_module.save_config(config)
 
-    assert auto.status()["ui_visible"] is True
+    # A stale config cache without the receipt database must not reveal the
+    # controls after a partial reinstall.
+    assert auto.status()["ui_visible"] is False
+
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    share_id = create_share(conn, ["session-one"])
+    conn.execute(
+        "UPDATE shares SET status = 'shared', shared_at = ?, "
+        "hosted_receipt_id = ?, submission_channel = 'manual' "
+        "WHERE share_id = ?",
+        (
+            "2026-07-23T12:00:00+00:00",
+            "manual-receipt-after-reinstall",
+            share_id,
+        ),
+    )
+    conn.commit()
+
+    result = auto.status(conn=conn)
+    conn.close()
+
+    assert result["offer_available"] is True
+    assert result["ui_visible"] is True
 
 
 def test_existing_auto_upload_authority_keeps_controls_visible(


### PR DESCRIPTION
## What changed

- Reveal Auto Upload after the installation has both a successful hosted manual receipt and a cached protocol-v2 recurring-upload offer.
- Keep the internal environment/config rollout overrides and existing-authority recovery behavior intact.
- Keep a partial reinstall fail-closed: a stale capability cache without the receipt database does not reveal the controls.
- Add regression coverage for Richard's fresh-install → manual-share → hosted-offer path.

## Why

After a complete reinstall, `auto_upload_ui_enabled` returns to its default `false` value. Even after a successful manual hosted share confirms protocol-v2 recurring enrollment is available and caches `auto_upload_capability_available=true`, the UI stayed hidden because visibility only considered the internal rollout flag or existing authority.

The cached capability remains non-authoritative: choosing Enable still fetches and validates the live capability document before any recurring authority is granted.

## User impact

A fresh installation will show the Auto Upload offer after a successful eligible hosted share, without requiring an internal rollout environment variable. A stale cache alone remains insufficient.

## Validation

- `python -m pytest tests/test_auto_upload.py tests/test_auto_upload_client.py tests/test_cli_auto_upload.py tests/workbench/test_auto_upload_index.py tests/workbench/test_daemon.py -q` — 362 passed
- `npm test` in `clawjournal/web/frontend` — 61 passed
- `git diff --check`
- Live non-mutating authorization challenge against the production Cloud Run service returned the current authorization, retention, and ownership-certification versions; no enrollment was created.