### PR TITLE
fix(share): keep a receiver-rebound share submittable after a retry

### DIFF
--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -44,8 +44,10 @@ BLOBS_DIR = CONFIG_DIR / "blobs"
 # version 7 adds the local automatic-upload enrollment/candidate foundation,
 # and version 8 adds durable per-agent hook observations plus the raw-source
 # fingerprint snapshot needed to recover a sealed artifact safely, version 9
-# pins hosted recurring-protocol-v2 authorization metadata, and version 10
-# stores the exact source/project pair snapshot used by recurring selection.
+# pins hosted recurring-protocol-v2 authorization metadata, version 10
+# stores the exact source/project pair snapshot used by recurring selection,
+# and version 11 records which share predecessors the hosted receiver dictated
+# so a retried submission can tell them apart from a locally stale claim.
 SECURITY_SCHEMA_VERSION = 2
 SESSION_IDENTITY_SCHEMA_VERSION = 3
 WIDENED_MESSAGE_SCHEMA_VERSION = 4
@@ -55,7 +57,13 @@ AUTO_UPLOAD_FOUNDATION_SCHEMA_VERSION = 7
 AUTO_UPLOAD_SCHEMA_VERSION = 8
 RECURRING_PROTOCOL_V2_SCHEMA_VERSION = 9
 EXACT_SCOPE_PAIRS_SCHEMA_VERSION = 10
-WORKBENCH_SCHEMA_VERSION = EXACT_SCOPE_PAIRS_SCHEMA_VERSION
+RECEIVER_PREDECESSOR_SCHEMA_VERSION = 11
+WORKBENCH_SCHEMA_VERSION = RECEIVER_PREDECESSOR_SCHEMA_VERSION
+
+# `share_sessions.predecessor_source` values. NULL means the predecessor is the
+# create-time local baseline; RECEIVER means the hosted lineage preflight
+# dictated it and local revision history cannot validate it.
+PREDECESSOR_SOURCE_RECEIVER = "receiver"
 BACKFILL_WINDOW = 100
 FAILURE_VALUE_SOURCE_SCOPE = ("claude", "claude-science", "codex", "opencode", "openclaw", "workbuddy")
 SHARE_RECOMMENDATION_LIMIT = 10
@@ -178,11 +186,12 @@ CREATE TABLE IF NOT EXISTS shares (
 );
 
 CREATE TABLE IF NOT EXISTS share_sessions (
-    share_id          TEXT NOT NULL REFERENCES shares(share_id),
-    session_id        TEXT NOT NULL REFERENCES sessions(session_id),
-    added_at          TEXT NOT NULL,
-    content_revision  TEXT,
-    replaces_revision TEXT,
+    share_id           TEXT NOT NULL REFERENCES shares(share_id),
+    session_id         TEXT NOT NULL REFERENCES sessions(session_id),
+    added_at           TEXT NOT NULL,
+    content_revision   TEXT,
+    replaces_revision  TEXT,
+    predecessor_source TEXT,
     PRIMARY KEY (share_id, session_id)
 );
 
@@ -613,6 +622,7 @@ def open_index() -> sqlite3.Connection:
     _migrate_auto_upload_recovery_metadata(conn)
     _migrate_recurring_protocol_v2(conn)
     _migrate_exact_scope_pairs(conn)
+    _migrate_receiver_predecessor(conn)
 
     # Clean up ai_outcome_badge values that the judge wrote before the
     # resolution validator rejected invalid labels. Idempotent: after
