### PR TITLE
Restore source setup guidance and success confetti

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ If ClawJournal is already installed, safely update its repository and rerun
 the installer. Never discard local changes or force-reset the checkout. If
 an update is blocked, explain why and stop.
 
-Look across all supported coding agents unless I tell you otherwise. Show me
-the discovered projects before confirming them so I can exclude personal,
+Look across all supported coding agents unless I tell you otherwise. Set that
+scope explicitly with `clawjournal config --source all`, then show me the
+discovered projects before confirming them so I can exclude personal,
 confidential, third-party, or unrelated work.
 
 Use the exact ClawJournal executable printed by the installer; do not assume
@@ -124,6 +125,7 @@ For the complete details, see [PRIVACY.md](PRIVACY.md).
 These are the main commands:
 
 ```bash
+clawjournal config --source all           # explicitly include all supported agent sources
 clawjournal serve                        # open the local workbench
 clawjournal share --interactive --weekly --no-score # guided sharing without AI scoring
 clawjournal status                       # check your setup

--- a/clawjournal/web/frontend/src/views/Share/DoneStep.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/DoneStep.test.tsx
@@ -1,0 +1,57 @@
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { DoneStep, type DoneStepProps } from './DoneStep.tsx';
+import { globalStyles } from './styles.tsx';
+
+vi.mock('../../components/AutoUploadControls.tsx', () => ({
+  AutoUploadOffer: () => null,
+}));
+
+function props(receiptId: string | null): DoneStepProps {
+  return {
+    stepperHeader: null,
+    bundle: { traces: 3, created: 'Jul 23', approxSize: '1.2 MB' },
+    receiptId,
+    hostedStatus: receiptId ? 'received' : null,
+    supportContact: null,
+    onDownloadAgain: vi.fn(),
+    onNew: vi.fn(),
+    globalStyles,
+    shareDestination: null,
+    destinationLoading: false,
+    destinationFailed: false,
+    onRetryDestination: vi.fn(),
+  };
+}
+
+describe('DoneStep success celebration', () => {
+  it('showers viewport confetti after a hosted submission succeeds', () => {
+    render(<DoneStep {...props('receipt-123')} />);
+
+    const confetti = screen.getByTestId('success-confetti');
+    expect(confetti).toHaveAttribute('aria-hidden', 'true');
+    expect(confetti).toHaveStyle({
+      position: 'fixed',
+      inset: '0',
+      overflow: 'hidden',
+    });
+    expect(confetti.querySelectorAll('span')).toHaveLength(144);
+    expect(confetti.querySelectorAll('.claw-confetti-later')).toHaveLength(96);
+  });
+
+  it('does not celebrate a bundle that stayed local', () => {
+    render(<DoneStep {...props(null)} />);
+
+    expect(screen.queryByTestId('success-confetti')).not.toBeInTheDocument();
+  });
+
+  it('keeps static confetti visible when reduced motion is requested', () => {
+    const { container } = render(<DoneStep {...props('receipt-123')} />);
+    const css = container.querySelector('style')?.textContent ?? '';
+
+    expect(css).toContain('@media (prefers-reduced-motion: reduce)');
+    expect(css).toContain('.claw-success-confetti .claw-confetti-later { display: none; }');
+    expect(css).toContain('opacity: .72 !important;');
+    expect(css).toContain('transform: translate3d(0,var(--cstatic-y),0) rotate(var(--cr));');
+  });
+});

--- a/clawjournal/web/frontend/src/views/Share/DoneStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/DoneStep.tsx
@@ -23,13 +23,15 @@ export interface DoneStepProps {
 
 export function DoneStep(p: DoneStepProps) {
   const [confettiPieces] = useState(() => {
-    const palette = ['#b47d08', '#558745', '#5f7191', '#df9d10', '#7aa568', '#c9655c', '#8a7555'];
-    const piecesPerWave = 42;
+    const palette = ['#D4AB73', '#45392C', '#725E47', '#E9DEC9', '#EDE2CC'];
+    const piecesPerWave = 48;
     return Array.from({ length: piecesPerWave * SUCCESS_WAVE_DELAYS.length }, (_, i) => ({
       id: i,
+      wave: Math.floor(i / piecesPerWave),
       left: 3 + Math.random() * 94,
-      dx: (Math.random() - 0.5) * 180,
-      dy: 360 + Math.random() * 300,
+      dx: (Math.random() - 0.5) * 24,
+      dy: 105 + Math.random() * 20,
+      staticY: 28 + Math.random() * 150,
       r: (Math.random() > 0.5 ? 1 : -1) * (540 + Math.random() * 720),
       width: 5 + Math.random() * 5,
       height: 8 + Math.random() * 9,
@@ -62,33 +64,48 @@ export function DoneStep(p: DoneStepProps) {
       {p.globalStyles}
       {p.stepperHeader}
       <div style={{ position: 'relative', padding: '56px 24px 24px', maxWidth: 680, margin: '0 auto', textAlign: 'center' }}>
-        {SUCCESS_WAVE_DELAYS.map((delay) => (
-          <div
-            key={delay}
-            className="claw-success-flash"
-            style={{
-              position: 'absolute', top: -24, left: '5%', right: '5%', height: 260,
-              pointerEvents: 'none', borderRadius: '50%',
-              background: 'radial-gradient(ellipse at top, rgba(85,135,69,.3) 0%, rgba(180,125,8,.13) 38%, rgba(255,255,255,0) 72%)',
-              opacity: 0,
-              ['--flash-delay' as string]: `${delay}ms`,
-            } as React.CSSProperties}
-          />
-        ))}
-        <div className="claw-success-confetti" style={{ position: 'absolute', inset: 0, zIndex: 1, pointerEvents: 'none', overflow: 'hidden' }}>
-          {confettiPieces.map((c) => (
-            <span key={c.id} style={{
-              position: 'absolute', top: -20, left: `${c.left}%`,
-              width: c.width, height: c.height, borderRadius: c.id % 4 === 0 ? '50%' : 1,
-              background: c.color, opacity: 0,
-              ['--cdx' as string]: `${c.dx}px`,
-              ['--cdy' as string]: `${c.dy}px`,
-              ['--cr' as string]: `${c.r}deg`,
-              ['--cduration' as string]: `${c.duration}ms`,
-              ['--cdelay' as string]: `${c.delay}ms`,
-            } as React.CSSProperties} />
-          ))}
-        </div>
+        {submitted && (
+          <>
+            {SUCCESS_WAVE_DELAYS.map((delay) => (
+              <div
+                key={delay}
+                aria-hidden="true"
+                className="claw-success-flash"
+                style={{
+                  position: 'fixed', top: -36, left: '8vw', right: '8vw', height: 96,
+                  zIndex: 99, pointerEvents: 'none', borderRadius: 48,
+                  background: 'rgba(212, 171, 115, .18)', filter: 'blur(18px)',
+                  opacity: 0,
+                  ['--flash-delay' as string]: `${delay}ms`,
+                } as React.CSSProperties}
+              />
+            ))}
+            <div
+              aria-hidden="true"
+              className="claw-success-confetti"
+              data-testid="success-confetti"
+              style={{ position: 'fixed', inset: 0, zIndex: 100, pointerEvents: 'none', overflow: 'hidden' }}
+            >
+              {confettiPieces.map((c) => (
+                <span
+                  key={c.id}
+                  className={c.wave > 0 ? 'claw-confetti-later' : undefined}
+                  style={{
+                    position: 'absolute', top: -20, left: `${c.left}%`,
+                    width: c.width, height: c.height, borderRadius: c.id % 4 === 0 ? '50%' : 1,
+                    background: c.color, opacity: 0,
+                    ['--cdx' as string]: `${c.dx}vw`,
+                    ['--cdy' as string]: `${c.dy}vh`,
+                    ['--cstatic-y' as string]: `${c.staticY}px`,
+                    ['--cr' as string]: `${c.r}deg`,
+                    ['--cduration' as string]: `${c.duration}ms`,
+                    ['--cdelay' as string]: `${c.delay}ms`,
+                  } as React.CSSProperties}
+                />
+              ))}
+            </div>
+          </>
+        )}
 
         <div style={{
           width: 72, height: 72, margin: '0 auto 24px',
@@ -317,4 +334,4 @@ const doneMiniRow: React.CSSProperties = {
   fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace', fontSize: 11.5,
 };
 
-const SUCCESS_WAVE_DELAYS = [0, 2300, 4600, 6900];
+const SUCCESS_WAVE_DELAYS = [0, 900, 1800];

--- a/clawjournal/web/frontend/src/views/Share/styles.tsx
+++ b/clawjournal/web/frontend/src/views/Share/styles.tsx
@@ -47,13 +47,20 @@ export const globalStyles = (
       animation-delay: var(--flash-delay, 0ms);
     }
     .claw-success-confetti span {
-      animation: clawConfettiDrop var(--cduration) cubic-bezier(.18,.68,.28,1) forwards;
+      animation: clawConfettiDrop var(--cduration) cubic-bezier(.18,.68,.28,1) both;
       animation-delay: var(--cdelay);
+      will-change: transform, opacity;
     }
     @keyframes clawPkgDrop { 0% { opacity: 0; transform: translate(-50%,-30px) scale(.85); } 15% { opacity: 1; } 70% { opacity: 1; transform: translate(-50%, 80px) scale(.85); } 100% { opacity: 0; transform: translate(-50%, 120px) scale(.3); } }
     @keyframes clawThump { 0% { transform: scale(1); } 40% { transform: scale(1.02) translateY(2px); } 100% { transform: scale(1); } }
     @media (prefers-reduced-motion: reduce) {
-      .claw-success-flash, .claw-success-confetti span { animation: none !important; }
+      .claw-success-flash { display: none; }
+      .claw-success-confetti .claw-confetti-later { display: none; }
+      .claw-success-confetti span {
+        animation: none !important;
+        opacity: .72 !important;
+        transform: translate3d(0,var(--cstatic-y),0) rotate(var(--cr));
+      }
     }
   `}</style>
 );


