### PR TITLE
Fix skill candidate pool starvation

### DIFF
--- a/clawjournal/skill/select.py
+++ b/clawjournal/skill/select.py
@@ -271,7 +271,6 @@ def select_skill_candidates(
 
     mode_counter: Counter[str] = Counter()
     recovery_counter: Counter[str] = Counter()
-    outcome_counter: Counter[str] = Counter()
     _counted: set[str] = set()  # count each session once (a session can match both queries)
     for row in list(fail_rows) + list(succ_rows):
         sid = row["session_id"]
@@ -280,8 +279,6 @@ def select_skill_candidates(
         _counted.add(sid)
         mode_counter.update(_parse_json_list(row["ai_failure_modes"]))
         recovery_counter.update(_parse_json_list(row["ai_recovery_labels"]))
-        if row["ai_outcome_badge"]:
-            outcome_counter.update([row["ai_outcome_badge"]])
 
     def _excerpts(session_id: str) -> list[Any]:
         if excerpt_loader is None:
@@ -340,7 +337,11 @@ def select_skill_candidates(
         elif recovery:
             support = max([recovery_counter[r] for r in recovery] or [1])
         else:
-            support = outcome_counter[row["ai_outcome_badge"]] or 1
+            # A generic outcome badge (for example, ``resolved``) says the session
+            # succeeded, not that this candidate's particular lesson recurred. Count
+            # only the directly evidenced session so ``support_count`` stays comparable
+            # with the structured mode/recovery recurrence used everywhere else.
+            support = 1
         q = row["ai_quality_score"]
         impact = float(q if q is not None else 3)  # 0 is a real score, not "unscored"
         recency = _recency_weight(row["start_time"], now=clock)
@@ -362,12 +363,33 @@ def select_skill_candidates(
     gated_eligible = [sid for sid in eligible_ids if sid not in blocked_ids]
     eligible_scored = len(gated_eligible)
 
-    ranked = sorted(
-        failures + successes,
-        key=lambda c: (c.rank_score, c.support_count, c.impact, c.start_time or ""),
-        reverse=True,
-    )
-    selected = ranked[:pool_cap] if pool_cap and pool_cap > 0 else ranked
+    def _ranked(candidates: list[SkillCandidate]) -> list[SkillCandidate]:
+        return sorted(
+            candidates,
+            key=lambda c: (c.rank_score, c.support_count, c.impact, c.start_time or ""),
+            reverse=True,
+        )
+
+    ranked_failures = _ranked(failures)
+    ranked_successes = _ranked(successes)
+    if pool_cap and pool_cap > 0:
+        # Reserve representation for both lesson kinds. A single shared ranking lets
+        # one abundant/high-support pool shut the other out completely; alternating
+        # the independently-ranked pools preserves their best evidence, then naturally
+        # fills any unused slots from the kind that still has candidates.
+        selected: list[SkillCandidate] = []
+        fi = si = 0
+        while len(selected) < pool_cap and (
+            fi < len(ranked_failures) or si < len(ranked_successes)
+        ):
+            if fi < len(ranked_failures):
+                selected.append(ranked_failures[fi])
+                fi += 1
+            if len(selected) < pool_cap and si < len(ranked_successes):
+                selected.append(ranked_successes[si])
+                si += 1
+    else:
+        selected = ranked_failures + ranked_successes
     selected_failures = [c for c in selected if c.kind == "avoid"]
     selected_successes = [c for c in selected if c.kind == "do"]
 

--- a/tests/skill/test_select.py
+++ b/tests/skill/test_select.py
@@ -63,6 +63,42 @@ def test_selection_caps_to_ranked_top_pool(index_conn, ins):
     assert len({"f0", "f1", "f2"} - selected) == 1
 
 
+def test_success_heavy_pool_keeps_real_failures_and_comparable_support(index_conn, ins):
+    # Regression for #156: generic resolved-badge frequency is not recurrence of any
+    # particular lesson, and many such successes must not starve real avoid evidence.
+    for i in range(30):
+        ins(index_conn, f"win{i}", outcome="resolved", quality=5,
+            learning=f"successful lesson {i}")
+    for i in range(3):
+        ins(index_conn, f"fail{i}", fvs=4, modes='["verification_skipped"]',
+            learning=f"failure lesson {i}")
+
+    corpus = select_skill_candidates(index_conn, now=NOW, pool_cap=5)
+
+    assert {c.session_id for c in corpus.failures} == {"fail0", "fail1", "fail2"}
+    assert len(corpus.candidates) == 5
+    assert {c.support_count for c in corpus.successes} == {1}
+
+
+def test_pool_cap_interleaves_kinds_when_success_rank_is_higher(index_conn, ins):
+    # Structured clean-recovery recurrence is legitimate support, but it still must
+    # not consume every prompt slot and make avoid lessons impossible to distill.
+    for i in range(12):
+        ins(index_conn, f"recovered{i}", outcome="resolved", quality=5,
+            recovery='["self_recovered"]', learning=f"recovery lesson {i}")
+    for i in range(2):
+        ins(index_conn, f"fail{i}", fvs=3, modes='["verification_skipped"]',
+            learning=f"failure lesson {i}")
+
+    corpus = select_skill_candidates(index_conn, now=NOW, pool_cap=4)
+
+    assert len(corpus.failures) == 2
+    assert len(corpus.successes) == 2
+    assert min(c.support_count for c in corpus.successes) > max(
+        c.support_count for c in corpus.failures
+    )
+
+
 def test_hold_state_gate_excludes_pending(index_conn, ins):
     ins(index_conn, "ok", fvs=5, learning="a", hold_state="auto_redacted")
     ins(index_conn, "pending", fvs=5, learning="b", hold_state="pending_review")


### PR DESCRIPTION
## Summary

- treat badge-only success candidates as one directly evidenced session instead of inflating support from the corpus-wide outcome badge count
- rank avoid and do candidates independently, then interleave them into the capped distill pool so either kind can fill unused slots without starving the other
- add regressions for a success-heavy corpus and for higher-ranked recovery successes competing with real failures

## Root cause

`select_skill_candidates` used one shared `rank_score` across both candidate kinds. Failure support counted sessions sharing a specific failure mode, while badge-only success support counted every session sharing a generic outcome such as `resolved`. Because rank amplifies support as `freq ** 1.5`, generic successes could occupy all 15 prompt slots and prevent real avoid evidence from reaching distillation.

## Impact

A success-heavy index now still sends real failure candidates to the distiller, while `support_count` no longer claims that a badge-only lesson recurred merely because many unrelated sessions were resolved. Structured failure-mode and recovery-label recurrence remains available as comparable pattern evidence.

On the live success-heavy index used for issue validation:

- 625 eligible scored sessions
- 76 avoid and 179 do candidates built
- capped prompt pool changed from 0 avoid / 15 do to 8 avoid / 7 do
- the real preview proposed 3 avoid and 2 do rules; the newly proposed avoid rule cited real selected failure sessions rather than only synthetic aggregates

## Validation

- `python -m pytest tests/skill/ -q` — 614 passed
- `python -m pytest -q` — 3616 passed, 1 skipped
- `git diff --check`
- `python -m clawjournal.cli skill --all --no-scan --no-score --preview`

Closes #156
