### PR TITLE
fix(share): soften success chime

### DIFF
--- a/clawjournal/web/frontend/src/views/Share/successChime.test.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.test.ts
@@ -64,7 +64,11 @@ describe('success sound', () => {
     expect(sound.loop).toBe(false);
     expect(sound.volume).toBe(0.25);
 
+    vi.advanceTimersByTime(900);
+    expect(sound.pause).not.toHaveBeenCalled();
+
     resolvePrimingPlayback();
+    await Promise.resolve();
     await Promise.resolve();
 
     expect(sound.play).toHaveBeenCalledOnce();
@@ -96,5 +100,42 @@ describe('success sound', () => {
     expect(sound.currentTime).toBe(0);
     expect(sound.loop).toBe(false);
     expect(sound.volume).toBe(0.25);
+  });
+
+  it('does not restart playback after cancellation wins a priming race', async () => {
+    vi.useFakeTimers();
+    let rejectPrimingPlayback!: () => void;
+    const sound = {
+      currentTime: 0,
+      loop: false,
+      paused: true,
+      preload: '',
+      volume: 1,
+      load: vi.fn(),
+      pause: vi.fn(),
+      play: vi.fn()
+        .mockImplementationOnce(() => new Promise<void>((_resolve, reject) => {
+          rejectPrimingPlayback = () => reject(new Error('cancelled'));
+        }))
+        .mockResolvedValue(undefined),
+    };
+    vi.stubGlobal('Audio', vi.fn(function AudioMock() { return sound; }));
+
+    const {
+      cancelSuccessChime,
+      playSuccessChime,
+      primeSuccessChime,
+    } = await import('./successChime.ts');
+    primeSuccessChime();
+    playSuccessChime();
+    cancelSuccessChime();
+    rejectPrimingPlayback();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(sound.play).toHaveBeenCalledOnce();
+    expect(sound.pause).toHaveBeenCalledOnce();
+    vi.advanceTimersByTime(900);
+    expect(sound.pause).toHaveBeenCalledOnce();
   });
 });