### PR DESCRIPTION
## What changed

- Restore the explicit `clawjournal config --source all` step in the setup prompt and terminal quick reference.
- Show success confetti only after a hosted submission receives a receipt.
- Move the celebration to a fixed viewport overlay so the paper falls visibly from the top of the screen.
- Use the OpenRefinery Honeyed Almond palette and replace the prior gradient flash with a restrained Honey wash.
- Preserve accessibility: reduced-motion users see one static confetti arrangement instead of a moving shower or a completely empty celebration.
- Add focused regression tests for successful submission, local-only bundles, and reduced-motion fallback.

## Why

The README's prompt-first rewrite stopped naming the command participants use to select all supported sources, leaving a fresh install with `source: null` until another workflow supplied the missing step.

PR #135's reduced-motion rule disabled the confetti animation while every piece still had `opacity: 0`; users with that preference heard the success sound but saw no celebration. The prior overlay was also confined to the narrow success card instead of the viewport.

## User impact

Fresh installs again receive an explicit source-scope command without weakening the source/project confirmation gate. Successful hosted submissions show a visible top-of-screen confetti shower, while reduced-motion users retain a static success treatment.

## Validation

- `npm test` — 64 passed across 10 files
- `npx eslint src/views/Share/DoneStep.tsx src/views/Share/DoneStep.test.tsx src/views/Share/styles.tsx`
- `npm run build`
- `git diff --check`
- Local visual verification against a real submitted share: 144 confetti pieces rendered in a fixed viewport overlay, with 30 visible during the captured animation frame

Full-repository ESLint still reports six pre-existing errors in unrelated files; the modified frontend files pass lint.