### PR TITLE
fix(skills): decouple objective feedback from AI scoring

### DIFF
--- a/clawjournal/cli_skill.py
+++ b/clawjournal/cli_skill.py
@@ -678,9 +678,9 @@ def _print_preview(res: SkillResult) -> None:
                 arrow = "↓ improving" if cur < prev - 1e-9 else ("↑ worsening" if cur > prev + 1e-9 else "→ flat")
                 print(_ascii_safe(f"    - {mode}: {prev:.0%} → {cur:.0%}  ({arrow})"))
     if res.objective_trend:
-        n = res.corpus.eligible_scored
-        print(_ascii_safe("\n  Objective feedback recurrence vs your last run "
-                          "(tool errors + rejections per scored session — verifiable, not judge-inferred):"))
+        n = res.corpus.objective_session_count
+        print(_ascii_safe(f"\n  Objective feedback recurrence vs your last run "
+                          f"(rate over {n} gated session(s) — verifiable, not judge-inferred):"))
         # most-recurrent first; cap so a long tail of rare signatures doesn't flood output
         ordered = sorted(res.objective_trend.items(),
                          key=lambda kv: -max(kv[1][0] or 0.0, kv[1][1]))[:6]
@@ -851,13 +851,14 @@ def run_skill(args) -> None:
             # Worst case the next run re-labels these rules [NEW]; the install is safe.
             try:
                 _store.mark_installed(conn, res.rules)  # upserts + marks 'kept'
-                # Only snapshot when the window actually had scored sessions — an idle
-                # run (empty corpus but kept rules re-proposed) must NOT overwrite the
-                # last real snapshot with an empty one (would reset the run-over-run trend).
+                # Judge-backed and objective telemetry have independent universes. An
+                # idle universe must not overwrite its last real snapshot with an empty
+                # one, while unscored objective evidence must still be persisted.
                 if res.corpus.eligible_scored > 0:
                     _store.save_mode_snapshot(conn, res.corpus.mode_rates(), res.corpus.eligible_scored)
+                if res.corpus.objective_session_count > 0:
                     _store.save_objective_snapshot(conn, res.corpus.objective_rates(),
-                                                   res.corpus.eligible_scored)
+                                                   res.corpus.objective_session_count)
             except Exception as exc:
                 print(f"note: installed to disk, but failed to record state "
                       f"({exc.__class__.__name__}); the next run may re-propose these rules.")

