### PR TITLE
release: 0.2.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "clawjournal",
-  "version": "0.1.16",
+  "version": "0.2.0",
   "description": "ClawJournal — review, curate, and share your coding agent conversation traces. 100% local. Scans sessions from Claude Code, Codex, Gemini CLI, OpenCode, OpenClaw, Kimi CLI, and Cline. Auto-redacts secrets and PII. Browser workbench for triage and export.",
   "owner": {
     "name": "rayward-external",
@@ -11,7 +11,7 @@
     {
       "name": "clawjournal",
       "description": "ClawJournal agent skills: /clawjournal-setup (install + scan + launch workbench), /clawjournal (review, triage, and share traces), and /clawjournal-score (AI-assisted quality scoring).",
-      "version": "0.1.16",
+      "version": "0.2.0",
       "author": {
         "name": "rayward-external",
         "url": "https://github.com/rayward-external"

--- a/clawjournal/__init__.py
+++ b/clawjournal/__init__.py
@@ -1,3 +1,3 @@
 """ClawJournal — Export and manage coding agent conversation data."""
 
-__version__ = "0.1.16"
+__version__ = "0.2.0"

--- a/plugins/clawjournal/.claude-plugin/plugin.json
+++ b/plugins/clawjournal/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "clawjournal",
-  "version": "0.1.16",
+  "version": "0.2.0",
   "description": "Review, curate, and share coding agent conversation traces. Bundles skills for setup, triage, and AI-assisted scoring.",
   "author": {
     "name": "kaiaiagent",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "clawjournal"
-version = "0.1.16"
+version = "0.2.0"
 description = "Review, score, and curate your coding agent conversation traces locally"
 requires-python = ">=3.10"
 license = "Apache-2.0"


### PR DESCRIPTION
## Summary

Bump ClawJournal from `0.1.16` to `0.2.0` across the Python package and plugin manifests so the 74 commits already merged to `main` since the last PyPI release can ship through the tag-based release workflow.

## What 0.2.0 ships

- **Recurring sharing:** daily, consented protocol-v2 uploads with exact scope enrollment, recovery-safe idempotency, stronger control checks, and a streamlined enrollment flow after a successful manual share.
- **Self-improving skills:** local history-backed lesson distillation, persistent objective feedback, trend reporting, expanded installed rules, and evidence-gated weekly focus selection.
- **Privacy and share safety:** Betterleaks as a default findings engine, tiered Betterleaks + TruffleHog share gates, scanner auto-installation, and hardened redaction/upload behavior.
- **Workbench and sharing UX:** guided scope setup, bounded share queues and redaction waits, clearer progress and status surfaces, daily Auto Upload controls, and refreshed prompt-first documentation.
- **Coverage and reliability:** WorkBuddy and Claude Science ingest support, stronger scoring for oversized traces, update/install reconciliation, scan serialization, and numerous upload/share fixes.

## User impact

After the `v0.2.0` tag is pushed, the existing Publish to PyPI workflow will rebuild the frontend, build and validate the wheel/sdist, and publish through trusted publishing. This is a release-only change; runtime behavior is already present on `main`.

## Validation

- `3614 passed, 1 skipped` (full pytest suite)
- Frontend production build passed (`npm ci && npm run build`)
- `python -m build` produced `clawjournal-0.2.0` wheel and sdist
- Wheel contains `clawjournal/web/frontend/dist/index.html`
- `twine check dist/*` passed
- `git diff --check` passed
