### PR TITLE
Guide Auto Upload scope setup and contain success confetti

### DIFF
--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -198,9 +198,10 @@ def set_source_scope(config: ClawJournalConfig, source: str) -> None:
 def source_scope_sources(source: str | None) -> tuple[str, ...] | None:
     """Return allowed session sources for a confirmed source scope.
 
-    ``None`` means unrestricted/all sources. Legacy ``both`` means the
-    original Claude+Codex pair, while ``all`` intentionally means every
-    supported indexed source.
+    ``None`` means unrestricted/all sources. ``both`` means the Claude+Codex
+    pair — it predates ``all`` and is also what the Auto Upload guided scope
+    setup writes, since those are exactly the recurring-capable sources —
+    while ``all`` intentionally means every supported indexed source.
     """
     normalized = (source or "").strip().lower()
     if normalized in ("", "auto", "all"):

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
@@ -2,7 +2,7 @@ import { act, fireEvent, render, screen, waitFor, within } from '@testing-librar
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { api, ApiError } from '../api.ts';
-import type { AutoUploadStatus } from '../types.ts';
+import type { AutoUploadStatus, WorkbenchConfig } from '../types.ts';
 import { AutoUploadOffer, AutoUploadPanel } from './AutoUploadControls.tsx';
 import { ToastProvider } from './Toast.tsx';
 
@@ -28,6 +28,22 @@ function status(overrides: Partial<AutoUploadStatus> = {}): AutoUploadStatus {
     hooks: [],
     eligibility: { selected_count: 0, eligible_count: 0, exclusion_counts: {} },
     last_result: null,
+    ...overrides,
+  };
+}
+
+function workbenchConfig(overrides: Partial<WorkbenchConfig> = {}): WorkbenchConfig {
+  return {
+    source: null,
+    projects_confirmed: false,
+    ai_pii_review_enabled: false,
+    scorer_backend: null,
+    scorer_backend_confirmed_at: null,
+    benchmark_tab_enabled: true,
+    scoring_warmup_declined: false,
+    source_choices: ['all', 'claude', 'codex'],
+    scorer_backend_choices: [],
+    scorer_backend_detected: null,
     ...overrides,
   };
 }
@@ -76,6 +92,28 @@ function authorizationRequired() {
     cadence_days: 1,
     maximum_bundle_size: 5_000_000,
     destination_origin: 'https://share.example.test',
+  });
+}
+
+function scopeRequired() {
+  return new ApiError(400, 'Scope confirmation required', {
+    code: 'source_confirmation_missing',
+    message: 'Confirm a non-empty source and project scope before enabling.',
+    scope_blockers: [
+      'source_confirmation_missing',
+      'project_confirmation_missing',
+      'source_scope_empty',
+      'project_scope_empty',
+    ],
+  });
+}
+
+function unsupportedScopeRequired() {
+  return new ApiError(400, 'Unsupported source', {
+    code: 'unsupported_source',
+    message: 'Confirm a non-empty source and project scope before enabling.',
+    scope_blockers: ['unsupported_source'],
+    unsupported_sources: ['gemini'],
   });
 }
 