@@ -1078,6 +1088,39 @@ def _migrate_exact_scope_pairs(conn: sqlite3.Connection) -> None:
             )
 
         conn.execute(f"PRAGMA user_version = {EXACT_SCOPE_PAIRS_SCHEMA_VERSION}")
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def _migrate_receiver_predecessor(conn: sqlite3.Connection) -> None:
+    """Advance v10 -> v11 with the receiver-dictated predecessor marker.
+
+    Rebinding a share to the hosted receiver's head writes a predecessor that
+    local revision history cannot reproduce, so the stale-predecessor gate
+    cannot tell it apart from a claim a newer local upload has overtaken.
+    Existing rows keep NULL, which reads as the create-time local baseline —
+    the strict interpretation, and the correct one for every share that
+    predates the lineage preflight.
+    """
+    version_row = conn.execute("PRAGMA user_version").fetchone()
+    version = version_row[0] if version_row else 0
+    if version >= RECEIVER_PREDECESSOR_SCHEMA_VERSION:
+        return
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        try:
+            conn.execute(
+                "ALTER TABLE share_sessions ADD COLUMN predecessor_source TEXT"
+            )
+        except sqlite3.OperationalError as exc:
+            if "duplicate column" not in str(exc):
+                raise
+        conn.execute(
+            f"PRAGMA user_version = {RECEIVER_PREDECESSOR_SCHEMA_VERSION}"
+        )
         conn.commit()
     except Exception:
         conn.rollback()