--- a/clawjournal/web/frontend/src/views/Share/successChime.test.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 describe('success sound', () => {
   beforeEach(() => {
@@ -6,7 +6,11 @@ describe('success sound', () => {
     vi.unstubAllGlobals();
   });
 
-  it('preloads the bundled MP3 without transforming it', async () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('preloads the bundled MP3 silently', async () => {
     const sound = {
       currentTime: 0,
       loop: false,
@@ -32,6 +36,7 @@ describe('success sound', () => {
   });
 
   it('restarts an armed element after delayed submission success', async () => {
+    vi.useFakeTimers();
     let resolvePrimingPlayback!: () => void;
     const sound = {
       currentTime: 0,
@@ -57,12 +62,17 @@ describe('success sound', () => {
     expect(sound.play).toHaveBeenCalledOnce();
     expect(sound.currentTime).toBe(0);
     expect(sound.loop).toBe(false);
-    expect(sound.volume).toBe(1);
+    expect(sound.volume).toBe(0.25);
 
     resolvePrimingPlayback();
     await Promise.resolve();
 
     expect(sound.play).toHaveBeenCalledOnce();
+    vi.advanceTimersByTime(899);
+    expect(sound.pause).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(1);
+    expect(sound.pause).toHaveBeenCalledOnce();
+    expect(sound.currentTime).toBe(0);
   });
 
   it('stops silent playback when submission does not succeed', async () => {
@@ -85,6 +95,6 @@ describe('success sound', () => {
     expect(sound.pause).toHaveBeenCalledOnce();
     expect(sound.currentTime).toBe(0);
     expect(sound.loop).toBe(false);
-    expect(sound.volume).toBe(1);
+    expect(sound.volume).toBe(0.25);
   });
 });

--- a/clawjournal/web/frontend/src/views/Share/successChime.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.ts
@@ -1,7 +1,10 @@
 const SUCCESS_SOUND_URL = '/sounds/submission-success.mp3';
+const SUCCESS_CHIME_VOLUME = 0.25;
+const SUCCESS_CHIME_DURATION_MS = 900;
 
 let successSound: HTMLAudioElement | null = null;
 let primingPlayback: Promise<boolean> | null = null;
+let stopPlaybackTimer: ReturnType<typeof setTimeout> | null = null;
 
 function getSuccessSound(): HTMLAudioElement | null {
   if (typeof Audio === 'undefined') return null;
@@ -23,6 +26,25 @@ function requestPlayback(sound: HTMLAudioElement): Promise<boolean> {
   }
 }
 
+function clearPlaybackStop() {
+  if (stopPlaybackTimer === null) return;
+  clearTimeout(stopPlaybackTimer);
+  stopPlaybackTimer = null;
+}
+
+function schedulePlaybackStop(sound: HTMLAudioElement) {
+  clearPlaybackStop();
+  stopPlaybackTimer = setTimeout(() => {
+    stopPlaybackTimer = null;
+    try {
+      sound.pause();
+      sound.currentTime = 0;
+    } catch {
+      // Sound is optional; cleanup must not affect the completed submission.
+    }
+  }, SUCCESS_CHIME_DURATION_MS);
+}
+
 /**
  * Begin loading the exact success MP3 while the upload is in progress.
  *
@@ -34,6 +56,7 @@ export function primeSuccessChime() {
   try {
     const sound = getSuccessSound();
     if (!sound) return;
+    clearPlaybackStop();
     if (!sound.paused) sound.pause();
     sound.currentTime = 0;
     sound.loop = true;
@@ -46,7 +69,7 @@ export function primeSuccessChime() {
   }
 }
 
-/** Play the bundled success MP3 from the beginning without transforming it. */
+/** Play a short, restrained excerpt of the bundled success MP3. */
 export function playSuccessChime() {
   try {
     const sound = getSuccessSound();
@@ -55,7 +78,8 @@ export function playSuccessChime() {
     primingPlayback = null;
     sound.loop = false;
     sound.currentTime = 0;
-    sound.volume = 1;
+    sound.volume = SUCCESS_CHIME_VOLUME;
+    schedulePlaybackStop(sound);
 
     // A normal submission is already playing the element silently, so changing
     // its time and volume does not need a fresh autoplay permission. Preserve a
@@ -75,12 +99,13 @@ export function playSuccessChime() {
 /** Stop the silent priming loop when submission does not succeed. */
 export function cancelSuccessChime() {
   primingPlayback = null;
+  clearPlaybackStop();
   try {
     if (!successSound) return;
     successSound.pause();
     successSound.loop = false;
     successSound.currentTime = 0;
-    successSound.volume = 1;
+    successSound.volume = SUCCESS_CHIME_VOLUME;
   } catch {
     // Sound is optional; failure cleanup must not mask the submission error.
   }

--- a/clawjournal/web/frontend/src/views/Share/successChime.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.ts
@@ -5,6 +5,7 @@ const SUCCESS_CHIME_DURATION_MS = 900;
 let successSound: HTMLAudioElement | null = null;
 let primingPlayback: Promise<boolean> | null = null;
 let stopPlaybackTimer: ReturnType<typeof setTimeout> | null = null;
+let playbackSequence = 0;
 
 function getSuccessSound(): HTMLAudioElement | null {
   if (typeof Audio === 'undefined') return null;
@@ -53,6 +54,7 @@ function schedulePlaybackStop(sound: HTMLAudioElement) {
  * succeeds, then restart it audibly in playSuccessChime().
  */
 export function primeSuccessChime() {
+  playbackSequence += 1;
   try {
     const sound = getSuccessSound();
     if (!sound) return;
@@ -71,25 +73,39 @@ export function primeSuccessChime() {
 
 /** Play a short, restrained excerpt of the bundled success MP3. */
 export function playSuccessChime() {
+  const sequence = ++playbackSequence;
   try {
     const sound = getSuccessSound();
     if (!sound) return;
+    clearPlaybackStop();
     const primed = primingPlayback;
     primingPlayback = null;
     sound.loop = false;
     sound.currentTime = 0;
     sound.volume = SUCCESS_CHIME_VOLUME;
-    schedulePlaybackStop(sound);
+
+    const stopAfterPlaybackStarts = (started: boolean) => {
+      if (started && sequence === playbackSequence) {
+        schedulePlaybackStop(sound);
+      }
+    };
 
     // A normal submission is already playing the element silently, so changing
     // its time and volume does not need a fresh autoplay permission. Preserve a
     // direct-call fallback for callers that did not prime it first.
     if (!primed) {
-      void requestPlayback(sound);
+      void requestPlayback(sound).then(stopAfterPlaybackStarts);
     } else if (sound.paused) {
       void primed.then((started) => {
-        if (!started || sound.paused) void requestPlayback(sound);
+        if (sequence !== playbackSequence) return;
+        if (started && !sound.paused) {
+          schedulePlaybackStop(sound);
+        } else {
+          void requestPlayback(sound).then(stopAfterPlaybackStarts);
+        }
       });
+    } else {
+      schedulePlaybackStop(sound);
     }
   } catch {
     // Sound is optional; submission has already succeeded.
@@ -98,6 +114,7 @@ export function playSuccessChime() {
 
 /** Stop the silent priming loop when submission does not succeed. */
 export function cancelSuccessChime() {
+  playbackSequence += 1;
   primingPlayback = null;
   clearPlaybackStop();
   try {


### PR DESCRIPTION
## Summary

- play the submission success chime at 25% volume instead of full volume
- stop playback 900 ms after audible playback actually begins
- ignore stale priming completions after cancellation or a newer submission
- cover reduced volume, delayed priming, bounded playback duration, and cancellation races with unit tests

## Why

The bundled success audio is about 9.35 seconds long. The existing implementation played it at full volume with no duration cap, making the confetti celebration louder and longer than intended.

The duration cap also needs to start when playback becomes audible. Starting it while Safari-compatible priming is still pending can cancel the priming request before any sound is heard, then leave fallback playback without a stop timer.

## Impact

Hosted submission success still gets an audible confirmation, but it is brief and restrained. Delayed media startup still receives the full short excerpt, while cancelled or superseded submissions cannot revive stale playback. Confetti animation behavior is unchanged.

## Validation

- `npm test` — 76 tests passed on the PR head
- synthetic merge with current `main`: `npm test` — 83 tests passed
- `npx eslint src/views/Share/successChime.ts src/views/Share/successChime.test.ts` — passed on the PR head and merge result
- `npm run build` — passed on the PR head and merge result
- visual regression check of the Done page — passed

The repository-wide `npm run lint` remains blocked by six pre-existing errors in unrelated frontend files.