@@ -140,6 +178,296 @@ describe('AutoUploadOffer', () => {
     statusSpy.mockResolvedValueOnce(status({ offer_available: true }));
     renderControl(<AutoUploadOffer manualReceiptId="receipt-3" />);
     expect(await screen.findByText('Share future traces automatically?')).toBeInTheDocument();
+  });
+
+  it('keeps missing scope setup inside the enable flow and continues to authorization', async () => {
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValueOnce(status({
+      offer_available: true,
+    }));
+    const enableSpy = vi.spyOn(api.autoUpload, 'enable')
+      .mockRejectedValueOnce(scopeRequired())
+      .mockRejectedValueOnce(authorizationRequired());
+    vi.spyOn(api.config, 'get').mockResolvedValueOnce(workbenchConfig());
+    const updateSpy = vi.spyOn(api.config, 'update').mockResolvedValueOnce(workbenchConfig({
+      source: 'both',
+      projects_confirmed: true,
+      source_choices: ['all', 'both', 'claude', 'codex'],
+    }));
+    vi.spyOn(api, 'projects').mockResolvedValueOnce([
+      {
+        source: 'claude',
+        project: 'research-notes',
+        session_count: 2,
+        total_tokens: 1_200,
+      },
+      {
+        source: 'codex',
+        project: 'analysis-pipeline',
+        session_count: 1,
+        total_tokens: 800,
+      },
+    ]);
+
+    renderControl(<AutoUploadOffer manualReceiptId="receipt-needs-scope" />);
+
+    expect(await screen.findByText('Choose what automatic uploads may include')).toBeInTheDocument();
+    expect(screen.queryByText('Confirm a non-empty source and project scope before enabling.')).not.toBeInTheDocument();
+    // Inline presentation: still dismissible, and the run-trigger select stays
+    // hidden while its labels would duplicate the source-scope options below.
+    expect(screen.getByRole('heading', { name: 'Share future traces automatically?' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Not now' })).toBeInTheDocument();
+    expect(screen.queryByLabelText('Run on agent sessions')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Export source scope')).toHaveValue('');
+
+    fireEvent.change(screen.getByLabelText('Export source scope'), {
+      target: { value: 'both' },
+    });
+    expect(screen.getByLabelText('Claude Code · research-notes · 2 sessions')).toBeInTheDocument();
+    expect(screen.getByLabelText('Codex · analysis-pipeline · 1 session')).toBeInTheDocument();
+
+    const projectConfirmation = screen.getByLabelText('Confirm all eligible projects for automatic upload');
+    expect(projectConfirmation).not.toBeChecked();
+    expect(screen.getByText('Confirm all eligible projects')).toBeInTheDocument();
+    expect(screen.getByText('I reviewed all 2 projects listed above. Only these projects may enter this automatic-upload scope.')).toBeInTheDocument();
+    fireEvent.click(projectConfirmation);
+    fireEvent.click(screen.getByRole('button', { name: 'Save scope and continue' }));
+
+    await waitFor(() => expect(updateSpy).toHaveBeenCalledWith({
+      source: 'both',
+      confirm_projects: true,
+    }));
+    await waitFor(() => expect(enableSpy).toHaveBeenCalledTimes(2));
+    expect(enableSpy).toHaveBeenNthCalledWith(2, {
+      agent: 'all',
+      challenge_only: true,
+    });
+    expect(await screen.findByText('I authorize capped recurring uploads of eligible future traces.')).toBeInTheDocument();
+    expect(screen.getByText('claude → project-a')).toBeInTheDocument();
+  });
+
+  it('retries with the hook matching a single-source scope after saving', async () => {
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValueOnce(status({
+      offer_available: true,
+    }));
+    const enableSpy = vi.spyOn(api.autoUpload, 'enable')
+      .mockRejectedValueOnce(scopeRequired())
+      .mockRejectedValueOnce(authorizationRequired());
+    vi.spyOn(api.config, 'get').mockResolvedValueOnce(workbenchConfig());
+    vi.spyOn(api.config, 'update').mockResolvedValueOnce(workbenchConfig({
+      source: 'claude',
+      projects_confirmed: true,
+    }));
+    vi.spyOn(api, 'projects').mockResolvedValueOnce([
+      {
+        source: 'claude',
+        project: 'research-notes',
+        session_count: 2,
+        total_tokens: 1_200,
+      },
+    ]);
+
+    renderControl(<AutoUploadOffer manualReceiptId="receipt-claude-only-scope" />);
+    fireEvent.change(await screen.findByLabelText('Export source scope'), {
+      target: { value: 'claude' },
+    });
+    fireEvent.click(screen.getByLabelText('Confirm all eligible projects for automatic upload'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save scope and continue' }));
+
+    // A claude-only scope must not schedule a codex SessionStart hook.
+    await waitFor(() => expect(enableSpy).toHaveBeenCalledTimes(2));
+    expect(enableSpy).toHaveBeenNthCalledWith(2, {
+      agent: 'claude',
+      challenge_only: true,
+    });
+  });
+
+  it('keeps scope setup open when saving the scope fails', async () => {
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValueOnce(status({
+      offer_available: true,
+    }));
+    const enableSpy = vi.spyOn(api.autoUpload, 'enable')
+      .mockRejectedValueOnce(scopeRequired());
+    vi.spyOn(api.config, 'get').mockResolvedValueOnce(workbenchConfig());
+    vi.spyOn(api.config, 'update').mockRejectedValueOnce(
+      new ApiError(500, 'Config persistence could not be confirmed.'),
+    );
+    vi.spyOn(api, 'projects').mockResolvedValueOnce([
+      {
+        source: 'claude',
+        project: 'research-notes',
+        session_count: 2,
+        total_tokens: 1_200,
+      },
+    ]);
+
+    renderControl(<AutoUploadOffer manualReceiptId="receipt-scope-save-fails" />);
+    fireEvent.change(await screen.findByLabelText('Export source scope'), {
+      target: { value: 'claude' },
+    });
+    fireEvent.click(screen.getByLabelText('Confirm all eligible projects for automatic upload'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save scope and continue' }));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'Config persistence could not be confirmed.',
+    );
+    expect(screen.getByText('Choose what automatic uploads may include')).toBeInTheDocument();
+    expect(screen.getByLabelText('Confirm all eligible projects for automatic upload')).toBeChecked();
+    expect(screen.getByRole('button', { name: 'Save scope and continue' })).toBeEnabled();
+    expect(enableSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('guides unsupported export scopes to the supported recurring sources', async () => {
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValueOnce(status({
+      offer_available: true,
+    }));
+    const enableSpy = vi.spyOn(api.autoUpload, 'enable')
+      .mockRejectedValueOnce(unsupportedScopeRequired())
+      .mockRejectedValueOnce(authorizationRequired());
+    vi.spyOn(api.config, 'get').mockResolvedValueOnce(workbenchConfig({
+      source: 'all',
+      projects_confirmed: true,
+      source_choices: ['aider', 'all', 'claude', 'codex', 'gemini'],
+    }));
+    const updateSpy = vi.spyOn(api.config, 'update').mockResolvedValueOnce(workbenchConfig({
+      source: 'both',
+      projects_confirmed: true,
+      source_choices: ['all', 'both', 'claude', 'codex'],
+    }));
+    vi.spyOn(api, 'projects').mockResolvedValueOnce([
+      {
+        source: 'claude',
+        project: 'research-notes',
+        session_count: 2,
+        total_tokens: 1_200,
+      },
+      {
+        source: 'gemini',
+        project: 'unsupported-project',
+        session_count: 1,
+        total_tokens: 500,
+      },
+    ]);
+
+    renderControl(<AutoUploadOffer manualReceiptId="receipt-unsupported-scope" />);
+
+    const source = await screen.findByLabelText('Export source scope');
+    expect(source).toHaveValue('');
+    expect(within(source).getByRole('option', { name: 'Claude Code and Codex' })).toBeInTheDocument();
+    expect(within(source).getByRole('option', { name: 'Claude Code' })).toBeInTheDocument();
+    expect(within(source).getByRole('option', { name: 'Codex' })).toBeInTheDocument();
+    expect(within(source).queryByRole('option', { name: 'All agents' })).not.toBeInTheDocument();
+    expect(within(source).queryByRole('option', { name: 'Gemini' })).not.toBeInTheDocument();
+
+    fireEvent.change(source, { target: { value: 'both' } });
+    expect(screen.getByLabelText('Claude Code · research-notes · 2 sessions')).toBeInTheDocument();
+    expect(screen.queryByText('unsupported-project')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByLabelText('Confirm all eligible projects for automatic upload'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save scope and continue' }));
+
+    await waitFor(() => expect(updateSpy).toHaveBeenCalledWith({
+      source: 'both',
+      confirm_projects: true,
+    }));
+    await waitFor(() => expect(enableSpy).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText('I authorize capped recurring uploads of eligible future traces.')).toBeInTheDocument();
+  });
+
+  it('omits excluded projects from the project confirmation step', async () => {
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValueOnce(status({
+      offer_available: true,
+    }));
+    vi.spyOn(api.autoUpload, 'enable').mockRejectedValueOnce(scopeRequired());
+    vi.spyOn(api.config, 'get').mockResolvedValueOnce(workbenchConfig());
+    vi.spyOn(api, 'projects').mockResolvedValueOnce([
+      {
+        source: 'claude',
+        project: 'eligible-project',
+        session_count: 2,
+        total_tokens: 1_200,
+        excluded: false,
+      },
+      {
+        source: 'claude',
+        project: 'excluded-project',
+        session_count: 1,
+        total_tokens: 500,
+        excluded: true,
+      },
+    ]);
+
+    renderControl(<AutoUploadOffer manualReceiptId="receipt-with-exclusion" />);
+    fireEvent.change(await screen.findByLabelText('Export source scope'), {
+      target: { value: 'claude' },
+    });
+
+    expect(screen.getByLabelText('Claude Code · eligible-project · 2 sessions')).toBeInTheDocument();
+    expect(screen.queryByText('excluded-project')).not.toBeInTheDocument();
+  });
+
+  it('requires fresh project confirmation when the source selection changes', async () => {
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValueOnce(status({
+      offer_available: true,
+    }));
+    vi.spyOn(api.autoUpload, 'enable').mockRejectedValueOnce(scopeRequired());
+    vi.spyOn(api.config, 'get').mockResolvedValueOnce(workbenchConfig({
+      source: 'both',
+      projects_confirmed: true,
+      source_choices: ['all', 'both', 'claude', 'codex'],
+    }));
+    vi.spyOn(api, 'projects').mockResolvedValueOnce([
+      {
+        source: 'claude',
+        project: 'claude-project',
+        session_count: 1,
+        total_tokens: 500,
+      },
+      {
+        source: 'codex',
+        project: 'codex-project',
+        session_count: 1,
+        total_tokens: 500,
+      },
+    ]);
+
+    renderControl(<AutoUploadOffer manualReceiptId="receipt-change-source" />);
+
+    const source = await screen.findByLabelText('Export source scope');
+    const projectConfirmation = screen.getByLabelText('Confirm all eligible projects for automatic upload');
+    expect(source).toHaveValue('both');
+    // A stored projects_confirmed never pre-checks the box: the confirmation
+    // attests to the list rendered here, not to an older one.
+    expect(projectConfirmation).not.toBeChecked();
+    expect(screen.getByRole('button', { name: 'Save scope and continue' })).toBeDisabled();
+    expect(screen.getByLabelText('Claude Code · claude-project · 1 session')).toBeInTheDocument();
+    expect(screen.getByLabelText('Codex · codex-project · 1 session')).toBeInTheDocument();
+
+    fireEvent.click(projectConfirmation);
+    expect(projectConfirmation).toBeChecked();
+    fireEvent.change(source, { target: { value: 'codex' } });
+
+    expect(projectConfirmation).not.toBeChecked();
+    expect(screen.getByRole('button', { name: 'Save scope and continue' })).toBeDisabled();
+    expect(screen.queryByLabelText('Claude Code · claude-project · 1 session')).not.toBeInTheDocument();
+    expect(screen.getByLabelText('Codex · codex-project · 1 session')).toBeInTheDocument();
+  });
+
+  it('explains an oversized scope instead of echoing the CLI-worded error', async () => {
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValueOnce(status({
+      offer_available: true,
+    }));
+    vi.spyOn(api.autoUpload, 'enable').mockRejectedValueOnce(new ApiError(400, 'Scope too large', {
+      code: 'scope_too_large',
+      message: 'The source x project scope exceeds the hosted limit of 200 entries; '
+        + 'exclude projects (config --exclude) or narrow the source scope first.',
+      scope_blockers: ['scope_too_large'],
+    }));
+
+    renderControl(<AutoUploadOffer manualReceiptId="receipt-oversized-scope" />);
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      'This scope has too many source and project combinations',
+    );
+    expect(screen.queryByText('Choose what automatic uploads may include')).not.toBeInTheDocument();
   });
 
   it('enables inline with the receipt grant and infers the only agent', async () => {
@@ -216,6 +544,43 @@ describe('AutoUploadPanel visibility', () => {
 });
 
 describe('AutoUploadPanel authorization', () => {
+  it('reports an inline scope save so Settings can update without a reload', async () => {
+    const savedConfig = workbenchConfig({
+      source: 'both',
+      projects_confirmed: true,
+      source_choices: ['all', 'both', 'claude', 'codex'],
+    });
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValueOnce(status({
+      offer_available: true,
+    }));
+    vi.spyOn(api.autoUpload, 'enable')
+      .mockRejectedValueOnce(scopeRequired())
+      .mockRejectedValueOnce(authorizationRequired());
+    vi.spyOn(api.config, 'get').mockResolvedValueOnce(workbenchConfig());
+    vi.spyOn(api.config, 'update').mockResolvedValueOnce(savedConfig);
+    vi.spyOn(api, 'projects').mockResolvedValueOnce([
+      {
+        source: 'claude',
+        project: 'research-notes',
+        session_count: 2,
+        total_tokens: 1_200,
+      },
+    ]);
+    const onConfigUpdated = vi.fn();
+
+    renderControl(<AutoUploadPanel onConfigUpdated={onConfigUpdated} />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Review and enable' }));
+    fireEvent.change(await screen.findByLabelText('Export source scope'), {
+      target: { value: 'both' },
+    });
+    fireEvent.click(screen.getByLabelText('Confirm all eligible projects for automatic upload'));
+    fireEvent.click(screen.getByRole('button', { name: 'Save scope and continue' }));
+
+    await waitFor(() => expect(onConfigUpdated).toHaveBeenCalledWith(savedConfig));
+    expect(onConfigUpdated).toHaveBeenCalledTimes(1);
+    expect(await screen.findByText('I authorize capped recurring uploads of eligible future traces.')).toBeInTheDocument();
+  });
+
   it('shows the distinct recurring wording, retains the selected hook, and rejects a stale GET after enable', async () => {
     const initial = status({
       mode: 'enabled',

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
@@ -7,6 +7,8 @@ import type {
   AutoUploadAuthorizationChallenge,
   AutoUploadCandidateReport,
   AutoUploadStatus,
+  ProjectSummary,
+  WorkbenchConfig,
 } from '../types.ts';
 import { colors, btnDanger, btnGhost, btnPrimary, btnSecondary, selectStyle } from '../theme.ts';
 import { ConfirmDialog } from './ConfirmDialog.tsx';
@@ -34,6 +36,17 @@ const reviewReasons = new Set([
   'blocked_review_status',
   'changed_revision_needing_approval',
 ]);
+
+const scopeSetupBlockers = new Set([
+  'source_confirmation_missing',
+  'project_confirmation_missing',
+  'source_scope_empty',
+  'project_scope_empty',
+  'unsupported_source',
+]);
+
+const automaticUploadSourceChoices = ['both', 'claude', 'codex'] as const;
+const automaticUploadSources = new Set<string>(automaticUploadSourceChoices);
 
 function asRecord(value: unknown): Record<string, unknown> | null {
   return value && typeof value === 'object' ? value as Record<string, unknown> : null;
@@ -122,6 +135,20 @@ function challengeFromError(error: unknown): AutoUploadAuthorizationChallenge | 
   };
 }
 
+function needsScopeSetup(error: unknown): boolean {
+  if (!(error instanceof ApiError)) return false;
+  const blockers = stringList(error.body, 'scope_blockers');
+  const code = stringField(error.body, 'code');
+  return blockers.some(blocker => scopeSetupBlockers.has(blocker))
+    || (code !== null && scopeSetupBlockers.has(code));
+}
+
+function hasScopeBlocker(error: unknown, blocker: string): boolean {
+  if (!(error instanceof ApiError)) return false;
+  return stringList(error.body, 'scope_blockers').includes(blocker)
+    || stringField(error.body, 'code') === blocker;
+}
+
 function requiresEmailVerification(error: unknown): boolean {
   return error instanceof ApiError && (
     error.body.code === 'email_verification_required' ||
@@ -147,6 +174,26 @@ function compactList(values: string[], empty: string): string {
   if (!values.length) return empty;
   if (values.length <= 4) return values.join(', ');
   return `${values.slice(0, 4).join(', ')} +${values.length - 4} more`;
+}
+
+function sourceLabel(source: string): string {
+  const labels: Record<string, string> = {
+    all: 'All agents',
+    aider: 'Aider',
+    both: 'Claude Code and Codex',
+    claude: 'Claude Code',
+    'claude-science': 'Claude Science',
+    codex: 'Codex',
+    copilot: 'GitHub Copilot',
+    cursor: 'Cursor',
+    custom: 'Custom',
+    gemini: 'Gemini',
+    kimi: 'Kimi',
+    openclaw: 'OpenClaw',
+    opencode: 'OpenCode',
+    workbuddy: 'WorkBuddy',
+  };
+  return labels[source] ?? source;
 }
 
 function disabledStyle(disabled: boolean): CSSProperties {
@@ -220,6 +267,7 @@ interface AuthorizationDialogProps {
   initialStatus: AutoUploadStatus;
   onClose: () => void;
   onEnabled: (status: AutoUploadStatus) => void;
+  onScopeSaved?: (config: WorkbenchConfig) => void;
   inline?: boolean;
 }
 
@@ -228,6 +276,7 @@ function AuthorizationDialog({
   initialStatus,
   onClose,
   onEnabled,
+  onScopeSaved,
   inline = false,
 }: AuthorizationDialogProps) {
   const { toast } = useToast();
@@ -256,6 +305,10 @@ function AuthorizationDialog({
   const [email, setEmail] = useState('');
   const [code, setCode] = useState('');
   const [devCode, setDevCode] = useState<string | null>(null);
+  const [scopeConfig, setScopeConfig] = useState<WorkbenchConfig | null>(null);
+  const [scopeProjects, setScopeProjects] = useState<ProjectSummary[]>([]);
+  const [scopeSource, setScopeSource] = useState('');
+  const [scopeProjectsConfirmed, setScopeProjectsConfirmed] = useState(false);
 
   const showEmailVerification = useCallback(async (
     message: string,
@@ -285,6 +338,8 @@ function AuthorizationDialog({
     setAccepted(false);
     setOwnershipCertified(false);
     setChallenge(null);
+    setScopeConfig(null);
+    setScopeProjects([]);
     try {
       // challenge_only can never enroll by contract, so a success here means
       // the daemon violated that contract; refuse to treat it as enabled.
@@ -298,6 +353,33 @@ function AuthorizationDialog({
       if (next) {
         setChallenge(next);
         setAgent(current => inferredAgent(next.scope.sources, current));
+      } else if (needsScopeSetup(requestError)) {
+        try {
+          const [config, projects] = await Promise.all([
+            api.config.get(),
+            api.projects(),
+          ]);
+          if (!isCurrent()) return;
+          const configuredSource = config.source ?? '';
+          const supportedSource = automaticUploadSources.has(configuredSource)
+            ? configuredSource
+            : '';
+          setScopeConfig(config);
+          setScopeProjects(projects);
+          setScopeSource(supportedSource);
+          // Always start unchecked, even when config already says confirmed:
+          // that stored confirmation may predate the project list shown here,
+          // and this checkbox attests to reviewing exactly this list.
+          setScopeProjectsConfirmed(false);
+          setError(null);
+        } catch (configError) {
+          if (isCurrent()) {
+            setError(errorMessage(
+              configError,
+              'Could not load the source and project settings.',
+            ));
+          }
+        }
       } else if (requiresEmailVerification(requestError)) {
         await showEmailVerification(
           'Verify your email before loading the recurring authorization.',
@@ -315,6 +397,15 @@ function AuthorizationDialog({
           'The running ClawJournal service is older than this page and returned '
           + 'an incompatible authorization challenge. Restart the service '
           + '(clawjournal serve) and reload, then try again.',
+        );
+      } else if (hasScopeBlocker(requestError, 'scope_too_large')) {
+        // The guided step cannot shrink an oversized scope: that needs project
+        // exclusions, which have no controls here. Say what to do instead of
+        // echoing the CLI-worded server message.
+        setError(
+          'This scope has too many source and project combinations for the '
+          + 'hosted service. Exclude projects from sharing (clawjournal config '
+          + '--exclude "<project>") or choose a single source, then try again.',
         );
       } else {
         setError(errorMessage(requestError, 'Could not load recurring authorization.'));
@@ -344,6 +435,10 @@ function AuthorizationDialog({
       setEmail('');
       setCode('');
       setDevCode(null);
+      setScopeConfig(null);
+      setScopeProjects([]);
+      setScopeSource('');
+      setScopeProjectsConfirmed(false);
       return;
     }
     if (!requestedRef.current) {
@@ -405,6 +500,63 @@ function AuthorizationDialog({
   const ai = challenge?.ai ?? initialStatus.ai;
   const cap = challenge?.cap ?? initialStatus.cap;
   const cadence = challenge?.cadence_days ?? initialStatus.cadence_days;
+  const selectedSourceProjects = scopeSource
+    ? scopeProjects.filter(project => (
+        scopeSource === 'both'
+          ? project.source === 'claude' || project.source === 'codex'
+          : project.source === scopeSource
+      ))
+    : [];
+  const visibleScopeProjects = selectedSourceProjects.filter(project => !project.excluded);
+  const excludedProjectCount = selectedSourceProjects.length - visibleScopeProjects.length;
+  const canSaveScope = Boolean(
+    scopeConfig
+    && scopeSource
+    && scopeProjectsConfirmed
+    && visibleScopeProjects.length > 0
+    && !loading,
+  );
+
+  const saveScopeAndContinue = async () => {
+    if (!canSaveScope) return;
+    const requestId = challengeRequestRef.current + 1;
+    challengeRequestRef.current = requestId;
+    const isCurrent = () => challengeRequestRef.current === requestId;
+    setLoading(true);
+    setSubmitting(true);
+    setError(null);
+    try {
+      // Save both values atomically. Changing source intentionally clears the
+      // prior project confirmation, so a split write would recreate the exact
+      // dead-end this guided step is meant to remove.
+      const nextConfig = await api.config.update({
+        source: scopeSource,
+        confirm_projects: true,
+      });
+      // Notify Settings even if the dialog was dismissed mid-save: the config
+      // write already happened, and a stale Settings view is worse than a
+      // callback from a closed dialog.
+      onScopeSaved?.(nextConfig);
+      if (!isCurrent()) return;
+      setSubmitting(false);
+      // Match the hook trigger to the scope just saved instead of the stale
+      // agent state: a claude-only scope must not install a codex hook.
+      const scopeAgent: AutoUploadAgent = scopeSource === 'both'
+        ? 'all'
+        : scopeSource as AutoUploadAgent;
+      setAgent(scopeAgent);
+      await requestChallenge(scopeAgent);
+    } catch (scopeError) {
+      if (isCurrent()) {
+        setError(errorMessage(scopeError, 'Could not save the automatic-upload scope.'));
+      }
+    } finally {
+      if (isCurrent()) {
+        setLoading(false);
+        setSubmitting(false);
+      }
+    }
+  };
 
   const enableWithAcceptedTerms = async () => {
     if (!challenge || !accepted || !ownershipCertified) return;
@@ -553,72 +705,208 @@ function AuthorizationDialog({
           {inline ? 'Share future traces automatically?' : 'Authorize future automatic uploads'}
         </h3>
         <p style={{ margin: '0 0 18px', fontSize: 13, lineHeight: 1.55, color: colors.gray600 }}>
-          {inline
-            ? `Enable up to ${cap} eligible future traces every ${cadence} day${cadence === 1 ? '' : 's'} from the exact scope below. ${
-              initialStatus.enrollment_grant_available
-                ? 'The receipt from this share lets you enable it without verifying your email again.'
-                : 'If its receipt-issued enrollment grant is unavailable or expires, you will verify your email before enabling.'
-            }`
-            : 'Future selected traces in this exact scope may be uploaded without you reviewing each bundle. This is separate from the consent you gave for the bundle you just reviewed.'}
+          {scopeConfig
+            ? 'Choose and confirm the source and project scope first. You will review the exact recurring scope and terms before anything is enabled.'
+            : inline
+              ? `Enable up to ${cap} eligible future traces every ${cadence} day${cadence === 1 ? '' : 's'} from the exact scope below. ${
+                initialStatus.enrollment_grant_available
+                  ? 'The receipt from this share lets you enable it without verifying your email again.'
+                  : 'If its receipt-issued enrollment grant is unavailable or expires, you will verify your email before enabling.'
+              }`
+              : 'Future selected traces in this exact scope may be uploaded without you reviewing each bundle. This is separate from the consent you gave for the bundle you just reviewed.'}
         </p>
 
-        {new Set(scope.sources.filter(source => source === 'claude' || source === 'codex')).size === 1 ? (
-          <SummaryItem
-            label="Run on agent sessions"
-            value={scope.sources.includes('codex') ? 'Codex' : 'Claude Code'}
-          />
-        ) : (
-          <label style={{ display: 'block', marginBottom: 14, fontSize: 12.5, color: colors.gray700 }}>
-            Run on agent sessions
-            <select
-              value={agent}
-              disabled={loading}
-              onChange={event => setAgent(event.target.value as AutoUploadAgent)}
-              style={{ ...selectStyle, display: 'block', marginTop: 5, minWidth: 220 }}
-            >
-              <option value="all">Claude Code and Codex</option>
-              <option value="claude">Claude Code</option>
-              <option value="codex">Codex</option>
-            </select>
-          </label>
+        {/* Hidden during scope setup: its options carry the same labels as the
+            source-scope select below and answer a later question (which agent
+            sessions trigger runs, not what may be exported). */}
+        {!scopeConfig && (
+          new Set(scope.sources.filter(source => source === 'claude' || source === 'codex')).size === 1 ? (
+            <SummaryItem
+              label="Run on agent sessions"
+              value={scope.sources.includes('codex') ? 'Codex' : 'Claude Code'}
+            />
+          ) : (
+            <label style={{ display: 'block', marginBottom: 14, fontSize: 12.5, color: colors.gray700 }}>
+              Run on agent sessions
+              <select
+                value={agent}
+                disabled={loading}
+                onChange={event => setAgent(event.target.value as AutoUploadAgent)}
+                style={{ ...selectStyle, display: 'block', marginTop: 5, minWidth: 220 }}
+              >
+                <option value="all">Claude Code and Codex</option>
+                <option value="claude">Claude Code</option>
+                <option value="codex">Codex</option>
+              </select>
+            </label>
+          )
         )}
 
-        <div style={summaryGridStyle}>
-          <SummaryItem label="Sources" value={compactList(scope.sources, 'No confirmed sources')} />
-          <SummaryItem label="Projects" value={compactList(scope.projects, 'No confirmed projects')} />
-          <SummaryItem label="Schedule" value={`Every ${cadence} day${cadence === 1 ? '' : 's'}, on the next supported agent session`} />
-          <SummaryItem label="Per-cycle cap" value={`Up to ${cap} selected traces`} />
-          {challenge && (
-            <SummaryItem
-              label="Hosted bundle limit"
-              value={`${(challenge.maximum_bundle_size / (1024 * 1024)).toFixed(1)} MiB`}
-            />
-          )}
-          {challenge?.destination_origin && (
-            <SummaryItem label="Destination" value={challenge.destination_origin} />
-          )}
-          <SummaryItem
-            label="Future-only boundary"
-            value={initialStatus.enrolled_at
-              ? `Traces completed after ${formatTimestamp(initialStatus.enrolled_at)}`
-              : 'Only traces completed after enrollment'}
-          />
-          <SummaryItem
-            label="AI-assisted PII review"
-            value={ai.enabled ? `On · ${ai.backend ?? 'configured provider'}` : 'Off'}
-          />
-        </div>
+        {scopeConfig ? (
+          <div style={{
+            padding: '16px 18px',
+            border: '1px solid #E9DEC9',
+            borderRadius: 12,
+            background: '#F7F3E8',
+            color: '#362815',
+          }}>
+            <div style={{
+              marginBottom: 4,
+              fontSize: 11,
+              fontWeight: 700,
+              letterSpacing: '0.06em',
+              textTransform: 'uppercase',
+              color: '#725E47',
+            }}>
+              Scope · step 1 of 2
+            </div>
+            <div style={{ fontSize: 16, fontWeight: 700 }}>
+              Choose what automatic uploads may include
+            </div>
+            <p style={{ margin: '5px 0 14px', fontSize: 12.5, lineHeight: 1.5, color: '#725E47' }}>
+              Automatic upload currently supports Claude Code and Codex. This also updates the
+              export scope in Settings. Excluded projects aren’t listed or authorized.
+            </p>
 
-        <div style={{ margin: '14px 0', fontSize: 12.5, lineHeight: 1.55, color: colors.gray600 }}>
-          <ul style={{ margin: 0, paddingLeft: 19 }}>
-            <li>ClawJournal anonymizes and redacts locally, then runs the existing findings and secret-scan gates.</li>
-            <li>Run now is an extra capped cycle and resets the next scheduled date.</li>
-            <li>You can preview, pause, review the scope, or turn this off in Settings.</li>
-            <li>Turning it off does not delete prior uploads. A request already being submitted may finish.</li>
-          </ul>
-        </div>
+            <label style={{ display: 'block', fontSize: 12.5, fontWeight: 650 }}>
+              Export source scope
+              <select
+                aria-label="Export source scope"
+                value={scopeSource}
+                disabled={loading}
+                onChange={event => {
+                  setScopeSource(event.target.value);
+                  // Any change shows a different project list, so the
+                  // review-confirmation below no longer applies.
+                  setScopeProjectsConfirmed(false);
+                }}
+                style={{
+                  ...selectStyle,
+                  display: 'block',
+                  width: '100%',
+                  marginTop: 6,
+                  background: '#FBF9F4',
+                  borderColor: '#E1D5BE',
+                  color: '#362815',
+                }}
+              >
+                <option value="" disabled>Choose a source…</option>
+                {automaticUploadSourceChoices.map(source => (
+                  <option key={source} value={source}>{sourceLabel(source)}</option>
+                ))}
+              </select>
+            </label>
 
-        {loading && !challenge && !verificationRequired && (
+            <div style={{ marginTop: 14, fontSize: 12.5, fontWeight: 650 }}>
+              Current projects in this scope
+            </div>
+            <div
+              role="list"
+              aria-label="Projects eligible for automatic upload"
+              style={{
+                maxHeight: 150,
+                marginTop: 6,
+                padding: '9px 11px',
+                overflow: 'auto',
+                border: '1px solid #E1D5BE',
+                borderRadius: 8,
+                background: '#FBF9F4',
+                fontSize: 12,
+                lineHeight: 1.5,
+                color: '#725E47',
+              }}
+            >
+              {!scopeSource ? (
+                <span>Choose a source to see its indexed projects.</span>
+              ) : visibleScopeProjects.length === 0 ? (
+                <span>
+                  {excludedProjectCount > 0
+                    ? 'Every indexed project for this source is excluded. Review project exclusions before continuing.'
+                    : 'No indexed projects were found for this source. Run an agent session, refresh the workbench, and try again.'}
+                </span>
+              ) : (
+                visibleScopeProjects.map(project => (
+                  <div
+                    key={`${project.source}:${project.project}`}
+                    role="listitem"
+                    aria-label={`${sourceLabel(project.source)} · ${project.project} · ${project.session_count} session${project.session_count === 1 ? '' : 's'}`}
+                  >
+                    <strong style={{ color: '#362815' }}>{sourceLabel(project.source)}</strong>
+                    {' · '}{project.project}
+                    <span> · {project.session_count} session{project.session_count === 1 ? '' : 's'}</span>
+                  </div>
+                ))
+              )}
+            </div>
+
+            <label style={{
+              display: 'flex',
+              alignItems: 'flex-start',
+              gap: 9,
+              marginTop: 13,
+              fontSize: 12.5,
+              lineHeight: 1.5,
+              color: '#362815',
+            }}>
+              <input
+                type="checkbox"
+                aria-label="Confirm all eligible projects for automatic upload"
+                checked={scopeProjectsConfirmed}
+                disabled={loading || visibleScopeProjects.length === 0}
+                onChange={event => setScopeProjectsConfirmed(event.target.checked)}
+                style={{ marginTop: 3 }}
+              />
+              <span>
+                <strong style={{ display: 'block', marginBottom: 2 }}>
+                  Confirm all eligible projects
+                </strong>
+                <span style={{ color: '#725E47' }}>
+                  I reviewed all {visibleScopeProjects.length} project{visibleScopeProjects.length === 1 ? '' : 's'} listed
+                  above. Only these projects may enter this automatic-upload scope.
+                </span>
+              </span>
+            </label>
+          </div>
+        ) : (
+          <>
+            <div style={summaryGridStyle}>
+              <SummaryItem label="Sources" value={compactList(scope.sources, 'No confirmed sources')} />
+              <SummaryItem label="Projects" value={compactList(scope.projects, 'No confirmed projects')} />
+              <SummaryItem label="Schedule" value={`Every ${cadence} day${cadence === 1 ? '' : 's'}, on the next supported agent session`} />
+              <SummaryItem label="Per-cycle cap" value={`Up to ${cap} selected traces`} />
+              {challenge && (
+                <SummaryItem
+                  label="Hosted bundle limit"
+                  value={`${(challenge.maximum_bundle_size / (1024 * 1024)).toFixed(1)} MiB`}
+                />
+              )}
+              {challenge?.destination_origin && (
+                <SummaryItem label="Destination" value={challenge.destination_origin} />
+              )}
+              <SummaryItem
+                label="Future-only boundary"
+                value={initialStatus.enrolled_at
+                  ? `Traces completed after ${formatTimestamp(initialStatus.enrolled_at)}`
+                  : 'Only traces completed after enrollment'}
+              />
+              <SummaryItem
+                label="AI-assisted PII review"
+                value={ai.enabled ? `On · ${ai.backend ?? 'configured provider'}` : 'Off'}
+              />
+            </div>
+
+            <div style={{ margin: '14px 0', fontSize: 12.5, lineHeight: 1.55, color: colors.gray600 }}>
+              <ul style={{ margin: 0, paddingLeft: 19 }}>
+                <li>ClawJournal anonymizes and redacts locally, then runs the existing findings and secret-scan gates.</li>
+                <li>Run now is an extra capped cycle and resets the next scheduled date.</li>
+                <li>You can preview, pause, review the scope, or turn this off in Settings.</li>
+                <li>Turning it off does not delete prior uploads. A request already being submitted may finish.</li>
+              </ul>
+            </div>
+          </>
+        )}
+
+        {loading && !challenge && !verificationRequired && !scopeConfig && (
           <div role="status" style={noticeStyle}>Loading the current authorization and retention terms…</div>
         )}
         {error && (
@@ -626,7 +914,7 @@ function AuthorizationDialog({
             {error}
           </div>
         )}
-        {error && !challenge && !loading && !verificationRequired && (
+        {error && !challenge && !loading && !verificationRequired && !scopeConfig && (
           <button onClick={() => void requestChallenge()} style={{ ...btnSecondary, marginBottom: 12 }}>
             Retry
           </button>
@@ -787,7 +1075,21 @@ function AuthorizationDialog({
           <button disabled={submitting} onClick={dismissDialog} style={{ ...btnSecondary, ...disabledStyle(submitting) }}>
             {inline ? 'Not now' : 'Cancel'}
           </button>
-          {!verificationRequired && (
+          {scopeConfig ? (
+            <button
+              disabled={!canSaveScope}
+              onClick={() => void saveScopeAndContinue()}
+              style={{
+                ...btnPrimary,
+                background: '#EDE2CC',
+                color: '#362815',
+                border: '1px solid #D4AB73',
+                ...disabledStyle(!canSaveScope),
+              }}
+            >
+              {submitting ? 'Saving scope…' : 'Save scope and continue'}
+            </button>
+          ) : !verificationRequired && (
             <button
               disabled={!challenge || !accepted || !ownershipCertified || loading}
               onClick={() => void accept()}
@@ -877,7 +1179,9 @@ export function AutoUploadOffer({ manualReceiptId }: { manualReceiptId: string |
   );
 }
 
-export function AutoUploadPanel() {
+export function AutoUploadPanel({ onConfigUpdated }: {
+  onConfigUpdated?: (config: WorkbenchConfig) => void;
+} = {}) {
   const { toast } = useToast();
   const [status, setStatus] = useState<AutoUploadStatus | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
@@ -1202,6 +1506,7 @@ export function AutoUploadPanel() {
         initialStatus={status}
         onClose={() => setDialogOpen(false)}
         onEnabled={commitActionStatus}
+        onScopeSaved={onConfigUpdated}
       />
       <ConfirmDialog
         open={disableOpen}

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -323,6 +323,8 @@ export interface ProjectSummary {
   source: string;
   session_count: number;
   total_tokens: number;
+  /** Whether the effective share policy excludes this project. */
+  excluded?: boolean;
 }
 
 export type ReviewStatus = 'new' | 'shortlisted' | 'approved' | 'blocked';  // shortlisted kept for DB compat

--- a/clawjournal/web/frontend/src/views/Settings.tsx
+++ b/clawjournal/web/frontend/src/views/Settings.tsx
@@ -138,7 +138,7 @@ export function Settings() {
         </label>
       </div>
 
-      <AutoUploadPanel />
+      <AutoUploadPanel onConfigUpdated={setCfg} />
 
       {/* Advanced — scoring + UI toggles most users never change. Collapsed by
           default so the page leads with the export-gate essentials above. */}

--- a/clawjournal/web/frontend/src/views/Share/DoneStep.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/DoneStep.test.tsx
@@ -25,18 +25,30 @@ function props(receiptId: string | null): DoneStepProps {
 }
 
 describe('DoneStep success celebration', () => {
-  it('showers viewport confetti after a hosted submission succeeds', () => {
+  it('showers main-content confetti after a hosted submission succeeds', () => {
     render(<DoneStep {...props('receipt-123')} />);
 
+    const shell = screen.getByTestId('share-done-shell');
     const confetti = screen.getByTestId('success-confetti');
+    const flashes = shell.querySelectorAll('.claw-success-flash');
+    expect(shell).toHaveStyle({ position: 'relative' });
+    expect(flashes).toHaveLength(3);
+    flashes.forEach((flash) => {
+      expect(flash.parentElement).toBe(shell);
+      expect(flash).toHaveStyle({ position: 'absolute' });
+    });
+    expect(confetti.parentElement).toBe(shell);
     expect(confetti).toHaveAttribute('aria-hidden', 'true');
     expect(confetti).toHaveStyle({
-      position: 'fixed',
+      position: 'absolute',
       inset: '0',
       overflow: 'hidden',
     });
     expect(confetti.querySelectorAll('span')).toHaveLength(144);
     expect(confetti.querySelectorAll('.claw-confetti-later')).toHaveLength(96);
+    const firstPiece = confetti.querySelector('span') as HTMLElement;
+    expect(firstPiece.style.getPropertyValue('--cdx')).toMatch(/px$/);
+    expect(firstPiece.style.getPropertyValue('--cdy')).toMatch(/px$/);
   });
 
   it('does not celebrate a bundle that stayed local', () => {

--- a/clawjournal/web/frontend/src/views/Share/DoneStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/DoneStep.tsx
@@ -29,8 +29,8 @@ export function DoneStep(p: DoneStepProps) {
       id: i,
       wave: Math.floor(i / piecesPerWave),
       left: 3 + Math.random() * 94,
-      dx: (Math.random() - 0.5) * 24,
-      dy: 105 + Math.random() * 20,
+      dx: (Math.random() - 0.5) * 180,
+      dy: 360 + Math.random() * 300,
       staticY: 28 + Math.random() * 150,
       r: (Math.random() > 0.5 ? 1 : -1) * (540 + Math.random() * 720),
       width: 5 + Math.random() * 5,
@@ -60,52 +60,55 @@ export function DoneStep(p: DoneStepProps) {
   ];
 
   return (
-    <div style={{ padding: '32px 24px 48px', maxWidth: SHARE_SHELL_WIDTH, margin: '0 auto' }}>
+    <div
+      data-testid="share-done-shell"
+      style={{ position: 'relative', padding: '32px 24px 48px', maxWidth: SHARE_SHELL_WIDTH, margin: '0 auto' }}
+    >
       {p.globalStyles}
       {p.stepperHeader}
-      <div style={{ position: 'relative', padding: '56px 24px 24px', maxWidth: 680, margin: '0 auto', textAlign: 'center' }}>
-        {submitted && (
-          <>
-            {SUCCESS_WAVE_DELAYS.map((delay) => (
-              <div
-                key={delay}
-                aria-hidden="true"
-                className="claw-success-flash"
+      {submitted && (
+        <>
+          {SUCCESS_WAVE_DELAYS.map((delay) => (
+            <div
+              key={delay}
+              aria-hidden="true"
+              className="claw-success-flash"
+              style={{
+                position: 'absolute', top: -36, left: '5%', right: '5%', height: 96,
+                zIndex: 1, pointerEvents: 'none', borderRadius: 48,
+                background: 'rgba(212, 171, 115, .18)', filter: 'blur(18px)',
+                opacity: 0,
+                ['--flash-delay' as string]: `${delay}ms`,
+              } as React.CSSProperties}
+            />
+          ))}
+          <div
+            aria-hidden="true"
+            className="claw-success-confetti"
+            data-testid="success-confetti"
+            style={{ position: 'absolute', inset: 0, zIndex: 2, pointerEvents: 'none', overflow: 'hidden' }}
+          >
+            {confettiPieces.map((c) => (
+              <span
+                key={c.id}
+                className={c.wave > 0 ? 'claw-confetti-later' : undefined}
                 style={{
-                  position: 'fixed', top: -36, left: '8vw', right: '8vw', height: 96,
-                  zIndex: 99, pointerEvents: 'none', borderRadius: 48,
-                  background: 'rgba(212, 171, 115, .18)', filter: 'blur(18px)',
-                  opacity: 0,
-                  ['--flash-delay' as string]: `${delay}ms`,
+                  position: 'absolute', top: -20, left: `${c.left}%`,
+                  width: c.width, height: c.height, borderRadius: c.id % 4 === 0 ? '50%' : 1,
+                  background: c.color, opacity: 0,
+                  ['--cdx' as string]: `${c.dx}px`,
+                  ['--cdy' as string]: `${c.dy}px`,
+                  ['--cstatic-y' as string]: `${c.staticY}px`,
+                  ['--cr' as string]: `${c.r}deg`,
+                  ['--cduration' as string]: `${c.duration}ms`,
+                  ['--cdelay' as string]: `${c.delay}ms`,
                 } as React.CSSProperties}
               />
             ))}
-            <div
-              aria-hidden="true"
-              className="claw-success-confetti"
-              data-testid="success-confetti"
-              style={{ position: 'fixed', inset: 0, zIndex: 100, pointerEvents: 'none', overflow: 'hidden' }}
-            >
-              {confettiPieces.map((c) => (
-                <span
-                  key={c.id}
-                  className={c.wave > 0 ? 'claw-confetti-later' : undefined}
-                  style={{
-                    position: 'absolute', top: -20, left: `${c.left}%`,
-                    width: c.width, height: c.height, borderRadius: c.id % 4 === 0 ? '50%' : 1,
-                    background: c.color, opacity: 0,
-                    ['--cdx' as string]: `${c.dx}vw`,
-                    ['--cdy' as string]: `${c.dy}vh`,
-                    ['--cstatic-y' as string]: `${c.staticY}px`,
-                    ['--cr' as string]: `${c.r}deg`,
-                    ['--cduration' as string]: `${c.duration}ms`,
-                    ['--cdelay' as string]: `${c.delay}ms`,
-                  } as React.CSSProperties}
-                />
-              ))}
-            </div>
-          </>
-        )}
+          </div>
+        </>
+      )}
+      <div style={{ position: 'relative', padding: '56px 24px 24px', maxWidth: 680, margin: '0 auto', textAlign: 'center' }}>
 
         <div style={{
           width: 72, height: 72, margin: '0 auto 24px',

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -3954,7 +3954,17 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                 "SUM(input_tokens + output_tokens) as total_tokens "
                 "FROM sessions GROUP BY project, source ORDER BY project"
             ).fetchall()
-            _json_response(self, [dict(r) for r in rows])
+            settings = get_effective_share_settings(conn, load_config())
+            excluded_projects = settings["excluded_projects"]
+            projects = []
+            for row in rows:
+                project = dict(row)
+                project["excluded"] = session_matches_excluded_projects(
+                    project,
+                    excluded_projects,
+                )
+                projects.append(project)
+            _json_response(self, projects)
         finally:
             conn.close()
 
@@ -4066,8 +4076,10 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         from ..cli import EXPLICIT_SOURCE_CHOICES
         from ..scoring.scoring import SUPPORTED_SCORING_BACKENDS
         config = load_config()
-        # 'both' is deprecated and hidden from the picker, but surface it if it is
-        # the currently-stored value so the select shows the real value rather
+        # 'both' is hidden from the manual picker ('claude' + 'codex' cover it
+        # more explicitly), but the Auto Upload guided scope setup writes it as
+        # the recurring claude+codex pair — so surface it whenever it is the
+        # currently-stored value, keeping the select on the real value rather
         # than a misleading "Select a source…" placeholder.
         stored_source = config.get("source")
         source_choices = sorted(

--- a/tests/workbench/test_daemon_config.py
+++ b/tests/workbench/test_daemon_config.py
@@ -85,6 +85,38 @@ class TestGetConfig:
             assert secret not in body
 
 
+class TestProjects:
+    def test_marks_projects_excluded_by_effective_share_policy(self, api):
+        save_config({"excluded_projects": ["claude:private-project"]})
+        conn = open_index()
+        try:
+            upsert_sessions(conn, [
+                {
+                    "session_id": "public-session",
+                    "project": "claude:public-project",
+                    "source": "claude",
+                    "messages": [{"role": "user", "content": "public"}],
+                    "stats": {"input_tokens": 10, "output_tokens": 5},
+                },
+                {
+                    "session_id": "private-session",
+                    "project": "claude:private-project",
+                    "source": "claude",
+                    "messages": [{"role": "user", "content": "private"}],
+                    "stats": {"input_tokens": 10, "output_tokens": 5},
+                },
+            ])
+        finally:
+            conn.close()
+
+        status, body = _get(api, "/api/projects")
+
+        assert status == 200
+        projects = {row["project"]: row for row in body}
+        assert projects["claude:public-project"]["excluded"] is False
+        assert projects["claude:private-project"]["excluded"] is True
+
+
 class TestUpdateConfig:
     def test_source_persisted(self, api):
         status, body = _post(api, "/api/config", {"source": "all"})


### PR DESCRIPTION
## What changed

- Turn source/project scope blockers into an inline setup step inside the Auto Upload authorization dialog.
- Limit the guided recurring-upload scope to the sources the unattended runner currently audits: Claude Code, Codex, or both.
- Route an existing `unsupported_source` configuration back into that guided setup instead of leaving the user at another dead end.
- Mark projects with the backend's effective exclusion policy and omit excluded projects from the confirmation list.
- Add an explicit **Confirm all eligible projects** action, including the exact count being confirmed, before the scope can be saved.
- Require a fresh project confirmation each time guided setup opens and whenever the source selection changes.
- Hide the separate run-trigger picker during scope setup so two similarly labelled source controls cannot be confused.
- Save source and project confirmation together, then continue automatically to the existing exact-scope, recurring-terms, ownership, and email-verification steps.
- Keep Settings synchronized even if the authorization dialog closes while the scope write finishes.
- Replace the CLI-oriented oversized-scope error with actionable UI guidance.
- Constrain the submitted-state flash and confetti to the Share main-content container, with a top-down fall that no longer covers the sidebar.

## Why

A fresh install could reach Auto Upload with no confirmed export scope, or with a global `all` scope that included agents the unattended runner cannot safely snapshot. The UI exposed every manual-export source and listed raw indexed projects, while recurring enrollment supports only Claude Code and Codex and applies project exclusions before authorization. Those mismatches could either dead-end the enable flow or show a project list different from the exact authorized scope.

The success celebration also used viewport-fixed positioning, so it covered the navigation sidebar instead of staying inside the Share surface.

## User impact

After one successful manual share, users can repair missing or unsupported scope configuration without leaving the Auto Upload dialog. They explicitly confirm all currently eligible projects, authorize only supported recurring sources, and see only projects eligible after effective exclusions. The success effect now drops through the Share content while leaving navigation unobstructed. Manual Share behavior and every existing backend privacy, redaction, hold-state, exact-scope, ownership, and email-verification gate remain unchanged.

## Validation

- `npm test -- --run` — 71 tests passed
- `npm run build` — production TypeScript/Vite build passed
- Targeted ESLint on every changed frontend source/test file passed
- `pytest tests/workbench/test_daemon_config.py -q` — 17 tests passed
- Python suite — 2,990 tests passed; the 28 trace-note tests affected by a local third-party `tests` package collision also passed in an isolated import run
- Scope-save failure regression test verifies that the dialog, confirmation, and retry action remain available when persistence cannot be confirmed
- Success-effect regression test verifies that all three flash layers and the confetti overlay are absolutely positioned inside the Share shell
- Oversized-scope regression test verifies that the guided UI returns actionable guidance instead of a CLI-only error
- Visual QA of the real `DoneStep` component at 1280px: sidebar occupied `0–190px`; confetti and Share shell both occupied `190–1280px`, with no overlap
- Interaction QA against an isolated unsupported-source fixture: unsupported `all` scope → choose Claude/Codex → excluded projects omitted → confirm all eligible projects → save → exact recurring authorization
- `git diff --check`

The Vite build retains the repository's existing bundle-size warning. The repository-wide lint command also retains unrelated pre-existing errors outside this PR's changed files.