### PR TITLE
feat(share): auto-include safe traces

### DIFF
--- a/clawjournal/web/frontend/src/views/Share/ReviewStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/ReviewStep.tsx
@@ -3,7 +3,7 @@ import { RedactedText } from '../../components/RedactedText.tsx';
 import { ToolUseCard } from '../../components/ToolUseCard.tsx';
 import { colors } from '../../theme.ts';
 import type { ReadySession, RedactedSessionData } from './types.ts';
-import { aggregateCategories, classify, formatTokens, hexAlpha, sessionTotalTokens } from './helpers.ts';
+import { aggregateCategories, classify, formatTokens, sessionTotalTokens } from './helpers.ts';
 import { SHARE_SHELL_WIDTH, btnGhost, btnPrimary, btnSecondary } from './styles.tsx';
 import { HelpModal, Icon, SourceBadge, StatusDot, ThinkingBlock, UsageDisclosure } from './shared.tsx';
 
@@ -18,8 +18,7 @@ export interface ReviewStepProps {
   aiPiiEnabled: boolean;
   onToggleExpand: (id: string) => void;
   onApprove: (id: string) => void;
-  onApproveAllClean: () => void;
-  onRemove: (id: string) => void;
+  onExclude: (id: string) => void;
   onRetryAi: (id: string) => void;
   onBack: () => void;
   onPackage: () => void;
@@ -30,6 +29,7 @@ export interface ReviewStepProps {
 
 export function ReviewStep(p: ReviewStepProps) {
   const [visibleCount, setVisibleCount] = useState(REVIEW_PAGE_SIZE);
+  const [showDetails, setShowDetails] = useState(false);
   const sorted = [...p.queuedSessions].sort((a, b) => {
     const sa = classify(p.redactedSessions[a.session_id]);
     const sb = classify(p.redactedSessions[b.session_id]);
@@ -38,10 +38,11 @@ export function ReviewStep(p: ReviewStepProps) {
   });
 
   const approvedCount = p.queuedSessions.filter((s) => p.approvedIds.has(s.session_id)).length;
-  const allApproved = p.queuedSessions.length > 0 && approvedCount === p.queuedSessions.length;
-  const cleanUnapprovedCount = p.queuedSessions.filter((s) => (
-    classify(p.redactedSessions[s.session_id]) === 'clear' && !p.approvedIds.has(s.session_id)
+  const needsReviewCount = p.queuedSessions.filter((s) => (
+    classify(p.redactedSessions[s.session_id]) === 'review'
   )).length;
+  const excludedCount = p.queuedSessions.length - approvedCount;
+  const canPackage = approvedCount > 0;
   const visibleSessions = sorted.slice(0, visibleCount);
   const hiddenCount = sorted.length - visibleSessions.length;
 
@@ -53,52 +54,41 @@ export function ReviewStep(p: ReviewStepProps) {
         <button onClick={p.onBack} style={btnGhost}>&larr; Back to redaction</button>
       </div>
       <h1 style={{ margin: '0 0 6px', fontSize: 22, fontWeight: 600, color: colors.gray900 }}>
-        Review what you&rsquo;re sharing
+        Ready to package
       </h1>
       <p style={{ margin: '0 0 20px', fontSize: 14, color: colors.gray500, maxWidth: '60ch', lineHeight: 1.55 }}>
-        You&rsquo;re the last checkpoint before packaging. Include each trace &mdash; or drop it
-        &mdash; so you know exactly what&rsquo;s in the zip.
+        Safe traces are included automatically. Anything uncertain stays out unless you
+        choose to review and include it.
       </p>
 
       <UsageDisclosure onLearnMore={() => p.setShowHelp(true)} aiPiiEnabled={p.aiPiiEnabled} />
 
-      {/* Bulk progress bar */}
       <div style={{
-        position: 'sticky', top: 0, zIndex: 6,
-        background: allApproved
-          ? `linear-gradient(90deg, rgba(250,248,245,0.95), ${hexAlpha('#558745', 0.12)}, rgba(250,248,245,0.95))`
-          : 'rgba(250,248,245,0.95)',
-        backdropFilter: 'blur(6px)',
-        padding: '10px 14px', marginBottom: 14,
+        padding: '16px', marginBottom: 14, background: colors.white,
         border: `1px solid ${colors.gray200}`, borderRadius: 8,
-        display: 'flex', alignItems: 'center', gap: 12, fontSize: 13,
+        display: 'grid', gridTemplateColumns: 'repeat(3, minmax(0, 1fr))', gap: 12,
       }}>
-        <span style={{
-          fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
-          fontVariantNumeric: 'tabular-nums', color: colors.gray900,
-        }}>
-          <strong style={{ color: allApproved ? colors.green500 : colors.gray900 }}>{approvedCount}</strong>
-          <span style={{ color: colors.gray500 }}> / {p.queuedSessions.length} included</span>
-        </span>
-        <span style={{ color: colors.gray500, fontSize: 12, marginRight: 'auto' }}>
-          {allApproved
-            ? 'All traces included. Ready to package.'
-            : 'Tap each card to inspect. You can include one-by-one or all clean ones at once.'}
-        </span>
-        <button
-          onClick={p.onApproveAllClean}
-          disabled={cleanUnapprovedCount === 0}
-          style={{
-            ...btnSecondary, padding: '6px 12px', fontSize: 12.5,
-            opacity: cleanUnapprovedCount === 0 ? 0.4 : 1,
-            cursor: cleanUnapprovedCount === 0 ? 'not-allowed' : 'pointer',
-          }}
-        >
-          Include all clean ({cleanUnapprovedCount})
-        </button>
+        <SummaryStat value={p.queuedSessions.length} label="traces processed" />
+        <SummaryStat value={approvedCount} label="ready to share" color={colors.green500} />
+        <SummaryStat
+          value={excludedCount}
+          label={needsReviewCount > 0 ? `not included · ${needsReviewCount} need review` : 'not included'}
+          color={excludedCount > 0 ? colors.yellow700 : colors.gray500}
+        />
       </div>
 
-      <div>
+      <div style={{ display: 'flex', alignItems: 'center', marginBottom: showDetails ? 12 : 0 }}>
+        <button onClick={() => setShowDetails((shown) => !shown)} style={btnSecondary} aria-expanded={showDetails}>
+          {showDetails ? 'Hide review details' : 'Review details'}
+        </button>
+        {!showDetails && needsReviewCount > 0 && (
+          <span style={{ marginLeft: 10, color: colors.gray500, fontSize: 12.5 }}>
+            Optional: inspect {needsReviewCount} excluded trace{needsReviewCount === 1 ? '' : 's'}.
+          </span>
+        )}
+      </div>
+
+      {showDetails && <div>
         {visibleSessions.map((s) => (
           <ReviewRow
             key={s.session_id}
@@ -109,7 +99,7 @@ export function ReviewStep(p: ReviewStepProps) {
             aiPiiEnabled={p.aiPiiEnabled}
             onToggle={() => p.onToggleExpand(s.session_id)}
             onApprove={() => p.onApprove(s.session_id)}
-            onRemove={() => p.onRemove(s.session_id)}
+            onExclude={() => p.onExclude(s.session_id)}
             onRetryAi={() => p.onRetryAi(s.session_id)}
           />
         ))}
@@ -124,7 +114,7 @@ export function ReviewStep(p: ReviewStepProps) {
             </button>
           </div>
         )}
-      </div>
+      </div>}
 
       <div style={{
         position: 'sticky', bottom: 0, marginTop: 14, paddingTop: 14,
@@ -138,7 +128,7 @@ export function ReviewStep(p: ReviewStepProps) {
         }}>
           <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
             <div style={{ fontSize: 13, color: colors.gray900 }}>
-              {allApproved ? 'All included — ready to package' : `${p.queuedSessions.length - approvedCount} still waiting on you`}
+              {canPackage ? `${approvedCount} trace${approvedCount === 1 ? '' : 's'} ready to package` : 'No traces are included yet'}
             </div>
             <div style={{ fontSize: 11.5, color: colors.gray500, fontVariantNumeric: 'tabular-nums' }}>
               Included traces will be packaged into draft-bundle.zip
@@ -147,11 +137,11 @@ export function ReviewStep(p: ReviewStepProps) {
           <div style={{ marginLeft: 'auto' }}>
             <button
               onClick={p.onPackage}
-              disabled={!allApproved}
-              style={{ ...btnPrimary, opacity: allApproved ? 1 : 0.4, cursor: allApproved ? 'pointer' : 'not-allowed' }}
+              disabled={!canPackage}
+              style={{ ...btnPrimary, opacity: canPackage ? 1 : 0.4, cursor: canPackage ? 'pointer' : 'not-allowed' }}
             >
               <Icon name="check" size={14} />
-              Package bundle
+              Package {approvedCount} trace{approvedCount === 1 ? '' : 's'}
             </button>
           </div>
         </div>
@@ -161,8 +151,21 @@ export function ReviewStep(p: ReviewStepProps) {
   );
 }
 
+function SummaryStat({ value, label, color = colors.gray900 }: { value: number; label: string; color?: string }) {
+  return (
+    <div>
+      <div style={{
+        color, fontSize: 22, fontWeight: 600,
+        fontFamily: 'ui-monospace, SFMono-Regular, Menlo, monospace',
+        fontVariantNumeric: 'tabular-nums',
+      }}>{value}</div>
+      <div style={{ color: colors.gray500, fontSize: 12, marginTop: 2 }}>{label}</div>
+    </div>
+  );
+}
+
 function ReviewRow({
-  session, data, approved, expanded, aiPiiEnabled, onToggle, onApprove, onRemove, onRetryAi,
+  session, data, approved, expanded, aiPiiEnabled, onToggle, onApprove, onExclude, onRetryAi,
 }: {
   session: ReadySession;
   data: RedactedSessionData | undefined;
@@ -171,7 +174,7 @@ function ReviewRow({
   aiPiiEnabled: boolean;
   onToggle: () => void;
   onApprove: () => void;
-  onRemove: () => void;
+  onExclude: () => void;
   onRetryAi: () => void;
 }) {
   const status = classify(data);
@@ -255,7 +258,7 @@ function ReviewRow({
                 width: 16, height: 16, borderRadius: '50%',
                 border: `1.5px dashed ${colors.gray400}`,
               }} />
-              {status === 'review' ? 'Needs your eyes' : 'Awaiting you'}
+              {status === 'review' ? 'Excluded — needs review' : 'Not included'}
             </span>
           )}
         </div>
@@ -398,12 +401,13 @@ function ReviewRow({
             <span style={{ fontSize: 12, color: colors.gray500, marginRight: 'auto' }}>
               {approved
                 ? 'Included with the redactions shown above.'
-                : 'Include if the redacted version looks good. Remove if not.'}
+                : 'This trace is currently excluded. Include it only if the redacted version looks good.'}
             </span>
-            <button onClick={onRemove} style={btnSecondary}>
-              Remove from bundle
-            </button>
-            {!approved && (
+            {approved ? (
+              <button onClick={onExclude} style={btnSecondary}>
+                Exclude from bundle
+              </button>
+            ) : (
               <button onClick={onApprove} style={btnPrimary}>
                 <Icon name="check" size={13} />
                 Include in bundle

--- a/clawjournal/web/frontend/src/views/Share/helpers.test.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.test.ts
@@ -1,11 +1,30 @@
 import { describe, expect, it } from 'vitest';
 import type { ReadySession, ShareReadyStats } from './types.ts';
 import {
+  classify,
   hasLockedQueueSelection,
   queueFromSelectionParams,
   queueFromStats,
   writeQueueSelectionParams,
 } from './helpers.ts';
+
+describe('Share review defaults', () => {
+  it('auto-clears deterministic-only results when AI was intentionally disabled', () => {
+    expect(classify({ messages: [], loading: false, aiCoverage: 'disabled' })).toBe('clear');
+  });
+
+  it('fails closed when an enabled AI pass was unavailable or uncertain', () => {
+    expect(classify({ messages: [], loading: false, aiCoverage: 'rules_only' })).toBe('review');
+    expect(classify({
+      messages: [],
+      loading: false,
+      aiCoverage: 'full',
+      aiPiiFindings: [{
+        entity_type: 'person', entity_text: 'masked', confidence: 0.5, field: 'content', source: 'ai',
+      }],
+    })).toBe('review');
+  });
+});
 
 export function readySession(id: string): ReadySession {
   return {

--- a/clawjournal/web/frontend/src/views/Share/helpers.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.ts
@@ -260,7 +260,11 @@ export function parseStep(value: string | null): StepKey {
 
 export function classify(d: RedactedSessionData | undefined): 'checking' | 'clear' | 'review' {
   if (!d || d.loading) return 'checking';
-  if (d.aiCoverage === 'rules_only' || d.aiCoverage === 'disabled') return 'review';
+  // `disabled` is an explicit user choice: the deterministic redaction and
+  // policy passes still completed, so these traces can follow the one-click
+  // safe default. `rules_only` means an enabled AI pass was unavailable and
+  // remains a genuine uncertainty, so fail closed and leave it out.
+  if (d.aiCoverage === 'rules_only') return 'review';
   const lowConf = (d.aiPiiFindings || []).some(f => f.confidence < CONFIDENCE_THRESHOLD);
   if (lowConf) return 'review';
   return 'clear';

--- a/clawjournal/web/frontend/src/views/Share/index.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.test.tsx
@@ -624,3 +624,68 @@ describe('Redaction completion', () => {
     expect(redactionSpy.mock.calls.map(([id]) => id)).toEqual(['s1', 's2']);
   });
 });
+
+describe('One-click review defaults', () => {
+  it('auto-includes deterministic-only traces and preserves a manual exclusion', async () => {
+    mockInitialLoad(readyStats(2));
+    vi.spyOn(api.sessions, 'redactionReport').mockImplementation(async (id) => ({
+      session_id: id,
+      redaction_count: 0,
+      redaction_log: [],
+      ai_pii_findings: [],
+      ai_coverage: 'disabled',
+      redacted_session: { messages: [] },
+    }) as unknown as Awaited<ReturnType<typeof api.sessions.redactionReport>>);
+
+    render(
+      <MemoryRouter initialEntries={['/share']}>
+        <ToastProvider><Share /></ToastProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('2 traces selected')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Redact & review' }));
+    expect(await screen.findByText('Redaction complete')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Review what I.m sharing/ }));
+
+    expect(await screen.findByRole('heading', { name: 'Ready to package' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Package 2 traces' })).toBeEnabled();
+    expect(screen.queryByText('Trace s1')).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Review details' }));
+    fireEvent.click(screen.getByText('Trace s1'));
+    fireEvent.click(screen.getByRole('button', { name: 'Exclude from bundle' }));
+    expect(screen.getByRole('button', { name: 'Package 1 trace' })).toBeEnabled();
+
+    fireEvent.click(screen.getByRole('button', { name: /Back to redaction/ }));
+    fireEvent.click(screen.getByRole('button', { name: /Review what I.m sharing/ }));
+    expect(await screen.findByRole('button', { name: 'Package 1 trace' })).toBeEnabled();
+  });
+
+  it('leaves an AI-unavailable trace out without blocking the safe subset', async () => {
+    mockInitialLoad(readyStats(2));
+    vi.spyOn(api.sessions, 'redactionReport').mockImplementation(async (id) => ({
+      session_id: id,
+      redaction_count: 0,
+      redaction_log: [],
+      ai_pii_findings: [],
+      ai_coverage: id === 's1' ? 'full' : 'rules_only',
+      redacted_session: { messages: [] },
+    }) as unknown as Awaited<ReturnType<typeof api.sessions.redactionReport>>);
+
+    render(
+      <MemoryRouter initialEntries={['/share?ai_pii=1']}>
+        <ToastProvider><Share /></ToastProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('2 traces selected')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Redact & review' }));
+    expect(await screen.findByText('Redaction complete')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /Review what I.m sharing/ }));
+
+    expect(await screen.findByRole('button', { name: 'Package 1 trace' })).toBeEnabled();
+    expect(screen.getByText('Optional: inspect 1 excluded trace.')).toBeInTheDocument();
+    expect(screen.getByText('not included · 1 need review')).toBeInTheDocument();
+  });
+});

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -211,6 +211,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
 
   // Review state
   const [approvedIds, setApprovedIds] = useState<Set<string>>(new Set());
+  const [manuallyExcludedIds, setManuallyExcludedIds] = useState<Set<string>>(new Set());
   const [expandedReviewIds, setExpandedReviewIds] = useState<Set<string>>(new Set());
 
   // Package state
@@ -338,6 +339,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
     setPackagedShareId(searchParams.get('share'));
     setRedactedSessions({});
     setApprovedIds(new Set());
+    setManuallyExcludedIds(new Set());
     setExpandedReviewIds(new Set());
     setBundleInfo(null);
     setReceiptId(null);
@@ -403,6 +405,15 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
       return changed ? next : prev;
     });
     setApprovedIds((prev) => {
+      let changed = false;
+      const next = new Set<string>();
+      for (const id of prev) {
+        if (queueSet.has(id)) next.add(id);
+        else changed = true;
+      }
+      return changed ? next : prev;
+    });
+    setManuallyExcludedIds((prev) => {
       let changed = false;
       const next = new Set<string>();
       for (const id of prev) {
@@ -618,6 +629,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
     setConfirmedLargeQueueIds(null);
     setRedactedSessions({});
     setApprovedIds(new Set());
+    setManuallyExcludedIds(new Set());
     setExpandedReviewIds(new Set());
     setPackagedShareId(null);
     setPackageProgress(0);
@@ -672,6 +684,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
     setAiPiiEnabled(false);
     setRedactedSessions({});
     setApprovedIds(new Set());
+    setManuallyExcludedIds(new Set());
     setExpandedReviewIds(new Set());
     setBundleInfo(null);
     setReceiptId(null);
@@ -889,11 +902,21 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
 
   const goToReview = () => {
     setCompletedKeys((prev) => new Set([...prev, 'queue', 'redact']));
-    // Auto-expand the first unapproved trace for immediate attention.
-    const firstUnapproved = queuedSessions.find((s) => !approvedIds.has(s.session_id));
-    if (firstUnapproved) {
-      setExpandedReviewIds(new Set([firstUnapproved.session_id]));
-    }
+    // The deterministic/AI result supplies the safe default. Clear traces are
+    // included in one batch; uncertain traces fail closed but no longer block
+    // packaging the safe subset. Details remain available for manual changes.
+    setApprovedIds((previous) => new Set(
+      queuedSessions
+        .filter((s) => (
+          previous.has(s.session_id)
+          || (
+            !manuallyExcludedIds.has(s.session_id)
+            && classify(redactedSessions[s.session_id]) === 'clear'
+          )
+        ))
+        .map((s) => s.session_id),
+    ));
+    setExpandedReviewIds(new Set());
     setActiveStep('review');
   };
 
@@ -903,6 +926,12 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
 
   const approveTrace = (id: string) => {
     setApprovedIds((prev) => new Set([...prev, id]));
+    setManuallyExcludedIds((prev) => {
+      if (!prev.has(id)) return prev;
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
     // auto-advance: collapse this row, expand next unapproved
     setExpandedReviewIds((prev) => {
       const n = new Set(prev);
@@ -920,14 +949,13 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
     });
   };
 
-  const approveAllClean = () => {
+  const excludeTrace = (id: string) => {
     setApprovedIds((prev) => {
-      const n = new Set(prev);
-      queuedSessions.forEach((s) => {
-        if (classify(redactedSessions[s.session_id]) === 'clear') n.add(s.session_id);
-      });
-      return n;
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
     });
+    setManuallyExcludedIds((prev) => new Set([...prev, id]));
   };
 
   const retryAiReview = async (id: string) => {
@@ -1136,7 +1164,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
   }, [installingScanners, runPackage, toast]);
 
   const handleStartPackage = () => {
-    if (queuedSessions.length === 0) return;
+    if (approvedSessions.length === 0) return;
     cancelAiRetries();
     setCompletedKeys((prev) => new Set([...prev, 'queue', 'redact', 'review']));
     setActiveStep('package');
@@ -1352,8 +1380,7 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
         aiPiiEnabled={aiPiiEnabled}
         onToggleExpand={toggleReviewExpand}
         onApprove={approveTrace}
-        onApproveAllClean={approveAllClean}
-        onRemove={removeFromQueue}
+        onExclude={excludeTrace}
         onRetryAi={retryAiReview}
         onBack={() => {
           cancelAiRetries();


### PR DESCRIPTION
## Summary

- automatically include traces that clear deterministic and configured AI review
- treat intentionally disabled AI as a valid deterministic-only path while excluding AI-unavailable or low-confidence traces by default
- replace per-trace blocking approval with a package-ready summary and optional review details
- preserve manual include/exclude choices when moving back through the wizard
- keep final secret-scan, PII, hold-state, and packaging gates unchanged

## Testing

- `npm test` (88 tests passed)
- `npx eslint src/views/Share/ReviewStep.tsx src/views/Share/helpers.ts src/views/Share/helpers.test.ts src/views/Share/index.tsx src/views/Share/index.test.tsx`
- `npm run build`
- `git diff --check`