### PR TITLE
fix(auto-upload): show live enrollment scan progress

### DIFF
--- a/clawjournal/web/frontend/src/api.test.ts
+++ b/clawjournal/web/frontend/src/api.test.ts
@@ -98,6 +98,75 @@ describe('automatic-upload API normalization', () => {
       },
     ]);
   });
+
+  it('tracks accepted enrollment requests and reads their local progress', async () => {
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ mode: 'enabled' }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          progress_id: 'progress-issue165',
+          stage: 'scanning',
+          message: 'Refreshing Codex source logs: 42/118 projects',
+          source: 'codex',
+          current_project: 42,
+          total_projects: 118,
+          updated_at: '2026-07-29T00:00:00Z',
+        }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await api.autoUpload.enable({
+      agent: 'auto',
+      accepted_authorization_profile_hash: 'profile-hash-v2',
+      progress_id: 'progress-issue165',
+    });
+    await expect(
+      api.autoUpload.enableProgress('progress-issue165'),
+    ).resolves.toMatchObject({
+      stage: 'scanning',
+      source: 'codex',
+      current_project: 42,
+      total_projects: 118,
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/auto-upload/enable', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        agent: 'auto',
+        accepted_authorization_profile_hash: 'profile-hash-v2',
+        progress_id: 'progress-issue165',
+      }),
+    });
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      2,
+      '/api/auto-upload/enable-progress/progress-issue165',
+      { headers: {} },
+    );
+  });
+
+  it('does not create progress state for a read-only challenge', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ mode: 'off' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await api.autoUpload.enable({ agent: 'auto', challenge_only: true });
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/auto-upload/enable', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ agent: 'auto', challenge_only: true }),
+    });
+  });
 });
 
 describe('share scanner recovery API', () => {

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -25,6 +25,7 @@ import type {
   WorkbenchConfig,
   AutoUploadAgent,
   AutoUploadCandidateReport,
+  AutoUploadEnableProgress,
   AutoUploadHookDiagnostic,
   AutoUploadStatus,
 } from './types.ts';
@@ -364,6 +365,7 @@ export const api = {
       accepted_authorization_profile_hash?: string;
       challenge_only?: boolean;
       prepare_for_manual_share?: boolean;
+      progress_id?: string;
     }): Promise<AutoUploadStatus> {
       const status = await request<Partial<AutoUploadStatus>>('/auto-upload/enable', {
         method: 'POST',
@@ -371,6 +373,12 @@ export const api = {
         body: JSON.stringify(body),
       });
       return normalizeAutoUploadStatus(status);
+    },
+
+    enableProgress(progressId: string): Promise<AutoUploadEnableProgress> {
+      return request(
+        `/auto-upload/enable-progress/${encodeURIComponent(progressId)}`,
+      );
     },
 
     async run(): Promise<AutoUploadStatus> {

--- a/clawjournal/web/frontend/src/autoUploadEnableProgress.ts
+++ b/clawjournal/web/frontend/src/autoUploadEnableProgress.ts
@@ -1,0 +1,43 @@
+import { api } from './api.ts';
+import type { AutoUploadEnableProgress } from './types.ts';
+
+export const AUTO_UPLOAD_ENABLE_PROGRESS_POLL_MS = 300;
+
+export function createAutoUploadEnableProgressId(): string {
+  if (typeof globalThis.crypto?.randomUUID === 'function') {
+    return globalThis.crypto.randomUUID();
+  }
+  return `progress-${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function startAutoUploadEnableProgressPolling(
+  progressId: string,
+  onProgress: (progress: AutoUploadEnableProgress) => void,
+): () => void {
+  let active = true;
+  onProgress({
+    progress_id: progressId,
+    stage: 'checking_hosted_service',
+    message: 'Checking the hosted service and current terms...',
+    source: null,
+    current_project: null,
+    total_projects: null,
+    updated_at: null,
+  });
+
+  const timer = window.setInterval(() => {
+    void api.autoUpload.enableProgress(progressId)
+      .then(progress => {
+        if (active) onProgress(progress);
+      })
+      .catch(() => {
+        // The POST and first poll can race. Keep the last known stage and try
+        // again rather than turning a transient local 404 into a user error.
+      });
+  }, AUTO_UPLOAD_ENABLE_PROGRESS_POLL_MS);
+
+  return () => {
+    active = false;
+    window.clearInterval(timer);
+  };
+}

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
@@ -667,6 +667,7 @@ describe('AutoUploadPanel authorization', () => {
       accepted_retention_version: 'retention-v3',
       accepted_ownership_certification_version: 'ownership-v1',
       accepted_authorization_profile_hash: 'profile-hash-v2',
+      progress_id: expect.any(String),
     });
     expect(await screen.findByText('recurring-v2')).toBeInTheDocument();
 
@@ -677,6 +678,79 @@ describe('AutoUploadPanel authorization', () => {
 
     expect(screen.getByText('recurring-v2')).toBeInTheDocument();
     expect(screen.queryByText('recurring-v1')).not.toBeInTheDocument();
+  });
+
+  it('shows scan-lock waiting and live source project progress while enabling', async () => {
+    const initial = status({
+      mode: 'enabled',
+      run_now_allowed: true,
+      scope: {
+        sources: ['claude'],
+        projects: ['project-a'],
+        entries: [['claude', 'project-a']],
+      },
+      authorization: { version: 'recurring-v1', text: 'old terms' },
+    });
+    const enabled = status({
+      ...initial,
+      authorization: { version: 'recurring-v2', text: 'new terms' },
+    });
+    const enableRequest = deferred<AutoUploadStatus>();
+    vi.spyOn(api.autoUpload, 'status').mockResolvedValue(initial);
+    vi.spyOn(api.autoUpload, 'enable')
+      .mockRejectedValueOnce(authorizationRequired())
+      .mockReturnValueOnce(enableRequest.promise);
+    vi.spyOn(api.autoUpload, 'enableProgress')
+      .mockResolvedValueOnce({
+        progress_id: 'progress-issue165',
+        stage: 'waiting_for_scan_lock',
+        message: 'Waiting for another scan to finish before refreshing...',
+        source: null,
+        current_project: null,
+        total_projects: null,
+        updated_at: '2026-07-29T00:00:00Z',
+      })
+      .mockResolvedValue({
+        progress_id: 'progress-issue165',
+        stage: 'scanning',
+        message: 'Refreshing Codex source logs: 42/118 projects',
+        source: 'codex',
+        current_project: 42,
+        total_projects: 118,
+        updated_at: '2026-07-29T00:00:01Z',
+      });
+
+    renderControl(<AutoUploadPanel />);
+    fireEvent.click(await screen.findByRole('button', { name: 'Review scope and terms' }));
+    await screen.findByRole('heading', { name: 'Authorize future automatic uploads' });
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[0]);
+    fireEvent.click(checkboxes[1]);
+    fireEvent.click(screen.getByRole('button', { name: 'Enable automatic upload' }));
+
+    expect(screen.getByText(
+      'Checking the hosted service and current terms...',
+    )).toBeInTheDocument();
+    expect(await screen.findByText(
+      'Waiting for another scan to finish before refreshing...',
+      {},
+      { timeout: 2_000 },
+    )).toBeInTheDocument();
+    expect(await screen.findByText(
+      'Refreshing Codex source logs: 42/118 projects',
+      {},
+      { timeout: 2_000 },
+    )).toBeInTheDocument();
+    const progress = screen.getByRole('progressbar', {
+      name: 'Automatic upload enrollment refresh',
+    });
+    expect(progress).toHaveAttribute('value', '42');
+    expect(progress).toHaveAttribute('max', '118');
+
+    await act(async () => {
+      enableRequest.resolve(enabled);
+      await flushPromises();
+    });
   });
 
   it('never blames a receipt grant when rotating an active enrollment', async () => {

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
@@ -2,9 +2,14 @@ import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import type { CSSProperties } from 'react';
 import { Link } from 'react-router-dom';
 import { api, ApiError } from '../api.ts';
+import {
+  createAutoUploadEnableProgressId,
+  startAutoUploadEnableProgressPolling,
+} from '../autoUploadEnableProgress.ts';
 import type {
   AutoUploadAuthorizationChallenge,
   AutoUploadCandidateReport,
+  AutoUploadEnableProgress,
   AutoUploadStatus,
   ProjectSummary,
   WorkbenchConfig,
@@ -222,6 +227,8 @@ function AuthorizationDialog({
   const [scopeProjects, setScopeProjects] = useState<ProjectSummary[]>([]);
   const [scopeSource, setScopeSource] = useState('');
   const [scopeProjectsConfirmed, setScopeProjectsConfirmed] = useState(false);
+  const [enableProgress, setEnableProgress] =
+    useState<AutoUploadEnableProgress | null>(null);
 
   const showEmailVerification = useCallback(async (
     message: string,
@@ -351,6 +358,7 @@ function AuthorizationDialog({
       setScopeProjects([]);
       setScopeSource('');
       setScopeProjectsConfirmed(false);
+      setEnableProgress(null);
       return;
     }
     if (!requestedRef.current) {
@@ -465,6 +473,11 @@ function AuthorizationDialog({
   const enableWithAcceptedTerms = async () => {
     if (!challenge || !accepted || !ownershipCertified) return;
     setSubmitting(true);
+    const progressId = createAutoUploadEnableProgressId();
+    const stopProgressPolling = startAutoUploadEnableProgressPolling(
+      progressId,
+      setEnableProgress,
+    );
     try {
       const next = await api.autoUpload.enable({
         agent: 'auto',
@@ -472,6 +485,7 @@ function AuthorizationDialog({
         accepted_retention_version: challenge.retention.version,
         accepted_ownership_certification_version: challenge.ownership_certification.version,
         accepted_authorization_profile_hash: challenge.authorization_profile_hash,
+        progress_id: progressId,
       });
       onEnabled(next);
       toast('Automatic upload enabled', 'success');
@@ -490,6 +504,8 @@ function AuthorizationDialog({
         setError(errorMessage(enableError, 'Could not enable automatic upload.'));
       }
     } finally {
+      stopProgressPolling();
+      setEnableProgress(null);
       setSubmitting(false);
     }
   };
@@ -956,6 +972,36 @@ function AuthorizationDialog({
                 )}
               </>
             )}
+          </div>
+        )}
+
+        {submitting && enableProgress && (
+          <div
+            role="status"
+            aria-live="polite"
+            style={{
+              marginTop: 14,
+              padding: '10px 12px',
+              border: `1px solid ${colors.primary200}`,
+              borderRadius: 8,
+              background: colors.primary50,
+              color: colors.gray800,
+              fontSize: 12.5,
+              lineHeight: 1.45,
+            }}
+          >
+            <div>{enableProgress.message}</div>
+            {enableProgress.stage === 'scanning'
+              && enableProgress.current_project !== null
+              && enableProgress.total_projects !== null
+              && enableProgress.total_projects > 0 && (
+                <progress
+                  aria-label="Automatic upload enrollment refresh"
+                  value={enableProgress.current_project}
+                  max={enableProgress.total_projects}
+                  style={{ width: '100%', marginTop: 8 }}
+                />
+              )}
           </div>
         )}
 

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -229,6 +229,21 @@ export type AutoUploadHealth = 'ready' | 'action_required' | 'retrying';
 export type AutoUploadOverlay = 'running' | 'revocation_pending' | null;
 export type AutoUploadAgent = 'claude' | 'codex' | 'all' | 'auto';
 
+export interface AutoUploadEnableProgress {
+  progress_id: string;
+  stage:
+    | 'checking_hosted_service'
+    | 'waiting_for_scan_lock'
+    | 'scanning'
+    | 'complete'
+    | 'failed';
+  message: string;
+  source: string | null;
+  current_project: number | null;
+  total_projects: number | null;
+  updated_at: string | null;
+}
+
 export interface AutoUploadHookDiagnostic {
   agent: string;
   selected: boolean;

--- a/clawjournal/web/frontend/src/views/Share/SubmitStep.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/SubmitStep.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { api, ApiError } from '../../api.ts';
 import type { AutoUploadStatus } from '../../types.ts';
@@ -10,6 +10,16 @@ vi.mock('./successChime.ts', () => ({
   playSuccessChime: vi.fn(),
   primeSuccessChime: vi.fn(),
 }));
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+}
 
 function automaticUploadStatus(
   overrides: Partial<AutoUploadStatus> = {},
@@ -163,6 +173,7 @@ describe('SubmitStep automatic-upload opt-in', () => {
 
   it('uses the manual receipt grant to enable automatic uploads in one submit', async () => {
     const calls: string[] = [];
+    const enableRequest = deferred<AutoUploadStatus>();
     vi.spyOn(api.share, 'consent').mockResolvedValue({
       consent_text: 'Manual share consent.',
       retention_text: 'Manual retention terms.',
@@ -182,8 +193,17 @@ describe('SubmitStep automatic-upload opt-in', () => {
       .mockRejectedValueOnce(authorizationRequired())
       .mockImplementationOnce(async () => {
         calls.push('enable');
-        return automaticUploadStatus({ mode: 'enabled' });
+        return enableRequest.promise;
       });
+    vi.spyOn(api.autoUpload, 'enableProgress').mockResolvedValue({
+      progress_id: 'progress-issue165',
+      stage: 'scanning',
+      message: 'Refreshing Codex source logs: 42/118 projects',
+      source: 'codex',
+      current_project: 42,
+      total_projects: 118,
+      updated_at: '2026-07-29T00:00:00Z',
+    });
     vi.spyOn(api.shares, 'upload').mockImplementation(async () => {
       calls.push('upload');
       return {
@@ -218,6 +238,19 @@ describe('SubmitStep automatic-upload opt-in', () => {
       name: 'Submit and enable automatic uploads',
     }));
 
+    expect(await screen.findByText(
+      'Refreshing Codex source logs: 42/118 projects',
+      {},
+      { timeout: 2_000 },
+    )).toBeInTheDocument();
+    expect(screen.getByRole('button', {
+      name: 'Refreshing history...',
+    })).toBeDisabled();
+    await act(async () => {
+      enableRequest.resolve(automaticUploadStatus({ mode: 'enabled' }));
+      await Promise.resolve();
+    });
+
     await waitFor(() => {
       expect(onSubmitted).toHaveBeenCalledWith(
         'receipt-1',
@@ -232,6 +265,7 @@ describe('SubmitStep automatic-upload opt-in', () => {
       accepted_retention_version: 'retention-v1',
       accepted_ownership_certification_version: 'ownership-v1',
       accepted_authorization_profile_hash: 'profile-hash-v3',
+      progress_id: expect.any(String),
     });
     expect(toast).toHaveBeenCalledWith(
       'Submitted and automatic uploads enabled',

--- a/clawjournal/web/frontend/src/views/Share/SubmitStep.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/SubmitStep.test.tsx
@@ -246,6 +246,14 @@ describe('SubmitStep automatic-upload opt-in', () => {
     expect(screen.getByRole('button', {
       name: 'Refreshing history...',
     })).toBeDisabled();
+    // The reported scan has to reach the bar itself, not just the text under
+    // it: 42 of 118 projects sits inside the enrollment band, above anything
+    // the timed crawl can reach on its own.
+    await waitFor(() => {
+      expect(
+        Number(screen.getByRole('progressbar').getAttribute('aria-valuenow')),
+      ).toBe(97);
+    });
     await act(async () => {
       enableRequest.resolve(automaticUploadStatus({ mode: 'enabled' }));
       await Promise.resolve();

--- a/clawjournal/web/frontend/src/views/Share/SubmitStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/SubmitStep.tsx
@@ -1,11 +1,16 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { api, ApiError } from '../../api.ts';
+import {
+  createAutoUploadEnableProgressId,
+  startAutoUploadEnableProgressPolling,
+} from '../../autoUploadEnableProgress.ts';
 import { colors } from '../../theme.ts';
 import { Spinner } from '../../components/Spinner.tsx';
 import { challengeFromError } from '../../components/autoUploadChallenge.ts';
 import type {
   AutoUploadAgent,
   AutoUploadAuthorizationChallenge,
+  AutoUploadEnableProgress,
   AutoUploadStatus,
 } from '../../types.ts';
 import type { HostedConsent, ShareDestination } from './types.ts';
@@ -68,6 +73,8 @@ export function SubmitStep(p: SubmitStepProps) {
   const [showAutomaticUploadDetails, setShowAutomaticUploadDetails] = useState(false);
   const [showAcceptedDomains, setShowAcceptedDomains] = useState(false);
   const [enablingAutomaticUploads, setEnablingAutomaticUploads] = useState(false);
+  const [automaticUploadEnableProgress, setAutomaticUploadEnableProgress] =
+    useState<AutoUploadEnableProgress | null>(null);
   const [busy, setBusy] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [submitStageIndex, setSubmitStageIndex] = useState(0);
@@ -280,6 +287,11 @@ export function SubmitStep(p: SubmitStepProps) {
       let automaticUploadEnabled = false;
       if (enableAutomaticUploads && autoUploadChallenge) {
         setEnablingAutomaticUploads(true);
+        const progressId = createAutoUploadEnableProgressId();
+        const stopProgressPolling = startAutoUploadEnableProgressPolling(
+          progressId,
+          setAutomaticUploadEnableProgress,
+        );
         try {
           await api.autoUpload.enable({
             agent: automaticUploadAgent(autoUploadChallenge),
@@ -290,6 +302,7 @@ export function SubmitStep(p: SubmitStepProps) {
               autoUploadChallenge.ownership_certification.version,
             accepted_authorization_profile_hash:
               autoUploadChallenge.authorization_profile_hash,
+            progress_id: progressId,
           });
           automaticUploadEnabled = true;
         } catch {
@@ -301,6 +314,8 @@ export function SubmitStep(p: SubmitStepProps) {
             'info',
           );
         } finally {
+          stopProgressPolling();
+          setAutomaticUploadEnableProgress(null);
           setEnablingAutomaticUploads(false);
         }
       }
@@ -354,9 +369,25 @@ export function SubmitStep(p: SubmitStepProps) {
   const supportContact = consent?.support_contact || p.shareDestination?.support_contact || null;
   const currentSubmitStage = enablingAutomaticUploads
     ? {
-        buttonLabel: 'Enabling automatic uploads...',
-        detail: 'Confirming the exact recurring scope and installing the session hook.',
-        progress: 96,
+        buttonLabel: automaticUploadEnableProgress?.stage === 'waiting_for_scan_lock'
+          ? 'Waiting for scanner...'
+          : automaticUploadEnableProgress?.stage === 'scanning'
+            ? 'Refreshing history...'
+            : 'Enabling automatic uploads...',
+        detail: automaticUploadEnableProgress?.message
+          ?? 'Confirming the exact recurring scope and installing the session hook.',
+        progress: automaticUploadEnableProgress?.stage === 'scanning'
+          && automaticUploadEnableProgress.current_project !== null
+          && automaticUploadEnableProgress.total_projects
+          ? Math.min(
+              99,
+              94 + Math.round(
+                5
+                * automaticUploadEnableProgress.current_project
+                / automaticUploadEnableProgress.total_projects,
+              ),
+            )
+          : 96,
       }
     : submitStages[submitStageIndex] ?? submitStages[0];
   const submitPipelineLabel = p.aiPiiEnabled

--- a/clawjournal/web/frontend/src/views/Share/SubmitStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/SubmitStep.tsx
@@ -218,8 +218,13 @@ export function SubmitStep(p: SubmitStepProps) {
         setSubmitProgress((prev) => Math.max(prev, stage.progress));
       }, stage.delayMs)
     ));
+    // `Math.min` alone would claw a higher value back down to the ceiling once
+    // the enrollment phase reports real progress above it, so the crawl only
+    // ever moves forward.
     const tick = window.setInterval(() => {
-      setSubmitProgress((prev) => Math.min(92, prev + (prev < 64 ? 3 : 1)));
+      setSubmitProgress((prev) => (
+        prev >= 92 ? prev : Math.min(92, prev + (prev < 64 ? 3 : 1))
+      ));
     }, 700);
 
     return () => {
@@ -227,6 +232,31 @@ export function SubmitStep(p: SubmitStepProps) {
       window.clearInterval(tick);
     };
   }, [submitting, submitStages]);
+
+  // Enrollment is the one phase that knows how much work is left, so it drives
+  // the bar directly instead of leaving it on the timed crawl. The band starts
+  // at the value the phase already showed, so beginning the refresh never
+  // reads as losing ground.
+  const enrollmentProgress = useMemo(() => {
+    if (!enablingAutomaticUploads) return null;
+    const scan = automaticUploadEnableProgress;
+    if (
+      scan?.stage === 'scanning'
+      && scan.current_project !== null
+      && scan.total_projects
+    ) {
+      return Math.min(
+        99,
+        96 + Math.round(3 * scan.current_project / scan.total_projects),
+      );
+    }
+    return 96;
+  }, [enablingAutomaticUploads, automaticUploadEnableProgress]);
+
+  useEffect(() => {
+    if (enrollmentProgress === null) return;
+    setSubmitProgress((prev) => Math.max(prev, enrollmentProgress));
+  }, [enrollmentProgress]);
 
   const sendCode = async () => {
     if (!email.trim()) return;
@@ -376,18 +406,7 @@ export function SubmitStep(p: SubmitStepProps) {
             : 'Enabling automatic uploads...',
         detail: automaticUploadEnableProgress?.message
           ?? 'Confirming the exact recurring scope and installing the session hook.',
-        progress: automaticUploadEnableProgress?.stage === 'scanning'
-          && automaticUploadEnableProgress.current_project !== null
-          && automaticUploadEnableProgress.total_projects
-          ? Math.min(
-              99,
-              94 + Math.round(
-                5
-                * automaticUploadEnableProgress.current_project
-                / automaticUploadEnableProgress.total_projects,
-              ),
-            )
-          : 96,
+        progress: enrollmentProgress ?? 96,
       }
     : submitStages[submitStageIndex] ?? submitStages[0];
   const submitPipelineLabel = p.aiPiiEnabled
@@ -728,7 +747,14 @@ export function SubmitStep(p: SubmitStepProps) {
                     }} />
                     {currentSubmitStage.detail}
                   </div>
-                  <div style={{ height: 4, background: colors.gray200, borderRadius: 2, overflow: 'hidden' }}>
+                  <div
+                    role="progressbar"
+                    aria-label="Submission progress"
+                    aria-valuenow={submitProgress}
+                    aria-valuemin={0}
+                    aria-valuemax={100}
+                    style={{ height: 4, background: colors.gray200, borderRadius: 2, overflow: 'hidden' }}
+                  >
                     <div style={{
                       width: `${submitProgress}%`,
                       height: '100%',

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -346,6 +346,8 @@ _share_rate_lock = threading.Lock()
 _share_zip_cache_lock = threading.RLock()
 _share_package_progress_lock = threading.Lock()
 _share_package_progress: dict[str, dict[str, Any]] = {}
+_auto_upload_enable_progress_lock = threading.Lock()
+_auto_upload_enable_progress: dict[str, dict[str, Any]] = {}
 _auto_upload_run_lock = threading.Lock()
 _auto_upload_run_thread: threading.Thread | None = None
 _HOSTED_EMAIL_SUFFIXES_DEFAULT = (".edu", ".ac.uk", ".edu.au", ".edu.cn", "ac.jp", "rayward.ai")
@@ -2136,6 +2138,48 @@ def _get_share_package_progress(share_id: str) -> dict[str, Any] | None:
         return dict(payload) if payload is not None else None
 
 
+def _set_auto_upload_enable_progress(
+    progress_id: str,
+    *,
+    stage: str,
+    message: str,
+    source: str | None = None,
+    current_project: int | None = None,
+    total_projects: int | None = None,
+) -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "progress_id": progress_id,
+        "stage": stage,
+        "message": message,
+        "source": source,
+        "current_project": current_project,
+        "total_projects": total_projects,
+        "updated_at": datetime.now(timezone.utc).isoformat(),
+    }
+    with _auto_upload_enable_progress_lock:
+        if (
+            progress_id not in _auto_upload_enable_progress
+            and len(_auto_upload_enable_progress) >= 100
+        ):
+            oldest = min(
+                _auto_upload_enable_progress,
+                key=lambda key: _auto_upload_enable_progress[key].get(
+                    "updated_at", ""
+                ),
+            )
+            _auto_upload_enable_progress.pop(oldest, None)
+        _auto_upload_enable_progress[progress_id] = payload
+    return dict(payload)
+
+
+def _get_auto_upload_enable_progress(
+    progress_id: str,
+) -> dict[str, Any] | None:
+    with _auto_upload_enable_progress_lock:
+        payload = _auto_upload_enable_progress.get(progress_id)
+        return dict(payload) if payload is not None else None
+
+
 def _share_zip_input_snapshot(export_dir: Path) -> dict[str, Any]:
     missing = [
         name for name in _SHARE_ZIP_REQUIRED_FILES
@@ -3798,6 +3842,11 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             self._handle_share_upload_status()
         elif path == "/api/auto-upload/status":
             self._handle_auto_upload_status()
+        elif path.startswith("/api/auto-upload/enable-progress/"):
+            progress_id = unquote(
+                path[len("/api/auto-upload/enable-progress/"):]
+            )
+            self._handle_auto_upload_enable_progress(progress_id)
         elif path == "/api/auto-upload/preview":
             self._handle_auto_upload_preview(refresh=False)
         elif path == "/api/scoring/backend":
@@ -5027,6 +5076,15 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
 
         self._send_auto_upload_result(status())
 
+    def _handle_auto_upload_enable_progress(
+        self, progress_id: str
+    ) -> None:
+        payload = _get_auto_upload_enable_progress(progress_id)
+        if payload is None:
+            _json_response(self, {"error": "Enable progress not found"}, 404)
+            return
+        _json_response(self, payload)
+
     def _handle_auto_upload_preview(self, *, refresh: bool) -> None:
         from ..auto_upload import preview
 
@@ -5036,35 +5094,115 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         from ..auto_upload import enable
 
         body = _read_body(self) or {}
-        self._send_auto_upload_result(
-            enable(
-                agent=str(body.get("agent") or "all"),
-                accepted_authorization_version=(
-                    str(body["accepted_authorization_version"])
-                    if body.get("accepted_authorization_version") is not None
-                    else None
+        profile_hash = (
+            str(body["accepted_authorization_profile_hash"])
+            if body.get("accepted_authorization_profile_hash") is not None
+            else None
+        )
+        progress_id = (
+            str(body["progress_id"])
+            if body.get("progress_id") is not None
+            else None
+        )
+        track_progress = (
+            bool(progress_id)
+            and bool(profile_hash)
+            and not bool(body.get("challenge_only"))
+        )
+
+        if track_progress and (
+            len(progress_id or "") > 128
+            or re.fullmatch(r"[A-Za-z0-9._:-]+", progress_id or "") is None
+        ):
+            _json_response(self, {"error": "Invalid progress identifier"}, 400)
+            return
+
+        def scan_wait_notice() -> None:
+            if progress_id is not None:
+                _set_auto_upload_enable_progress(
+                    progress_id,
+                    stage="waiting_for_scan_lock",
+                    message="Waiting for another scan to finish before refreshing...",
+                )
+
+        def scan_progress(source: str, current: int, total: int) -> None:
+            if progress_id is None:
+                return
+            source_label = {
+                "claude": "Claude Code",
+                "codex": "Codex",
+            }.get(source, source)
+            _set_auto_upload_enable_progress(
+                progress_id,
+                stage="scanning",
+                message=(
+                    f"Refreshing {source_label} source logs: "
+                    f"{current}/{total} projects"
                 ),
-                accepted_retention_version=(
-                    str(body["accepted_retention_version"])
-                    if body.get("accepted_retention_version") is not None
-                    else None
-                ),
-                accepted_ownership_certification_version=(
-                    str(body["accepted_ownership_certification_version"])
-                    if body.get("accepted_ownership_certification_version") is not None
-                    else None
-                ),
-                accepted_authorization_profile_hash=(
-                    str(body["accepted_authorization_profile_hash"])
-                    if body.get("accepted_authorization_profile_hash") is not None
-                    else None
-                ),
-                challenge_only=bool(body.get("challenge_only")),
-                prepare_for_manual_share=bool(
-                    body.get("prepare_for_manual_share")
+                source=source,
+                current_project=current,
+                total_projects=total,
+            )
+
+        if track_progress and progress_id is not None:
+            _set_auto_upload_enable_progress(
+                progress_id,
+                stage="checking_hosted_service",
+                message="Checking the hosted service and current terms...",
+            )
+
+        enable_kwargs: dict[str, Any] = {
+            "agent": str(body.get("agent") or "all"),
+            "accepted_authorization_version": (
+                str(body["accepted_authorization_version"])
+                if body.get("accepted_authorization_version") is not None
+                else None
+            ),
+            "accepted_retention_version": (
+                str(body["accepted_retention_version"])
+                if body.get("accepted_retention_version") is not None
+                else None
+            ),
+            "accepted_ownership_certification_version": (
+                str(body["accepted_ownership_certification_version"])
+                if body.get("accepted_ownership_certification_version") is not None
+                else None
+            ),
+            "accepted_authorization_profile_hash": profile_hash,
+            "challenge_only": bool(body.get("challenge_only")),
+            "prepare_for_manual_share": bool(
+                body.get("prepare_for_manual_share")
+            ),
+        }
+        if track_progress:
+            enable_kwargs["scan_progress"] = scan_progress
+            enable_kwargs["scan_wait_notice"] = scan_wait_notice
+
+        try:
+            result = enable(**enable_kwargs)
+        except Exception:
+            if track_progress and progress_id is not None:
+                _set_auto_upload_enable_progress(
+                    progress_id,
+                    stage="failed",
+                    message="Automatic upload could not be enabled.",
+                )
+            raise
+
+        if track_progress and progress_id is not None:
+            _set_auto_upload_enable_progress(
+                progress_id,
+                stage="complete" if result.get("ok") else "failed",
+                message=(
+                    "Automatic upload enabled."
+                    if result.get("ok")
+                    else str(
+                        result.get("message")
+                        or "Automatic upload could not be enabled."
+                    )
                 ),
             )
-        )
+        self._send_auto_upload_result(result)
 
     def _handle_auto_upload_run(self) -> None:
         global _auto_upload_run_thread

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -336,6 +336,7 @@ def _delete(port, path, *, skip_auth=False):
     ("method", "path"),
     [
         ("get", "/api/auto-upload/status"),
+        ("get", "/api/auto-upload/enable-progress/missing-profile"),
         ("get", "/api/auto-upload/preview"),
         ("post", "/api/auto-upload/preview"),
         ("post", "/api/auto-upload/enable"),
@@ -431,6 +432,84 @@ def test_auto_upload_enable_forwards_authorization_profile_hash(server, monkeypa
             "prepare_for_manual_share": False,
         }
     ]
+
+
+def test_auto_upload_enable_reports_lock_wait_and_scan_progress(server, monkeypatch):
+    from clawjournal import auto_upload
+
+    waiting = Event()
+    continue_to_scan = Event()
+    scanning = Event()
+    finish = Event()
+    response = {}
+    profile_hash = "profile-progress-v2"
+    progress_id = "progress-issue165"
+
+    def fake_enable(**kwargs):
+        kwargs["scan_wait_notice"]()
+        waiting.set()
+        if not continue_to_scan.wait(timeout=5):
+            raise AssertionError("test did not release scan-lock wait")
+        kwargs["scan_progress"]("codex", 42, 118)
+        scanning.set()
+        if not finish.wait(timeout=5):
+            raise AssertionError("test did not release scan progress")
+        return {"ok": True, "mode": "enabled", "health": "ready"}
+
+    monkeypatch.setattr(auto_upload, "enable", fake_enable)
+
+    def post_enable():
+        response["value"] = _post(
+            server,
+            "/api/auto-upload/enable",
+            {
+                "agent": "codex",
+                "accepted_authorization_profile_hash": profile_hash,
+                "progress_id": progress_id,
+            },
+        )
+
+    thread = Thread(target=post_enable, daemon=True)
+    thread.start()
+    try:
+        assert waiting.wait(timeout=5)
+        status_code, body = _get(
+            server, f"/api/auto-upload/enable-progress/{progress_id}"
+        )
+        assert status_code == 200
+        assert body == {
+            "progress_id": progress_id,
+            "stage": "waiting_for_scan_lock",
+            "message": "Waiting for another scan to finish before refreshing...",
+            "source": None,
+            "current_project": None,
+            "total_projects": None,
+            "updated_at": body["updated_at"],
+        }
+
+        continue_to_scan.set()
+        assert scanning.wait(timeout=5)
+        status_code, body = _get(
+            server, f"/api/auto-upload/enable-progress/{progress_id}"
+        )
+        assert status_code == 200
+        assert body["stage"] == "scanning"
+        assert body["source"] == "codex"
+        assert body["current_project"] == 42
+        assert body["total_projects"] == 118
+        assert body["message"] == "Refreshing Codex source logs: 42/118 projects"
+    finally:
+        continue_to_scan.set()
+        finish.set()
+        thread.join(timeout=5)
+
+    assert response["value"][0] == 200
+    status_code, body = _get(
+        server, f"/api/auto-upload/enable-progress/{progress_id}"
+    )
+    assert status_code == 200
+    assert body["stage"] == "complete"
+    assert body["message"] == "Automatic upload enabled."
 
 
 def test_auto_upload_enable_forwards_manual_share_preparation(server, monkeypatch):

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -512,6 +512,105 @@ def test_auto_upload_enable_reports_lock_wait_and_scan_progress(server, monkeypa
     assert body["message"] == "Automatic upload enabled."
 
 
+@pytest.mark.parametrize(
+    ("label", "progress_id"),
+    [
+        ("path traversal", "../../etc/passwd"),
+        ("over the length cap", "a" * 129),
+        ("embedded whitespace", "has spaces"),
+        ("non-ascii", "pr\u00f6gress"),
+    ],
+)
+def test_auto_upload_enable_rejects_an_unusable_progress_id(
+    server, monkeypatch, label, progress_id
+):
+    """The progress id is client-supplied and becomes a URL path segment.
+
+    It is only ever a dict key today, but the filter is what keeps it that way,
+    so it is pinned rather than left to the reader to re-derive.
+    """
+    from clawjournal import auto_upload
+
+    called = []
+    monkeypatch.setattr(
+        auto_upload,
+        "enable",
+        lambda **kwargs: called.append(kwargs) or {"ok": True, "mode": "enabled"},
+    )
+
+    status, body = _post(
+        server,
+        "/api/auto-upload/enable",
+        {
+            "accepted_authorization_profile_hash": "profile-hash",
+            "progress_id": progress_id,
+        },
+    )
+
+    assert status == 400, label
+    assert body["error"] == "Invalid progress identifier"
+    # Rejected before the enrollment call, not after.
+    assert called == []
+
+
+def test_read_only_challenge_creates_no_progress_state(server, monkeypatch):
+    """`challenge_only` cannot enroll, so it must not publish enable progress."""
+    from clawjournal import auto_upload
+
+    monkeypatch.setattr(
+        auto_upload,
+        "enable",
+        lambda **kwargs: {"ok": True, "mode": "off", "challenge": {}},
+    )
+
+    status, _body = _post(
+        server,
+        "/api/auto-upload/enable",
+        {
+            "accepted_authorization_profile_hash": "profile-hash",
+            "progress_id": "challenge-only-probe",
+            "challenge_only": True,
+        },
+    )
+    assert status == 200
+
+    status, _body = _get(
+        server, "/api/auto-upload/enable-progress/challenge-only-probe"
+    )
+    assert status == 404
+
+
+def test_auto_upload_enable_publishes_the_refusal_reason(server, monkeypatch):
+    """A refused enrollment ends in a terminal stage carrying its reason.
+
+    Without this the poller's last word is whatever stage it happened to catch,
+    so the dialog would sit on "scanning" after the attempt was already over.
+    """
+    from clawjournal import auto_upload
+
+    monkeypatch.setattr(
+        auto_upload,
+        "enable",
+        lambda **kwargs: {"ok": False, "message": "Hosted submissions are closed."},
+    )
+
+    _post(
+        server,
+        "/api/auto-upload/enable",
+        {
+            "accepted_authorization_profile_hash": "profile-hash",
+            "progress_id": "refused-enrollment",
+        },
+    )
+
+    status, body = _get(
+        server, "/api/auto-upload/enable-progress/refused-enrollment"
+    )
+    assert status == 200
+    assert body["stage"] == "failed"
+    assert body["message"] == "Hosted submissions are closed."
+
+
 def test_auto_upload_enable_forwards_manual_share_preparation(server, monkeypatch):
     from clawjournal import auto_upload
 


### PR DESCRIPTION
## Summary
- expose local recurring-enrollment progress through an authenticated polling endpoint
- show hosted capability checks, scan-lock waiting, current source, and project counts while enable is in flight
- cover both the Auto Upload authorization dialog and the combined manual-share enrollment path
- correlate each request with a unique progress ID so retries and multiple tabs cannot surface stale progress
- preserve the existing hosted protocol and CLI behavior

## Validation
- `python -m pytest tests/workbench/test_daemon.py -q` — 225 passed
- `npm --prefix clawjournal/web/frontend test -- --run` — 87 passed
- `npm --prefix clawjournal/web/frontend run build` — passed
- `git diff --check origin/main...HEAD` — passed

Closes #165