### PR TITLE
fix(share): stop trusting a timezone-less hosted head timestamp

### DIFF
--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -1416,6 +1416,50 @@ def _email_domain_allowed(
     )
 
 
+class _AmbiguousTimestamp(ValueError):
+    """An instant was supplied without enough information to place it."""
+
+
+def _unambiguous_epoch_seconds(value: Any) -> float | None:
+    """Return epoch seconds for a value that names one instant, or None.
+
+    Unlike ``_expiry_timestamp`` this refuses a timezone-less ISO string
+    instead of reading it as local time. That reading is harmless for a token
+    expiry the same machine wrote, but not for comparing a local clock against
+    a remote one: at a positive UTC offset it shifts the remote instant into
+    the past by the size of the offset (UTC+8 reads a UTC instant as 8 hours
+    earlier), which is the permissive direction for the lineage rebase guard.
+
+    Missing (None) is a legitimate "not supplied" and returns None. A value
+    that is present but cannot name an instant raises, so a malformed hosted
+    response surfaces as a protocol error rather than as advice to the
+    participant that they should create a new share.
+    """
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        raise _AmbiguousTimestamp("Timestamp must not be a boolean.")
+    if isinstance(value, (int, float)):
+        # Epoch seconds are UTC by definition, so there is nothing to resolve.
+        return float(value)
+    if not isinstance(value, str) or not value.strip():
+        raise _AmbiguousTimestamp("Timestamp must be a non-empty ISO 8601 string.")
+    raw = value.strip()
+    try:
+        return float(raw)
+    except ValueError:
+        pass
+    try:
+        parsed = datetime.fromisoformat(raw.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise _AmbiguousTimestamp(f"Timestamp {raw!r} is not ISO 8601.") from exc
+    if parsed.tzinfo is None or parsed.tzinfo.utcoffset(parsed) is None:
+        raise _AmbiguousTimestamp(
+            f"Timestamp {raw!r} has no UTC offset, so it names no single instant."
+        )
+    return parsed.timestamp()
+
+
 def _expiry_timestamp(value: Any) -> float | None:
     if isinstance(value, (int, float)):
         return float(value)
@@ -1593,6 +1637,12 @@ def _manual_share_lineage_claims(
 
 _LINEAGE_PREFLIGHT_ABSENT_STATUSES = frozenset({404, 405, 410, 501})
 
+# How far apart the participant's clock and the receiver's clock may plausibly
+# be. The rebase guard compares one against the other, so a gap smaller than
+# this proves nothing about which instant really came first and must not be
+# read as "my package is newer".
+_LINEAGE_CLOCK_SKEW_SECONDS = 300
+
 
 def _lineage_preflight_is_unavailable(exc: urllib.error.HTTPError) -> bool:
     """Whether a preflight failure means the capability is simply not there.
@@ -1710,11 +1760,23 @@ def _synchronize_manual_share_lineage(
             "blocked_sessions": stale_ids,
         }
 
-    share_created_at = _expiry_timestamp(share.get("created_at"))
+    try:
+        share_created_at = _unambiguous_epoch_seconds(share.get("created_at"))
+    except _AmbiguousTimestamp:
+        share_created_at = None
     for session_id, status in statuses.items():
         if status != "rebase_required":
             continue
-        receiver_accepted_at = _expiry_timestamp(head_accepted_at[session_id])
+        # A malformed instant here is the hosted service breaking the contract,
+        # not something the participant can fix by re-reviewing the trace.
+        try:
+            receiver_accepted_at = _unambiguous_epoch_seconds(
+                head_accepted_at[session_id]
+            )
+        except _AmbiguousTimestamp as exc:
+            raise ValueError(
+                f"Hosted lineage preflight returned an unusable head timestamp: {exc}"
+            ) from exc
         if (
             share_created_at is None
             or receiver_accepted_at is None
@@ -1725,6 +1787,22 @@ def _synchronize_manual_share_lineage(
                 "error": (
                     "This package was created before another revision reached the "
                     "hosted service. Review the latest trace and create a new share."
+                ),
+                "status": 409,
+                "blocked_sessions": [session_id],
+            }
+        # The two instants come from different clocks — the participant's and
+        # the receiver's — so a margin narrower than plausible drift proves
+        # nothing about which really happened first. Rebasing on a tie would
+        # declare that this package supersedes a head it may not contain, so
+        # anything inside the margin blocks and resolves itself as time passes.
+        if share_created_at - receiver_accepted_at <= _LINEAGE_CLOCK_SKEW_SECONDS:
+            return {
+                "supported": True,
+                "error": (
+                    "This package and another revision reached the hosted service "
+                    "too close together to tell apart. Wait a few minutes, then "
+                    "review the latest trace and create a new share."
                 ),
                 "status": 409,
                 "blocked_sessions": [session_id],

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -3344,6 +3344,61 @@ def _share_config(**overrides):
     return config
 
 
+def test_unambiguous_epoch_seconds_refuses_what_it_cannot_place():
+    from clawjournal.workbench.daemon import (
+        _AmbiguousTimestamp,
+        _expiry_timestamp,
+        _unambiguous_epoch_seconds,
+    )
+
+    aware = "2026-07-02T00:00:00+00:00"
+    assert _unambiguous_epoch_seconds(aware) == datetime(
+        2026, 7, 2, tzinfo=timezone.utc
+    ).timestamp()
+    assert _unambiguous_epoch_seconds("2026-07-02T00:00:00Z") == (
+        _unambiguous_epoch_seconds(aware)
+    )
+    # Epoch seconds are UTC by definition, so there is nothing to resolve.
+    assert _unambiguous_epoch_seconds(1_800_000_000) == 1_800_000_000.0
+    assert _unambiguous_epoch_seconds("1800000000") == 1_800_000_000.0
+    # Not supplied stays a legitimate answer; the caller decides what to do.
+    assert _unambiguous_epoch_seconds(None) is None
+
+    for unplaceable in (
+        "2026-07-02T00:00:00",       # no offset — the whole point
+        "2026-07-02",                # date only
+        "not a timestamp",
+        "",
+        True,
+        {"when": "now"},
+    ):
+        with pytest.raises(_AmbiguousTimestamp):
+            _unambiguous_epoch_seconds(unplaceable)
+
+    # Why a naive string has to be refused rather than guessed at: the same
+    # characters denote a different instant in every zone that reads them, and
+    # the client reading them is not the service that wrote them.
+    naive = "2026-07-02T00:00:00"
+    base = datetime.fromisoformat(naive)
+    readings = {
+        offset: base.replace(tzinfo=timezone(timedelta(hours=offset))).timestamp()
+        for offset in (0, 8, -7)
+    }
+    assert len(set(readings.values())) == 3
+    # The hazard is directional. A reader at a positive offset places the
+    # instant *earlier* than a UTC writer meant, so the receiver's head looks
+    # older than it is — the direction that licenses a rebase. A reader west of
+    # UTC places it later, which only blocks.
+    assert readings[8] < readings[0] < readings[-7]
+
+    # `_expiry_timestamp` still picks one of those readings (the local one).
+    # That is fine for an expiry this machine wrote, and is exactly why the
+    # lineage guard cannot use it against a remote clock.
+    assert _expiry_timestamp(naive) == base.timestamp()
+    with pytest.raises(_AmbiguousTimestamp):
+        _unambiguous_epoch_seconds(naive)
+
+
 def test_manual_lineage_preflight_must_stay_on_hosted_origin(monkeypatch):
     from clawjournal.workbench import daemon
 
@@ -5271,6 +5326,195 @@ class TestShareAPI:
             "clawjournal.workbench.daemon.urllib.request.urlopen",
             side_effect=_mock_urlopen_factory(
                 lineage_preflight=lineage_preflight,
+                upload_assert=lambda req: captured.update(
+                    manifest=self._manifest_from_upload(req)
+                ),
+            ),
+        ):
+            status, data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+
+        assert status == 200, data
+        assert captured["manifest"]["sessions"][0][
+            "replaces_revision_hash"
+        ] == receiver_head
+
+    def _rebase_preflight_server(self, session_id, receiver_head, accepted_at):
+        """A hosted server asking this session to rebase onto `receiver_head`."""
+        def lineage_preflight(payload):
+            claim = payload["sessions"][0]
+            ready = claim["replaces_revision_hash"] == receiver_head
+            return {
+                "lineage_contract": "logical_sessions_v1",
+                "sessions": [{
+                    "session_id": session_id,
+                    "status": "ready" if ready else "rebase_required",
+                    "current_head_revision_hash": receiver_head,
+                    "current_head_accepted_at": accepted_at,
+                    "required_replaces_revision_hash": receiver_head,
+                }],
+            }
+        return lineage_preflight
+
+    def _continued_share(self, server, session_id):
+        """A share whose trace grew after an earlier revision was uploaded."""
+        from clawjournal.workbench.index import (
+            create_share,
+            open_index,
+            update_session,
+        )
+
+        self._seed_released_session(session_id, "first locally shared revision")
+        conn = open_index()
+        try:
+            update_session(conn, session_id, status="approved")
+            first_share = create_share(conn, [session_id])
+            conn.execute(
+                "UPDATE shares SET status='shared', shared_at=? WHERE share_id=?",
+                ("2026-07-01T00:00:00+00:00", first_share),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        self._seed_released_session(session_id, "continued work after first upload")
+        conn = open_index()
+        try:
+            update_session(conn, session_id, status="approved")
+            share_id = create_share(conn, [session_id])
+        finally:
+            conn.close()
+        status, exported = _post(server, f"/api/shares/{share_id}/export")
+        assert status == 200, exported
+        return share_id
+
+    def test_rebase_refuses_a_head_timestamp_without_a_utc_offset(
+        self, server, monkeypatch
+    ):
+        """A naive instant names no single moment, so it cannot clear the guard.
+
+        Read as local time at a positive UTC offset it lands in the past by the
+        size of the offset, which is the permissive direction — it would
+        license a rebase the participant never earned. That is the hosted
+        service breaking its contract, not something re-reviewing the trace can
+        fix, so it must not surface as share advice.
+        """
+        WorkbenchHandler._last_share_time = 0.0
+        session_id = "naive-timestamp-session"
+        share_id = self._continued_share(server, session_id)
+        receiver_head = "sha256:" + ("b" * 64)
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: _share_config(),
+        )
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                lineage_preflight=self._rebase_preflight_server(
+                    session_id, receiver_head, "2026-07-02T00:00:00"
+                ),
+                upload_assert=lambda _req: pytest.fail("rebased on a naive instant"),
+            ),
+        ):
+            status, data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+
+        assert status == 502, data
+        assert "no UTC offset" in data["error"]
+
+        conn = open_index()
+        try:
+            stored = conn.execute(
+                "SELECT replaces_revision, predecessor_source "
+                "FROM share_sessions WHERE share_id = ?",
+                (share_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+        assert stored["replaces_revision"] != receiver_head
+        assert stored["predecessor_source"] is None
+
+    def test_rebase_refuses_a_head_accepted_within_the_clock_skew_margin(
+        self, server, monkeypatch
+    ):
+        """Two clocks, one margin: a near-tie proves nothing and must block."""
+        WorkbenchHandler._last_share_time = 0.0
+        session_id = "skewed-clock-session"
+        share_id = self._continued_share(server, session_id)
+        receiver_head = "sha256:" + ("b" * 64)
+
+        conn = open_index()
+        try:
+            created_at = conn.execute(
+                "SELECT created_at FROM shares WHERE share_id = ?",
+                (share_id,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        # The receiver accepted its head one minute before this share was
+        # created — later in wall-clock terms, but well inside plausible drift.
+        accepted_at = datetime.fromisoformat(created_at) - timedelta(seconds=60)
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: _share_config(),
+        )
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                lineage_preflight=self._rebase_preflight_server(
+                    session_id, receiver_head, accepted_at.isoformat()
+                ),
+                upload_assert=lambda _req: pytest.fail("rebased on a near-tie"),
+            ),
+        ):
+            status, data = _post(
+                server,
+                f"/api/shares/{share_id}/upload",
+                self._consent_body(),
+            )
+
+        assert status == 409, data
+        assert "too close together" in data["error"]
+        assert data["blocked_sessions"] == [session_id]
+
+    def test_rebase_allows_a_head_accepted_beyond_the_clock_skew_margin(
+        self, server, monkeypatch
+    ):
+        """Just past the margin the ordering is unambiguous, so it proceeds."""
+        WorkbenchHandler._last_share_time = 0.0
+        session_id = "clear-margin-session"
+        share_id = self._continued_share(server, session_id)
+        receiver_head = "sha256:" + ("b" * 64)
+
+        conn = open_index()
+        try:
+            created_at = conn.execute(
+                "SELECT created_at FROM shares WHERE share_id = ?",
+                (share_id,),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        accepted_at = datetime.fromisoformat(created_at) - timedelta(seconds=301)
+
+        captured = {}
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: _share_config(),
+        )
+        with patch(
+            "clawjournal.workbench.daemon.urllib.request.urlopen",
+            side_effect=_mock_urlopen_factory(
+                lineage_preflight=self._rebase_preflight_server(
+                    session_id, receiver_head, accepted_at.isoformat()
+                ),
                 upload_assert=lambda req: captured.update(
                     manifest=self._manifest_from_upload(req)
                 ),


### PR DESCRIPTION
## Summary

- refuse a timezone-less `current_head_accepted_at` instead of resolving it as local time
- require the share to postdate the receiver's head by more than plausible clock drift before rebasing
- surface a malformed hosted timestamp as a protocol error, not as advice to re-review the trace

Last open item from the #162 review. Follows #167.

## Problem

`_synchronize_manual_share_lineage` decides whether a package may declare that it supersedes the receiver's head by comparing the share's `created_at` against the head's `current_head_accepted_at`. That single comparison is what separates "my trace continued past your head" from "I am claiming a head I may not contain", and it had two weaknesses.

**It read the remote value through `_expiry_timestamp`,** which resolves a timezone-less ISO string as *local* time. A naive string names a different instant in every zone that reads it, and the client reading it is not the service that wrote it. The hazard is directional — measured, not reasoned:

```
TZ=UTC                   naive-as-local minus true-UTC =  +0h
TZ=Asia/Shanghai         naive-as-local minus true-UTC =  -8h  -> head looks EARLIER (allows more)
TZ=America/Los_Angeles   naive-as-local minus true-UTC =  +7h  -> head looks LATER   (blocks more)
```

At a positive UTC offset the head looks *older* than it is, so `share_created_at > receiver_accepted_at` holds more readily and the rebase is allowed. West of UTC the same bug only over-blocks. A server that omits the offset therefore hands the permissive reading to exactly the clients east of it.

**It compared two clocks with no margin.** Even with both instants parsed correctly, one comes from the participant's machine and one from the receiver. A gap of seconds establishes no ordering between them, and rebasing on a tie is the unsafe direction.

## Approach

`_unambiguous_epoch_seconds` accepts only values that name one instant: epoch numbers (UTC by definition) and ISO strings carrying a UTC offset. Absent stays absent — the caller decides. Anything present but unplaceable raises `_AmbiguousTimestamp`.

For the hosted value that raise becomes a 502 rather than a 409. A naive timestamp is the service breaking its contract; telling the participant to "create a new share" would send them round a loop that cannot fix it.

Rebasing then additionally requires `share_created_at - receiver_accepted_at > 300s`. Inside the margin the ordering is not established, so it blocks with a message that says so and resolves itself as time passes.

`_expiry_timestamp` is unchanged and keeps its local-time reading for token expiries, where the same machine wrote the value.

## Safety

- every path that cannot establish ordering blocks; nothing new is allowed
- the receiver's compare-and-set at upload time is unaffected and remains the authority
- a share already declaring the receiver's head (`status: ready`) never reaches this guard, so the margin cannot strand a normal resubmission
- 300s is a deliberate trade: a participant who continues a trace and re-shares within five minutes of the previous upload landing is told to wait, rather than silently rebased on an ordering nobody established

## Validation

- `test_rebase_refuses_a_head_timestamp_without_a_utc_offset` — 502, and the row keeps its original predecessor and NULL `predecessor_source`
- `test_rebase_refuses_a_head_accepted_within_the_clock_skew_margin` — head accepted 60s before the share was created still blocks
- `test_rebase_allows_a_head_accepted_beyond_the_clock_skew_margin` — 301s proceeds and uploads the receiver head
- `test_unambiguous_epoch_seconds_refuses_what_it_cannot_place` — including the portable demonstration that one naive string denotes three different instants, ordered `+8 < UTC < -7`
- both refusal tests verified red without the fix; the allow test is green either way, pinning that the feature still works
- lineage suite green under `TZ=UTC`, `TZ=Asia/Shanghai`, and `TZ=America/Los_Angeles`
- full suite: 3649 passed, 1 skipped

## A stronger guard, not taken here

The timestamp is a proxy for the real question: *does my revision descend from the receiver's head?* A clock-free answer is available locally — if the head hash appears in this session's `share_sessions.content_revision` history, then it was a snapshot of this same append-only trace and the current revision contains it.

That would be strictly stronger, but it is a contract change rather than a fix: it rejects rebasing onto a head this machine has no record of, which is what `test_hosted_upload_rebases_to_receiver_head_and_repackages` models today. Raising it here rather than implementing it — happy to follow up if that tightening is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HnkimhqM4uAyiSYuLQNdo7