--- a/clawjournal/skill/select.py
+++ b/clawjournal/skill/select.py
@@ -1,4 +1,4 @@
-"""Select skill candidates from the user's own *scored* sessions (Mode A).
+"""Select skill candidates and objective feedback sessions for Mode A.
 
 Two pools, all pure SQL/Python (no LLM):
   - **avoid** = recurring failure modes with real impact (the ``ai_failure_modes``
@@ -73,8 +73,11 @@ class SkillCorpus:
     total_successes: int = 0
     eligible_scored: int = 0   # scored sessions in the window (rate denominator)
     # every gated (hold-state + exclusion checked) scored session in the window —
-    # the scan universe for cross-session env-signature candidates (skill.turns)
+    # the judge-backed universe used by candidate attribution/focus selection
     eligible_session_ids: list[str] = field(default_factory=list)
+    # every gated session in the window, scored or not — the judge-independent scan
+    # universe for tool-error signatures and human rejections (skill.turns)
+    objective_session_ids: list[str] = field(default_factory=list)
     # OBJECTIVE feedback recurrence: {readable signal key -> distinct-session count}
     # for tool-error signatures + human rejections (skill.turns populates it). Judge-
     # free ground truth; snapshotted run-over-run for a verifiable improvement trend.
@@ -87,10 +90,15 @@ class SkillCorpus:
         return {m: n / self.eligible_scored for m, n in self.mode_recurrence.items()}
 
     def objective_rates(self) -> dict[str, float]:
-        """Per-objective-signal incidence rate over eligible scored sessions."""
-        if self.eligible_scored <= 0:
+        """Per-objective-signal incidence rate over all gated window sessions."""
+        denominator = self.objective_session_count
+        if denominator <= 0:
             return {}
-        return {k: n / self.eligible_scored for k, n in self.objective_recurrence.items()}
+        return {k: n / denominator for k, n in self.objective_recurrence.items()}
+
+    @property
+    def objective_session_count(self) -> int:
+        return len(self.objective_session_ids)
 
     @property
     def candidates(self) -> list[SkillCandidate]:
@@ -253,7 +261,7 @@ def select_skill_candidates(
     )
     succ_rows = [r for r in conn.execute(succ_sql, [window_floor, *src]).fetchall() if _keep(r)]
 
-    # eligible = the rate denominator; a SUPERSET of every session that can feed
+    # eligible = the judge-backed rate denominator; a SUPERSET of every session that can feed
     # mode_counter (the numerator), else a rate can exceed 100%. A candidate qualifies
     # by score, by outcome badge, or by failure_modes+recovery — so count any judge verdict.
     # Excluded projects are dropped here too (they're not candidates).
@@ -265,9 +273,17 @@ def select_skill_candidates(
     eligible_ids = [r["session_id"] for r in conn.execute(eligible_sql, [window_floor, *src]).fetchall()
                     if _keep(r)]
 
-    candidate_ids = [row["session_id"] for row in list(fail_rows) + list(succ_rows)]
-    # One hold-state gate pass over the union (candidates are a subset of eligible).
-    blocked_ids = _release_blocked_ids(conn, candidate_ids + eligible_ids, now=clock)
+    # Objective feedback is intentionally judge-independent. Its universe includes every
+    # session in the same time/source/project scope, whether or not the scoring budget has
+    # reached it. Run the hold-state gate once over this superset; judge candidates and
+    # eligible_ids are subsets, so the same blocked set protects both paths.
+    objective_sql = f"SELECT session_id, start_time, project, source {base}"
+    objective_ids = [
+        r["session_id"]
+        for r in conn.execute(objective_sql, [window_floor, *src]).fetchall()
+        if _keep(r)
+    ]
+    blocked_ids = _release_blocked_ids(conn, objective_ids, now=clock)
 
     mode_counter: Counter[str] = Counter()
     recovery_counter: Counter[str] = Counter()
@@ -361,6 +377,7 @@ def select_skill_candidates(
 
     # eligible_ids computed above; reuse the single blocked_ids pass (no second gate query).
     gated_eligible = [sid for sid in eligible_ids if sid not in blocked_ids]
+    gated_objective = [sid for sid in objective_ids if sid not in blocked_ids]
     eligible_scored = len(gated_eligible)
 
     def _ranked(candidates: list[SkillCandidate]) -> list[SkillCandidate]:
@@ -400,4 +417,5 @@ def select_skill_candidates(
         total_failures=len(failures), total_successes=len(successes),
         eligible_scored=eligible_scored,
         eligible_session_ids=gated_eligible,
+        objective_session_ids=gated_objective,
     )

--- a/clawjournal/skill/store.py
+++ b/clawjournal/skill/store.py
@@ -169,10 +169,11 @@ def _ensure_snapshots(conn: sqlite3.Connection) -> None:
         "CREATE TABLE IF NOT EXISTS skill_mode_snapshots ("
         "recorded_at TEXT, n INTEGER, rates_json TEXT)"
     )
-    # Separate table (not an ALTER) so an older DB with no objective column can't break;
-    # same shape as the mode snapshot, holding objective-signal rates instead.
+    # The objective metric originally used scored sessions as its denominator. Keep the
+    # replacement in a new table so the first judge-independent run starts a clean
+    # baseline instead of comparing incompatible rate definitions.
     conn.execute(
-        "CREATE TABLE IF NOT EXISTS skill_objective_snapshots ("
+        "CREATE TABLE IF NOT EXISTS skill_objective_session_snapshots ("
         "recorded_at TEXT, n INTEGER, rates_json TEXT)"
     )
     conn.commit()
@@ -215,7 +216,8 @@ def save_objective_snapshot(conn: sqlite3.Connection, rates: dict[str, float], n
     """Record the window's objective-signal incidence rates (run-over-run trend)."""
     _ensure_snapshots(conn)
     conn.execute(
-        "INSERT INTO skill_objective_snapshots (recorded_at, n, rates_json) VALUES (?,?,?)",
+        "INSERT INTO skill_objective_session_snapshots "
+        "(recorded_at, n, rates_json) VALUES (?,?,?)",
         (now or now_iso(), int(n), json.dumps(rates)),
     )
     conn.commit()
@@ -223,7 +225,7 @@ def save_objective_snapshot(conn: sqlite3.Connection, rates: dict[str, float], n
 
 def last_objective_snapshot(conn: sqlite3.Connection) -> tuple[str, int, dict[str, float]] | None:
     """Return the most recent (recorded_at, n, rates) objective snapshot, or None."""
-    return _read_last_snapshot(conn, "skill_objective_snapshots")
+    return _read_last_snapshot(conn, "skill_objective_session_snapshots")
 
 
 def reject(conn: sqlite3.Connection, fp: str, *, now: str | None = None) -> bool:

--- a/clawjournal/skill/turns.py
+++ b/clawjournal/skill/turns.py
@@ -331,8 +331,9 @@ def add_env_candidates(
     This is the judge-free evidence path: ``support_count`` is the number of
     DISTINCT sessions that hit the same normalized tool error — a real count the
     user can verify, not an AI-inferred failure mode. Scans only
-    ``corpus.eligible_session_ids`` (already hold-state + exclusion gated), so the
-    egress surface is identical to the rest of the corpus. Best-effort per session.
+    ``corpus.objective_session_ids`` (already hold-state + exclusion gated), including
+    unscored sessions so scoring budget cannot hide objective evidence. Best-effort per
+    session.
     """
     from .select import SkillCandidate, _candidate_rank, _recency_weight
 
@@ -340,7 +341,7 @@ def add_env_candidates(
         from ..workbench.index import get_session_detail
         loader = get_session_detail
     hits: dict[str, dict[str, Any]] = {}
-    for sid in getattr(corpus, "eligible_session_ids", []) or []:
+    for sid in getattr(corpus, "objective_session_ids", []) or []:
         try:
             detail = loader(conn, sid) or {}
             messages = detail.get("messages") or []
@@ -439,7 +440,8 @@ def add_rejection_candidate(
     human feedback the correction heuristic never sees. ``support_count`` is the
     number of distinct sessions containing at least one rejection (a real count).
     Excerpts render as pivotal_turns: agent_before = the attempted action,
-    user_correction = the rejection reason. Scans only the gated session ids.
+    user_correction = the rejection reason. Scans all gated window sessions regardless
+    of whether the judge has scored them.
     """
     from .select import SkillCandidate, _candidate_rank, _recency_weight
 
@@ -450,7 +452,7 @@ def add_rejection_candidate(
     reasons: Counter[str] = Counter()
     excerpts: list[TurnExcerpt] = []
     last_detail: dict[str, Any] = {}
-    for sid in getattr(corpus, "eligible_session_ids", []) or []:
+    for sid in getattr(corpus, "objective_session_ids", []) or []:
         try:
             detail = loader(conn, sid) or {}
             messages = detail.get("messages") or []

--- a/tests/skill/test_render_install.py
+++ b/tests/skill/test_render_install.py
@@ -8,6 +8,14 @@ from clawjournal.skill.schema import SkillRule
 META = {"generated_at": "2026-06-30", "window_days": 7, "sources": 9}
 
 
+@pytest.fixture
+def agent_home(tmp_path, monkeypatch):
+    """Keep global Claude/Codex install tests inside the temporary directory."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("USERPROFILE", str(tmp_path))
+    return tmp_path
+
+
 def _rule(kind="avoid", guidance="run the test suite first"):
     return SkillRule(kind=kind, trigger="before done", guidance=guidance, why="premature 4x")
 
@@ -361,11 +369,10 @@ def test_gate_rendered_blocks_trufflehog_scan_errors(monkeypatch):
     assert render.gate_rendered("ordinary text") == ["trufflehog: trufflehog-error"]
 
 
-def test_install_writes_and_overwrites(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
+def test_install_writes_and_overwrites(agent_home):
     md = render.render_skill_md([_rule()], META)
     p = install.install_claude(md)
-    assert p == tmp_path / ".claude" / "skills" / "clawjournal-lessons" / "SKILL.md"
+    assert p == agent_home / ".claude" / "skills" / "clawjournal-lessons" / "SKILL.md"
     assert p.read_text().startswith("---\nname: clawjournal-lessons")
     assert install.INTEGRITY_PREFIX in p.read_text()          # self-verifying, no sidecar
     assert not install.claude_skill_hash_path(p).exists()     # legacy sidecar retired
@@ -374,10 +381,9 @@ def test_install_writes_and_overwrites(tmp_path, monkeypatch):
     assert "updated rule" in p.read_text()
 
 
-def test_install_claude_backs_up_external_edit_and_regenerates(tmp_path, monkeypatch):
+def test_install_claude_backs_up_external_edit_and_regenerates(agent_home):
     # #8: a weekly-regenerated artifact must not brick on an external touch — the edit
     # is preserved in a .bak and the file is regenerated (not a hard refusal).
-    monkeypatch.setenv("HOME", str(tmp_path))
     p = install.install_claude(render.render_skill_md([_rule()], META))
     p.write_text(p.read_text() + "\nmanual edit\n", encoding="utf-8")     # external touch (append)
     install.install_claude(render.render_skill_md([_rule(guidance="updated rule")], META))
@@ -386,8 +392,7 @@ def test_install_claude_backs_up_external_edit_and_regenerates(tmp_path, monkeyp
     assert bak.exists() and "manual edit" in bak.read_text()              # user's copy preserved
 
 
-def test_install_claude_refuses_non_managed_existing_file(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
+def test_install_claude_refuses_non_managed_existing_file(agent_home):
     p = install.claude_skill_path()
     p.parent.mkdir(parents=True)
     p.write_text("custom skill\n", encoding="utf-8")
@@ -396,10 +401,9 @@ def test_install_claude_refuses_non_managed_existing_file(tmp_path, monkeypatch)
         install.install_claude(render.render_skill_md([_rule()], META))
 
 
-def test_install_claude_backs_up_mid_body_edit(tmp_path, monkeypatch):
+def test_install_claude_backs_up_mid_body_edit(agent_home):
     # #2 + #8: a mid-body edit (integrity line intact at the end) is still detected by
     # the embedded hash — and preserved in .bak, not silently overwritten or refused.
-    monkeypatch.setenv("HOME", str(tmp_path))
     p = install.install_claude(render.render_skill_md([_rule()], META))
     p.write_text(p.read_text().replace("premature 4x", "REWORDED BY USER"), encoding="utf-8")
     install.install_claude(render.render_skill_md([_rule(guidance="v2")], META))
@@ -408,10 +412,9 @@ def test_install_claude_backs_up_mid_body_edit(tmp_path, monkeypatch):
     assert bak.exists() and "REWORDED BY USER" in bak.read_text()
 
 
-def test_install_claude_migrates_pre_integrity_file(tmp_path, monkeypatch):
+def test_install_claude_migrates_pre_integrity_file(agent_home):
     # #1: a managed file from before the embedded-hash change (provenance marker, no
     # integrity line, possibly a stale/absent sidecar) must regenerate, not brick.
-    monkeypatch.setenv("HOME", str(tmp_path))
     p = install.claude_skill_path()
     p.parent.mkdir(parents=True)
     p.write_text(render.render_skill_md([_rule()], META), encoding="utf-8")  # no integrity line
@@ -439,9 +442,8 @@ def test_upsert_region_escapes_inner_managed_markers():
     assert "<!-- clawjournal BEGIN marker escaped -->" in rendered
 
 
-def test_install_codex_managed_region_preserves_user_content(tmp_path, monkeypatch):
-    monkeypatch.setenv("HOME", str(tmp_path))
-    agents = tmp_path / ".codex" / "AGENTS.md"
+def test_install_codex_managed_region_preserves_user_content(agent_home):
+    agents = agent_home / ".codex" / "AGENTS.md"
     agents.parent.mkdir(parents=True)
     agents.write_text("# My project rules\n\nkeep this\n")
     region = render.render_agents_region([_rule()], META)

--- a/tests/skill/test_select.py
+++ b/tests/skill/test_select.py
@@ -116,6 +116,35 @@ def test_hold_state_gate_excludes_pending_from_rates(index_conn, ins):
     assert corpus.eligible_scored == 1
 
 
+def test_objective_universe_includes_unscored_sessions(index_conn, ins):
+    ins(index_conn, "scored", fvs=5, learning="judge evidence")
+    ins(index_conn, "unscored")
+
+    corpus = select_skill_candidates(index_conn, now=NOW)
+
+    assert corpus.eligible_session_ids == ["scored"]
+    assert set(corpus.objective_session_ids) == {"scored", "unscored"}
+    assert corpus.objective_session_count == 2
+
+
+def test_objective_universe_preserves_scope_and_release_gates(index_conn, ins):
+    ins(index_conn, "keep")
+    ins(index_conn, "held", hold_state="pending_review")
+    ins(index_conn, "excluded", project="private-client")
+    ins(index_conn, "other-source", source="claude")
+    ins(index_conn, "segmented", review_status="segmented")
+    ins(index_conn, "old", start_time="2026-05-01T00:00:00+00:00")
+
+    corpus = select_skill_candidates(
+        index_conn,
+        now=NOW,
+        sources=["codex"],
+        excluded_projects=["codex:private-client"],
+    )
+
+    assert corpus.objective_session_ids == ["keep"]
+
+
 def test_window_and_source_scope(index_conn, ins):
     ins(index_conn, "recent", fvs=4, learning="x", start_time="2026-05-28T00:00:00+00:00")
     ins(index_conn, "old", fvs=4, learning="x", start_time="2026-05-01T00:00:00+00:00")

--- a/tests/skill/test_telemetry.py
+++ b/tests/skill/test_telemetry.py
@@ -27,6 +27,18 @@ def test_eligible_denominator_and_rate(index_conn, ins):
     assert abs(corpus.mode_rates()["verification_skipped"] - 0.5) < 1e-9
 
 
+def test_objective_rate_uses_all_gated_sessions_not_scored_subset(index_conn, ins):
+    ins(index_conn, "scored", fvs=5, learning="x")
+    for i in range(3):
+        ins(index_conn, f"unscored-{i}")
+    corpus = select_skill_candidates(index_conn, now=NOW)
+    corpus.objective_recurrence["tool error"] = 2
+
+    assert corpus.eligible_scored == 1
+    assert corpus.objective_session_count == 4
+    assert abs(corpus.objective_rates()["tool error"] - 0.5) < 1e-9
+
+
 def test_snapshot_round_trip(index_conn):
     store.save_mode_snapshot(index_conn, {"verification_skipped": 0.9}, 20)
     last = store.last_mode_snapshot(index_conn)
@@ -59,13 +71,27 @@ def test_objective_snapshot_round_trip(index_conn):
     assert n == 15 and abs(rates["user-rejected actions"] - 0.2) < 1e-9
 
 
+def test_legacy_scored_denominator_objective_snapshot_is_not_reused(index_conn):
+    index_conn.execute(
+        "CREATE TABLE skill_objective_snapshots "
+        "(recorded_at TEXT, n INTEGER, rates_json TEXT)"
+    )
+    index_conn.execute(
+        "INSERT INTO skill_objective_snapshots VALUES (?,?,?)",
+        ("2026-05-30T00:00:00+00:00", 10, '{"tool error": 0.9}'),
+    )
+    index_conn.commit()
+
+    assert store.last_objective_snapshot(index_conn) is None
+
+
 def test_generate_reports_objective_trend(index_conn, ins, monkeypatch):
     store.save_objective_snapshot(index_conn, {"user-rejected actions": 0.40}, 20)   # prior run
     for i in range(12):
         ins(index_conn, f"ok{i}", quality=5, outcome="resolved", learning="y")
     # `ins` seeds no message blobs, so inject a known objective signal directly
     def fake_env(conn, corpus, **kw):
-        corpus.objective_recurrence["user-rejected actions"] = 3   # 3 of 12 scored = 25%
+        corpus.objective_recurrence["user-rejected actions"] = 3   # 3 of 12 gated = 25%
     monkeypatch.setattr("clawjournal.cli_skill._turns.add_env_candidates", fake_env)
     monkeypatch.setattr("clawjournal.cli_skill._turns.add_rejection_candidate", lambda *a, **k: None)
     fake = FakeCaller({"rules": [

--- a/tests/skill/test_turns.py
+++ b/tests/skill/test_turns.py
@@ -189,7 +189,7 @@ def test_excerpts_for_session_puts_corrections_first_and_caps():
 def test_add_env_candidates_clusters_across_sessions():
     from clawjournal.skill.turns import add_env_candidates
     corpus = SkillCorpus(window_start="a", window_end="b",
-                         eligible_session_ids=["s1", "s2", "s3"])
+                         objective_session_ids=["s1", "s2", "s3"])
 
     def loader(conn, sid):
         return {"project": "p", "source": "claude", "start_time": "2026-07-01T00:00:00+00:00",
@@ -211,7 +211,7 @@ def test_add_env_candidates_clusters_across_sessions():
 def test_add_env_candidates_requires_min_recurrence():
     from clawjournal.skill.turns import add_env_candidates
     corpus = SkillCorpus(window_start="a", window_end="b",
-                         eligible_session_ids=["s1", "s2"])
+                         objective_session_ids=["s1", "s2"])
 
     def loader(conn, sid):
         return {"messages": [_at(_tu("Edit", "x", status="error",
@@ -270,7 +270,7 @@ def test_teammate_relays_are_not_corrections():
 def test_add_rejection_candidate_clusters_across_sessions():
     from clawjournal.skill.turns import add_rejection_candidate
     corpus = SkillCorpus(window_start="a", window_end="b",
-                         eligible_session_ids=["s1", "s2", "s3"])
+                         objective_session_ids=["s1", "s2", "s3"])
     denials = {
         "s1": "The user doesn't want to take this action right now. STOP what you are doing.",
         "s2": ("Permission for this action was denied by the Claude Code auto mode "
@@ -297,7 +297,7 @@ def test_add_rejection_candidate_clusters_across_sessions():
 def test_add_rejection_candidate_requires_min_recurrence():
     from clawjournal.skill.turns import add_rejection_candidate
     corpus = SkillCorpus(window_start="a", window_end="b",
-                         eligible_session_ids=["s1", "s2"])
+                         objective_session_ids=["s1", "s2"])
 
     def loader(conn, sid):
         return {"messages": [_at(_tu("Bash", "rm -rf x", status="error",
@@ -313,7 +313,7 @@ def test_synthetic_candidates_get_noncolliding_ids():
     # support across the shared alias.
     from clawjournal.skill.turns import add_env_candidates, add_rejection_candidate
     corpus = SkillCorpus(window_start="a", window_end="b",
-                         eligible_session_ids=["s1", "s2", "s3"])
+                         objective_session_ids=["s1", "s2", "s3"])
 
     def loader(conn, sid):
         return {"project": "p", "source": "claude", "start_time": "2026-07-01T00:00:00+00:00",
@@ -335,17 +335,22 @@ def test_synthetic_candidates_get_noncolliding_ids():
 
 def test_objective_recurrence_populated_for_trend():
     from clawjournal.skill.turns import add_env_candidates, add_rejection_candidate
-    corpus = SkillCorpus(window_start="a", window_end="b", eligible_scored=10,
-                         eligible_session_ids=["s1", "s2", "s3"])
+    corpus = SkillCorpus(
+        window_start="a", window_end="b", eligible_scored=1,
+        objective_session_ids=[f"s{i}" for i in range(1, 11)],
+    )
 
     def loader(conn, sid):
+        messages = []
+        if sid in {"s1", "s2", "s3"}:
+            messages = [
+                _at(_tu("Edit", "x", status="error",
+                        output="String to replace not found in file.")),
+                _at(_tu("Bash", "git push", status="error",
+                        output="The user doesn't want to take this action right now.")),
+            ]
         return {"project": "p", "source": "claude", "start_time": "2026-07-01T00:00:00+00:00",
-                "messages": [
-                    _at(_tu("Edit", "x", status="error",
-                            output="String to replace not found in file.")),
-                    _at(_tu("Bash", "git push", status="error",
-                            output="The user doesn't want to take this action right now.")),
-                ]}
+                "messages": messages}
 
     add_env_candidates(None, corpus, loader=loader)
     add_rejection_candidate(None, corpus, loader=loader)
@@ -359,7 +364,7 @@ def test_objective_recurrence_records_below_teach_bar():
     # but must NOT become a taught candidate (bar is 3).
     from clawjournal.skill.turns import add_env_candidates
     corpus = SkillCorpus(window_start="a", window_end="b", eligible_scored=10,
-                         eligible_session_ids=["s1", "s2"])
+                         objective_session_ids=["s1", "s2"])
 
     def loader(conn, sid):
         return {"messages": [_at(_tu("Edit", "x", status="error",
@@ -379,7 +384,7 @@ def test_newer_rejection_phrasing_is_human_not_env():
     assert _teachable_error({"output": {"text": msg}}) == ""   # not an env signal
 
     corpus = SkillCorpus(window_start="a", window_end="b", eligible_scored=10,
-                         eligible_session_ids=["s1", "s2", "s3"])
+                         objective_session_ids=["s1", "s2", "s3"])
 
     def loader(conn, sid):
         return {"project": "p", "source": "codex", "start_time": "2026-07-01T00:00:00+00:00",


### PR DESCRIPTION
## Summary
- scan recurring environment/tool errors and human rejections across every gated session in the skill window, including sessions not reached by the AI scoring budget
- keep judge-backed candidate selection, failure-mode rates, and focus attribution restricted to scored sessions
- give objective recurrence its own all-session denominator and start a clean snapshot baseline so old scored-denominator rates are never compared with the new metric
- make Claude/Codex install tests isolate both `HOME` and `USERPROFILE`, preventing Windows tests from touching the real user profile

## Why
The objective feedback channels are deterministic regex scans intended to work without an AI judge. They previously iterated `eligible_session_ids`, which only contains sessions with a judge verdict. Sessions beyond `--score-limit` therefore contributed no tool-error or rejection evidence, and the supposedly judge-free metric was still constrained by judge cost and reliability.

Closes #104.

## Safety
- preserves the existing source, exact time-window, non-segmented, excluded-project, and hold-state gates before raw session details are loaded
- leaves judge candidate ranking and spotlight attribution unchanged
- keeps synthetic objective candidates out of direct-session focus evidence
- requires no hosted-service/API change and no core workbench schema migration
- stores the new objective-rate definition in a separate lazily-created table, so legacy snapshots remain untouched and are not compared across incompatible denominators

## Validation
- `python -m pytest tests/skill -q` — **616 passed, 2 skipped**
- targeted Claude/Codex installation tests — **6 passed**
- `git diff --check`