@@ -4439,10 +4482,20 @@ def synchronize_share_predecessors(
             required = required_predecessors[session_id]
             if row["replaces_revision"] == required:
                 continue
+            # Mark only the rows the receiver actually redirected. Marking a row
+            # whose predecessor already matched would disable the local stale
+            # check for ordinary shares, where it still does real work.
             conn.execute(
-                "UPDATE share_sessions SET replaces_revision = ? "
+                "UPDATE share_sessions "
+                "SET replaces_revision = ?, predecessor_source = ? "
                 "WHERE share_id = ? AND session_id = ? AND content_revision = ?",
-                (required, share_id, session_id, expected_revisions[session_id]),
+                (
+                    required,
+                    PREDECESSOR_SOURCE_RECEIVER,
+                    share_id,
+                    session_id,
+                    expected_revisions[session_id],
+                ),
             )
             changed += 1
         conn.commit()
@@ -5277,9 +5330,19 @@ def share_predecessor_blockers(
     this share's own revision, it is a known duplicate. Any third revision
     means a newer replacement won the race and this share must not overwrite
     it.
+
+    A row the hosted receiver redirected (``predecessor_source`` is
+    ``receiver``) is exempt from that last rule, because its predecessor is the
+    receiver's head rather than anything local revision history can reproduce —
+    reading it as a third revision is what stranded a rebound share after a
+    failed attempt. The duplicate check above still applies, and the receiver's
+    own compare-and-set remains the authority on whether the claim is current.
+    ``accepted_predecessors`` carries the same exemption for the response being
+    processed right now; the column is what makes it survive a retry.
     """
     rows = conn.execute(
-        "SELECT session_id, content_revision, replaces_revision "
+        "SELECT session_id, content_revision, replaces_revision, "
+        "predecessor_source "
         "FROM share_sessions WHERE share_id = ? ORDER BY session_id",
         (share_id,),
     ).fetchall()
@@ -5298,6 +5361,8 @@ def share_predecessor_blockers(
         if latest == row["content_revision"]:
             reason = "already_shared_revision"
         elif latest == row["replaces_revision"]:
+            continue
+        elif row["predecessor_source"] == PREDECESSOR_SOURCE_RECEIVER:
             continue
         elif (
             accepted_predecessors is not None

--- a/tests/workbench/test_auto_upload_index.py
+++ b/tests/workbench/test_auto_upload_index.py
@@ -10,6 +10,8 @@ import pytest
 
 from clawjournal.workbench.index import (
     EXACT_SCOPE_PAIRS_SCHEMA_VERSION,
+    PREDECESSOR_SOURCE_RECEIVER,
+    RECEIVER_PREDECESSOR_SCHEMA_VERSION,
     RECURRING_PROTOCOL_V2_SCHEMA_VERSION,
     WORKBENCH_SCHEMA_VERSION,
     already_shared_revision_blockers,
@@ -108,8 +110,9 @@ def _mark_shared(conn, session_id: str) -> str:
 
 def test_fresh_schema_has_auto_upload_foundation(index_conn):
     assert index_conn.execute("PRAGMA user_version").fetchone()[0] == WORKBENCH_SCHEMA_VERSION
-    assert WORKBENCH_SCHEMA_VERSION == EXACT_SCOPE_PAIRS_SCHEMA_VERSION
+    assert WORKBENCH_SCHEMA_VERSION == RECEIVER_PREDECESSOR_SCHEMA_VERSION
     assert EXACT_SCOPE_PAIRS_SCHEMA_VERSION == 10
+    assert RECEIVER_PREDECESSOR_SCHEMA_VERSION == 11
     assert RECURRING_PROTOCOL_V2_SCHEMA_VERSION == 9
 
     session_columns = {
@@ -647,3 +650,45 @@ def test_candidate_report_fails_closed_when_enrolled_scope_loses_confirmation(in
         "enrolled_project_removed",
     ]
     assert report["exclusion_counts"]["scope_confirmation_changed"] == 1
+
+
+def test_v11_migration_adds_the_receiver_predecessor_marker(tmp_path, monkeypatch):
+    """An index predating the marker must upgrade to the strict reading.
+
+    NULL is the create-time local baseline, so every historical share keeps the
+    behavior it had before the lineage preflight existed.
+    """
+    db_path = tmp_path / "index.db"
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", db_path)
+    monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+    monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path)
+
+    conn = open_index()
+    upsert_sessions(conn, [_session("trace-legacy")])
+    set_hold_state(conn, "trace-legacy", "released", changed_by="user", reason="t")
+    share_id = create_share(conn, ["trace-legacy"])
+    conn.close()
+
+    raw = sqlite3.connect(db_path)
+    raw.execute("ALTER TABLE share_sessions DROP COLUMN predecessor_source")
+    raw.execute(f"PRAGMA user_version = {EXACT_SCOPE_PAIRS_SCHEMA_VERSION}")
+    raw.commit()
+    raw.close()
+
+    conn = open_index()
+    try:
+        assert conn.execute(
+            "PRAGMA user_version"
+        ).fetchone()[0] == WORKBENCH_SCHEMA_VERSION
+        assert conn.execute(
+            "SELECT predecessor_source FROM share_sessions WHERE share_id = ?",
+            (share_id,),
+        ).fetchone()[0] is None
+        # The column exists and is writable at the new version.
+        conn.execute(
+            "UPDATE share_sessions SET predecessor_source = ? WHERE share_id = ?",
+            (PREDECESSOR_SOURCE_RECEIVER, share_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -3725,6 +3725,13 @@ def test_finalize_reraises_control_gate_instead_of_swallowing(
     from clawjournal.redaction.pii import _AgentCallGateError
     from clawjournal.auto_upload import ControlChanged
 
+    # This test does not take `index_setup`, so without these it opens the
+    # developer's real ~/.clawjournal/index.db — writing to live data and
+    # contending with a running `clawjournal serve` for the write lock.
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+    monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+    monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path / "config")
+
     export_dir = tmp_path / "share"
     export_dir.mkdir()
     (export_dir / "sessions.jsonl").write_text('{"session_id":"s1"}\n', encoding="utf-8")
@@ -5165,6 +5172,120 @@ class TestShareAPI:
         assert status == 200, data
         uploaded = captured["manifest"]["sessions"][0]
         assert uploaded["replaces_revision_hash"] == receiver_head
+
+    def test_rebound_share_can_be_retried_after_a_failed_upload(
+        self, server, monkeypatch
+    ):
+        """The rebase persists before the upload, so a retry must still work.
+
+        A transient upload failure leaves a receiver-authoritative predecessor
+        in the row. Read strictly that looks like a third revision overtaking
+        the share, and the up-front gate rejected the retry before the preflight
+        that would re-authorize it could run — stranding the share for good.
+        """
+        from clawjournal.workbench.index import (
+            create_share,
+            open_index,
+            update_session,
+        )
+
+        WorkbenchHandler._last_share_time = 0.0
+        session_id = "retryable-hosted-session"
+        self._seed_released_session(session_id, "first locally shared revision")
+        conn = open_index()
+        try:
+            update_session(conn, session_id, status="approved")
+            first_share = create_share(conn, [session_id])
+            conn.execute(
+                "UPDATE shares SET status='shared', shared_at=? WHERE share_id=?",
+                ("2026-07-01T00:00:00+00:00", first_share),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        self._seed_released_session(session_id, "continued work after first upload")
+        conn = open_index()
+        try:
+            update_session(conn, session_id, status="approved")
+            share_id = create_share(conn, [session_id])
+        finally:
+            conn.close()
+
+        status, exported = _post(server, f"/api/shares/{share_id}/export")
+        assert status == 200, exported
+        receiver_head = "sha256:" + ("b" * 64)
+
+        def lineage_preflight(payload):
+            claim = payload["sessions"][0]
+            ready = claim["replaces_revision_hash"] == receiver_head
+            return {
+                "lineage_contract": "logical_sessions_v1",
+                "sessions": [{
+                    "session_id": session_id,
+                    "status": "ready" if ready else "rebase_required",
+                    "current_head_revision_hash": receiver_head,
+                    "current_head_accepted_at": "2026-07-02T00:00:00+00:00",
+                    "required_replaces_revision_hash": receiver_head,
+                }],
+            }
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: _share_config(),
+        )
+
+        def fail_upload(_req):
+            raise urllib.error.URLError("connection reset during upload")
+
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                lineage_preflight=lineage_preflight,
+                upload_assert=fail_upload,
+            ),
+        ):
+            status, _data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+        assert status != 200
+
+        conn = open_index()
+        try:
+            row = conn.execute(
+                "SELECT replaces_revision, predecessor_source "
+                "FROM share_sessions WHERE share_id = ?",
+                (share_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert row["replaces_revision"] == receiver_head
+        assert row["predecessor_source"] == "receiver"
+
+        # The retry: same healthy server, nothing changed remotely.
+        WorkbenchHandler._last_share_time = 0.0
+        captured = {}
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                lineage_preflight=lineage_preflight,
+                upload_assert=lambda req: captured.update(
+                    manifest=self._manifest_from_upload(req)
+                ),
+            ),
+        ):
+            status, data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+
+        assert status == 200, data
+        assert captured["manifest"]["sessions"][0][
+            "replaces_revision_hash"
+        ] == receiver_head
 
     def test_hosted_upload_does_not_rebase_draft_older_than_receiver_head(
         self, server, monkeypatch

--- a/tests/workbench/test_revision_tracking.py
+++ b/tests/workbench/test_revision_tracking.py
@@ -10,6 +10,7 @@ import pytest
 
 from clawjournal.workbench.index import (
     WORKBENCH_SCHEMA_VERSION,
+    PREDECESSOR_SOURCE_RECEIVER,
     RevisionConflictError,
     already_shared_revision_blockers,
     compute_content_revision,
@@ -490,9 +491,12 @@ def test_receiver_preflight_rebinds_only_the_unsubmitted_share(index_conn):
     ).fetchone()
     assert row["content_revision"] == revision_r2
     assert row["replaces_revision"] == receiver_head
-    assert share_predecessor_blockers(index_conn, share_r2)[0][
-        "reason"
-    ] == "stale_predecessor"
+    # This assertion used to expect `stale_predecessor` without an explicit
+    # `accepted_predecessors`. That reading is what stranded a rebound share
+    # after a failed attempt, so the redirected row now carries the receiver
+    # marker and clears the gate on its own; see
+    # test_receiver_rebound_predecessor_survives_a_retry.
+    assert share_predecessor_blockers(index_conn, share_r2) == []
     assert share_predecessor_blockers(
         index_conn,
         share_r2,
@@ -668,3 +672,114 @@ def test_v5_migration_missing_blob_uses_safe_legacy_baseline(tmp_path, monkeypat
         assert get_share_ready_stats(conn)["sessions"] == []
     finally:
         conn.close()
+
+
+def test_receiver_rebound_predecessor_survives_a_retry(index_conn):
+    """A rebound share must stay submittable after a failed attempt.
+
+    The rebase persists before the upload, so any transient failure leaves a
+    receiver-authoritative predecessor in the row. Read strictly, that looks
+    exactly like a third revision overtaking the share, and the up-front gate
+    stranded it permanently — the preflight that would re-authorize it never
+    ran.
+    """
+    upsert_sessions(index_conn, [_session(content="r1")])
+    _approve(index_conn)
+    share_r1 = create_share(index_conn, ["trace-1"])
+    _mark_shared(index_conn, share_r1, "2026-07-02T00:00:00+00:00")
+
+    upsert_sessions(index_conn, [_session(content="r2")])
+    _approve(index_conn)
+    share_r2 = create_share(index_conn, ["trace-1"])
+    revision_r2 = index_conn.execute(
+        "SELECT content_revision FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()[0]
+    receiver_head = "sha256:" + ("b" * 64)
+
+    synchronize_share_predecessors(
+        index_conn,
+        share_r2,
+        expected_revisions={"trace-1": revision_r2},
+        required_predecessors={"trace-1": receiver_head},
+    )
+
+    assert index_conn.execute(
+        "SELECT predecessor_source FROM share_sessions WHERE share_id = ?",
+        (share_r2,),
+    ).fetchone()[0] == PREDECESSOR_SOURCE_RECEIVER
+
+    # The retry: no preflight response in hand, so no `accepted_predecessors`.
+    assert share_predecessor_blockers(index_conn, share_r2) == []
+
+
+def test_receiver_marker_does_not_excuse_a_duplicate_revision(index_conn):
+    """The exemption covers stale predecessors, never a duplicate upload."""
+    upsert_sessions(index_conn, [_session(content="r1")])
+    _approve(index_conn)
+    share_r1 = create_share(index_conn, ["trace-1"])
+
+    upsert_sessions(index_conn, [_session(content="r2")])
+    _approve(index_conn)
+    share_r2 = create_share(index_conn, ["trace-1"])
+    revision_r2 = index_conn.execute(
+        "SELECT content_revision FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()[0]
+    receiver_head = "sha256:" + ("b" * 64)
+
+    synchronize_share_predecessors(
+        index_conn,
+        share_r2,
+        expected_revisions={"trace-1": revision_r2},
+        required_predecessors={"trace-1": receiver_head},
+    )
+    # A sibling share uploads this share's own revision.
+    index_conn.execute(
+        "UPDATE share_sessions SET content_revision = ? WHERE share_id = ?",
+        (revision_r2, share_r1),
+    )
+    _mark_shared(index_conn, share_r1, "2026-07-03T00:00:00+00:00")
+
+    blockers = share_predecessor_blockers(index_conn, share_r2)
+    assert [b["reason"] for b in blockers] == ["already_shared_revision"]
+
+
+def test_ordinary_shares_keep_the_strict_stale_predecessor_check(index_conn):
+    """Only redirected rows are exempt; an untouched share stays strict."""
+    upsert_sessions(index_conn, [_session(content="r1")])
+    _approve(index_conn)
+    share_r1 = create_share(index_conn, ["trace-1"])
+    _mark_shared(index_conn, share_r1, "2026-07-02T00:00:00+00:00")
+
+    upsert_sessions(index_conn, [_session(content="r2")])
+    _approve(index_conn)
+    share_r2 = create_share(index_conn, ["trace-1"])
+    revision_r2 = index_conn.execute(
+        "SELECT content_revision FROM sessions WHERE session_id = 'trace-1'"
+    ).fetchone()[0]
+
+    # The receiver confirms the predecessor the share already declared, so
+    # nothing is redirected and the row must not be marked.
+    local_predecessor = index_conn.execute(
+        "SELECT replaces_revision FROM share_sessions WHERE share_id = ?",
+        (share_r2,),
+    ).fetchone()[0]
+    assert synchronize_share_predecessors(
+        index_conn,
+        share_r2,
+        expected_revisions={"trace-1": revision_r2},
+        required_predecessors={"trace-1": local_predecessor},
+    ) == 0
+    assert index_conn.execute(
+        "SELECT predecessor_source FROM share_sessions WHERE share_id = ?",
+        (share_r2,),
+    ).fetchone()[0] is None
+
+    # A third revision then wins the race locally.
+    upsert_sessions(index_conn, [_session(content="r3")])
+    _approve(index_conn)
+    share_r3 = create_share(index_conn, ["trace-1"])
+    _mark_shared(index_conn, share_r3, "2026-07-04T00:00:00+00:00")
+
+    assert [
+        b["reason"] for b in share_predecessor_blockers(index_conn, share_r2)
+    ] == ["stale_predecessor"]


### PR DESCRIPTION
## Summary

- add `share_sessions.predecessor_source` (schema v11) so a share the hosted receiver rebound stays submittable after a failed attempt
- keep the strict stale-predecessor reading for every share the receiver did not redirect
- isolate a test that was running against the real `~/.clawjournal/index.db`

Follow-up to #162, which shipped the manual-lineage preflight. Found while reviewing that PR; it merged before this could be folded in.

## Problem

The rebase persists to `share_sessions.replaces_revision` **before** the upload. Any transient failure after that — connection reset, rate limit, a 5xx from the submissions endpoint, the participant closing the tab — leaves a receiver-authoritative predecessor in the row.

Local revision history cannot reproduce that value, so the strict reading in `share_predecessor_blockers` classifies it as a third revision overtaking the share. The up-front gate in `submit_share_to_hosted` then returns `stale_predecessor` and never reaches the preflight that would re-authorize it:

```
attempt 1 -> 502 Could not reach hosted submission service
persisted replaces_revision after attempt 1: sha256:bbbb...
attempt 2 -> 409 Share revisions are duplicate or based on a stale predecessor
attempt 2 blockers: [{..., 'reason': 'stale_predecessor'}]
attempt 2 reached preflight: False
```

The share is unsubmittable for good; recovery means creating a new one. The happy path in #162 only works because the rebase and the upload land in the same request, where `accepted_predecessors` carries the exemption in memory.

## Approach

`predecessor_source` records where a row's predecessor came from:

- **NULL** — the create-time local baseline. Every existing share migrates to this, so the strict reading is preserved for anything predating the lineage preflight.
- **`receiver`** — the hosted preflight redirected this row. Local revision history cannot validate it, so reading it as a third revision is simply wrong.

Only rows the receiver actually redirected are marked. Marking a row whose predecessor already matched would disable the stale check for ordinary shares, where it still does real work.

## Safety

- the duplicate-revision check (`already_shared_revision`) is evaluated first and is untouched — the exemption never excuses re-uploading a revision that already landed
- a share the receiver did not redirect keeps the full strict check
- the receiver's compare-and-set at upload time remains the authority on whether a claim is current; this only stops the local gate from guessing about a value it cannot derive
- migration is additive and nullable; historical rows read as the strict baseline

## Validation

- `test_rebound_share_can_be_retried_after_a_failed_upload` — end to end: upload fails, retry succeeds with the receiver head in the uploaded manifest
- `test_receiver_rebound_predecessor_survives_a_retry` — the same at the index level, with no `accepted_predecessors` in hand
- `test_v11_migration_adds_the_receiver_predecessor_marker` — an index at v10 upgrades, existing rows read NULL
- `test_receiver_marker_does_not_excuse_a_duplicate_revision` and `test_ordinary_shares_keep_the_strict_stale_predecessor_check` — guard tests, green with and without the fix
- the first three are verified red without the read-side change
- full suite: 3645 passed, 1 skipped

`test_receiver_preflight_rebinds_only_the_unsubmitted_share` asserted the old reading (`stale_predecessor` without an explicit `accepted_predecessors`) and is updated, with a comment pointing at the new test. @JustMeStudio worth a look since you wrote that assertion deliberately.

## Test isolation

`test_finalize_reraises_control_gate_instead_of_swallowing` does not take the `index_setup` fixture, so `open_index()` opened the developer's real `~/.clawjournal/index.db`. It was already writing there via the `ai_outcome_badge` cleanup in `open_index`; adding a schema migration turned that into a live schema change and a write-lock fight with a running `clawjournal serve`, which failed the test. Now isolated to `tmp_path`.

Anyone who ran the suite from this branch before that fix has a local index at `user_version = 11` with the column already added. Harmless — the migration is idempotent and re-running it is a no-op.

## Still open from the #162 review

Not addressed here: the rebase guard compares a local clock against a server clock, and `_expiry_timestamp` parses a timezone-less `current_head_accepted_at` as **local** time, which shifts the receiver's timestamp into the past for participants west of UTC — the permissive direction. That comparison is the only thing separating "my continued trace" from "claim a head I don't descend from", so it's worth requiring tz-aware and adding a skew margin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnkimhqM4uAyiSYuLQNdo7
