### PR TITLE
fix(share): reconcile continued traces before hosted upload

### DIFF
--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -3041,7 +3041,8 @@ def _handle_codex_session_meta(
     payload = entry.get("payload", {})
     session_cwd = payload.get("cwd")
     if isinstance(session_cwd, str) and session_cwd.strip():
-        state.raw_cwd = session_cwd
+        if state.raw_cwd == UNKNOWN_CODEX_CWD:
+            state.raw_cwd = session_cwd
         if state.metadata["cwd"] is None:
             state.metadata["cwd"] = anonymizer.path(session_cwd)
     if state.metadata["session_id"] == filepath.stem:
@@ -3067,7 +3068,8 @@ def _handle_codex_turn_context(
     payload = entry.get("payload", {})
     session_cwd = payload.get("cwd")
     if isinstance(session_cwd, str) and session_cwd.strip():
-        state.raw_cwd = session_cwd
+        if state.raw_cwd == UNKNOWN_CODEX_CWD:
+            state.raw_cwd = session_cwd
         if state.metadata["cwd"] is None:
             state.metadata["cwd"] = anonymizer.path(session_cwd)
     if state.metadata["model"] is None:

--- a/clawjournal/web/frontend/src/views/Share/successChime.test.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.test.ts
@@ -64,7 +64,7 @@ describe('success sound', () => {
     expect(sound.loop).toBe(false);
     expect(sound.volume).toBe(0.15);
 
-    vi.advanceTimersByTime(900);
+    vi.advanceTimersByTime(1500);
     expect(sound.pause).not.toHaveBeenCalled();
 
     resolvePrimingPlayback();
@@ -72,11 +72,19 @@ describe('success sound', () => {
     await Promise.resolve();
 
     expect(sound.play).toHaveBeenCalledOnce();
-    vi.advanceTimersByTime(899);
+    vi.advanceTimersByTime(1499);
     expect(sound.pause).not.toHaveBeenCalled();
     vi.advanceTimersByTime(1);
+    expect(sound.pause).not.toHaveBeenCalled();
+    expect(sound.volume).toBe(0.15);
+    vi.advanceTimersByTime(250);
+    expect(sound.pause).not.toHaveBeenCalled();
+    expect(sound.volume).toBeGreaterThan(0);
+    expect(sound.volume).toBeLessThan(0.15);
+    vi.advanceTimersByTime(250);
     expect(sound.pause).toHaveBeenCalledOnce();
     expect(sound.currentTime).toBe(0);
+    expect(sound.volume).toBe(0.15);
   });
 
   it('stops silent playback when submission does not succeed', async () => {
@@ -135,7 +143,7 @@ describe('success sound', () => {
 
     expect(sound.play).toHaveBeenCalledOnce();
     expect(sound.pause).toHaveBeenCalledOnce();
-    vi.advanceTimersByTime(900);
+    vi.advanceTimersByTime(1500);
     expect(sound.pause).toHaveBeenCalledOnce();
   });
 });

--- a/clawjournal/web/frontend/src/views/Share/successChime.test.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.test.ts
@@ -62,7 +62,7 @@ describe('success sound', () => {
     expect(sound.play).toHaveBeenCalledOnce();
     expect(sound.currentTime).toBe(0);
     expect(sound.loop).toBe(false);
-    expect(sound.volume).toBe(0.25);
+    expect(sound.volume).toBe(0.15);
 
     vi.advanceTimersByTime(900);
     expect(sound.pause).not.toHaveBeenCalled();
@@ -99,7 +99,7 @@ describe('success sound', () => {
     expect(sound.pause).toHaveBeenCalledOnce();
     expect(sound.currentTime).toBe(0);
     expect(sound.loop).toBe(false);
-    expect(sound.volume).toBe(0.25);
+    expect(sound.volume).toBe(0.15);
   });
 
   it('does not restart playback after cancellation wins a priming race', async () => {

--- a/clawjournal/web/frontend/src/views/Share/successChime.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.ts
@@ -1,6 +1,8 @@
 const SUCCESS_SOUND_URL = '/sounds/submission-success.mp3';
 const SUCCESS_CHIME_VOLUME = 0.15;
-const SUCCESS_CHIME_DURATION_MS = 900;
+const SUCCESS_CHIME_HOLD_MS = 1500;
+const SUCCESS_CHIME_FADE_MS = 500;
+const SUCCESS_CHIME_FADE_STEP_MS = 25;
 
 let successSound: HTMLAudioElement | null = null;
 let primingPlayback: Promise<boolean> | null = null;
@@ -33,17 +35,40 @@ function clearPlaybackStop() {
   stopPlaybackTimer = null;
 }
 
+function finishPlayback(sound: HTMLAudioElement) {
+  sound.pause();
+  sound.currentTime = 0;
+  sound.volume = SUCCESS_CHIME_VOLUME;
+}
+
 function schedulePlaybackStop(sound: HTMLAudioElement) {
   clearPlaybackStop();
   stopPlaybackTimer = setTimeout(() => {
     stopPlaybackTimer = null;
-    try {
-      sound.pause();
-      sound.currentTime = 0;
-    } catch {
-      // Sound is optional; cleanup must not affect the completed submission.
-    }
-  }, SUCCESS_CHIME_DURATION_MS);
+    const initialVolume = sound.volume;
+    const fadeStartedAt = Date.now();
+    const fadeStep = () => {
+      try {
+        const elapsed = Date.now() - fadeStartedAt;
+        const progress = Math.min(1, elapsed / SUCCESS_CHIME_FADE_MS);
+        sound.volume = initialVolume * (1 - progress);
+        if (progress >= 1) {
+          stopPlaybackTimer = null;
+          finishPlayback(sound);
+          return;
+        }
+        stopPlaybackTimer = setTimeout(fadeStep, SUCCESS_CHIME_FADE_STEP_MS);
+      } catch {
+        stopPlaybackTimer = null;
+        try {
+          finishPlayback(sound);
+        } catch {
+          // Sound is optional; cleanup must not affect the completed submission.
+        }
+      }
+    };
+    fadeStep();
+  }, SUCCESS_CHIME_HOLD_MS);
 }
 
 /**

--- a/clawjournal/web/frontend/src/views/Share/successChime.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.ts
@@ -1,5 +1,5 @@
 const SUCCESS_SOUND_URL = '/sounds/submission-success.mp3';
-const SUCCESS_CHIME_VOLUME = 0.25;
+const SUCCESS_CHIME_VOLUME = 0.15;
 const SUCCESS_CHIME_DURATION_MS = 900;
 
 let successSound: HTMLAudioElement | null = null;

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -25,7 +25,7 @@ from http import HTTPStatus
 from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from typing import Any, Callable, Iterator
-from urllib.parse import parse_qs, unquote, urlparse
+from urllib.parse import parse_qs, unquote, urljoin, urlparse
 
 from .. import __version__
 from ..auto_upload_client import (
@@ -91,6 +91,7 @@ from .index import (
     share_predecessor_blockers,
     share_revision_blockers,
     source_scope_blockers,
+    synchronize_share_predecessors,
     update_session,
     upsert_sessions,
 )
@@ -1524,6 +1525,155 @@ def _fetch_hosted_share_capabilities(*, force: bool = False) -> dict[str, Any]:
     return capabilities
 
 
+def _manual_lineage_preflight_url(
+    capabilities: dict[str, Any],
+) -> str | None:
+    advertised = capabilities.get("manual_lineage_preflight_url")
+    if not isinstance(advertised, str) or not advertised.strip():
+        return None
+    api_base = _hosted_api_base()
+    resolved = urljoin(f"{api_base}/", advertised.strip())
+    if comparable_origin(resolved) != comparable_origin(api_base):
+        raise ValueError("Hosted lineage preflight must use the configured origin.")
+    return resolved
+
+
+def _manual_share_lineage_claims(share: dict[str, Any]) -> list[dict[str, Any]]:
+    claims: list[dict[str, Any]] = []
+    for session in share.get("sessions") or []:
+        session_id = session.get("session_id")
+        revision_hash = session.get("share_content_revision")
+        if not isinstance(session_id, str) or not session_id:
+            raise ValueError("Share contains an invalid session identity.")
+        if not isinstance(revision_hash, str) or not revision_hash:
+            raise ValueError("Share contains a session without a revision identity.")
+        predecessor = session.get("share_replaces_revision")
+        if predecessor is not None and not isinstance(predecessor, str):
+            raise ValueError("Share contains an invalid predecessor identity.")
+        claims.append({
+            "session_id": session_id,
+            "revision_hash": revision_hash,
+            "replaces_revision_hash": predecessor,
+        })
+    if not claims:
+        raise ValueError("Share contains no session lineage claims.")
+    return claims
+
+
+def _synchronize_manual_share_lineage(
+    conn: sqlite3.Connection,
+    *,
+    share_id: str,
+    share: dict[str, Any],
+    upload_token: str,
+    capabilities: dict[str, Any],
+) -> dict[str, Any]:
+    preflight_url = _manual_lineage_preflight_url(capabilities)
+    if preflight_url is None:
+        return {
+            "supported": False,
+            "changed": False,
+            "accepted_predecessors": None,
+        }
+
+    claims = _manual_share_lineage_claims(share)
+    response = _json_request(
+        preflight_url,
+        method="POST",
+        payload={"upload_token": upload_token, "sessions": claims},
+        timeout=30,
+    )
+    rows = response.get("sessions")
+    if not isinstance(rows, list):
+        raise ValueError("Hosted lineage preflight returned no session results.")
+
+    expected_revisions = {
+        str(claim["session_id"]): str(claim["revision_hash"])
+        for claim in claims
+    }
+    local_predecessors = {
+        str(claim["session_id"]): claim.get("replaces_revision_hash")
+        for claim in claims
+    }
+    required_predecessors: dict[str, str | None] = {}
+    head_accepted_at: dict[str, str | None] = {}
+    statuses: dict[str, str] = {}
+    for row in rows:
+        if not isinstance(row, dict):
+            raise ValueError("Hosted lineage preflight returned an invalid result.")
+        session_id = row.get("session_id")
+        status = row.get("status")
+        required = row.get("required_replaces_revision_hash")
+        accepted_at = row.get("current_head_accepted_at")
+        if (
+            not isinstance(session_id, str)
+            or session_id not in expected_revisions
+            or session_id in statuses
+            or status not in {"ready", "rebase_required", "stale_revision"}
+            or (required is not None and not isinstance(required, str))
+            or (accepted_at is not None and not isinstance(accepted_at, str))
+        ):
+            raise ValueError("Hosted lineage preflight returned an invalid result.")
+        statuses[session_id] = status
+        required_predecessors[session_id] = required
+        head_accepted_at[session_id] = accepted_at
+    if set(statuses) != set(expected_revisions):
+        raise ValueError("Hosted lineage preflight returned incomplete results.")
+
+    stale_ids = sorted(
+        session_id
+        for session_id, status in statuses.items()
+        if status == "stale_revision"
+    )
+    if stale_ids:
+        return {
+            "supported": True,
+            "error": (
+                "The hosted service already has a newer revision of this trace. "
+                "Review the latest local trace and create a new share."
+            ),
+            "status": 409,
+            "blocked_sessions": stale_ids,
+        }
+
+    share_created_at = _expiry_timestamp(share.get("created_at"))
+    for session_id, status in statuses.items():
+        if status != "rebase_required":
+            continue
+        receiver_accepted_at = _expiry_timestamp(head_accepted_at[session_id])
+        if (
+            share_created_at is None
+            or receiver_accepted_at is None
+            or share_created_at <= receiver_accepted_at
+        ):
+            return {
+                "supported": True,
+                "error": (
+                    "This package was created before another revision reached the "
+                    "hosted service. Review the latest trace and create a new share."
+                ),
+                "status": 409,
+                "blocked_sessions": [session_id],
+            }
+
+    changed = any(
+        local_predecessors[session_id] != required
+        for session_id, required in required_predecessors.items()
+    )
+    if changed:
+        synchronize_share_predecessors(
+            conn,
+            share_id,
+            expected_revisions=expected_revisions,
+            required_predecessors=required_predecessors,
+        )
+    return {
+        "supported": True,
+        "changed": changed,
+        "accepted_predecessors": required_predecessors,
+    }
+
+
 def _recurring_offer_available(capabilities: dict[str, Any]) -> bool:
     """Return whether the live capability document offers this protocol."""
 
@@ -2351,6 +2501,7 @@ def _load_finalized_share_export(
     ai_pii: bool | None = None,
     ai_backend: str | None = None,
     expected_fingerprint: str | None = None,
+    expected_lineage: dict[str, tuple[str, str | None]] | None = None,
 ) -> tuple[Path, dict[str, Any]] | None:
     # Finalized exports are point-in-time artifacts: a later config change
     # creates a new share/seal operation rather than mutating this cached zip.
@@ -2386,6 +2537,27 @@ def _load_finalized_share_export(
         return None
     if manifest.get("share_id") != share_id and manifest.get("bundle_id") != share_id:
         return None
+    if expected_lineage is not None:
+        manifest_sessions = manifest.get("sessions")
+        if not isinstance(manifest_sessions, list):
+            return None
+        manifest_lineage: dict[str, tuple[str, str | None]] = {}
+        for item in manifest_sessions:
+            if not isinstance(item, dict):
+                return None
+            session_id = item.get("session_id")
+            revision_hash = item.get("revision_hash")
+            predecessor = item.get("replaces_revision_hash")
+            if (
+                not isinstance(session_id, str)
+                or not isinstance(revision_hash, str)
+                or (predecessor is not None and not isinstance(predecessor, str))
+                or session_id in manifest_lineage
+            ):
+                return None
+            manifest_lineage[session_id] = (revision_hash, predecessor)
+        if manifest_lineage != expected_lineage:
+            return None
     if not _manifest_is_finalized_for_upload(
         manifest,
         ai_pii=ai_pii,
@@ -2429,6 +2601,14 @@ def _prepare_share_export_for_upload(
             "status": 409,
         }
     settings_fingerprint = _redaction_settings_fingerprint(settings)
+    expected_lineage = {
+        str(session["session_id"]): (
+            str(session["share_content_revision"]),
+            session.get("share_replaces_revision"),
+        )
+        for session in share.get("sessions") or []
+        if session.get("session_id") and session.get("share_content_revision")
+    }
     if reuse_finalized:
         # Pass the RAW override (not effective_ai_pii) on purpose: a finalized
         # export is a point-in-time artifact. With an explicit ai_pii override
@@ -2443,6 +2623,7 @@ def _prepare_share_export_for_upload(
             ai_pii=ai_pii_review_enabled,
             ai_backend=(ai_pii_backend if ai_pii_review_enabled else None),
             expected_fingerprint=settings_fingerprint,
+            expected_lineage=expected_lineage,
         )
         if cached is not None:
             export_dir, manifest = cached
@@ -2509,6 +2690,8 @@ def _final_manual_share_egress_gate(
     share_id: str,
     session_ids: list[str],
     source_filter: str | list[str] | tuple[str, ...] | None,
+    *,
+    accepted_predecessors: dict[str, str | None] | None = None,
 ) -> dict[str, Any] | None:
     """Re-check mutable share gates immediately before manual upload egress."""
     release_blockers = release_gate_blockers(conn, session_ids)
@@ -2541,7 +2724,11 @@ def _final_manual_share_egress_gate(
     # share in the same revision chain lands first), so re-check it here too —
     # otherwise a stale-predecessor duplicate that #109 added this gate to
     # refuse could still cross egress.
-    predecessor_blockers = share_predecessor_blockers(conn, share_id)
+    predecessor_blockers = share_predecessor_blockers(
+        conn,
+        share_id,
+        accepted_predecessors=accepted_predecessors,
+    )
     if predecessor_blockers:
         return {
             "error": "Share revisions are duplicate or based on a stale predecessor",
@@ -2862,7 +3049,6 @@ def submit_share_to_hosted(
             "blockers": predecessor_blockers,
             "status": 409,
         }
-
     try:
         _verified_email, upload_token = _ensure_hosted_upload_token()
     except RuntimeError as exc:
@@ -2879,16 +3065,106 @@ def submit_share_to_hosted(
             "status": 403,
         }
 
-    export_dir, manifest, error = _prepare_share_export_for_upload(
-        conn,
-        share_id,
-        share,
-        settings,
-        reuse_finalized=True,
-        ai_pii_review_enabled=ai_pii_review_enabled,
-    )
-    if error:
-        return error
+    export_dir: Path | None = None
+    manifest: dict[str, Any] = {}
+    accepted_predecessors: dict[str, str | None] | None = None
+    for synchronization_attempt in range(2):
+        try:
+            lineage = _synchronize_manual_share_lineage(
+                conn,
+                share_id=share_id,
+                share=share,
+                upload_token=upload_token,
+                capabilities=capabilities,
+            )
+        except urllib.error.HTTPError as exc:
+            return _hosted_http_error_result(exc)
+        except RevisionConflictError as exc:
+            return {
+                "error": "Trace revisions changed while synchronizing the hosted predecessor.",
+                "blocked_sessions": exc.blockers,
+                "status": 409,
+            }
+        except (OSError, ValueError, RuntimeError, urllib.error.URLError) as exc:
+            return {
+                "error": f"Could not verify the hosted trace revision: {exc}",
+                "status": 502,
+            }
+        if lineage.get("error"):
+            return lineage
+        if lineage.get("changed"):
+            refreshed_share = get_share(conn, share_id)
+            if refreshed_share is None:
+                return {"error": "Share not found", "status": 404}
+            share = refreshed_share
+            session_ids = [s["session_id"] for s in share.get("sessions") or []]
+
+        accepted_predecessors = lineage.get("accepted_predecessors")
+        predecessor_blockers = share_predecessor_blockers(
+            conn,
+            share_id,
+            accepted_predecessors=accepted_predecessors,
+        )
+        if predecessor_blockers:
+            return {
+                "error": "Share revisions are duplicate or based on a stale predecessor",
+                "blockers": predecessor_blockers,
+                "status": 409,
+            }
+
+        export_dir, manifest, error = _prepare_share_export_for_upload(
+            conn,
+            share_id,
+            share,
+            settings,
+            reuse_finalized=True,
+            ai_pii_review_enabled=ai_pii_review_enabled,
+        )
+        if error:
+            return error
+        if export_dir is None:
+            return {"error": "Failed to prepare upload zip", "status": 500}
+        if not lineage.get("supported"):
+            break
+
+        try:
+            final_lineage = _synchronize_manual_share_lineage(
+                conn,
+                share_id=share_id,
+                share=share,
+                upload_token=upload_token,
+                capabilities=capabilities,
+            )
+        except urllib.error.HTTPError as exc:
+            return _hosted_http_error_result(exc)
+        except RevisionConflictError as exc:
+            return {
+                "error": "Trace revisions changed while rechecking the hosted predecessor.",
+                "blocked_sessions": exc.blockers,
+                "status": 409,
+            }
+        except (OSError, ValueError, RuntimeError, urllib.error.URLError) as exc:
+            return {
+                "error": f"Could not recheck the hosted trace revision: {exc}",
+                "status": 502,
+            }
+        if final_lineage.get("error"):
+            return final_lineage
+        accepted_predecessors = final_lineage.get("accepted_predecessors")
+        if not final_lineage.get("changed"):
+            break
+        refreshed_share = get_share(conn, share_id)
+        if refreshed_share is None:
+            return {"error": "Share not found", "status": 404}
+        share = refreshed_share
+        if synchronization_attempt == 1:
+            return {
+                "error": (
+                    "The hosted trace changed repeatedly while packaging. "
+                    "Review the latest trace and try again."
+                ),
+                "status": 409,
+            }
     if export_dir is None:
         return {"error": "Failed to prepare upload zip", "status": 500}
 
@@ -2955,7 +3231,11 @@ def submit_share_to_hosted(
         "status": 504,
     }
     final_gate_error = _final_manual_share_egress_gate(
-        conn, share_id, session_ids, settings.get("source_filter")
+        conn,
+        share_id,
+        session_ids,
+        settings.get("source_filter"),
+        accepted_predecessors=accepted_predecessors,
     )
     if final_gate_error:
         return final_gate_error

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -1572,6 +1572,24 @@ def _manual_share_lineage_claims(
     return claims
 
 
+_LINEAGE_PREFLIGHT_ABSENT_STATUSES = frozenset({404, 405, 410, 501})
+
+
+def _lineage_preflight_is_unavailable(exc: urllib.error.HTTPError) -> bool:
+    """Whether a preflight failure means the capability is simply not there.
+
+    A capability document can advertise the endpoint before the deployment that
+    serves it, and a live endpoint can have an outage. Neither should be a new
+    way for manual submission to fail, so those two shapes — the endpoint is
+    absent, or the endpoint is broken — degrade instead of blocking. Anything
+    else (auth, a semantic rejection) is a real answer and still surfaces.
+    """
+    code = getattr(exc, "code", None)
+    if not isinstance(code, int):
+        return False
+    return code in _LINEAGE_PREFLIGHT_ABSENT_STATUSES or code >= 500
+
+
 def _synchronize_manual_share_lineage(
     conn: sqlite3.Connection,
     *,
@@ -1595,12 +1613,31 @@ def _synchronize_manual_share_lineage(
         excluded_projects=excluded_projects,
         included_session_ids=included_session_ids,
     )
-    response = _json_request(
-        preflight_url,
-        method="POST",
-        payload={"upload_token": upload_token, "sessions": claims},
-        timeout=30,
-    )
+    try:
+        response = _json_request(
+            preflight_url,
+            method="POST",
+            payload={"upload_token": upload_token, "sessions": claims},
+            timeout=30,
+        )
+    except urllib.error.HTTPError as exc:
+        if not _lineage_preflight_is_unavailable(exc):
+            raise
+        # Degrading here restores the pre-preflight behavior exactly: no
+        # predecessor is rebound, `accepted_predecessors` stays None so the
+        # local gate keeps its strict reading, and the hosted compare-and-set
+        # still refuses a claim that does not match the receiver's head. The
+        # participant loses the reconciliation, not the protection.
+        logger.warning(
+            "Hosted lineage preflight unavailable (HTTP %s); "
+            "submitting with the locally declared predecessor.",
+            exc.code,
+        )
+        return {
+            "supported": False,
+            "changed": False,
+            "accepted_predecessors": None,
+        }
     rows = response.get("sessions")
     if not isinstance(rows, list):
         raise ValueError("Hosted lineage preflight returned no session results.")
@@ -3245,6 +3282,13 @@ def submit_share_to_hosted(
             }
         if final_lineage.get("error"):
             return final_lineage
+        if not final_lineage.get("supported"):
+            # The endpoint went away between the two calls. Keep the
+            # predecessors the first response accepted rather than dropping to
+            # None — the packaged bundle was built from them, and discarding
+            # them here would make the egress gate refuse a share this same
+            # request just rebound.
+            break
         accepted_predecessors = final_lineage.get("accepted_predecessors")
         if not final_lineage.get("changed"):
             break

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -1538,13 +1538,25 @@ def _manual_lineage_preflight_url(
     return resolved
 
 
-def _manual_share_lineage_claims(share: dict[str, Any]) -> list[dict[str, Any]]:
+def _manual_share_lineage_claims(
+    share: dict[str, Any],
+    *,
+    excluded_projects: list[str] | None = None,
+    included_session_ids: set[str] | None = None,
+) -> list[dict[str, Any]]:
     claims: list[dict[str, Any]] = []
     for session in share.get("sessions") or []:
         session_id = session.get("session_id")
         revision_hash = session.get("share_content_revision")
         if not isinstance(session_id, str) or not session_id:
             raise ValueError("Share contains an invalid session identity.")
+        if (
+            included_session_ids is not None
+            and session_id not in included_session_ids
+        ):
+            continue
+        if session_matches_excluded_projects(session, excluded_projects):
+            continue
         if not isinstance(revision_hash, str) or not revision_hash:
             raise ValueError("Share contains a session without a revision identity.")
         predecessor = session.get("share_replaces_revision")
@@ -1567,6 +1579,8 @@ def _synchronize_manual_share_lineage(
     share: dict[str, Any],
     upload_token: str,
     capabilities: dict[str, Any],
+    excluded_projects: list[str] | None = None,
+    included_session_ids: set[str] | None = None,
 ) -> dict[str, Any]:
     preflight_url = _manual_lineage_preflight_url(capabilities)
     if preflight_url is None:
@@ -1576,7 +1590,11 @@ def _synchronize_manual_share_lineage(
             "accepted_predecessors": None,
         }
 
-    claims = _manual_share_lineage_claims(share)
+    claims = _manual_share_lineage_claims(
+        share,
+        excluded_projects=excluded_projects,
+        included_session_ids=included_session_ids,
+    )
     response = _json_request(
         preflight_url,
         method="POST",
@@ -1666,6 +1684,7 @@ def _synchronize_manual_share_lineage(
             share_id,
             expected_revisions=expected_revisions,
             required_predecessors=required_predecessors,
+            allow_subset=True,
         )
     return {
         "supported": True,
@@ -2720,7 +2739,11 @@ def _final_manual_share_egress_gate(
             "status": 409,
         }
 
-    revision_blockers = share_revision_blockers(conn, share_id)
+    revision_blockers = share_revision_blockers(
+        conn,
+        share_id,
+        session_ids=session_ids,
+    )
     if revision_blockers:
         return {
             "error": "Trace revisions changed after review.",
@@ -2738,6 +2761,7 @@ def _final_manual_share_egress_gate(
         conn,
         share_id,
         accepted_predecessors=accepted_predecessors,
+        session_ids=session_ids,
     )
     if predecessor_blockers:
         return {
@@ -3044,7 +3068,14 @@ def submit_share_to_hosted(
         }
 
     from .index import release_gate_blockers
-    session_ids = [s["session_id"] for s in share.get("sessions") or []]
+    try:
+        scoped_claims = _manual_share_lineage_claims(
+            share,
+            excluded_projects=settings.get("excluded_projects"),
+        )
+    except ValueError as exc:
+        return {"error": str(exc), "status": 409}
+    session_ids = [str(claim["session_id"]) for claim in scoped_claims]
     blockers = release_gate_blockers(conn, session_ids)
     if blockers:
         return {
@@ -3066,7 +3097,11 @@ def submit_share_to_hosted(
             "blockers": source_blockers,
             "status": 409,
         }
-    predecessor_blockers = share_predecessor_blockers(conn, share_id)
+    predecessor_blockers = share_predecessor_blockers(
+        conn,
+        share_id,
+        session_ids=session_ids,
+    )
     if predecessor_blockers:
         return {
             "error": "Share revisions are duplicate or based on a stale predecessor",
@@ -3100,6 +3135,8 @@ def submit_share_to_hosted(
                 share=share,
                 upload_token=upload_token,
                 capabilities=capabilities,
+                excluded_projects=settings.get("excluded_projects"),
+                included_session_ids=set(session_ids),
             )
         except urllib.error.HTTPError as exc:
             return _hosted_http_error_result(exc)
@@ -3128,6 +3165,7 @@ def submit_share_to_hosted(
             conn,
             share_id,
             accepted_predecessors=accepted_predecessors,
+            session_ids=session_ids,
         )
         if predecessor_blockers:
             return {
@@ -3148,6 +3186,37 @@ def submit_share_to_hosted(
             return error
         if export_dir is None:
             return {"error": "Failed to prepare upload zip", "status": 500}
+        manifest_sessions = manifest.get("sessions")
+        if not isinstance(manifest_sessions, list):
+            return {
+                "error": "Finalized share contains no session manifest.",
+                "status": 500,
+            }
+        packaged_session_ids: list[str] = []
+        for item in manifest_sessions:
+            session_id = item.get("session_id") if isinstance(item, dict) else None
+            if not isinstance(session_id, str) or not session_id:
+                return {
+                    "error": "Finalized share contains an invalid session identity.",
+                    "status": 500,
+                }
+            packaged_session_ids.append(session_id)
+        if not packaged_session_ids:
+            return {
+                "error": "Share contains no sessions eligible for upload.",
+                "status": 409,
+            }
+        if len(set(packaged_session_ids)) != len(packaged_session_ids):
+            return {
+                "error": "Finalized share contains duplicate session identities.",
+                "status": 500,
+            }
+        if not set(packaged_session_ids).issubset(session_ids):
+            return {
+                "error": "Finalized share no longer matches the confirmed project scope.",
+                "status": 409,
+            }
+        session_ids = packaged_session_ids
         if not lineage.get("supported"):
             break
 
@@ -3158,6 +3227,8 @@ def submit_share_to_hosted(
                 share=share,
                 upload_token=upload_token,
                 capabilities=capabilities,
+                excluded_projects=settings.get("excluded_projects"),
+                included_session_ids=set(session_ids),
             )
         except urllib.error.HTTPError as exc:
             return _hosted_http_error_result(exc)

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -2556,7 +2556,17 @@ def _load_finalized_share_export(
             ):
                 return None
             manifest_lineage[session_id] = (revision_hash, predecessor)
-        if manifest_lineage != expected_lineage:
+        # The export skips sessions an `excluded_projects` change filtered out
+        # (or whose detail row is gone), so the manifest legitimately carries a
+        # subset of the share's rows. Compare only what the bundle actually
+        # ships: a rebased predecessor still invalidates the cache, while a
+        # skipped session no longer forces a rebuild on every seal / download /
+        # submit. Composition changes arrive through `excluded_projects`, which
+        # `redaction_settings_fingerprint` already covers.
+        if any(
+            expected_lineage.get(session_id) != lineage
+            for session_id, lineage in manifest_lineage.items()
+        ):
             return None
     if not _manifest_is_finalized_for_upload(
         manifest,
@@ -3040,6 +3050,20 @@ def submit_share_to_hosted(
         return {
             "error": "Share contains sessions that are not released",
             "blockers": blockers,
+            "status": 409,
+        }
+    # Confirmed source scope is the control that decides whether these sessions
+    # may leave the machine at all, so it has to clear before the first request
+    # that carries their identities. `_prepare_share_export_for_upload` re-checks
+    # it, but that runs after the lineage preflight has already sent session ids
+    # and revision hashes to the hosted service.
+    source_blockers = source_scope_blockers(
+        conn, session_ids, settings.get("source_filter")
+    )
+    if source_blockers:
+        return {
+            "error": "Share contains sessions outside the confirmed source scope",
+            "blockers": source_blockers,
             "status": 409,
         }
     predecessor_blockers = share_predecessor_blockers(conn, share_id)

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -4380,12 +4380,15 @@ def synchronize_share_predecessors(
     *,
     expected_revisions: Mapping[str, str],
     required_predecessors: Mapping[str, str | None],
+    allow_subset: bool = False,
 ) -> int:
     """Bind an unsubmitted share to receiver-authoritative predecessors.
 
     The hosted preflight is advisory; this local write is guarded by the exact
     create-time content revisions, and the server still repeats its
-    compare-and-set during upload.
+    compare-and-set during upload. ``allow_subset`` is reserved for a finalized
+    package whose manifest legitimately omits excluded or unavailable rows;
+    omitted share rows remain unchanged.
     """
     started_transaction = not conn.in_transaction
     if started_transaction:
@@ -4406,18 +4409,27 @@ def synchronize_share_predecessors(
             (share_id,),
         ).fetchall()
         found_ids = {str(row["session_id"]) for row in rows}
-        if found_ids != set(expected_revisions) or found_ids != set(required_predecessors):
+        expected_ids = set(expected_revisions)
+        required_ids = set(required_predecessors)
+        ids_match = expected_ids == required_ids and (
+            expected_ids.issubset(found_ids)
+            if allow_subset
+            else expected_ids == found_ids
+        )
+        if not ids_match:
             raise RevisionConflictError([{
                 "session_id": session_id,
                 "expected_revision_hash": expected_revisions.get(session_id),
                 "current_revision_hash": None,
             } for session_id in sorted(
-                found_ids | set(expected_revisions) | set(required_predecessors)
+                found_ids | expected_ids | required_ids
             )])
 
         changed = 0
         for row in rows:
             session_id = str(row["session_id"])
+            if session_id not in expected_ids:
+                continue
             if row["content_revision"] != expected_revisions[session_id]:
                 raise RevisionConflictError([{
                     "session_id": session_id,
@@ -4443,18 +4455,30 @@ def synchronize_share_predecessors(
 def share_revision_blockers(
     conn: sqlite3.Connection,
     share_id: str,
+    *,
+    session_ids: Iterable[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Return selected share snapshots whose local trace has since changed."""
-    rows = conn.execute(
+    selected_ids = set(session_ids) if session_ids is not None else None
+    if selected_ids is not None and not selected_ids:
+        return []
+    session_filter = ""
+    params: list[Any] = [share_id]
+    if selected_ids is not None:
+        placeholders = ", ".join("?" for _ in selected_ids)
+        session_filter = f"AND ss.session_id IN ({placeholders}) "
+        params.extend(sorted(selected_ids))
+    query = (
         "SELECT ss.session_id, ss.content_revision AS expected_revision_hash, "
         "s.content_revision AS current_revision_hash, s.review_status "
         "FROM share_sessions ss "
         "JOIN sessions s ON s.session_id = ss.session_id "
         "WHERE ss.share_id = ? "
-        "AND ss.content_revision IS NOT s.content_revision "
-        "ORDER BY ss.session_id",
-        (share_id,),
-    ).fetchall()
+        + session_filter
+        + "AND ss.content_revision IS NOT s.content_revision "
+        "ORDER BY ss.session_id"
+    )
+    rows = conn.execute(query, params).fetchall()
     return [dict(row) for row in rows]
 
 
@@ -5244,6 +5268,7 @@ def share_predecessor_blockers(
     share_id: str,
     *,
     accepted_predecessors: Mapping[str, str | None] | None = None,
+    session_ids: Iterable[str] | None = None,
 ) -> list[dict[str, Any]]:
     """Return packaged replacements based on a stale uploaded predecessor.
 
@@ -5258,8 +5283,11 @@ def share_predecessor_blockers(
         "FROM share_sessions WHERE share_id = ? ORDER BY session_id",
         (share_id,),
     ).fetchall()
+    selected_ids = set(session_ids) if session_ids is not None else None
     blockers: list[dict[str, Any]] = []
     for row in rows:
+        if selected_ids is not None and row["session_id"] not in selected_ids:
+            continue
         latest = _latest_successful_revision(
             conn,
             row["session_id"],

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -4374,6 +4374,72 @@ def create_share(
     return share_id
 
 
+def synchronize_share_predecessors(
+    conn: sqlite3.Connection,
+    share_id: str,
+    *,
+    expected_revisions: Mapping[str, str],
+    required_predecessors: Mapping[str, str | None],
+) -> int:
+    """Bind an unsubmitted share to receiver-authoritative predecessors.
+
+    The hosted preflight is advisory; this local write is guarded by the exact
+    create-time content revisions, and the server still repeats its
+    compare-and-set during upload.
+    """
+    started_transaction = not conn.in_transaction
+    if started_transaction:
+        conn.execute("BEGIN IMMEDIATE")
+    try:
+        share = conn.execute(
+            "SELECT shared_at, hosted_receipt_id FROM shares WHERE share_id = ?",
+            (share_id,),
+        ).fetchone()
+        if share is None:
+            raise ValueError("Share not found")
+        if share["shared_at"] is not None or share["hosted_receipt_id"] is not None:
+            raise ValueError("Submitted shares cannot change predecessor claims")
+
+        rows = conn.execute(
+            "SELECT session_id, content_revision, replaces_revision "
+            "FROM share_sessions WHERE share_id = ? ORDER BY session_id",
+            (share_id,),
+        ).fetchall()
+        found_ids = {str(row["session_id"]) for row in rows}
+        if found_ids != set(expected_revisions) or found_ids != set(required_predecessors):
+            raise RevisionConflictError([{
+                "session_id": session_id,
+                "expected_revision_hash": expected_revisions.get(session_id),
+                "current_revision_hash": None,
+            } for session_id in sorted(
+                found_ids | set(expected_revisions) | set(required_predecessors)
+            )])
+
+        changed = 0
+        for row in rows:
+            session_id = str(row["session_id"])
+            if row["content_revision"] != expected_revisions[session_id]:
+                raise RevisionConflictError([{
+                    "session_id": session_id,
+                    "expected_revision_hash": expected_revisions[session_id],
+                    "current_revision_hash": row["content_revision"],
+                }])
+            required = required_predecessors[session_id]
+            if row["replaces_revision"] == required:
+                continue
+            conn.execute(
+                "UPDATE share_sessions SET replaces_revision = ? "
+                "WHERE share_id = ? AND session_id = ? AND content_revision = ?",
+                (required, share_id, session_id, expected_revisions[session_id]),
+            )
+            changed += 1
+        conn.commit()
+        return changed
+    except Exception:
+        conn.rollback()
+        raise
+
+
 def share_revision_blockers(
     conn: sqlite3.Connection,
     share_id: str,
@@ -5176,6 +5242,8 @@ def already_shared_revision_blockers(
 def share_predecessor_blockers(
     conn: sqlite3.Connection,
     share_id: str,
+    *,
+    accepted_predecessors: Mapping[str, str | None] | None = None,
 ) -> list[dict[str, Any]]:
     """Return packaged replacements based on a stale uploaded predecessor.
 
@@ -5202,6 +5270,12 @@ def share_predecessor_blockers(
         if latest == row["content_revision"]:
             reason = "already_shared_revision"
         elif latest == row["replaces_revision"]:
+            continue
+        elif (
+            accepted_predecessors is not None
+            and row["session_id"] in accepted_predecessors
+            and accepted_predecessors[row["session_id"]] == row["replaces_revision"]
+        ):
             continue
         else:
             reason = "stale_predecessor"

--- a/tests/parsing/test_parser.py
+++ b/tests/parsing/test_parser.py
@@ -1046,6 +1046,58 @@ class TestDiscoverProjects:
         paragraphs = [p.strip() for p in thinking.split("\n\n") if p.strip()]
         assert paragraphs == ["Planning fix", "Reading code"]
 
+    def test_codex_parser_keeps_initial_cwd_when_windows_case_changes(
+        self, tmp_path, mock_anonymizer
+    ):
+        session_file = tmp_path / "rollout-windows-cwd.jsonl"
+        lines = [
+            {
+                "timestamp": "2026-07-28T07:13:20.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "session-windows-cwd",
+                    "cwd": "d:\\work\\clawjournal",
+                    "model_provider": "openai",
+                },
+            },
+            {
+                "timestamp": "2026-07-28T07:13:21.000Z",
+                "type": "turn_context",
+                "payload": {
+                    "cwd": "D:\\work\\clawjournal",
+                    "model": "gpt-5.6-sol",
+                },
+            },
+            {
+                "timestamp": "2026-07-28T07:13:22.000Z",
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": "hello"},
+            },
+            {
+                "timestamp": "2026-07-28T07:13:23.000Z",
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "hi"},
+            },
+        ]
+        session_file.write_text(
+            "\n".join(json.dumps(line) for line in lines) + "\n",
+            encoding="utf-8",
+        )
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="d:\\work\\clawjournal",
+        )
+
+        assert result is not None
+        assert result["session_id"] == "session-windows-cwd"
+        assert [message["role"] for message in result["messages"]] == [
+            "user",
+            "assistant",
+        ]
+
     def test_discover_opencode_projects(self, tmp_path, monkeypatch):
         self._disable_codex(tmp_path, monkeypatch)
         db_path = tmp_path / "opencode.db"

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -3226,10 +3226,16 @@ class TestRunServerPortFallback:
         mock_open.assert_called_once_with("http://localhost:9999/")
 
 
-def _mock_urlopen_factory(upload_response=None, upload_error=None, upload_assert=None, capabilities=None):
+def _mock_urlopen_factory(
+    upload_response=None,
+    upload_error=None,
+    upload_assert=None,
+    capabilities=None,
+    lineage_preflight=None,
+):
     """Create a mock urlopen that handles the hosted research API."""
     upload_resp = upload_response or {"receipt_id": "rcpt-test-123", "status": "received"}
-    cap_resp = capabilities or {
+    cap_resp = dict(capabilities or {
         "submissions_open": True,
         "preferred_upload_flow": "browser_zip",
         "cli_ingest_supported": False,
@@ -3240,7 +3246,12 @@ def _mock_urlopen_factory(upload_response=None, upload_error=None, upload_assert
         "supported_institution_email_policy": {"domain_suffixes": [".edu", "rayward.ai"]},
         "contact_email": "contact@example.test",
         "cache_seconds": 0,
-    }
+    })
+    if lineage_preflight is not None:
+        cap_resp.setdefault(
+            "manual_lineage_preflight_url",
+            "/api/manual-lineage-preflight",
+        )
 
     def _resp(payload):
         resp = MagicMock()
@@ -3271,6 +3282,16 @@ def _mock_urlopen_factory(upload_response=None, upload_error=None, upload_assert
                 "verification_id": "verify-123",
                 "expires_at": "2026-01-01T00:00:00+00:00",
             })
+        if "/api/manual-lineage-preflight" in url:
+            if lineage_preflight is None:
+                raise ValueError("Unexpected lineage preflight request")
+            request_payload = json.loads(req.data.decode("utf-8"))
+            response_payload = (
+                lineage_preflight(request_payload)
+                if callable(lineage_preflight)
+                else lineage_preflight
+            )
+            return _resp(response_payload)
         if "/api/submissions" in url:
             if upload_assert is not None:
                 upload_assert(req)
@@ -3291,6 +3312,21 @@ def _share_config(**overrides):
     }
     config.update(overrides)
     return config
+
+
+def test_manual_lineage_preflight_must_stay_on_hosted_origin(monkeypatch):
+    from clawjournal.workbench import daemon
+
+    monkeypatch.setattr(
+        daemon,
+        "_HOSTED_SHARE_URL",
+        "https://hosted.example.test/share",
+    )
+
+    with pytest.raises(ValueError, match="configured origin"):
+        daemon._manual_lineage_preflight_url({
+            "manual_lineage_preflight_url": "https://attacker.example/api/preflight",
+        })
 
 
 def _mock_trufflehog_clean(monkeypatch):
@@ -4706,6 +4742,201 @@ class TestShareAPI:
 
         assert status == 409
         assert data["blockers"][0]["reason"] == "stale_predecessor"
+
+    def test_hosted_upload_rebases_to_receiver_head_and_repackages(
+        self, server, monkeypatch
+    ):
+        from clawjournal.workbench.index import (
+            create_share,
+            get_share,
+            open_index,
+            update_session,
+        )
+
+        WorkbenchHandler._last_share_time = 0.0
+        session_id = "continued-hosted-session"
+        self._seed_released_session(session_id, "first locally shared revision")
+        conn = open_index()
+        try:
+            update_session(conn, session_id, status="approved")
+            first_share = create_share(conn, [session_id])
+            conn.execute(
+                "UPDATE shares SET status='shared', shared_at=? WHERE share_id=?",
+                ("2026-07-01T00:00:00+00:00", first_share),
+            )
+            conn.commit()
+            local_predecessor = conn.execute(
+                "SELECT content_revision FROM share_sessions WHERE share_id = ?",
+                (first_share,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+        self._seed_released_session(session_id, "continued work after first upload")
+        conn = open_index()
+        try:
+            update_session(conn, session_id, status="approved")
+            share_id = create_share(conn, [session_id])
+            share = get_share(conn, share_id)
+            assert share is not None
+            current_revision = share["sessions"][0]["share_content_revision"]
+            assert share["sessions"][0]["share_replaces_revision"] == local_predecessor
+        finally:
+            conn.close()
+
+        status, exported = _post(server, f"/api/shares/{share_id}/export")
+        assert status == 200, exported
+
+        receiver_head = "sha256:" + ("b" * 64)
+        preflight_claims = []
+
+        def lineage_preflight(payload):
+            assert payload["upload_token"] == "test-upload-token"
+            assert len(payload["sessions"]) == 1
+            claim = payload["sessions"][0]
+            preflight_claims.append(dict(claim))
+            assert claim["session_id"] == session_id
+            assert claim["revision_hash"] == current_revision
+            ready = claim["replaces_revision_hash"] == receiver_head
+            return {
+                "lineage_contract": "logical_sessions_v1",
+                "sessions": [{
+                    "session_id": session_id,
+                    "status": "ready" if ready else "rebase_required",
+                    "current_head_revision_hash": receiver_head,
+                    "current_head_accepted_at": "2026-07-02T00:00:00+00:00",
+                    "required_replaces_revision_hash": receiver_head,
+                }],
+            }
+
+        captured = {}
+
+        def assert_zip(req):
+            captured["manifest"] = self._manifest_from_upload(req)
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: _share_config(),
+        )
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                lineage_preflight=lineage_preflight,
+                upload_assert=assert_zip,
+            ),
+        ):
+            status, data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+
+        assert status == 200, data
+        assert [
+            claim["replaces_revision_hash"] for claim in preflight_claims
+        ] == [local_predecessor, receiver_head]
+        uploaded_session = next(
+            item
+            for item in captured["manifest"]["sessions"]
+            if item["session_id"] == session_id
+        )
+        assert uploaded_session["replaces_revision_hash"] == receiver_head
+        conn = open_index()
+        try:
+            stored = conn.execute(
+                "SELECT replaces_revision FROM share_sessions WHERE share_id = ?",
+                (share_id,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert stored == receiver_head
+
+    def test_hosted_upload_does_not_rebase_draft_older_than_receiver_head(
+        self, server, monkeypatch
+    ):
+        from clawjournal.workbench.index import create_share, open_index, update_session
+
+        WorkbenchHandler._last_share_time = 0.0
+        session_id = "stale-hosted-draft"
+        self._seed_released_session(session_id, "draft created before remote update")
+        conn = open_index()
+        try:
+            update_session(conn, session_id, status="approved")
+            share_id = create_share(conn, [session_id])
+        finally:
+            conn.close()
+
+        receiver_head = "sha256:" + ("c" * 64)
+
+        def lineage_preflight(payload):
+            claim = payload["sessions"][0]
+            return {
+                "lineage_contract": "logical_sessions_v1",
+                "sessions": [{
+                    "session_id": session_id,
+                    "status": "rebase_required",
+                    "current_head_revision_hash": receiver_head,
+                    "current_head_accepted_at": "2099-01-01T00:00:00+00:00",
+                    "required_replaces_revision_hash": receiver_head,
+                }],
+            }
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: _share_config(),
+        )
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                lineage_preflight=lineage_preflight,
+                upload_assert=lambda _req: pytest.fail("stale draft uploaded"),
+            ),
+        ):
+            status, data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+
+        assert status == 409
+        assert "created before another revision" in data["error"]
+
+    def test_hosted_lineage_sync_revision_conflict_returns_409(
+        self, server, monkeypatch
+    ):
+        from clawjournal.workbench import daemon
+        from clawjournal.workbench.index import RevisionConflictError
+
+        WorkbenchHandler._last_share_time = 0.0
+        share_id = self._create_and_export_share(server)
+        blocker = {
+            "session_id": "sess-0",
+            "expected_revision_hash": "sha256:old",
+            "current_revision_hash": "sha256:new",
+        }
+
+        def fail_sync(*_args, **_kwargs):
+            raise RevisionConflictError([blocker])
+
+        monkeypatch.setattr(
+            daemon,
+            "_synchronize_manual_share_lineage",
+            fail_sync,
+        )
+        monkeypatch.setattr(daemon, "load_config", lambda: _share_config())
+
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(lineage_preflight={}),
+        ):
+            status, data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+
+        assert status == 409
+        assert data["blocked_sessions"] == [blocker]
 
     def test_duplicate_receipt_returned_even_without_valid_token(self, server, monkeypatch):
         """Receipt hydration/retry should not require a still-valid upload token."""

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -4967,6 +4967,175 @@ class TestShareAPI:
             item["session_id"] for item in captured["manifest"]["sessions"]
         } == {"sess-0"}
 
+    @pytest.mark.parametrize("preflight_status", [404, 405, 410, 500, 502, 503])
+    def test_unavailable_lineage_preflight_degrades_instead_of_blocking(
+        self, server, monkeypatch, preflight_status
+    ):
+        """An advertised endpoint that is absent or broken must not block.
+
+        A capability document can name the endpoint before the deployment that
+        serves it, and a live endpoint can have an outage. Either would
+        otherwise take down manual submission entirely.
+        """
+        WorkbenchHandler._last_share_time = 0.0
+        share_id = self._create_and_export_share(server)
+
+        def unavailable(_payload):
+            raise urllib.error.HTTPError(
+                "https://example.test/api/manual-lineage-preflight",
+                preflight_status,
+                "Unavailable",
+                {},
+                BytesIO(b'{"error":"unavailable"}'),
+            )
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: _share_config(),
+        )
+        captured = {}
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                lineage_preflight=unavailable,
+                upload_assert=lambda req: captured.update(
+                    manifest=self._manifest_from_upload(req)
+                ),
+            ),
+        ):
+            status, data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+
+        assert status == 200, data
+        # Degrading must not rewrite lineage: the bundle ships the locally
+        # declared predecessor, exactly as it did before the preflight existed.
+        assert captured["manifest"]["sessions"]
+        for item in captured["manifest"]["sessions"]:
+            assert item["replaces_revision_hash"] is None
+
+    def test_auth_failure_on_lineage_preflight_still_blocks(self, server, monkeypatch):
+        """Only absent/broken degrades — a real answer still surfaces."""
+        WorkbenchHandler._last_share_time = 0.0
+        share_id = self._create_and_export_share(server)
+
+        def forbidden(_payload):
+            raise urllib.error.HTTPError(
+                "https://example.test/api/manual-lineage-preflight",
+                403,
+                "Forbidden",
+                {},
+                BytesIO(b'{"error":"upload token rejected"}'),
+            )
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: _share_config(),
+        )
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                lineage_preflight=forbidden,
+                upload_assert=lambda _req: pytest.fail("uploaded despite 403"),
+            ),
+        ):
+            status, data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+
+        assert status != 200
+        assert "upload token rejected" in data["error"]
+
+    def test_recheck_going_unavailable_keeps_the_accepted_predecessor(
+        self, server, monkeypatch
+    ):
+        """A rebase, then the endpoint disappears before the recheck.
+
+        The bundle was packaged from the predecessor the first response
+        accepted, so dropping it would make the egress gate refuse a share this
+        same request just rebound.
+        """
+        from clawjournal.workbench.index import (
+            create_share,
+            open_index,
+            update_session,
+        )
+
+        WorkbenchHandler._last_share_time = 0.0
+        session_id = "recheck-vanishes-session"
+        self._seed_released_session(session_id, "first locally shared revision")
+        conn = open_index()
+        try:
+            update_session(conn, session_id, status="approved")
+            first_share = create_share(conn, [session_id])
+            conn.execute(
+                "UPDATE shares SET status='shared', shared_at=? WHERE share_id=?",
+                ("2026-07-01T00:00:00+00:00", first_share),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        self._seed_released_session(session_id, "continued work after first upload")
+        conn = open_index()
+        try:
+            update_session(conn, session_id, status="approved")
+            share_id = create_share(conn, [session_id])
+        finally:
+            conn.close()
+
+        status, exported = _post(server, f"/api/shares/{share_id}/export")
+        assert status == 200, exported
+
+        receiver_head = "sha256:" + ("b" * 64)
+        calls = []
+
+        def lineage_preflight(payload):
+            calls.append(payload)
+            if len(calls) > 1:
+                raise urllib.error.HTTPError(
+                    "https://example.test/api/manual-lineage-preflight",
+                    503, "Unavailable", {}, BytesIO(b"{}"),
+                )
+            return {
+                "lineage_contract": "logical_sessions_v1",
+                "sessions": [{
+                    "session_id": session_id,
+                    "status": "rebase_required",
+                    "current_head_revision_hash": receiver_head,
+                    "current_head_accepted_at": "2026-07-02T00:00:00+00:00",
+                    "required_replaces_revision_hash": receiver_head,
+                }],
+            }
+
+        captured = {}
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: _share_config(),
+        )
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                lineage_preflight=lineage_preflight,
+                upload_assert=lambda req: captured.update(
+                    manifest=self._manifest_from_upload(req)
+                ),
+            ),
+        ):
+            status, data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+
+        assert status == 200, data
+        uploaded = captured["manifest"]["sessions"][0]
+        assert uploaded["replaces_revision_hash"] == receiver_head
+
     def test_hosted_upload_does_not_rebase_draft_older_than_receiver_head(
         self, server, monkeypatch
     ):

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -4902,6 +4902,71 @@ class TestShareAPI:
         assert "confirmed source scope" in data["error"]
         assert preflight_calls == []
 
+    def test_lineage_preflight_omits_excluded_project_sessions(
+        self, server, monkeypatch
+    ):
+        from clawjournal.workbench.index import open_index
+
+        WorkbenchHandler._last_share_time = 0.0
+        conn = open_index()
+        try:
+            conn.execute(
+                "UPDATE sessions SET project = ? WHERE session_id = ?",
+                ("excluded-project", "sess-1"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        share_id = self._create_and_export_share(server)
+        preflight_calls = []
+        captured = {}
+
+        def lineage_preflight(payload):
+            preflight_calls.append(payload)
+            return {
+                "lineage_contract": "logical_sessions_v1",
+                "sessions": [{
+                    "session_id": claim["session_id"],
+                    "status": "ready",
+                    "current_head_revision_hash": None,
+                    "current_head_accepted_at": None,
+                    "required_replaces_revision_hash": claim[
+                        "replaces_revision_hash"
+                    ],
+                } for claim in payload["sessions"]],
+            }
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: _share_config(
+                excluded_projects=["claude:excluded-project"],
+            ),
+        )
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                lineage_preflight=lineage_preflight,
+                upload_assert=lambda req: captured.update(
+                    manifest=self._manifest_from_upload(req)
+                ),
+            ),
+        ):
+            status, data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+
+        assert status == 200, data
+        assert preflight_calls
+        assert all(
+            {claim["session_id"] for claim in call["sessions"]} == {"sess-0"}
+            for call in preflight_calls
+        )
+        assert {
+            item["session_id"] for item in captured["manifest"]["sessions"]
+        } == {"sess-0"}
+
     def test_hosted_upload_does_not_rebase_draft_older_than_receiver_head(
         self, server, monkeypatch
     ):

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -4851,6 +4851,57 @@ class TestShareAPI:
             conn.close()
         assert stored == receiver_head
 
+    def test_lineage_preflight_waits_for_the_source_scope_gate(
+        self, server, monkeypatch
+    ):
+        """Confirmed source scope decides whether these sessions may leave.
+
+        The preflight carries session ids and content-revision hashes, so it is
+        egress: it must not run before the gate that authorizes it. The export
+        re-checks the same gate, but that happens after the request is already
+        on the wire.
+        """
+        WorkbenchHandler._last_share_time = 0.0
+        share_id = self._create_and_export_share(server)
+        preflight_calls = []
+
+        def lineage_preflight(payload):
+            preflight_calls.append(payload)
+            return {
+                "lineage_contract": "logical_sessions_v1",
+                "sessions": [{
+                    "session_id": claim["session_id"],
+                    "status": "ready",
+                    "current_head_revision_hash": None,
+                    "current_head_accepted_at": None,
+                    "required_replaces_revision_hash": claim[
+                        "replaces_revision_hash"
+                    ],
+                } for claim in payload["sessions"]],
+            }
+
+        # The seeded sessions are `claude`; the confirmed scope is `codex`.
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: _share_config(source="codex"),
+        )
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                lineage_preflight=lineage_preflight,
+                upload_assert=lambda _req: pytest.fail("out-of-scope share uploaded"),
+            ),
+        ):
+            status, data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+
+        assert status == 409, data
+        assert "confirmed source scope" in data["error"]
+        assert preflight_calls == []
+
     def test_hosted_upload_does_not_rebase_draft_older_than_receiver_head(
         self, server, monkeypatch
     ):

--- a/tests/workbench/test_revision_tracking.py
+++ b/tests/workbench/test_revision_tracking.py
@@ -512,6 +512,55 @@ def test_receiver_preflight_rebinds_only_the_unsubmitted_share(index_conn):
     assert revision_r1 != receiver_head
 
 
+def test_receiver_preflight_can_rebind_only_the_packaged_subset(index_conn):
+    upsert_sessions(index_conn, [
+        _session("trace-1", "first trace"),
+        _session("trace-2", "second trace"),
+    ])
+    _approve(index_conn, "trace-1")
+    _approve(index_conn, "trace-2")
+    share_id = create_share(index_conn, ["trace-1", "trace-2"])
+    revisions = {
+        row["session_id"]: row["content_revision"]
+        for row in index_conn.execute(
+            "SELECT session_id, content_revision FROM share_sessions "
+            "WHERE share_id = ?",
+            (share_id,),
+        )
+    }
+    receiver_head = "sha256:" + ("c" * 64)
+
+    with pytest.raises(RevisionConflictError):
+        synchronize_share_predecessors(
+            index_conn,
+            share_id,
+            expected_revisions={"trace-1": revisions["trace-1"]},
+            required_predecessors={"trace-1": receiver_head},
+        )
+
+    changed = synchronize_share_predecessors(
+        index_conn,
+        share_id,
+        expected_revisions={"trace-1": revisions["trace-1"]},
+        required_predecessors={"trace-1": receiver_head},
+        allow_subset=True,
+    )
+
+    assert changed == 1
+    predecessors = {
+        row["session_id"]: row["replaces_revision"]
+        for row in index_conn.execute(
+            "SELECT session_id, replaces_revision FROM share_sessions "
+            "WHERE share_id = ?",
+            (share_id,),
+        )
+    }
+    assert predecessors == {
+        "trace-1": receiver_head,
+        "trace-2": None,
+    }
+
+
 def test_share_predecessor_blocks_same_revision_uploaded_by_another_share(index_conn):
     upsert_sessions(index_conn, [_session(content="r1")])
     _approve(index_conn)

--- a/tests/workbench/test_revision_tracking.py
+++ b/tests/workbench/test_revision_tracking.py
@@ -22,6 +22,7 @@ from clawjournal.workbench.index import (
     set_hold_state,
     share_predecessor_blockers,
     share_revision_blockers,
+    synchronize_share_predecessors,
     update_session,
     upsert_sessions,
 )
@@ -455,6 +456,60 @@ def test_share_predecessor_detects_newer_successful_revision(index_conn):
         "latest_shared_revision_hash": revision_r3,
         "reason": "stale_predecessor",
     }]
+
+
+def test_receiver_preflight_rebinds_only_the_unsubmitted_share(index_conn):
+    upsert_sessions(index_conn, [_session(content="r1")])
+    _approve(index_conn)
+    share_r1 = create_share(index_conn, ["trace-1"])
+    _mark_shared(index_conn, share_r1, "2026-07-02T00:00:00+00:00")
+    revision_r1 = index_conn.execute(
+        "SELECT content_revision FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()[0]
+
+    upsert_sessions(index_conn, [_session(content="r2")])
+    _approve(index_conn)
+    share_r2 = create_share(index_conn, ["trace-1"])
+    revision_r2 = index_conn.execute(
+        "SELECT content_revision FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()[0]
+    receiver_head = "sha256:" + ("b" * 64)
+
+    changed = synchronize_share_predecessors(
+        index_conn,
+        share_r2,
+        expected_revisions={"trace-1": revision_r2},
+        required_predecessors={"trace-1": receiver_head},
+    )
+
+    assert changed == 1
+    row = index_conn.execute(
+        "SELECT content_revision, replaces_revision FROM share_sessions "
+        "WHERE share_id = ?",
+        (share_r2,),
+    ).fetchone()
+    assert row["content_revision"] == revision_r2
+    assert row["replaces_revision"] == receiver_head
+    assert share_predecessor_blockers(index_conn, share_r2)[0][
+        "reason"
+    ] == "stale_predecessor"
+    assert share_predecessor_blockers(
+        index_conn,
+        share_r2,
+        accepted_predecessors={"trace-1": receiver_head},
+    ) == []
+    assert synchronize_share_predecessors(
+        index_conn,
+        share_r2,
+        expected_revisions={"trace-1": revision_r2},
+        required_predecessors={"trace-1": receiver_head},
+    ) == 0
+
+    assert index_conn.execute(
+        "SELECT replaces_revision FROM share_sessions WHERE share_id = ?",
+        (share_r1,),
+    ).fetchone()[0] is None
+    assert revision_r1 != receiver_head
 
 
 def test_share_predecessor_blocks_same_revision_uploaded_by_another_share(index_conn):

--- a/tests/workbench/test_share_gates.py
+++ b/tests/workbench/test_share_gates.py
@@ -737,6 +737,132 @@ class TestSecretScanGate:
         assert cached_dir == export_dir
         assert cached_manifest == manifest
 
+    def test_finalized_export_reuse_survives_a_skipped_session(
+        self,
+        conn,
+        monkeypatch,
+        tmp_path,
+    ):
+        """A session the export skipped must not defeat the lineage check.
+
+        `excluded_projects` filters sessions out of the bundle at export time,
+        so the manifest carries a subset of the share's rows. Comparing the two
+        sets for equality made every seal / download / submit rebuild the
+        artifact — re-running the gate and the AI-PII pass, so the bytes the
+        participant reviewed were not the bytes submitted.
+        """
+        from clawjournal.workbench import daemon as daemon_module
+        from clawjournal.workbench.daemon import _prepare_share_export_for_upload
+
+        monkeypatch.setattr(daemon_module, "CONFIG_DIR", tmp_path)
+        _mock_gate_engines(monkeypatch)
+
+        kept = _settled_session("sess-keep", content="ordinary trace content")
+        dropped = _settled_session("sess-drop", content="ordinary trace content")
+        dropped["project"] = "excluded-demo"
+        upsert_sessions(conn, [kept, dropped])
+        conn.commit()
+        share_id = create_share(conn, ["sess-keep", "sess-drop"], note="t")
+        share = get_share(conn, share_id)
+        settings = {
+            "custom_strings": [],
+            "extra_usernames": [],
+            "excluded_projects": ["claude:excluded-demo"],
+            "blocked_domains": [],
+            "allowlist_entries": [],
+            "source_filter": None,
+            "ai_pii_review_enabled": False,
+        }
+
+        export_dir, manifest, error = _prepare_share_export_for_upload(
+            conn,
+            share_id,
+            share,
+            settings,
+            reuse_finalized=True,
+        )
+        assert error is None
+        assert export_dir is not None
+        assert [item["session_id"] for item in manifest["sessions"]] == ["sess-keep"]
+
+        def unexpected_rebuild(*_args, **_kwargs):
+            raise AssertionError("skipped session must not force a rebuild")
+
+        monkeypatch.setattr(daemon_module, "export_share_to_disk", unexpected_rebuild)
+
+        cached_dir, cached_manifest, cached_error = _prepare_share_export_for_upload(
+            conn,
+            share_id,
+            share,
+            settings,
+            reuse_finalized=True,
+        )
+
+        assert cached_error is None
+        assert cached_dir == export_dir
+        assert cached_manifest == manifest
+
+    def test_finalized_export_reuse_rejects_a_rebased_predecessor(
+        self,
+        conn,
+        monkeypatch,
+        tmp_path,
+    ):
+        """Rebinding the predecessor must still invalidate the sealed bundle."""
+        from clawjournal.workbench import daemon as daemon_module
+        from clawjournal.workbench.daemon import _load_finalized_share_export
+
+        monkeypatch.setattr(daemon_module, "CONFIG_DIR", tmp_path)
+        _mock_gate_engines(monkeypatch)
+        share_id, share = self._share(conn, content="ordinary trace content")
+        settings = {
+            "custom_strings": [],
+            "extra_usernames": [],
+            "excluded_projects": [],
+            "blocked_domains": [],
+            "allowlist_entries": [],
+            "source_filter": None,
+            "ai_pii_review_enabled": False,
+        }
+
+        export_dir, manifest, error = daemon_module._prepare_share_export_for_upload(
+            conn,
+            share_id,
+            share,
+            settings,
+            reuse_finalized=True,
+        )
+        assert error is None
+        assert export_dir is not None
+        sealed = manifest["sessions"][0]
+
+        fingerprint = manifest["redaction_settings_fingerprint"]
+        unchanged = _load_finalized_share_export(
+            share_id,
+            ai_pii=None,
+            expected_fingerprint=fingerprint,
+            expected_lineage={
+                sealed["session_id"]: (
+                    sealed["revision_hash"],
+                    sealed["replaces_revision_hash"],
+                ),
+            },
+        )
+        assert unchanged is not None
+
+        rebased = _load_finalized_share_export(
+            share_id,
+            ai_pii=None,
+            expected_fingerprint=fingerprint,
+            expected_lineage={
+                sealed["session_id"]: (
+                    sealed["revision_hash"],
+                    "sha256:" + ("b" * 64),
+                ),
+            },
+        )
+        assert rebased is None
+
     def test_unverified_token_is_redacted_and_share_advances(self, conn, monkeypatch):
         # The headline behavior change: a recognizable-but-unverified
         # token no longer rejects the session — the exact span is


### PR DESCRIPTION
## Summary

- use the hosted service's advertised manual-lineage preflight before manual upload
- rebind an unsubmitted share to the receiver-authoritative predecessor when the participant created the reviewed share after that hosted head was accepted
- invalidate any finalized ZIP with stale lineage metadata, rebuild it, and recheck the hosted head after packaging
- keep locally known stale drafts blocked before network access and keep the final hosted compare-and-set authoritative
- reduce the hosted submission success-sound volume from `0.25` to `0.15`

## Problem

Participants often continue working in the same Claude Code or Codex session after sharing it once. The local predecessor can lag the hosted receiver's current logical-session head, causing an otherwise valid updated trace to fail with:

`Declared predecessor does not match the receiver's current head.`

## Safety

- preflight URLs must remain on the configured hosted origin
- submitted shares cannot have predecessor claims rewritten
- exact local content revisions are checked atomically before synchronization
- drafts older than the receiver head remain blocked and require fresh review
- the hosted upload transaction still rejects races that occur after preflight

## Server dependency

Requires the optional preflight capability added by rayward-internal/clawjournal-share#48. Deploy the server PR first. Against older servers, the client retains the existing behavior.

## Validation

- complete Share API class plus revision-tracking tests — 65 passed
- final lineage/preflight regression selection — 4 passed
- frontend test suite — 83 passed
- production frontend build — passed
- `git diff --check` — passed