### PR TITLE
fix: add safe recovery for corrupted workbench indexes

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ If you are unsure at any point, stop before **Submit**. Your review and package 
 ## Privacy in plain English
 
 - **Local by default.** Scanning and reviewing create a local index and local copies of your agent sessions. Those copies can contain the original text.
+- **Index recovery is backup-first.** The workbench checks its local SQLite index at startup. If the index is damaged, database-backed work and uploads stay stopped while the UI offers one guided action that backs up the old index before rebuilding it from the original agent logs.
 - **AI features are optional.** If you enable them, ClawJournal removes home-folder paths and usernames locally first. The remaining session text is sent to the AI service you choose and may still contain identifying details.
 - **Sharing has safety checks.** Redaction and secret scans run before a package can be submitted. One scanner may contact a credential provider to check whether a suspected secret is live. A missing or failed required scan blocks sharing.
 - **Automatic uploads remain off until a successful manual share.** When the hosted recurring terms are available, the final Submit screen selects the combined “submit and enable” action by default, automatically includes every observed recurring-capable source, shows the exact cadence/cap, and links to the full terms and source/project pairs. You can uncheck it before submitting. After the manual receipt is saved, recurring setup is queued locally and continues in the daemon without holding the receipt screen open; closing the browser does not cancel it, and restarting `clawjournal serve` resumes it. If automatic uploads are already configured, the same row stays checked and locked; review, pause, or turn them off from Settings.
@@ -175,6 +176,14 @@ clawjournal --help                       # see every command
 ```
 
 If `clawjournal` is not found, use the full command printed by the installer.
+
+On a cluster or another machine whose home directory is on a shared/network
+filesystem, set `CLAWJOURNAL_HOME` to a private, persistent local-filesystem
+directory before first use. For an existing install, stop ClawJournal and move
+the whole state directory together (index, review state, tokens, and local trace
+copies) before setting the variable; setting it alone selects a separate state
+root. For example, use `export CLAWJOURNAL_HOME=/local/path/clawjournal` on
+macOS/Linux or `$env:CLAWJOURNAL_HOME='D:\local\clawjournal'` in PowerShell.
 
 `clawjournal skill` uses one optional AI distill call to propose up to five
 coding-agent lessons. Its preview names one human-facing weekly focus only when a

--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -729,11 +729,11 @@ def status(*, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
         from .workbench import index as index_module
 
         path = Path(index_module.INDEX_DB)
-        if not path.exists():
+        if not path.exists() or index_module._index_recovery_marker_path().exists():
             return _off_status(config)
         try:
-            db = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True)
-        except sqlite3.Error:
+            db = index_module.open_existing_index(readonly=True)
+        except (OSError, sqlite3.Error):
             return _off_status(config)
         db.row_factory = sqlite3.Row
         own_connection = True
@@ -743,7 +743,7 @@ def status(*, conn: sqlite3.Connection | None = None) -> dict[str, Any]:
         try:
             enrollment = get_auto_upload_enrollment(db)
             enrollment_job = get_auto_upload_enrollment_job(db)
-        except sqlite3.DatabaseError:
+        except (OSError, sqlite3.DatabaseError):
             return _off_status(config)
         report = _candidate_report(db, enrollment, config=config)
         successful_manual = _has_successful_manual_receipt(db)
@@ -887,7 +887,7 @@ def preview(
         from .workbench import index as index_module
 
         path = Path(index_module.INDEX_DB)
-        if not path.exists():
+        if not path.exists() or index_module._index_recovery_marker_path().exists():
             return {
                 "ok": True,
                 "eligible": [],
@@ -902,15 +902,14 @@ def preview(
                 "limit": MAX_SESSIONS,
             }
         try:
-            readonly = sqlite3.connect(path.resolve().as_uri() + "?mode=ro", uri=True)
-            readonly.row_factory = sqlite3.Row
+            readonly = index_module.open_existing_index(readonly=True)
             try:
                 enrollment = get_auto_upload_enrollment(readonly)
                 report = _candidate_report(readonly, enrollment, now=now)
                 return {"ok": True, **report}
             finally:
                 readonly.close()
-        except sqlite3.DatabaseError:
+        except (OSError, sqlite3.DatabaseError):
             return AutoUploadError(
                 "index_upgrade_required",
                 "Refresh the local index before previewing automatic uploads.",
@@ -5039,15 +5038,15 @@ def _open_existing_hook_index() -> sqlite3.Connection | None:
 
     path = Path(index_module.INDEX_DB)
     try:
-        if not path.is_file():
+        if (
+            not path.is_file()
+            or index_module._index_recovery_marker_path().exists()
+        ):
             return None
-        conn = sqlite3.connect(
-            path.resolve().as_uri() + "?mode=rw",
-            uri=True,
+        conn = index_module.open_existing_index(
             timeout=HOOK_DB_BUSY_TIMEOUT_MS / 1000,
             isolation_level=None,
         )
-        conn.row_factory = sqlite3.Row
         conn.execute(f"PRAGMA busy_timeout={HOOK_DB_BUSY_TIMEOUT_MS}")
         return conn
     except (OSError, sqlite3.Error):

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -14,6 +14,7 @@ from typing import Any, Mapping, cast
 
 from .redaction.anonymizer import Anonymizer
 from .config import (
+    CONFIG_DIR,
     CONFIG_FILE,
     ClawJournalConfig,
     load_config,
@@ -46,6 +47,13 @@ from .redaction.secrets import _has_mixed_char_types, _shannon_entropy, redact_s
 
 REPO_URL = "https://github.com/rayward-external/clawjournal"
 SKILL_URL = "https://raw.githubusercontent.com/rayward-external/clawjournal/main/skills/clawjournal/SKILL.md"
+
+
+def _argparse_path(path: Path) -> str:
+    """Escape a dynamic path for argparse's percent-formatted help text."""
+
+    return str(path).replace("%", "%%")
+
 
 REQUIRED_REVIEW_ATTESTATIONS: dict[str, str] = {
     "asked_full_name": "I asked the user for their full name and scanned for it.",
@@ -1195,7 +1203,12 @@ def prep(source_filter: str = "auto") -> None:
             from .parsing.parser import GEMINI_DIR
             err = f"{GEMINI_DIR} was not found."
         else:
-            err = "None of ~/.claude, ~/.claude-science, ~/.codex, ~/.gemini/tmp, ~/WorkBuddy, or ~/.clawjournal/workbuddy were found."
+            err = (
+                "No supported session sources were found. Checked the standard "
+                "agent directories (~/.claude, ~/.claude-science, ~/.codex, "
+                f"~/.gemini/tmp, ~/WorkBuddy), {WORKBUDDY_IMPORT_DIR}, and "
+                f"{CUSTOM_DIR}."
+            )
         print(json.dumps({"error": err}))
         sys.exit(1)
 
@@ -4201,7 +4214,10 @@ def main() -> None:
     th_sub = th.add_subparsers(dest="trufflehog_command")
     th_install = th_sub.add_parser(
         "install",
-        help="Download the pinned, checksum-verified TruffleHog into ~/.clawjournal/bin")
+        help=(
+            "Download the pinned, checksum-verified TruffleHog into "
+            f"{_argparse_path(CONFIG_DIR / 'bin')}"
+        ))
     th_install.add_argument("--force", action="store_true",
                             help="Reinstall even if a managed binary already exists")
     th_install.add_argument("--json", action="store_true", help="Output result as JSON")
@@ -4214,7 +4230,10 @@ def main() -> None:
     bl_sub = bl.add_subparsers(dest="betterleaks_command")
     bl_install = bl_sub.add_parser(
         "install",
-        help="Download the pinned, checksum-verified Betterleaks into ~/.clawjournal/bin")
+        help=(
+            "Download the pinned, checksum-verified Betterleaks into "
+            f"{_argparse_path(CONFIG_DIR / 'bin')}"
+        ))
     bl_install.add_argument("--force", action="store_true",
                             help="Reinstall even if a managed binary already exists")
     bl_install.add_argument("--json", action="store_true", help="Output result as JSON")
@@ -4335,7 +4354,10 @@ def main() -> None:
         dest="output",
         type=str,
         default=None,
-        help="Output path (default: ~/.clawjournal/exports/clawjournal-bundle-<hash>.json)",
+        help=(
+            "Output path (default: "
+            f"{_argparse_path(CONFIG_DIR / 'exports' / 'clawjournal-bundle-<hash>.json')})"
+        ),
     )
     events_export.add_argument(
         "--no-snippets",
@@ -6620,7 +6642,7 @@ def _run_events_search(args) -> None:
                     code=9,
                     kind=KIND_UNSPECIFIED,
                     message=f"FTS rebuild failed: {exc}",
-                    hint="check `~/.clawjournal/index.db` is writable",
+                    hint=f"check `{CONFIG_DIR / 'index.db'}` is writable",
                     request_id=request_id,
                     json_mode=json_mode,
                 )
@@ -7102,7 +7124,13 @@ def _run_export(args) -> None:
             from .parsing.parser import GEMINI_DIR
             print(f"Error: {GEMINI_DIR} not found.", file=sys.stderr)
         else:
-            print("Error: none of ~/.claude, ~/.claude-science, ~/.codex, ~/.gemini/tmp, ~/WorkBuddy, or ~/.clawjournal/workbuddy were found.", file=sys.stderr)
+            print(
+                "Error: no supported session sources were found. Checked the "
+                "standard agent directories (~/.claude, ~/.claude-science, "
+                f"~/.codex, ~/.gemini/tmp, ~/WorkBuddy), {WORKBUDDY_IMPORT_DIR}, "
+                f"and {CUSTOM_DIR}.",
+                file=sys.stderr,
+            )
         sys.exit(1)
 
     projects = discover_projects(source_filter=source_filter)

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -1,4 +1,4 @@
-"""Persistent config for ClawJournal — stored at ~/.clawjournal/config.json"""
+"""Persistent ClawJournal state rooted at ``CLAWJOURNAL_HOME`` or ``~/.clawjournal``."""
 
 import json
 import os
@@ -9,7 +9,20 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator, Mapping, TypedDict, cast
 
-CONFIG_DIR = Path.home() / ".clawjournal"
+# Keep the install as one coherent state root: the index, blobs, API token,
+# finding hash salt, share ledger, and recurring-upload authority are coupled.
+# An environment override gives shared-home/HPC users a supported way to place
+# that whole state on SQLite-safe storage without splitting those invariants.
+def _resolve_config_dir() -> Path:
+    override = os.environ.get("CLAWJOURNAL_HOME", "").strip()
+    return (
+        Path(override).expanduser().resolve()
+        if override
+        else Path.home() / ".clawjournal"
+    )
+
+
+CONFIG_DIR = _resolve_config_dir()
 CONFIG_FILE = CONFIG_DIR / "config.json"
 AUTO_UPLOAD_EGRESS_LOCK_FILENAME = "auto-upload-egress.lock"
 

--- a/clawjournal/config.py
+++ b/clawjournal/config.py
@@ -25,6 +25,7 @@ def _resolve_config_dir() -> Path:
 CONFIG_DIR = _resolve_config_dir()
 CONFIG_FILE = CONFIG_DIR / "config.json"
 AUTO_UPLOAD_EGRESS_LOCK_FILENAME = "auto-upload-egress.lock"
+INDEX_RECOVERY_MARKER_FILENAME = "index-recovery-in-progress.json"
 
 
 @contextmanager
@@ -334,9 +335,15 @@ def save_config(config: ClawJournalConfig) -> bool:
                 # a caller holding its own write transaction while saving
                 # config) must not stall for long or fail the config write.
                 index_path = CONFIG_DIR / "index.db"
-                if index_path.exists():
+                recovery_marker = CONFIG_DIR / INDEX_RECOVERY_MARKER_FILENAME
+                if index_path.exists() and not recovery_marker.exists():
                     try:
-                        conn = sqlite3.connect(index_path, timeout=5)
+                        # Import lazily: ``workbench.index`` imports this module.
+                        # The guarded opener holds a cross-process lease so a
+                        # recovery cannot retire the database under this stamp.
+                        from .workbench.index import open_existing_index
+
+                        conn = open_existing_index(timeout=5)
                         try:
                             conn.execute("BEGIN IMMEDIATE")
                             mark_auto_upload_profile_changed(conn)
@@ -346,7 +353,7 @@ def save_config(config: ClawJournalConfig) -> bool:
                             raise
                         finally:
                             conn.close()
-                    except sqlite3.Error as e:
+                    except (OSError, sqlite3.Error) as e:
                         print(
                             "Warning: could not pause automatic upload after a "
                             f"profile change: {e}",

--- a/clawjournal/events/doctor/overlay.py
+++ b/clawjournal/events/doctor/overlay.py
@@ -18,6 +18,7 @@ import warnings
 from pathlib import Path
 from typing import Any, Mapping
 
+from clawjournal import config as config_module
 from clawjournal.events.capabilities import CAPABILITY_MATRIX
 from clawjournal.events.types import EVENT_TYPES
 
@@ -28,7 +29,7 @@ SUPPORTED_OVERLAY_CLIENTS = ("claude", "codex", "openclaw")
 
 
 def overlay_path() -> Path:
-    return Path.home() / ".clawjournal" / OVERLAY_FILENAME
+    return Path(config_module.CONFIG_DIR) / OVERLAY_FILENAME
 
 
 _cached_matrix: dict[tuple[str, str], tuple[bool, str]] | None = None

--- a/clawjournal/events/doctor/probes.py
+++ b/clawjournal/events/doctor/probes.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
+from clawjournal import config as config_module
 from clawjournal.events.capabilities import effective_matrix
 from clawjournal.events.export.bundle import (
     BUNDLE_SCHEMA_VERSION,
@@ -27,6 +28,7 @@ from clawjournal.events.export.bundle import (
 from clawjournal.events.types import EVENT_TYPE_SET
 from clawjournal.parsing import parser as parser_mod
 from clawjournal.redaction import trufflehog as th
+from clawjournal.workbench import index as index_module
 
 # Install-state branches (per plan 08 §Install-state probe)
 INSTALL_FRESH = "fresh"
@@ -116,7 +118,7 @@ class DoctorReport:
 
 
 def config_dir() -> Path:
-    return Path.home() / ".clawjournal"
+    return Path(config_module.CONFIG_DIR)
 
 
 def index_db_path() -> Path:
@@ -252,10 +254,12 @@ def _classify_install_state(
 
 
 def _open_readonly(path: Path) -> sqlite3.Connection | None:
+    conn: sqlite3.Connection | None = None
     try:
-        uri = f"file:{path}?mode=ro"
-        conn = sqlite3.connect(uri, uri=True)
-        conn.row_factory = sqlite3.Row
+        conn = index_module.open_existing_index(
+            database=path,
+            readonly=True,
+        )
         # Single read transaction snapshot — every query runs against
         # one consistent view even when serve is writing.
         conn.execute("BEGIN")
@@ -263,9 +267,9 @@ def _open_readonly(path: Path) -> sqlite3.Connection | None:
         # `sqlite_master` is the cheapest read that will surface that.
         conn.execute("SELECT name FROM sqlite_master LIMIT 1").fetchone()
         return conn
-    except sqlite3.OperationalError:
-        return None
-    except sqlite3.DatabaseError:
+    except (OSError, sqlite3.Error):
+        if conn is not None:
+            conn.close()
         return None
 
 

--- a/clawjournal/events/doctor/render.py
+++ b/clawjournal/events/doctor/render.py
@@ -178,7 +178,7 @@ def _suggested_next_steps(report: DoctorReport) -> list[str]:
         )
         lines.append(
             "inspect a schema_unknown row: `clawjournal events inspect "
-            "<event_id>` (find ids via `sqlite3 ~/.clawjournal/index.db "
+            f"<event_id>` (find ids via `sqlite3 \"{report.index_db_path}\" "
             "\"SELECT id FROM events WHERE type='schema_unknown' LIMIT 5\"`)"
         )
     if has_unknown:

--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+from ..config import CONFIG_DIR
 from ..redaction.anonymizer import Anonymizer
 from ..redaction.secrets import redact_text
 
@@ -63,13 +64,13 @@ COPILOT_DIR = Path.home() / ".copilot" / "session-state"
 AIDER_HISTORY_FILENAME = ".aider.chat.history.md"
 WORKBUDDY_DIR = Path.home() / "WorkBuddy"
 WORKBUDDY_AI_PROJECTS_DIR = Path.home() / ".workbuddy-ai" / "projects"
-WORKBUDDY_IMPORT_DIR = Path.home() / ".clawjournal" / "workbuddy"
+WORKBUDDY_IMPORT_DIR = CONFIG_DIR / "workbuddy"
 WORKBUDDY_MAX_FILE_BYTES = 100 * 1024 * 1024
 WORKBUDDY_MAX_ZIP_MEMBER_BYTES = 25 * 1024 * 1024
 WORKBUDDY_TRACE_SUFFIXES = {".json", ".jsonl", ".ndjson", ".log"}
 WORKBUDDY_ARCHIVE_SUFFIXES = {".zip"}
 
-CUSTOM_DIR = Path.home() / ".clawjournal" / "custom"
+CUSTOM_DIR = CONFIG_DIR / "custom"
 
 # Claude Desktop local-agent-mode-sessions (macOS only for now)
 LOCAL_AGENT_DIR = (

--- a/clawjournal/web/frontend/src/App.test.tsx
+++ b/clawjournal/web/frontend/src/App.test.tsx
@@ -1,0 +1,129 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import App from './App.tsx';
+import { api } from './api.ts';
+import type { AdvisorData, Features, IndexHealth, Stats } from './types.ts';
+
+function features(indexHealth: IndexHealth): Features {
+  return {
+    benchmark_tab_enabled: true,
+    scoring_warmup_declined: true,
+    index_health: indexHealth,
+  };
+}
+
+const emptyStats: Stats = {
+  total: 0,
+  by_status: {},
+  by_source: {},
+  by_project: {},
+  by_task_type: {},
+};
+
+const emptyAdvisor: AdvisorData = {
+  generated_at: '2026-07-30T00:00:00Z',
+  period: 'test',
+  headline: '',
+  recommendations: [],
+  summary_stats: {
+    total_cost_usd: 0,
+    total_sessions: 0,
+    cost_per_session: 0,
+    most_efficient_model: null,
+    highest_quality_model: null,
+    potential_savings_usd: 0,
+  },
+};
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  window.history.replaceState({}, '', '/');
+});
+
+describe('workbench index startup gate', () => {
+  it('does not mount any DB-backed UI while recovery is required', async () => {
+    vi.spyOn(api, 'features').mockResolvedValue(features({
+      status: 'recovery_required',
+      message: 'The workbench index is damaged and must be rebuilt.',
+      automatic_recovery_available: true,
+    }));
+    const stats = vi.spyOn(api, 'stats');
+    const advisor = vi.spyOn(api, 'advisor');
+    const sessions = vi.spyOn(api.sessions, 'list');
+    const scoringWarmup = vi.spyOn(api, 'scoringWarmup');
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: 'Your local index needs repair' })).toBeInTheDocument();
+    expect(screen.queryByRole('link', { name: 'Sessions' })).not.toBeInTheDocument();
+    expect(stats).not.toHaveBeenCalled();
+    expect(advisor).not.toHaveBeenCalled();
+    expect(sessions).not.toHaveBeenCalled();
+    expect(scoringWarmup).not.toHaveBeenCalled();
+  });
+
+  it('mounts the normal workbench only after a successful ready probe', async () => {
+    vi.spyOn(api, 'features').mockResolvedValue(features({ status: 'ready' }));
+    vi.spyOn(api, 'stats').mockResolvedValue(emptyStats);
+    vi.spyOn(api, 'advisor').mockResolvedValue(emptyAdvisor);
+    vi.spyOn(api.sessions, 'list').mockResolvedValue([]);
+    vi.spyOn(api, 'scoringWarmup').mockResolvedValue({ status: 'declined' });
+    localStorage.setItem('cj.gettingStartedGuideV2Dismissed', '1');
+
+    render(<App />);
+
+    expect(screen.getByText('Checking the local index...')).toBeInTheDocument();
+    expect(await screen.findByRole('link', { name: 'Sessions' })).toBeInTheDocument();
+    await waitFor(() => expect(api.sessions.list).toHaveBeenCalled());
+  });
+
+  it('polls rebuilding health until the verified index is ready', async () => {
+    const rebuilding = features({
+      status: 'rebuilding',
+      stage: 'reindexing',
+      message: 'Rebuilding from source logs...',
+    });
+    const ready = features({ status: 'ready' });
+    const featureProbe = vi.spyOn(api, 'features')
+      .mockResolvedValueOnce(rebuilding)
+      // The polling cadence switches as soon as the first result changes the
+      // status, which causes one immediate fresh probe before the 1s interval.
+      .mockResolvedValueOnce(rebuilding)
+      .mockResolvedValue(ready);
+    vi.spyOn(api, 'stats').mockResolvedValue(emptyStats);
+    vi.spyOn(api, 'advisor').mockResolvedValue(emptyAdvisor);
+    vi.spyOn(api.sessions, 'list').mockResolvedValue([]);
+    vi.spyOn(api, 'scoringWarmup').mockResolvedValue({ status: 'declined' });
+    localStorage.setItem('cj.gettingStartedGuideV2Dismissed', '1');
+
+    render(<App />);
+
+    expect(await screen.findByRole('heading', { name: 'Rebuilding your local index' })).toBeInTheDocument();
+    await waitFor(() => expect(featureProbe).toHaveBeenCalledTimes(2));
+    await waitFor(
+      () => expect(screen.getByRole('link', { name: 'Sessions' })).toBeInTheDocument(),
+      { timeout: 3_000 },
+    );
+    expect(featureProbe.mock.calls.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('surfaces the backup and recovery warnings without another required action', async () => {
+    vi.spyOn(api, 'features').mockResolvedValue(features({
+      status: 'ready',
+      backup_path: 'D:/state/index-backups/recovery-1',
+      restored_state_counts: { session_decisions: 3, policies: 1 },
+      warnings: ['Automatic uploads were restored paused and must be reviewed.'],
+    }));
+    vi.spyOn(api, 'stats').mockResolvedValue(emptyStats);
+    vi.spyOn(api, 'advisor').mockResolvedValue(emptyAdvisor);
+    vi.spyOn(api.sessions, 'list').mockResolvedValue([]);
+    vi.spyOn(api, 'scoringWarmup').mockResolvedValue({ status: 'declined' });
+    localStorage.setItem('cj.gettingStartedGuideV2Dismissed', '1');
+
+    render(<App />);
+
+    expect(await screen.findByText('Index rebuilt and verified.')).toBeInTheDocument();
+    expect(screen.getByText(/Restored 4 saved state records/)).toBeInTheDocument();
+    expect(screen.getByText('Automatic uploads were restored paused and must be reviewed.')).toBeInTheDocument();
+  });
+});

--- a/clawjournal/web/frontend/src/App.tsx
+++ b/clawjournal/web/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { BrowserRouter, Routes, Route, NavLink, Navigate, useLocation } from 'react-router-dom';
 import { Inbox } from './views/Inbox.tsx';
 import { Search } from './views/Search.tsx';
@@ -12,11 +12,12 @@ import { Benchmark } from './views/Benchmark.tsx';
 import { Settings } from './views/Settings.tsx';
 import { ToastProvider } from './components/Toast.tsx';
 import { ConfirmDialog } from './components/ConfirmDialog.tsx';
+import { IndexRecoveryScreen } from './components/IndexRecoveryScreen.tsx';
 import { WorkflowProgress } from './components/WorkflowProgress.tsx';
 import { workflowProgressStageFor } from './components/workflowProgressStage.ts';
 import { colors, fontFamily } from './theme.ts';
 import { api, ApiError } from './api.ts';
-import type { Features } from './types.ts';
+import type { Features, IndexHealth } from './types.ts';
 
 interface SidebarCounts {
   toReview: number;
@@ -153,38 +154,97 @@ function WorkflowProgressTracker({ submittedShareId }: { submittedShareId: strin
   return <WorkflowProgress stage={stage} />;
 }
 
+function IndexRecoverySummary({ health }: { health: IndexHealth }) {
+  if (!health.backup_path) return null;
+  const warnings = Array.isArray(health.warnings) ? health.warnings : [];
+  const restoredCounts = health.restored_state_counts ?? health.restored_counts ?? {};
+  const restoredTotal = Object.values(restoredCounts).reduce(
+    (total, value) => total + (Number.isFinite(value) && value > 0 ? value : 0),
+    0,
+  );
+  const hasWarnings = warnings.length > 0;
+
+  return (
+    <div
+      role={hasWarnings ? 'alert' : 'status'}
+      aria-live="polite"
+      style={{
+        padding: '10px 16px',
+        flexShrink: 0,
+        borderBottom: `1px solid ${hasWarnings ? colors.yellow200 : colors.green200}`,
+        background: hasWarnings ? colors.yellow50 : colors.green50,
+        color: hasWarnings ? colors.yellow700 : colors.green700,
+        fontSize: 12.5,
+        lineHeight: 1.5,
+      }}
+    >
+      <strong>Index rebuilt and verified.</strong>{' '}
+      The original index is backed up at <code style={{ overflowWrap: 'anywhere' }}>{health.backup_path}</code>.
+      {restoredTotal > 0 && <> Restored {restoredTotal} saved state record{restoredTotal === 1 ? '' : 's'}.</>}
+      {hasWarnings && (
+        <ul style={{ margin: '5px 0 0', paddingLeft: 20 }}>
+          {warnings.map((warning) => <li key={warning}>{warning}</li>)}
+        </ul>
+      )}
+    </div>
+  );
+}
+
 export default function App() {
-  // Feature flags + the persisted auto-scorer decline come from /api/features.
-  // benchmark_tab_enabled is initialised true so the common case never flashes;
-  // only an explicitly-disabled install briefly shows the tab before it resolves.
-  const [features, setFeatures] = useState<Features>({
-    benchmark_tab_enabled: true,
-    scoring_warmup_declined: false,
-  });
-  const benchmarkEnabled = features.benchmark_tab_enabled;
+  // /api/features is deliberately DB-free and carries the cached startup
+  // integrity diagnosis. Keep DB-backed views unmounted until its first
+  // successful ready result.
+  const [features, setFeatures] = useState<Features | null>(null);
+  const [featuresError, setFeaturesError] = useState<string | null>(null);
+  const indexHealth = features?.index_health ?? null;
+  const indexReady = indexHealth?.status === 'ready';
+  const benchmarkEnabled = features?.benchmark_tab_enabled ?? true;
   const [submittedShareId, setSubmittedShareId] = useState<string | null>(null);
 
   // The same probe doubles as a connectivity check: the loopback daemon going
   // away (e.g. `clawjournal serve` stopped) otherwise just renders zero counts
   // silently. A persistent banner makes that state visible.
   const [daemonReachable, setDaemonReachable] = useState(true);
+  const featureProbeVersion = useRef(0);
   useEffect(() => {
     let cancelled = false;
-    const probe = () => api.features()
-      .then(f => { if (!cancelled) { setFeatures(f); setDaemonReachable(true); } })
+    const probe = () => {
+      const version = ++featureProbeVersion.current;
+      return api.features()
+        .then(f => {
+          if (cancelled || version !== featureProbeVersion.current) return;
+          const next = f.index_health
+            ? f
+            : {
+                ...f,
+                index_health: {
+                  status: 'unavailable' as const,
+                  message: 'This workbench version did not report index health.',
+                },
+              };
+          setFeatures(next);
+          setFeaturesError(null);
+          setDaemonReachable(true);
+        })
       // An ApiError means the daemon answered (any HTTP status) — connectivity is
       // fine. Only a fetch-level failure (network/daemon down) flips the banner.
-      .catch(err => { if (!cancelled) setDaemonReachable(err instanceof ApiError); });
+        .catch(err => {
+          if (cancelled || version !== featureProbeVersion.current) return;
+          setFeaturesError(err instanceof Error ? err.message : 'Could not check index health.');
+          setDaemonReachable(err instanceof ApiError);
+        });
+    };
     probe();
-    const iv = setInterval(probe, 20_000);
+    const iv = setInterval(probe, indexHealth?.status === 'rebuilding' ? 1_000 : 20_000);
     return () => { cancelled = true; clearInterval(iv); };
-  }, []);
+  }, [indexHealth?.status]);
 
   // Deferred, non-blocking warmup prompt (replaces the old mount-time
   // window.confirm). The server gates this: a previously-declined install
   // returns status 'declined', so we never re-prompt.
   const [warmupPrompt, setWarmupPrompt] = useState<{ backend: string; displayName: string } | null>(null);
   useEffect(() => {
+    if (!indexReady) return;
     let cancelled = false;
     const timer = window.setTimeout(async () => {
       try {
@@ -201,7 +261,7 @@ export default function App() {
       cancelled = true;
       window.clearTimeout(timer);
     };
-  }, []);
+  }, [indexReady]);
 
   const confirmWarmup = async () => {
     const prompt = warmupPrompt;
@@ -214,10 +274,16 @@ export default function App() {
 
   const declineWarmup = async () => {
     setWarmupPrompt(null);
-    setFeatures(f => ({ ...f, scoring_warmup_declined: true }));
+    setFeatures(f => f ? ({ ...f, scoring_warmup_declined: true }) : f);
     try {
       await api.scoringWarmup({ decline: true });
     } catch { /* opportunistic */ }
+  };
+
+  const updateIndexHealth = (health: IndexHealth) => {
+    // Invalidate a slower probe that may still contain the pre-rebuild state.
+    featureProbeVersion.current += 1;
+    setFeatures(current => current ? ({ ...current, index_health: health }) : current);
   };
 
   return (
@@ -244,40 +310,51 @@ export default function App() {
               Can’t reach the ClawJournal workbench. Is <code>clawjournal serve</code> still running?
             </div>
           )}
-          <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
-            <Sidebar />
-            <div style={{ display: 'flex', flex: 1, flexDirection: 'column', minWidth: 0, minHeight: 0 }}>
-              <main style={{ flex: 1, minHeight: 0, overflow: 'auto', background: colors.white }}>
-                <Routes>
-                  <Route path="/" element={<Inbox />} />
-                  <Route path="/search" element={<Search />} />
-                  <Route path="/session/:id" element={<SessionDetail />} />
-                  {/* Analytics groups the three read-only "understand" views as sub-tabs. */}
-                  <Route path="/analytics" element={<Analytics benchmarkEnabled={benchmarkEnabled} />}>
-                    <Route index element={<Dashboard />} />
-                    <Route path="insights" element={<Insights />} />
-                    <Route
-                      path="benchmark"
-                      element={benchmarkEnabled ? <Benchmark /> : <Navigate to="/analytics" replace />}
-                    />
-                  </Route>
-                  <Route path="/share" element={<Share onSubmittedShareChange={setSubmittedShareId} />} />
-                  <Route path="/share/rules" element={<Policies />} />
-                  <Route path="/settings" element={<Settings />} />
-                  {/* Back-compat redirects for the pre-regroup routes + bookmarks. */}
-                  <Route path="/dashboard" element={<Navigate to="/analytics" replace />} />
-                  <Route path="/insights" element={<Navigate to="/analytics/insights" replace />} />
-                  <Route path="/benchmark" element={<Navigate to="/analytics/benchmark" replace />} />
-                  <Route path="/bundles" element={<Navigate to="/share" replace />} />
-                  <Route path="/policies" element={<Navigate to="/share/rules" replace />} />
-                </Routes>
-              </main>
-              <WorkflowProgressTracker submittedShareId={submittedShareId} />
-            </div>
-          </div>
+          {indexReady && indexHealth ? (
+            <>
+              <IndexRecoverySummary health={indexHealth} />
+              <div style={{ display: 'flex', flex: 1, minHeight: 0 }}>
+                <Sidebar />
+                <div style={{ display: 'flex', flex: 1, flexDirection: 'column', minWidth: 0, minHeight: 0 }}>
+                  <main style={{ flex: 1, minHeight: 0, overflow: 'auto', background: colors.white }}>
+                    <Routes>
+                      <Route path="/" element={<Inbox />} />
+                      <Route path="/search" element={<Search />} />
+                      <Route path="/session/:id" element={<SessionDetail />} />
+                      {/* Analytics groups the three read-only "understand" views as sub-tabs. */}
+                      <Route path="/analytics" element={<Analytics benchmarkEnabled={benchmarkEnabled} />}>
+                        <Route index element={<Dashboard />} />
+                        <Route path="insights" element={<Insights />} />
+                        <Route
+                          path="benchmark"
+                          element={benchmarkEnabled ? <Benchmark /> : <Navigate to="/analytics" replace />}
+                        />
+                      </Route>
+                      <Route path="/share" element={<Share onSubmittedShareChange={setSubmittedShareId} />} />
+                      <Route path="/share/rules" element={<Policies />} />
+                      <Route path="/settings" element={<Settings />} />
+                      {/* Back-compat redirects for the pre-regroup routes + bookmarks. */}
+                      <Route path="/dashboard" element={<Navigate to="/analytics" replace />} />
+                      <Route path="/insights" element={<Navigate to="/analytics/insights" replace />} />
+                      <Route path="/benchmark" element={<Navigate to="/analytics/benchmark" replace />} />
+                      <Route path="/bundles" element={<Navigate to="/share" replace />} />
+                      <Route path="/policies" element={<Navigate to="/share/rules" replace />} />
+                    </Routes>
+                  </main>
+                  <WorkflowProgressTracker submittedShareId={submittedShareId} />
+                </div>
+              </div>
+            </>
+          ) : (
+            <IndexRecoveryScreen
+              health={indexHealth}
+              probeError={featuresError}
+              onHealthChange={updateIndexHealth}
+            />
+          )}
         </div>
         <ConfirmDialog
-          open={warmupPrompt !== null}
+          open={indexReady && warmupPrompt !== null}
           title="Turn on background AI scoring?"
           message={warmupPrompt
             ? `Run ${warmupPrompt.displayName} on your recent traces in the background to grade them? Each trace is anonymized on this machine (home-dir paths and usernames removed) before it is sent to your configured AI backend (${warmupPrompt.displayName}), which runs locally as a subprocess but may call its provider and incur usage cost.`

--- a/clawjournal/web/frontend/src/api.test.ts
+++ b/clawjournal/web/frontend/src/api.test.ts
@@ -24,6 +24,37 @@ describe('desktop open notification API', () => {
   });
 });
 
+describe('index recovery API', () => {
+  afterEach(() => {
+    delete window.__CLAWJOURNAL_API_TOKEN__;
+    vi.unstubAllGlobals();
+  });
+
+  it('starts the authenticated guided rebuild and returns its initial health', async () => {
+    window.__CLAWJOURNAL_API_TOKEN__ = 'recovery-test-token';
+    const payload = {
+      ok: true,
+      index_health: {
+        status: 'rebuilding' as const,
+        stage: 'queued',
+        message: 'Starting the safe index recovery...',
+      },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 202,
+      json: async () => payload,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.index.rebuild()).resolves.toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith('/api/index/rebuild', {
+      method: 'POST',
+      headers: { Authorization: 'Bearer recovery-test-token' },
+    });
+  });
+});
+
 describe('automatic-upload API normalization', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -18,6 +18,7 @@ import type {
   FindingsAllowlistEntry,
   HoldHistoryEntry,
   HoldState,
+  IndexRebuildResponse,
   Benchmark,
   BenchmarkSummary,
   BenchmarkTrend,
@@ -318,6 +319,12 @@ export const api = {
 
   features(): Promise<Features> {
     return request('/features');
+  },
+
+  index: {
+    rebuild(): Promise<IndexRebuildResponse> {
+      return request('/index/rebuild', { method: 'POST' });
+    },
   },
 
   config: {

--- a/clawjournal/web/frontend/src/components/IndexRecoveryScreen.test.tsx
+++ b/clawjournal/web/frontend/src/components/IndexRecoveryScreen.test.tsx
@@ -1,0 +1,141 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api, ApiError } from '../api.ts';
+import type { IndexHealth, IndexRebuildResponse } from '../types.ts';
+import { IndexRecoveryScreen } from './IndexRecoveryScreen.tsx';
+
+function recoveryRequired(overrides: Partial<IndexHealth> = {}): IndexHealth {
+  return {
+    status: 'recovery_required',
+    message: 'The workbench index is damaged and must be rebuilt.',
+    automatic_recovery_available: true,
+    database_path: 'D:/state/index.db',
+    ...overrides,
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('IndexRecoveryScreen', () => {
+  it('offers one explicit action without adding a second confirmation dialog', () => {
+    render(
+      <IndexRecoveryScreen
+        health={recoveryRequired()}
+        onHealthChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Your local index needs repair' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back up and rebuild index' })).toBeEnabled();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByText(/Sharing and automatic uploads stay blocked/)).toBeInTheDocument();
+  });
+
+  it('submits once, disables the action, and accepts an asynchronous rebuilding response', async () => {
+    let resolveRebuild!: (value: IndexRebuildResponse) => void;
+    const rebuild = vi.spyOn(api.index, 'rebuild').mockImplementationOnce(() => (
+      new Promise(resolve => { resolveRebuild = resolve; })
+    ));
+    const onHealthChange = vi.fn();
+    render(
+      <IndexRecoveryScreen
+        health={recoveryRequired()}
+        onHealthChange={onHealthChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back up and rebuild index' }));
+    const busyButton = screen.getByRole('button', { name: 'Starting safe rebuild...' });
+    expect(busyButton).toBeDisabled();
+    fireEvent.click(busyButton);
+    expect(rebuild).toHaveBeenCalledTimes(1);
+
+    const rebuilding: IndexHealth = {
+      status: 'rebuilding',
+      stage: 'queued',
+      message: 'Starting the safe index recovery...',
+    };
+    await act(async () => {
+      resolveRebuild({ ok: true, index_health: rebuilding });
+    });
+
+    expect(onHealthChange).toHaveBeenCalledWith(rebuilding);
+  });
+
+  it('also accepts a rebuild that completes in the initial response', async () => {
+    const ready: IndexHealth = {
+      status: 'ready',
+      backup_path: 'D:/state/index-backups/recovery-2',
+      restored_state_counts: { session_decisions: 2 },
+      warnings: [],
+    };
+    vi.spyOn(api.index, 'rebuild').mockResolvedValueOnce({ ok: true, index_health: ready });
+    const onHealthChange = vi.fn();
+    render(
+      <IndexRecoveryScreen
+        health={recoveryRequired()}
+        onHealthChange={onHealthChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back up and rebuild index' }));
+
+    await waitFor(() => expect(onHealthChange).toHaveBeenCalledWith(ready));
+  });
+
+  it('keeps a failed recovery retryable and adopts health returned with the error', async () => {
+    const failedHealth = recoveryRequired({
+      message: 'Recovery did not finish. The original backup is intact.',
+      backup_path: 'D:/state/index-backups/recovery-1',
+    });
+    vi.spyOn(api.index, 'rebuild').mockRejectedValueOnce(new ApiError(
+      500,
+      'The source-log rescan did not complete cleanly.',
+      { index_health: failedHealth },
+    ));
+    const onHealthChange = vi.fn();
+    render(
+      <IndexRecoveryScreen
+        health={recoveryRequired()}
+        onHealthChange={onHealthChange}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'Back up and rebuild index' }));
+
+    expect(await screen.findByText('The source-log rescan did not complete cleanly.')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Back up and rebuild index' })).toBeEnabled();
+    expect(onHealthChange).toHaveBeenCalledWith(failedHealth);
+  });
+
+  it('shows progress or safe diagnostics without exposing a rebuild action', async () => {
+    const { rerender } = render(
+      <IndexRecoveryScreen
+        health={{ status: 'rebuilding', message: 'Restoring local decisions...' }}
+        onHealthChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Rebuilding your local index' })).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+
+    rerender(
+      <IndexRecoveryScreen
+        health={{
+          status: 'unavailable',
+          message: 'The state directory is not writable.',
+          automatic_recovery_available: false,
+        }}
+        onHealthChange={vi.fn()}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: 'The local index is unavailable' })).toBeInTheDocument();
+    });
+    expect(screen.getByText('The state directory is not writable.')).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+});

--- a/clawjournal/web/frontend/src/components/IndexRecoveryScreen.tsx
+++ b/clawjournal/web/frontend/src/components/IndexRecoveryScreen.tsx
@@ -1,0 +1,206 @@
+import { useState } from 'react';
+import { api, ApiError } from '../api.ts';
+import type { IndexHealth } from '../types.ts';
+import { colors, btnPrimary, fontFamily } from '../theme.ts';
+import { Spinner } from './Spinner.tsx';
+
+interface IndexRecoveryScreenProps {
+  health: IndexHealth | null;
+  probeError?: string | null;
+  onHealthChange: (health: IndexHealth) => void;
+}
+
+const HEALTH_STATUSES = new Set([
+  'ready',
+  'recovery_required',
+  'rebuilding',
+  'unavailable',
+]);
+
+function healthFromError(error: unknown): IndexHealth | null {
+  if (!(error instanceof ApiError)) return null;
+  const value = error.body.index_health;
+  if (
+    !value
+    || typeof value !== 'object'
+    || !('status' in value)
+    || typeof value.status !== 'string'
+    || !HEALTH_STATUSES.has(value.status)
+  ) {
+    return null;
+  }
+  return value as IndexHealth;
+}
+
+function DiagnosticDetails({ health }: { health: IndexHealth }) {
+  if (!health.detail && !health.database_path && !health.backup_path) return null;
+  return (
+    <details style={{ marginTop: 18, color: colors.gray500, fontSize: 12.5 }}>
+      <summary style={{ cursor: 'pointer', fontWeight: 600 }}>Technical details</summary>
+      <div style={{ marginTop: 8, lineHeight: 1.6, overflowWrap: 'anywhere' }}>
+        {health.detail && <div>{health.detail}</div>}
+        {health.database_path && <div>Index: <code>{health.database_path}</code></div>}
+        {health.backup_path && <div>Backup: <code>{health.backup_path}</code></div>}
+      </div>
+    </details>
+  );
+}
+
+export function IndexRecoveryScreen({
+  health,
+  probeError = null,
+  onHealthChange,
+}: IndexRecoveryScreenProps) {
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const startRecovery = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const result = await api.index.rebuild();
+      if (!result.index_health) {
+        throw new Error('The workbench did not return recovery progress.');
+      }
+      onHealthChange(result.index_health);
+    } catch (caught) {
+      const nextHealth = healthFromError(caught);
+      if (nextHealth) onHealthChange(nextHealth);
+      setError(caught instanceof Error ? caught.message : 'Index recovery could not be started.');
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  let content: React.ReactNode;
+
+  if (!health) {
+    content = probeError ? (
+      <div role="alert">
+        <h1 style={{ margin: '0 0 8px', fontSize: 21, color: colors.gray900 }}>
+          Cannot check the local index
+        </h1>
+        <p style={{ margin: 0, color: colors.red700, fontSize: 14, lineHeight: 1.55 }}>
+          {probeError} ClawJournal will retry automatically.
+        </p>
+      </div>
+    ) : (
+      <Spinner text="Checking the local index..." />
+    );
+  } else if (health.status === 'rebuilding') {
+    content = (
+      <div role="status" aria-live="polite" aria-busy="true">
+        <h1 style={{ margin: '0 0 6px', fontSize: 21, color: colors.gray900 }}>
+          Rebuilding your local index
+        </h1>
+        <p style={{ margin: '0 0 2px', color: colors.gray600, fontSize: 14, lineHeight: 1.55 }}>
+          ClawJournal keeps the original index in a backup while it rebuilds from your original session logs. Keep ClawJournal open until this finishes.
+        </p>
+        <Spinner text={health.message || 'Backing up and rebuilding...'} />
+        <DiagnosticDetails health={health} />
+      </div>
+    );
+  } else if (health.status === 'recovery_required') {
+    const canRecover = health.automatic_recovery_available !== false;
+    content = (
+      <div role="alert">
+        <h1 style={{ margin: '0 0 8px', fontSize: 21, color: colors.gray900 }}>
+          Your local index needs repair
+        </h1>
+        <p style={{ margin: '0 0 12px', color: colors.gray600, fontSize: 14, lineHeight: 1.55 }}>
+          {health.message || 'ClawJournal could not safely open its local index.'}
+        </p>
+        <p style={{ margin: '0 0 18px', color: colors.gray600, fontSize: 14, lineHeight: 1.55 }}>
+          ClawJournal will first save the current database, then rebuild the index from your original session logs and restore every readable review and safety decision. Sharing and automatic uploads stay blocked until recovery finishes.
+        </p>
+        <p style={{ margin: '0 0 18px', color: colors.gray500, fontSize: 12.5, lineHeight: 1.55 }}>
+          If this keeps happening on a shared or network home, stop ClawJournal, move the whole state directory to persistent local storage, and set <code>CLAWJOURNAL_HOME</code> to that directory before restarting.
+        </p>
+        {error && (
+          <div role="alert" style={{
+            marginBottom: 14,
+            padding: '10px 12px',
+            borderRadius: 8,
+            border: `1px solid ${colors.red200}`,
+            background: colors.red50,
+            color: colors.red700,
+            fontSize: 13,
+          }}>
+            {error}
+          </div>
+        )}
+        {canRecover ? (
+          <button
+            type="button"
+            onClick={startRecovery}
+            disabled={submitting}
+            style={{
+              ...btnPrimary,
+              fontWeight: 600,
+              opacity: submitting ? 0.65 : 1,
+              cursor: submitting ? 'wait' : 'pointer',
+            }}
+          >
+            {submitting ? 'Starting safe rebuild...' : 'Back up and rebuild index'}
+          </button>
+        ) : (
+          <p style={{ margin: 0, color: colors.red700, fontSize: 13.5, lineHeight: 1.55 }}>
+            Automatic recovery is not available because the existing safety state could not be read reliably. No index files were changed. Check the workbench log for the next safe step.
+          </p>
+        )}
+        <DiagnosticDetails health={health} />
+      </div>
+    );
+  } else if (health.status === 'unavailable') {
+    content = (
+      <div role="alert">
+        <h1 style={{ margin: '0 0 8px', fontSize: 21, color: colors.gray900 }}>
+          The local index is unavailable
+        </h1>
+        <p style={{ margin: '0 0 12px', color: colors.red700, fontSize: 14, lineHeight: 1.55 }}>
+          {health.message || 'ClawJournal could not open the local index safely.'}
+        </p>
+        <p style={{ margin: 0, color: colors.gray600, fontSize: 13.5, lineHeight: 1.55 }}>
+          Background index work and uploads were not started. Check that the state directory is writable and available, then restart ClawJournal.
+        </p>
+        <p style={{ margin: '12px 0 0', color: colors.gray500, fontSize: 12.5, lineHeight: 1.55 }}>
+          On a shared or network home, move the whole state directory to persistent local storage and set <code>CLAWJOURNAL_HOME</code> to it before restarting.
+        </p>
+        <DiagnosticDetails health={health} />
+      </div>
+    );
+  } else {
+    content = <Spinner text="Opening the workbench..." />;
+  }
+
+  return (
+    <main style={{
+      flex: 1,
+      minHeight: 0,
+      boxSizing: 'border-box',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 24,
+      background: colors.gray50,
+      fontFamily,
+    }}>
+      <section style={{
+        width: '100%',
+        maxWidth: 590,
+        padding: '28px 30px',
+        boxSizing: 'border-box',
+        borderRadius: 12,
+        border: `1px solid ${colors.gray200}`,
+        background: colors.white,
+        boxShadow: '0 8px 28px rgba(42, 40, 37, 0.08)',
+      }}>
+        <div style={{ marginBottom: 20, color: colors.gray800, fontSize: 17, fontWeight: 700 }}>
+          ClawJournal
+        </div>
+        {content}
+      </section>
+    </main>
+  );
+}

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -204,11 +204,44 @@ export interface Policy {
   created_at: string;
 }
 
+export type IndexHealthStatus =
+  | 'ready'
+  | 'recovery_required'
+  | 'rebuilding'
+  | 'unavailable';
+
+export interface IndexHealth {
+  status: IndexHealthStatus;
+  message?: string | null;
+  detail?: string | null;
+  stage?: string | null;
+  database_path?: string | null;
+  backup_path?: string | null;
+  sqlite_version?: string | null;
+  journal_mode?: string | null;
+  automatic_recovery_available?: boolean;
+  interrupted_recovery?: boolean;
+  unreadable_state?: string[];
+  recoverable_state_counts?: Record<string, number>;
+  /** Counts returned by the current guided-recovery implementation. */
+  restored_state_counts?: Record<string, number>;
+  /** Backward-compatible alias accepted from early recovery builds. */
+  restored_counts?: Record<string, number>;
+  warnings?: string[];
+}
+
+export interface IndexRebuildResponse {
+  ok: boolean;
+  index_health: IndexHealth;
+}
+
 export interface Features {
   /** Whether the Benchmark tab is shown in the workbench UI (config: benchmark_tab_enabled). */
   benchmark_tab_enabled: boolean;
   /** Whether the user declined the background auto-scorer warmup (config: scoring_warmup_declined). */
   scoring_warmup_declined: boolean;
+  /** Cached startup integrity result. Database-backed UI mounts only when ready. */
+  index_health: IndexHealth;
 }
 
 export interface WorkbenchConfig {

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -7173,11 +7173,6 @@ def run_server(
 
     scanner = Scanner(source_filter=source_filter)
     _open_request_admission()
-    # Publish a non-ready state before accepting requests. The authenticated
-    # identity/features endpoints can now make ``clawjournal open`` and the SPA
-    # responsive while the potentially long SQLite check runs, but every
-    # database-backed route and background worker remains fail-closed.
-    begin_index_health_check()
 
     # Start HTTP server first so it's responsive immediately. The primary socket
     # is IPv4 127.0.0.1 — what the CLI health probe, curl, and SSH `-L` tunnels
@@ -7191,6 +7186,12 @@ def run_server(
         port = server.server_address[1]
     server._scanner = scanner  # type: ignore[attr-defined]
     server._frontend_snapshot = frontend_snapshot  # type: ignore[attr-defined]
+
+    # Publish a non-ready state only after the primary socket binds. A rejected
+    # launch (for example, the desktop port is already occupied) must not leave
+    # this process's cached health stuck at ``checking``. No serving loop or
+    # background worker starts before this fail-closed state is visible.
+    begin_index_health_check()
 
     # Companion IPv6 loopback socket on the same port. Browsers resolve
     # `localhost` to ::1 (IPv6) first and don't all fall back to IPv4, so an

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -94,6 +94,15 @@ from .index import (
     update_session,
     upsert_sessions,
 )
+from .index_recovery import (
+    UnsafeIndexRecovery,
+    begin_guided_rebuild,
+    current_index_health,
+    guided_rebuild,
+    initialize_index_health,
+    inspect_index_health,
+    synchronize_index_health,
+)
 from .timeline import (
     canonical_session_path,
     load_timeline_page,
@@ -352,6 +361,8 @@ _auto_upload_run_lock = threading.Lock()
 _auto_upload_run_thread: threading.Thread | None = None
 _auto_upload_enrollment_lock = threading.Lock()
 _auto_upload_enrollment_thread: threading.Thread | None = None
+_index_recovery_lock = threading.Lock()
+_index_recovery_thread: threading.Thread | None = None
 _HOSTED_EMAIL_SUFFIXES_DEFAULT = (".edu", ".ac.uk", ".edu.au", ".edu.cn", "ac.jp", "rayward.ai")
 _hosted_capabilities_cache: tuple[str, float, dict[str, Any]] | None = None
 
@@ -715,6 +726,48 @@ class Scanner:
                         "Another scan is still refreshing the index; try again shortly."
                     )
                 return self._scan_once_report(required_sources=None)["new_by_source"]
+
+    def rebuild_damaged_index(self) -> dict[str, Any]:
+        """Run recovery after every automatic-upload and scan writer is idle."""
+
+        from ..auto_upload import whole_run_lock
+        from ..config import auto_upload_egress_lock
+
+        # Keep the same global order used by the automatic-upload runner. This
+        # prevents a runner from retaining an open connection to the old file
+        # while recovery backs it up and replaces it.
+        with whole_run_lock(blocking=True) as run_acquired:
+            if not run_acquired:
+                raise ScanBusyError(
+                    "Automatic-upload activity could not be paused for recovery."
+                )
+            with self._scan_lock:
+                with _scan_process_lock(
+                    wait_seconds=SCAN_LOCK_WAIT_SECONDS
+                ) as scan_acquired:
+                    if not scan_acquired:
+                        raise ScanBusyError(
+                            "Another scan is still using the workbench index."
+                        )
+                    with auto_upload_egress_lock():
+                        # A second daemon may have completed recovery while this
+                        # process waited on the cross-process locks. Do not
+                        # rebuild a now-healthy database from stale cached health.
+                        if inspect_index_health().get("status") == "ready":
+                            return initialize_index_health()
+
+                        def recovery_scan() -> dict[str, Any]:
+                            # A serve-time --source filter is a UI/runtime
+                            # preference, not permission to omit other source
+                            # logs from a full index reconstruction.
+                            original_filter = self.source_filter
+                            self.source_filter = None
+                            try:
+                                return self._scan_once_report(required_sources=None)
+                            finally:
+                                self.source_filter = original_filter
+
+                        return guided_rebuild(recovery_scan)
 
     def _scan_tick(self) -> dict[str, int] | None:
         """One background-loop pass; skips when another process is scanning.
@@ -3864,6 +3917,23 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         self.send_header("Content-Length", "0")
         self.end_headers()
 
+    def _reject_unhealthy_index(self) -> bool:
+        """Fail every DB-backed API closed while guided recovery is active."""
+
+        health = synchronize_index_health()
+        if health.get("status") == "ready":
+            return False
+        _json_response(
+            self,
+            {
+                "error": "The workbench index is unavailable until recovery finishes.",
+                "code": "index_recovery_required",
+                "index_health": health,
+            },
+            status=503,
+        )
+        return True
+
     def do_OPTIONS(self) -> None:
         self.send_response(200)
         origin = _cors_origin(self)
@@ -3910,6 +3980,12 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                     "proof": api_health_proof(token, challenge),
                 },
             )
+        # This DB-free probe carries the cached startup diagnosis so the SPA
+        # can render recovery guidance without touching the damaged index.
+        elif path == "/api/features":
+            self._handle_features()
+        elif path.startswith("/api/") and self._reject_unhealthy_index():
+            return
         # API routes
         elif path == "/api/sessions":
             self._handle_list_sessions(params)
@@ -3998,8 +4074,6 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             self._handle_list_findings_allowlist()
         elif path == "/api/config":
             self._handle_get_config()
-        elif path == "/api/features":
-            self._handle_features()
         elif path == "/api/benchmarks":
             self._handle_benchmarks_list()
         elif path == "/api/benchmarks/latest":
@@ -4011,6 +4085,8 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         elif path.startswith("/api/benchmarks/"):
             self._handle_benchmark_get(path[len("/api/benchmarks/"):])
         elif path.startswith("/timeline/"):
+            if self._reject_unhealthy_index():
+                return
             if self._handle_session_timeline(path):
                 return
             self._serve_static(parsed.path)
@@ -4026,7 +4102,11 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path.rstrip("/")
 
-        if path.startswith("/api/sessions/") and path.endswith("/score"):
+        if path == "/api/index/rebuild":
+            self._handle_index_rebuild()
+        elif path.startswith("/api/") and self._reject_unhealthy_index():
+            return
+        elif path.startswith("/api/sessions/") and path.endswith("/score"):
             session_id = _api_session_id(path, suffix="/score")
             self._handle_score_session(session_id)
         elif path.startswith("/api/sessions/") and path.endswith("/scan"):
@@ -4109,6 +4189,8 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
 
         parsed = urlparse(self.path)
         path = parsed.path.rstrip("/")
+        if path.startswith("/api/") and self._reject_unhealthy_index():
+            return
         if path == "/api/findings":
             self._handle_patch_findings()
         else:
@@ -4121,6 +4203,9 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
 
         parsed = urlparse(self.path)
         path = parsed.path.rstrip("/")
+
+        if path.startswith("/api/") and self._reject_unhealthy_index():
+            return
 
         if path.startswith("/api/policies/"):
             policy_id = path[len("/api/policies/"):]
@@ -4850,7 +4935,94 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         _json_response(self, {
             "benchmark_tab_enabled": bool(config.get("benchmark_tab_enabled", True)),
             "scoring_warmup_declined": bool(config.get("scoring_warmup_declined", False)),
+            "index_health": synchronize_index_health(),
         })
+
+    def _handle_index_rebuild(self) -> None:
+        """Start the one-click, backup-first index rebuild in the background."""
+
+        global _index_recovery_thread
+
+        scanner = getattr(self.server, "_scanner", None)
+        if scanner is None:
+            _json_response(
+                self,
+                {"error": "The recovery worker is unavailable."},
+                status=503,
+            )
+            return
+
+        with _index_recovery_lock:
+            health = synchronize_index_health()
+            if (
+                health.get("status") == "rebuilding"
+                and _index_recovery_thread is not None
+                and _index_recovery_thread.is_alive()
+            ):
+                _json_response(
+                    self,
+                    {"ok": True, "index_health": health},
+                    status=202,
+                )
+                return
+            try:
+                begin_guided_rebuild()
+            except UnsafeIndexRecovery as exc:
+                _json_response(
+                    self,
+                    {
+                        "error": str(exc),
+                        "index_health": current_index_health(),
+                    },
+                    status=409,
+                )
+                return
+
+            def _recover() -> None:
+                try:
+                    recovery_result = scanner.rebuild_damaged_index()
+                except Exception:
+                    logger.exception("Workbench index recovery worker failed")
+                    # Lock acquisition can fail before guided_rebuild() creates
+                    # its persistent marker. Re-run the read-only startup check
+                    # so the UI is offered Retry instead of polling forever.
+                    if current_index_health().get("status") == "rebuilding":
+                        initialize_index_health()
+                    return
+                if recovery_result.get("status") != "ready":
+                    logger.warning(
+                        "Index recovery did not produce a ready index; "
+                        "background workers remain stopped."
+                    )
+                    return
+                if scanner._stop_event.is_set():
+                    return
+                try:
+                    trigger_scoring_warmup(scanner)
+                except Exception:
+                    logger.warning(
+                        "Scoring warmup after index recovery was skipped",
+                        exc_info=True,
+                    )
+                scanner.start()
+                logger.info(
+                    "Index recovery completed; background scanner resumed "
+                    "(interval: %ds)",
+                    SCAN_INTERVAL,
+                )
+
+            _index_recovery_thread = threading.Thread(
+                target=_recover,
+                daemon=True,
+                name="index-recovery",
+            )
+            _index_recovery_thread.start()
+
+        _json_response(
+            self,
+            {"ok": True, "index_health": current_index_health()},
+            status=202,
+        )
 
     def _handle_get_config(self) -> None:
         """Return the UI-editable config subset plus the valid option lists.
@@ -6662,6 +6834,9 @@ def _background_workers_active(scanner: Scanner | None = None) -> bool:
     """Whether re-exec would interrupt durable or expensive background work."""
     if _BENCHMARK_GEN_LOCK.locked():
         return True
+    recovery_thread = _index_recovery_thread
+    if recovery_thread is not None and recovery_thread.is_alive():
+        return True
     upload_thread = _auto_upload_run_thread
     if upload_thread is not None and upload_thread.is_alive():
         return True
@@ -6930,6 +7105,12 @@ def run_server(
 
     scanner = Scanner(source_filter=source_filter)
     _open_request_admission()
+    index_health = initialize_index_health()
+    if index_health.get("status") != "ready":
+        logger.warning(
+            "Workbench index startup gate: %s",
+            index_health.get("message", "index recovery is required"),
+        )
 
     # Start HTTP server first so it's responsive immediately. The primary socket
     # is IPv4 127.0.0.1 — what the CLI health probe, curl, and SSH `-L` tunnels
@@ -6959,7 +7140,8 @@ def run_server(
     # A manual Share may have queued recurring enrollment immediately before
     # the daemon or machine stopped.  The accepted request lives in SQLite, so
     # resume it before the ordinary background scan; no browser tab is needed.
-    _start_auto_upload_enrollment_worker()
+    if index_health.get("status") == "ready":
+        _start_auto_upload_enrollment_worker()
 
     if remote:
         import socket
@@ -6996,7 +7178,13 @@ def run_server(
             scanner.start()
             logger.info("Background scanner started (interval: %ds)", SCAN_INTERVAL)
 
-    threading.Thread(target=_initial_scan, daemon=True).start()
+    if index_health.get("status") == "ready":
+        threading.Thread(target=_initial_scan, daemon=True).start()
+    else:
+        logger.warning(
+            "Scanner, scoring, benchmarks, and automatic uploads remain "
+            "stopped until the index is recovered."
+        )
 
     # Watch the editable checkout: once the background auto-update has both
     # moved HEAD and reconciled the install, restart at a quiet moment so the
@@ -7048,17 +7236,21 @@ def run_server(
 
     # Reconcile benchmark rows orphaned in 'generating' by a previous crash/restart
     # (the only normal exit from 'generating' is the in-process worker).
-    try:
-        from ..benchmark import store as _bstore
-        _bconn = open_index()
+    if index_health.get("status") == "ready":
         try:
-            n = _bstore.reconcile_stale_generating(_bconn)
-            if n:
-                logger.info("Reconciled %d stale 'generating' benchmark row(s) -> failed", n)
-        finally:
-            _bconn.close()
-    except Exception:
-        logger.warning("benchmark stale-row reconcile skipped", exc_info=True)
+            from ..benchmark import store as _bstore
+            _bconn = open_index()
+            try:
+                n = _bstore.reconcile_stale_generating(_bconn)
+                if n:
+                    logger.info(
+                        "Reconciled %d stale 'generating' benchmark row(s) -> failed",
+                        n,
+                    )
+            finally:
+                _bconn.close()
+        except Exception:
+            logger.warning("benchmark stale-row reconcile skipped", exc_info=True)
 
     try:
         server.serve_forever()

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -6,6 +6,7 @@ import logging
 import os
 import re
 import sqlite3
+import threading
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -32,6 +33,21 @@ from ..pricing import estimate_cost
 
 INDEX_DB = CONFIG_DIR / "index.db"
 BLOBS_DIR = CONFIG_DIR / "blobs"
+INDEX_JOURNAL_MODE = "delete"
+INDEX_RECOVERY_MARKER_FILENAME = "index-recovery-in-progress.json"
+_INDEX_RECOVERY_ACCESS = threading.local()
+
+
+def _set_index_recovery_access(enabled: bool) -> bool:
+    """Allow only the recovery worker to open the marker-guarded live index."""
+
+    previous = bool(getattr(_INDEX_RECOVERY_ACCESS, "enabled", False))
+    _INDEX_RECOVERY_ACCESS.enabled = enabled
+    return previous
+
+
+def _index_recovery_marker_path() -> Path:
+    return Path(str(INDEX_DB)).parent / INDEX_RECOVERY_MARKER_FILENAME
 
 # Schema version sentinels. Version 1 is the bundles→shares migration,
 # version 2 is the security refactor, version 3 adds the
@@ -549,6 +565,15 @@ def open_index() -> sqlite3.Connection:
     if they do not already exist. Returns a connection with
     row_factory set to sqlite3.Row for dict-like access.
     """
+    if (
+        _index_recovery_marker_path().exists()
+        and not bool(getattr(_INDEX_RECOVERY_ACCESS, "enabled", False))
+    ):
+        raise sqlite3.DatabaseError(
+            "The workbench index is guarded by an unfinished recovery. "
+            "Open the workbench and finish or retry the backup-first rebuild."
+        )
+
     CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     BLOBS_DIR.mkdir(parents=True, exist_ok=True)
 
@@ -560,7 +585,18 @@ def open_index() -> sqlite3.Connection:
 
     conn = sqlite3.connect(str(INDEX_DB), timeout=30)
     conn.row_factory = sqlite3.Row
-    conn.execute("PRAGMA journal_mode=WAL")
+    journal_row = conn.execute(
+        f"PRAGMA journal_mode={INDEX_JOURNAL_MODE}"
+    ).fetchone()
+    actual_journal_mode = str(journal_row[0]).lower() if journal_row else ""
+    if actual_journal_mode != INDEX_JOURNAL_MODE:
+        conn.close()
+        raise sqlite3.DatabaseError(
+            "ClawJournal could not select the safe SQLite journal mode "
+            f"{INDEX_JOURNAL_MODE!r} for {INDEX_DB}; SQLite returned "
+            f"{actual_journal_mode or 'no mode'!r}. Close other ClawJournal "
+            "processes and try again."
+        )
     conn.execute("PRAGMA busy_timeout=30000")
     conn.execute("PRAGMA foreign_keys=ON")
 
@@ -3365,7 +3401,8 @@ def effective_hold_state(
     Callers that gate on the effective state (share/upload) should use
     this; UI/audit surfaces read the raw column directly.
     """
-    state = hold_state or "auto_redacted"
+    # Missing or unknown state is corruption, not implied consent to share.
+    state = hold_state if hold_state in HOLD_STATES else "pending_review"
     if state != "embargoed" or not embargo_until:
         return state
     try:

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -7,11 +7,13 @@ import os
 import re
 import sqlite3
 import threading
+import time
 import uuid
+from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from typing import Any
+from typing import Any, BinaryIO, Iterator
 
 logger = logging.getLogger(__name__)
 
@@ -23,6 +25,7 @@ from ..redaction.secrets import (
 from ..scoring.badges import compute_all_badges
 from ..config import (
     CONFIG_DIR,
+    INDEX_RECOVERY_MARKER_FILENAME,
     load_config,
     mark_auto_upload_profile_changed,
     normalize_excluded_project_names,
@@ -34,7 +37,8 @@ from ..pricing import estimate_cost
 INDEX_DB = CONFIG_DIR / "index.db"
 BLOBS_DIR = CONFIG_DIR / "blobs"
 INDEX_JOURNAL_MODE = "delete"
-INDEX_RECOVERY_MARKER_FILENAME = "index-recovery-in-progress.json"
+INDEX_CONNECTION_LEASE_FILENAME = "index-connections.lock"
+_INDEX_CONNECTION_LEASE_SLOTS = 256
 _INDEX_RECOVERY_ACCESS = threading.local()
 
 
@@ -46,8 +50,201 @@ def _set_index_recovery_access(enabled: bool) -> bool:
     return previous
 
 
-def _index_recovery_marker_path() -> Path:
-    return Path(str(INDEX_DB)).parent / INDEX_RECOVERY_MARKER_FILENAME
+def _index_recovery_marker_path(database: Path | None = None) -> Path:
+    path = Path(str(INDEX_DB)) if database is None else Path(database)
+    return path.parent / INDEX_RECOVERY_MARKER_FILENAME
+
+
+def _index_connection_lease_path(database: Path | None = None) -> Path:
+    path = Path(str(INDEX_DB)) if database is None else Path(database)
+    return path.parent / INDEX_CONNECTION_LEASE_FILENAME
+
+
+def _open_index_lease_file(database: Path | None = None) -> BinaryIO:
+    path = _index_connection_lease_path(database)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    file = path.open("a+b")
+    file.seek(0, os.SEEK_END)
+    if file.tell() < _INDEX_CONNECTION_LEASE_SLOTS:
+        # ``a+b`` forces writes to EOF even after seek on Windows. truncate()
+        # is the portable way to make every byte-range lock slot addressable.
+        file.truncate(_INDEX_CONNECTION_LEASE_SLOTS)
+        file.flush()
+    return file
+
+
+def _release_index_lease(file: BinaryIO, slot: int | None) -> None:
+    try:
+        if os.name == "nt":
+            import msvcrt
+
+            file.seek(0 if slot is None else slot)
+            msvcrt.locking(
+                file.fileno(),
+                msvcrt.LK_UNLCK,
+                _INDEX_CONNECTION_LEASE_SLOTS if slot is None else 1,
+            )
+        else:
+            import fcntl
+
+            fcntl.flock(file.fileno(), fcntl.LOCK_UN)
+    finally:
+        file.close()
+
+
+def _acquire_index_connection_lease(
+    *, database: Path | None = None, timeout: float = 30.0,
+) -> tuple[BinaryIO, int | None]:
+    """Register one live ``open_index`` connection across processes."""
+
+    file = _open_index_lease_file(database)
+    deadline = time.monotonic() + max(0.0, timeout)
+    try:
+        while True:
+            if os.name == "nt":
+                import msvcrt
+
+                for slot in range(_INDEX_CONNECTION_LEASE_SLOTS):
+                    try:
+                        file.seek(slot)
+                        msvcrt.locking(file.fileno(), msvcrt.LK_NBLCK, 1)
+                    except OSError:
+                        continue
+                    return file, slot
+            else:
+                import fcntl
+
+                try:
+                    fcntl.flock(file.fileno(), fcntl.LOCK_SH | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    pass
+                else:
+                    return file, None
+            if time.monotonic() >= deadline:
+                raise sqlite3.OperationalError(
+                    "Timed out waiting for the workbench index recovery lock."
+                )
+            time.sleep(0.05)
+    except Exception:
+        file.close()
+        raise
+
+
+@contextmanager
+def _exclusive_index_recovery_lease(
+    *, timeout: float = 30.0,
+) -> Iterator[None]:
+    """Wait for every guarded connection and prevent another from opening."""
+
+    file = _open_index_lease_file()
+    deadline = time.monotonic() + max(0.0, timeout)
+    locked = False
+    try:
+        while not locked:
+            if os.name == "nt":
+                import msvcrt
+
+                try:
+                    file.seek(0)
+                    msvcrt.locking(
+                        file.fileno(),
+                        msvcrt.LK_NBLCK,
+                        _INDEX_CONNECTION_LEASE_SLOTS,
+                    )
+                except OSError:
+                    pass
+                else:
+                    locked = True
+            else:
+                import fcntl
+
+                try:
+                    fcntl.flock(file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    pass
+                else:
+                    locked = True
+            if locked:
+                break
+            if time.monotonic() >= deadline:
+                raise sqlite3.OperationalError(
+                    "Timed out waiting for other ClawJournal processes to close "
+                    "the workbench index."
+                )
+            time.sleep(0.05)
+        yield
+    finally:
+        if locked:
+            _release_index_lease(file, None)
+        else:
+            file.close()
+
+
+class _LeasedIndexConnection(sqlite3.Connection):
+    """SQLite connection that releases its cross-process lease on close."""
+
+    _index_lease: tuple[BinaryIO, int | None] | None = None
+
+    def close(self) -> None:
+        lease = self._index_lease
+        self._index_lease = None
+        try:
+            super().close()
+        finally:
+            if lease is not None:
+                _release_index_lease(*lease)
+
+
+def open_existing_index(
+    *,
+    database: Path | None = None,
+    readonly: bool = False,
+    timeout: float = 5.0,
+    isolation_level: str | None = "",
+) -> sqlite3.Connection:
+    """Open the existing DB without migrations while honoring recovery leases."""
+
+    recovery_access = bool(getattr(_INDEX_RECOVERY_ACCESS, "enabled", False))
+    path = Path(str(INDEX_DB)) if database is None else Path(database)
+    marker = _index_recovery_marker_path(path)
+    if marker.exists() and not recovery_access:
+        raise sqlite3.DatabaseError(
+            "The workbench index is guarded by an unfinished recovery."
+        )
+    if not path.is_file():
+        raise sqlite3.OperationalError("The workbench index does not exist.")
+
+    lease: tuple[BinaryIO, int | None] | None = None
+    if not recovery_access:
+        lease = _acquire_index_connection_lease(
+            database=path,
+            timeout=timeout,
+        )
+        if marker.exists():
+            _release_index_lease(*lease)
+            raise sqlite3.DatabaseError(
+                "The workbench index is guarded by an unfinished recovery."
+            )
+    try:
+        conn = sqlite3.connect(
+            path.resolve().as_uri() + ("?mode=ro" if readonly else "?mode=rw"),
+            uri=True,
+            timeout=timeout,
+            isolation_level=isolation_level,
+            factory=_LeasedIndexConnection,
+        )
+    except Exception:
+        if lease is not None:
+            _release_index_lease(*lease)
+        raise
+    conn._index_lease = lease
+    if marker.exists() and not recovery_access:
+        conn.close()
+        raise sqlite3.DatabaseError(
+            "The workbench index is guarded by an unfinished recovery."
+        )
+    conn.row_factory = sqlite3.Row
+    return conn
 
 # Schema version sentinels. Version 1 is the bundles→shares migration,
 # version 2 is the security refactor, version 3 adds the
@@ -565,10 +762,8 @@ def open_index() -> sqlite3.Connection:
     if they do not already exist. Returns a connection with
     row_factory set to sqlite3.Row for dict-like access.
     """
-    if (
-        _index_recovery_marker_path().exists()
-        and not bool(getattr(_INDEX_RECOVERY_ACCESS, "enabled", False))
-    ):
+    recovery_access = bool(getattr(_INDEX_RECOVERY_ACCESS, "enabled", False))
+    if _index_recovery_marker_path().exists() and not recovery_access:
         raise sqlite3.DatabaseError(
             "The workbench index is guarded by an unfinished recovery. "
             "Open the workbench and finish or retry the backup-first rebuild."
@@ -583,7 +778,37 @@ def open_index() -> sqlite3.Connection:
     # keeps them isolated to the test directory.
     ensure_install_files(Path(str(INDEX_DB)).parent)
 
-    conn = sqlite3.connect(str(INDEX_DB), timeout=30)
+    lease: tuple[BinaryIO, int | None] | None = None
+    if not recovery_access:
+        lease = _acquire_index_connection_lease()
+        # Close the marker/connect race: a recovery that published its marker
+        # after the first check will wait on this lease, while this opener now
+        # declines to create or migrate the guarded database.
+        if _index_recovery_marker_path().exists():
+            _release_index_lease(*lease)
+            raise sqlite3.DatabaseError(
+                "The workbench index is guarded by an unfinished recovery. "
+                "Open the workbench and finish or retry the backup-first rebuild."
+            )
+
+    try:
+        conn = sqlite3.connect(
+            Path(str(INDEX_DB)).resolve().as_uri() + "?mode=rwc",
+            uri=True,
+            timeout=30,
+            factory=_LeasedIndexConnection,
+        )
+    except Exception:
+        if lease is not None:
+            _release_index_lease(*lease)
+        raise
+    conn._index_lease = lease
+    if _index_recovery_marker_path().exists() and not recovery_access:
+        conn.close()
+        raise sqlite3.DatabaseError(
+            "The workbench index is guarded by an unfinished recovery. "
+            "Open the workbench and finish or retry the backup-first rebuild."
+        )
     conn.row_factory = sqlite3.Row
     journal_row = conn.execute(
         f"PRAGMA journal_mode={INDEX_JOURNAL_MODE}"

--- a/clawjournal/workbench/index_recovery.py
+++ b/clawjournal/workbench/index_recovery.py
@@ -86,7 +86,172 @@ _DURABLE_TABLES = (
     "session_hold_history",
     "auto_upload_enrollment",
     "auto_upload_enrollment_job",
+    "benchmarks",
+    "benchmark_tasks",
+    "benchmark_exports",
 )
+
+_EVENT_SESSION_COLUMNS = (
+    "id",
+    "session_key",
+    "parent_session_key",
+    "parent_session_id",
+    "client",
+    "client_version",
+    "started_at",
+    "ended_at",
+    "status",
+)
+_EVENT_COLUMNS = (
+    "id",
+    "session_id",
+    "type",
+    "event_key",
+    "event_at",
+    "ingested_at",
+    "source",
+    "source_path",
+    "source_offset",
+    "seq",
+    "client",
+    "confidence",
+    "lossiness",
+    "raw_json",
+)
+_EVENT_OVERRIDE_COLUMNS = (
+    "session_id",
+    "event_key",
+    "type",
+    "source",
+    "confidence",
+    "lossiness",
+    "event_at",
+    "payload_json",
+    "origin",
+    "created_at",
+    "write_seq",
+)
+_EVENT_SNIPPET_COLUMNS = (
+    "source_path",
+    "source_offset",
+    "seq",
+    "text",
+    "imported_at",
+)
+_CAPTURE_CURSOR_COLUMNS = (
+    "consumer_id",
+    "source_path",
+    "inode",
+    "last_offset",
+    "last_modified",
+    "client",
+    "first_seen",
+    "last_seen",
+)
+_TOKEN_USAGE_COLUMNS = (
+    "event_id",
+    "session_id",
+    "model",
+    "model_family",
+    "model_tier",
+    "model_provider",
+    "input",
+    "output",
+    "cache_read",
+    "cache_write",
+    "reasoning",
+    "service_tier",
+    "data_source",
+    "cost_estimate",
+    "pricing_table_version",
+    "event_at",
+)
+_COST_ANOMALY_COLUMNS = (
+    "id",
+    "session_id",
+    "turn_event_id",
+    "kind",
+    "confidence",
+    "evidence_json",
+    "created_at",
+)
+_COST_INGEST_STATE_COLUMNS = ("consumer_id", "last_event_id")
+_INCIDENT_COLUMNS = (
+    "id",
+    "session_id",
+    "kind",
+    "first_event_id",
+    "last_event_id",
+    "evidence_json",
+    "count",
+    "confidence",
+    "created_at",
+)
+_LOOP_INGEST_STATE_COLUMNS = (
+    "consumer_id",
+    "last_event_id",
+    "last_override_write_seq",
+    "last_override_created_at",
+    "last_override_session_id",
+    "last_override_event_key",
+)
+
+_EVENT_REQUIRED_COLUMNS = frozenset({
+    "id",
+    "session_id",
+    "type",
+    "ingested_at",
+    "source",
+    "source_path",
+    "source_offset",
+    "client",
+    "confidence",
+    "lossiness",
+    "raw_json",
+})
+_EVENT_SESSION_REQUIRED_COLUMNS = frozenset({"id", "session_key", "client"})
+_EVENT_OVERRIDE_REQUIRED_COLUMNS = frozenset({
+    "session_id",
+    "event_key",
+    "type",
+    "source",
+    "confidence",
+    "lossiness",
+    "payload_json",
+    "created_at",
+})
+_EVENT_SNIPPET_REQUIRED_COLUMNS = frozenset(_EVENT_SNIPPET_COLUMNS)
+_CAPTURE_CURSOR_REQUIRED_COLUMNS = frozenset(_CAPTURE_CURSOR_COLUMNS)
+_TOKEN_USAGE_REQUIRED_COLUMNS = frozenset({
+    "event_id",
+    "session_id",
+    "data_source",
+})
+_COST_ANOMALY_REQUIRED_COLUMNS = frozenset(_COST_ANOMALY_COLUMNS)
+_COST_INGEST_STATE_REQUIRED_COLUMNS = frozenset(_COST_INGEST_STATE_COLUMNS)
+_INCIDENT_REQUIRED_COLUMNS = frozenset(_INCIDENT_COLUMNS)
+_LOOP_INGEST_STATE_REQUIRED_COLUMNS = frozenset({
+    "consumer_id",
+    "last_event_id",
+})
+
+_EXECUTION_RECORDER_TABLES = frozenset({
+    "event_sessions",
+    "events",
+    "event_overrides",
+    "event_source_snippets",
+    "token_usage",
+    "cost_anomalies",
+    "cost_ingest_state",
+    "incidents",
+    "loop_ingest_state",
+    "capture_cursors",
+})
+_NON_SAFETY_RELATIONAL_TABLES = _EXECUTION_RECORDER_TABLES | frozenset({
+    "benchmarks",
+    "benchmark_tasks",
+    "benchmark_exports",
+})
 
 
 class UnsafeIndexRecovery(RuntimeError):
@@ -180,7 +345,7 @@ def synchronize_index_health() -> dict[str, Any]:
 
 
 def begin_guided_rebuild() -> dict[str, Any]:
-    """Atomically reserve the one recovery worker slot."""
+    """Reserve the worker and publish the cross-process gate before returning."""
 
     with _STATE_LOCK:
         if _INDEX_HEALTH.get("status") == "rebuilding":
@@ -191,10 +356,20 @@ def begin_guided_rebuild() -> dict[str, Any]:
             raise UnsafeIndexRecovery(
                 "Automatic recovery is not available for this index state."
             )
+        database = _index_path()
+        marker = _load_marker(database)
+        if marker is None:
+            marker = {
+                "version": 1,
+                "database_path": str(database.resolve()),
+                "started_at": datetime.now(timezone.utc).isoformat(),
+                "stage": "draining",
+            }
+            _write_marker(database, marker)
         _INDEX_HEALTH.update({
             "status": "rebuilding",
-            "stage": "queued",
-            "message": "Starting the safe index recovery...",
+            "stage": "draining",
+            "message": "Waiting for active index work to finish safely...",
         })
         return dict(_INDEX_HEALTH)
 
@@ -210,6 +385,25 @@ def _read_only_connection(path: Path) -> sqlite3.Connection:
     return conn
 
 
+def _exclusive_source_connection(path: Path) -> sqlite3.Connection:
+    """Hold the source stable while its decisions and exact files are copied."""
+
+    conn = sqlite3.connect(
+        path.resolve().as_uri() + "?mode=rw",
+        uri=True,
+        timeout=5,
+        isolation_level=None,
+    )
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA busy_timeout=5000")
+    try:
+        conn.execute("BEGIN EXCLUSIVE")
+    except Exception:
+        conn.close()
+        raise
+    return conn
+
+
 def _health_connection(path: Path) -> sqlite3.Connection:
     """Open for checks while allowing SQLite's own hot-journal rollback.
 
@@ -221,12 +415,10 @@ def _health_connection(path: Path) -> sqlite3.Connection:
     therefore never alter a damaged source or its backup.
     """
 
-    conn = sqlite3.connect(
-        path.resolve().as_uri() + "?mode=rw",
-        uri=True,
+    conn = index_module.open_existing_index(
+        database=path,
         timeout=5,
     )
-    conn.row_factory = sqlite3.Row
     conn.execute("PRAGMA query_only=ON")
     return conn
 
@@ -301,7 +493,11 @@ def _recovery_snapshot(
         return {}, ["database schema"]
 
     try:
-        if conn.execute("PRAGMA foreign_key_check").fetchone() is not None:
+        violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+        if any(
+            str(row[0]) not in _NON_SAFETY_RELATIONAL_TABLES
+            for row in violations
+        ):
             errors.append("relational safety state")
     except sqlite3.DatabaseError:
         errors.append("relational safety state")
@@ -349,6 +545,20 @@ def _recovery_snapshot(
     return snapshot, errors
 
 
+def _snapshot_from_path(
+    path: Path,
+) -> tuple[dict[str, list[dict[str, Any]]], list[str]]:
+    conn: sqlite3.Connection | None = None
+    try:
+        conn = _read_only_connection(path)
+        return _recovery_snapshot(conn)
+    except (OSError, sqlite3.DatabaseError):
+        return {}, ["database schema and durable safety state"]
+    finally:
+        if conn is not None:
+            conn.close()
+
+
 def inspect_index_health(path: Path | None = None) -> dict[str, Any]:
     database = Path(path) if path is not None else _index_path()
     base: dict[str, Any] = {
@@ -379,7 +589,7 @@ def inspect_index_health(path: Path | None = None) -> dict[str, Any]:
                 "A previous index rebuild was interrupted. The original backup "
                 "is still available and recovery can be retried safely."
             )
-        elif marker.get("stage") == "preparing" and database.is_file():
+        elif marker.get("stage") in {"draining", "preparing"} and database.is_file():
             message = (
                 "A previous index rebuild stopped before its backup completed. "
                 "The original index has not been replaced and recovery can be "
@@ -388,7 +598,7 @@ def inspect_index_health(path: Path | None = None) -> dict[str, Any]:
         else:
             detail = (
                 "The original index is missing from the preparation stage."
-                if marker.get("stage") == "preparing"
+                if marker.get("stage") in {"draining", "preparing"}
                 else str(_marker_path(database).resolve())
             )
             return {
@@ -481,8 +691,8 @@ def inspect_index_health(path: Path | None = None) -> dict[str, Any]:
             "unreadable_state": errors,
             "recoverable_state_counts": counts,
         }
-    except sqlite3.DatabaseError as exc:
-        if _is_storage_or_lock_error(exc):
+    except (OSError, sqlite3.DatabaseError) as exc:
+        if isinstance(exc, OSError) or _is_storage_or_lock_error(exc):
             return {
                 **base,
                 "status": "unavailable",
@@ -621,6 +831,400 @@ def _insert_rows(
         )
         inserted += 1
     return inserted
+
+
+def _attached_table_names(
+    conn: sqlite3.Connection,
+    schema: str,
+) -> set[str]:
+    return {
+        str(row[0])
+        for row in conn.execute(
+            f'SELECT name FROM "{schema}".sqlite_master WHERE type = \'table\''
+        ).fetchall()
+    }
+
+
+def _attached_table_columns(
+    conn: sqlite3.Connection,
+    schema: str,
+    table: str,
+) -> set[str]:
+    # Schema and table names come only from fixed constants in this module.
+    return {
+        str(row[1])
+        for row in conn.execute(
+            f'PRAGMA "{schema}".table_info("{table}")'
+        ).fetchall()
+    }
+
+
+def _copy_attached_rows(
+    conn: sqlite3.Connection,
+    *,
+    schema: str,
+    table: str,
+    requested: tuple[str, ...],
+    required: frozenset[str],
+    where: str = "",
+    params: tuple[Any, ...] = (),
+) -> int:
+    source_columns = _attached_table_columns(conn, schema, table)
+    missing = required - source_columns
+    if missing:
+        raise sqlite3.DatabaseError(
+            f'{table} is missing recovery column(s): {", ".join(sorted(missing))}'
+        )
+    target_columns = _table_columns(conn, table)
+    columns = [
+        column
+        for column in requested
+        if column in source_columns and column in target_columns
+    ]
+    if not columns:
+        return 0
+    quoted = ", ".join(f'"{column}"' for column in columns)
+    sql = (
+        f'INSERT INTO main."{table}" ({quoted}) '
+        f'SELECT {quoted} FROM "{schema}"."{table}"'
+    )
+    if where:
+        sql += f" WHERE {where}"
+    conn.execute(sql, params)
+    return int(conn.execute(f'SELECT COUNT(*) FROM "{table}"').fetchone()[0])
+
+
+def _restore_execution_recorder(
+    conn: sqlite3.Connection,
+    source_database: Path,
+) -> tuple[dict[str, int], list[str]]:
+    """Restore non-rebuildable event data from the fsynced backup database.
+
+    The large ``events.raw_json`` payload stays inside SQLite via
+    ``INSERT ... SELECT``; it is never materialized as a Python ``fetchall``.
+    Historical cost and incident rows are copied exactly; only FTS is rebuilt.
+    """
+
+    counts: dict[str, int] = {}
+    warnings: list[str] = []
+    if not source_database.is_file():
+        return counts, warnings
+
+    from clawjournal.capture.cursors import ensure_schema as ensure_cursor_schema
+    from clawjournal.events.cost.schema import ensure_cost_schema
+    from clawjournal.events.export.schema import ensure_export_schema
+    from clawjournal.events.incidents.schema import ensure_incidents_schema
+    from clawjournal.events.schema import ensure_schema as ensure_event_schema
+    from clawjournal.events.view import ensure_view_schema
+
+    ensure_event_schema(conn)
+    ensure_view_schema(conn)
+    ensure_cost_schema(conn)
+    ensure_incidents_schema(conn)
+    ensure_export_schema(conn)
+    ensure_cursor_schema(conn)
+    conn.commit()
+
+    schema = "recovery_source"
+    attached = False
+    try:
+        conn.execute(
+            f'ATTACH DATABASE ? AS "{schema}"',
+            (source_database.resolve().as_uri() + "?mode=ro",),
+        )
+        attached = True
+        source_tables = _attached_table_names(conn, schema)
+    except sqlite3.DatabaseError as exc:
+        if attached:
+            try:
+                conn.execute(f'DETACH DATABASE "{schema}"')
+            except sqlite3.DatabaseError:
+                pass
+        warnings.append(
+            "Execution-recorder state could not be read and remains in the "
+            f"index backup ({exc})."
+        )
+        return counts, warnings
+
+    core_restored = False
+    override_frontier_restored = False
+    try:
+        has_sessions = "event_sessions" in source_tables
+        has_events = "events" in source_tables
+        if has_sessions != has_events:
+            warnings.append(
+                "Execution-recorder state was incomplete and remains in the "
+                "index backup."
+            )
+        elif has_sessions and has_events:
+            try:
+                conn.execute("BEGIN IMMEDIATE")
+                conn.execute("PRAGMA defer_foreign_keys=ON")
+                conn.execute("DELETE FROM events")
+                conn.execute("DELETE FROM event_sessions")
+                counts["event_sessions"] = _copy_attached_rows(
+                    conn,
+                    schema=schema,
+                    table="event_sessions",
+                    requested=_EVENT_SESSION_COLUMNS,
+                    required=_EVENT_SESSION_REQUIRED_COLUMNS,
+                )
+                counts["events"] = _copy_attached_rows(
+                    conn,
+                    schema=schema,
+                    table="events",
+                    requested=_EVENT_COLUMNS,
+                    required=_EVENT_REQUIRED_COLUMNS,
+                )
+                foreign_key_errors = [
+                    row
+                    for row in conn.execute("PRAGMA foreign_key_check").fetchall()
+                    if str(row[0]) in {"event_sessions", "events"}
+                ]
+                if foreign_key_errors:
+                    raise sqlite3.DatabaseError(
+                        "restored execution-recorder rows violate a foreign key"
+                    )
+                conn.commit()
+                core_restored = True
+            except Exception as exc:
+                conn.rollback()
+                counts.pop("event_sessions", None)
+                counts.pop("events", None)
+                warnings.append(
+                    "Execution-recorder state could not be restored and remains "
+                    f"in the index backup ({exc})."
+                )
+
+            if core_restored and "event_overrides" in source_tables:
+                conn.execute("SAVEPOINT restore_event_overrides")
+                try:
+                    source_override_columns = _attached_table_columns(
+                        conn,
+                        schema,
+                        "event_overrides",
+                    )
+                    conn.execute("DELETE FROM event_overrides")
+                    counts["event_overrides"] = _copy_attached_rows(
+                        conn,
+                        schema=schema,
+                        table="event_overrides",
+                        requested=_EVENT_OVERRIDE_COLUMNS,
+                        required=_EVENT_OVERRIDE_REQUIRED_COLUMNS,
+                    )
+                    conn.execute("RELEASE SAVEPOINT restore_event_overrides")
+                    # The loop detector can retain its exact frontier only
+                    # when the source rows carried their original sequence.
+                    # Legacy rows are restored, then assigned fresh sequences
+                    # below, so their old cursor must be replayed from zero.
+                    override_frontier_restored = (
+                        "write_seq" in source_override_columns
+                    )
+                except Exception as exc:
+                    conn.execute("ROLLBACK TO SAVEPOINT restore_event_overrides")
+                    conn.execute("RELEASE SAVEPOINT restore_event_overrides")
+                    counts.pop("event_overrides", None)
+                    warnings.append(
+                        "Execution-recorder overrides could not be restored and "
+                        f"remain in the index backup ({exc})."
+                    )
+            elif core_restored:
+                counts["event_overrides"] = 0
+
+            if core_restored and "capture_cursors" in source_tables:
+                conn.execute("SAVEPOINT restore_event_cursors")
+                try:
+                    conn.execute(
+                        "DELETE FROM capture_cursors WHERE consumer_id = ?",
+                        ("events",),
+                    )
+                    _copy_attached_rows(
+                        conn,
+                        schema=schema,
+                        table="capture_cursors",
+                        requested=_CAPTURE_CURSOR_COLUMNS,
+                        required=_CAPTURE_CURSOR_REQUIRED_COLUMNS,
+                        where='"consumer_id" = ?',
+                        params=("events",),
+                    )
+                    counts["event_capture_cursors"] = int(
+                        conn.execute(
+                            "SELECT COUNT(*) FROM capture_cursors "
+                            "WHERE consumer_id = ?",
+                            ("events",),
+                        ).fetchone()[0]
+                    )
+                    conn.execute("RELEASE SAVEPOINT restore_event_cursors")
+                except Exception as exc:
+                    conn.execute("ROLLBACK TO SAVEPOINT restore_event_cursors")
+                    conn.execute("RELEASE SAVEPOINT restore_event_cursors")
+                    counts.pop("event_capture_cursors", None)
+                    warnings.append(
+                        "Execution-recorder cursors could not be restored and "
+                        f"remain in the index backup ({exc})."
+                    )
+
+            cost_tables = {
+                "token_usage",
+                "cost_anomalies",
+                "cost_ingest_state",
+            }
+            available_cost_tables = cost_tables & source_tables
+            if core_restored and available_cost_tables == cost_tables:
+                conn.execute("SAVEPOINT restore_event_cost")
+                try:
+                    conn.execute("DELETE FROM cost_anomalies")
+                    conn.execute("DELETE FROM token_usage")
+                    conn.execute("DELETE FROM cost_ingest_state")
+                    counts["token_usage"] = _copy_attached_rows(
+                        conn,
+                        schema=schema,
+                        table="token_usage",
+                        requested=_TOKEN_USAGE_COLUMNS,
+                        required=_TOKEN_USAGE_REQUIRED_COLUMNS,
+                    )
+                    counts["cost_anomalies"] = _copy_attached_rows(
+                        conn,
+                        schema=schema,
+                        table="cost_anomalies",
+                        requested=_COST_ANOMALY_COLUMNS,
+                        required=_COST_ANOMALY_REQUIRED_COLUMNS,
+                    )
+                    counts["cost_ingest_state"] = _copy_attached_rows(
+                        conn,
+                        schema=schema,
+                        table="cost_ingest_state",
+                        requested=_COST_INGEST_STATE_COLUMNS,
+                        required=_COST_INGEST_STATE_REQUIRED_COLUMNS,
+                    )
+                    conn.execute("RELEASE SAVEPOINT restore_event_cost")
+                except Exception as exc:
+                    conn.execute("ROLLBACK TO SAVEPOINT restore_event_cost")
+                    conn.execute("RELEASE SAVEPOINT restore_event_cost")
+                    for name in cost_tables:
+                        counts.pop(name, None)
+                    warnings.append(
+                        "Historical event cost data could not be restored and "
+                        f"remains in the index backup ({exc})."
+                    )
+            elif core_restored and available_cost_tables:
+                warnings.append(
+                    "Historical event cost state was incomplete and remains in "
+                    "the index backup."
+                )
+
+            incident_tables = {"incidents", "loop_ingest_state"}
+            available_incident_tables = incident_tables & source_tables
+            if core_restored and available_incident_tables == incident_tables:
+                conn.execute("SAVEPOINT restore_event_incidents")
+                try:
+                    reset_override_cursor = not override_frontier_restored
+                    conn.execute("DELETE FROM incidents")
+                    conn.execute("DELETE FROM loop_ingest_state")
+                    counts["incidents"] = _copy_attached_rows(
+                        conn,
+                        schema=schema,
+                        table="incidents",
+                        requested=_INCIDENT_COLUMNS,
+                        required=_INCIDENT_REQUIRED_COLUMNS,
+                    )
+                    counts["loop_ingest_state"] = _copy_attached_rows(
+                        conn,
+                        schema=schema,
+                        table="loop_ingest_state",
+                        requested=_LOOP_INGEST_STATE_COLUMNS,
+                        required=_LOOP_INGEST_STATE_REQUIRED_COLUMNS,
+                    )
+                    if reset_override_cursor:
+                        conn.execute(
+                            "UPDATE loop_ingest_state SET "
+                            "last_override_write_seq = 0, "
+                            "last_override_created_at = NULL, "
+                            "last_override_session_id = 0, "
+                            "last_override_event_key = ''"
+                        )
+                    conn.execute("RELEASE SAVEPOINT restore_event_incidents")
+                    if reset_override_cursor:
+                        warnings.append(
+                            "The execution-incident override cursor was reset so "
+                            "future hook events cannot be skipped."
+                        )
+                except Exception as exc:
+                    conn.execute("ROLLBACK TO SAVEPOINT restore_event_incidents")
+                    conn.execute("RELEASE SAVEPOINT restore_event_incidents")
+                    for name in incident_tables:
+                        counts.pop(name, None)
+                    warnings.append(
+                        "Historical execution incidents could not be restored and "
+                        f"remain in the index backup ({exc})."
+                    )
+            elif core_restored and available_incident_tables:
+                warnings.append(
+                    "Historical execution-incident state was incomplete and "
+                    "remains in the index backup."
+                )
+
+        if "event_source_snippets" in source_tables:
+            conn.execute("SAVEPOINT restore_event_snippets")
+            try:
+                conn.execute("DELETE FROM event_source_snippets")
+                counts["event_source_snippets"] = _copy_attached_rows(
+                    conn,
+                    schema=schema,
+                    table="event_source_snippets",
+                    requested=_EVENT_SNIPPET_COLUMNS,
+                    required=_EVENT_SNIPPET_REQUIRED_COLUMNS,
+                )
+                conn.execute("RELEASE SAVEPOINT restore_event_snippets")
+            except Exception as exc:
+                conn.execute("ROLLBACK TO SAVEPOINT restore_event_snippets")
+                conn.execute("RELEASE SAVEPOINT restore_event_snippets")
+                counts.pop("event_source_snippets", None)
+                warnings.append(
+                    "Imported event source snippets could not be restored and "
+                    f"remain in the index backup ({exc})."
+                )
+        conn.commit()
+    finally:
+        try:
+            conn.execute(f'DETACH DATABASE "{schema}"')
+        except sqlite3.DatabaseError:
+            logger.warning("Could not detach the index-recovery source", exc_info=True)
+
+    if not core_restored:
+        return counts, warnings
+
+    # Legacy override tables may not carry write_seq. Re-running the additive
+    # schema helper assigns a stable frontier after all rows have landed. When
+    # override restoration failed or its exact sequence was unavailable, the
+    # loop cursor above was reset so low-numbered hook writes cannot be skipped.
+    # A usable ordering frontier is part of the recorder's durable state. If
+    # this additive migration cannot complete, leave recovery failed (with the
+    # verified backup retained) instead of reporting a ready index that could
+    # silently skip later hook overrides.
+    ensure_view_schema(conn)
+    conn.commit()
+
+    try:
+        from clawjournal.events.search.schema import ensure_search_schema
+
+        ensure_search_schema(conn)
+    except Exception as exc:
+        conn.rollback()
+        warnings.append(
+            "The event search index could not be rebuilt; the base events were "
+            f"preserved ({exc})."
+        )
+    try:
+        index_module.backfill_session_keys(conn)
+        conn.commit()
+    except Exception as exc:
+        conn.rollback()
+        warnings.append(
+            "Workbench-to-event links could not be refreshed; event data was "
+            f"preserved ({exc})."
+        )
+    return counts, warnings
 
 
 def _filter_rows_with_references(
@@ -862,6 +1466,47 @@ def _restore_snapshot(
     warnings: list[str] = []
     conn.execute("BEGIN IMMEDIATE")
     try:
+        conn.execute("SAVEPOINT restore_benchmarks")
+        try:
+            counts["benchmarks"] = _insert_rows(
+                conn, "benchmarks", snapshot.get("benchmarks", [])
+            )
+            benchmark_tasks, skipped_benchmark_tasks = _filter_rows_with_references(
+                conn,
+                snapshot.get("benchmark_tasks", []),
+                (("benchmark_id", "benchmarks", "benchmark_id"),),
+            )
+            counts["benchmark_tasks"] = _insert_rows(
+                conn, "benchmark_tasks", benchmark_tasks
+            )
+            benchmark_exports, skipped_benchmark_exports = (
+                _filter_rows_with_references(
+                    conn,
+                    snapshot.get("benchmark_exports", []),
+                    (("benchmark_id", "benchmarks", "benchmark_id"),),
+                )
+            )
+            counts["benchmark_exports"] = _insert_rows(
+                conn, "benchmark_exports", benchmark_exports
+            )
+            skipped_benchmark_rows = (
+                skipped_benchmark_tasks + skipped_benchmark_exports
+            )
+            if skipped_benchmark_rows:
+                warnings.append(
+                    f"{skipped_benchmark_rows} orphaned benchmark row(s) remain "
+                    "in the backup."
+                )
+            conn.execute("RELEASE SAVEPOINT restore_benchmarks")
+        except Exception as exc:
+            conn.execute("ROLLBACK TO SAVEPOINT restore_benchmarks")
+            conn.execute("RELEASE SAVEPOINT restore_benchmarks")
+            for name in ("benchmarks", "benchmark_tasks", "benchmark_exports"):
+                counts.pop(name, None)
+            warnings.append(
+                "Historical benchmark state could not be restored and remains "
+                f"in the index backup ({exc})."
+            )
         counts["shares"] = _insert_rows(conn, "shares", snapshot.get("shares", []))
         restored, needs_review, skipped_session_share_links = _restore_session_state(
             conn, snapshot.get("sessions", [])
@@ -935,7 +1580,23 @@ def _restore_snapshot(
             warnings.append(
                 "An unfinished automatic-upload setup was left in the backup."
             )
-        if unreadable_state:
+        benchmark_state_names = {
+            "benchmarks",
+            "benchmark tasks",
+            "benchmark exports",
+        }
+        unreadable_benchmark_state = [
+            name for name in unreadable_state if name in benchmark_state_names
+        ]
+        unreadable_safety_state = [
+            name for name in unreadable_state if name not in benchmark_state_names
+        ]
+        if unreadable_benchmark_state:
+            warnings.append(
+                "Some historical benchmark state was unreadable and remains in "
+                "the index backup."
+            )
+        if unreadable_safety_state:
             # Losing hold/share history must never silently make a rebuilt
             # trace eligible for egress. The user can review and release
             # individual traces after seeing the recovery warning.
@@ -954,8 +1615,10 @@ def _restore_snapshot(
     return counts, warnings
 
 
-def guided_rebuild(
+def _guided_rebuild_locked(
     scan_callback: Callable[[], dict[str, Any]],
+    *,
+    on_source_retired: Callable[[], None] | None = None,
 ) -> dict[str, Any]:
     """Back up, rebuild, rescan, and restore durable state synchronously."""
 
@@ -974,6 +1637,13 @@ def guided_rebuild(
     if isinstance(raw_backup, str) and raw_backup:
         backup_dir, backup_files = _backup_from_marker(database, marker)
         recovery_source = backup_dir / database.name
+        snapshot, errors = _snapshot_from_path(recovery_source)
+        _set_health({
+            **current_index_health(),
+            "status": "rebuilding",
+            "stage": "backing_up",
+            "message": "Using the verified backup from the previous attempt...",
+        })
     else:
         marker = dict(marker or {})
         marker.setdefault("started_at", datetime.now(timezone.utc).isoformat())
@@ -989,27 +1659,42 @@ def guided_rebuild(
         # tells a retry to create a fresh backup rather than guess.
         _write_marker(database, marker)
         recovery_source = database
+        source_guard: sqlite3.Connection | None = None
+        snapshot = {}
+        errors = []
+        try:
+            try:
+                source_guard = _exclusive_source_connection(database)
+            except sqlite3.DatabaseError as exc:
+                if _is_storage_or_lock_error(exc):
+                    raise UnsafeIndexRecovery(
+                        "The workbench index is still in use. Close other "
+                        "ClawJournal processes and retry recovery."
+                    ) from exc
+                # A structurally unreadable SQLite file cannot provide a
+                # transaction snapshot. Preserve its exact bytes first, then
+                # make one best-effort read from that immutable backup.
+                errors = ["database schema and durable safety state"]
+            if source_guard is not None:
+                snapshot, errors = _recovery_snapshot(source_guard)
 
-    snapshot: dict[str, list[dict[str, Any]]] = {}
-    errors: list[str] = []
-    conn: sqlite3.Connection | None = None
-    try:
-        conn = _read_only_connection(recovery_source)
-        snapshot, errors = _recovery_snapshot(conn)
-    except (OSError, sqlite3.DatabaseError):
-        errors = ["database schema and durable safety state"]
-    finally:
-        if conn is not None:
-            conn.close()
+            _set_health({
+                **current_index_health(),
+                "status": "rebuilding",
+                "stage": "backing_up",
+                "message": "Backing up the damaged index before changing anything...",
+            })
+            backup_dir, backup_files = _backup_index_files(database)
+        finally:
+            if source_guard is not None:
+                try:
+                    source_guard.rollback()
+                finally:
+                    source_guard.close()
 
-    _set_health({
-        **current_index_health(),
-        "status": "rebuilding",
-        "stage": "backing_up",
-        "message": "Backing up the damaged index before changing anything...",
-    })
-    if backup_dir is None:
-        backup_dir, backup_files = _backup_index_files(database)
+        recovery_source = backup_dir / database.name
+        if not snapshot and errors == ["database schema and durable safety state"]:
+            snapshot, errors = _snapshot_from_path(recovery_source)
         manifest = {
             "created_at": datetime.now(timezone.utc).isoformat(),
             "database_path": str(database.resolve()),
@@ -1037,6 +1722,14 @@ def guided_rebuild(
     previous_recovery_access = index_module._set_index_recovery_access(True)
     try:
         _remove_index_files(database)
+        if on_source_retired is not None:
+            try:
+                on_source_retired()
+            except Exception:
+                logger.exception(
+                    "Could not resume workbench request admission after retiring "
+                    "the damaged index"
+                )
         marker["stage"] = "reindexing"
         _write_marker(database, marker)
         _set_health({
@@ -1062,11 +1755,19 @@ def guided_rebuild(
         })
         rebuilt = index_module.open_index()
         try:
+            event_counts, event_warnings = _restore_execution_recorder(
+                rebuilt,
+                recovery_source,
+            )
             restored_counts, warnings = _restore_snapshot(
                 rebuilt,
                 snapshot,
                 unreadable_state=errors,
             )
+            restored_counts.update(event_counts)
+            warnings = event_warnings + warnings
+            index_module.backfill_session_keys(rebuilt)
+            rebuilt.commit()
             check = [str(row[0]) for row in rebuilt.execute("PRAGMA quick_check(1)")]
             if check != ["ok"]:
                 raise sqlite3.DatabaseError(check[0] if check else "integrity check failed")
@@ -1115,3 +1816,47 @@ def guided_rebuild(
         "warnings": warnings,
     }
     return _set_health(ready)
+
+
+def guided_rebuild(
+    scan_callback: Callable[[], dict[str, Any]],
+    *,
+    on_source_retired: Callable[[], None] | None = None,
+) -> dict[str, Any]:
+    """Rebuild only after every guarded cross-process connection has closed."""
+
+    database = _index_path()
+    marker = _load_marker(database)
+    if marker is None:
+        marker = {
+            "version": 1,
+            "database_path": str(database.resolve()),
+            "started_at": datetime.now(timezone.utc).isoformat(),
+            "stage": "preparing",
+        }
+        _write_marker(database, marker)
+    lease = index_module._exclusive_index_recovery_lease(timeout=30.0)
+    try:
+        lease.__enter__()
+    except sqlite3.OperationalError as exc:
+        failed = {
+            **current_index_health(),
+            "status": "recovery_required",
+            "stage": "waiting_for_connections",
+            "message": (
+                "Close other ClawJournal processes that are using the index, "
+                "then retry recovery. The original index was not changed."
+            ),
+            "detail": str(exc),
+            "automatic_recovery_available": True,
+            "interrupted_recovery": True,
+        }
+        _set_health(failed)
+        raise UnsafeIndexRecovery(failed["message"]) from exc
+    try:
+        return _guided_rebuild_locked(
+            scan_callback,
+            on_source_retired=on_source_retired,
+        )
+    finally:
+        lease.__exit__(None, None, None)

--- a/clawjournal/workbench/index_recovery.py
+++ b/clawjournal/workbench/index_recovery.py
@@ -1,0 +1,1117 @@
+"""Startup integrity guard and guided recovery for the workbench index.
+
+The workbench SQLite database mixes rebuildable index data with durable user
+decisions.  Recovery therefore never deletes a damaged database silently:
+the authenticated UI must request it, the exact database sidecars are backed
+up first, and safety-relevant state is copied into the rebuilt index whenever
+it can be read.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import shutil
+import sqlite3
+import threading
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable
+
+from . import index as index_module
+
+logger = logging.getLogger(__name__)
+
+RECOVERY_MARKER_FILENAME = index_module.INDEX_RECOVERY_MARKER_FILENAME
+
+_STATE_LOCK = threading.Lock()
+_INDEX_HEALTH: dict[str, Any] = {
+    "status": "ready",
+    "message": "The workbench index is ready.",
+}
+
+_SESSION_STATE_COLUMNS = (
+    "session_id",
+    "project",
+    "source",
+    "display_title",
+    "review_status",
+    "selection_reason",
+    "reviewer_notes",
+    "reviewed_at",
+    "blob_path",
+    "raw_source_path",
+    "indexed_at",
+    "updated_at",
+    "share_id",
+    "hold_state",
+    "embargo_until",
+    "content_revision",
+)
+
+_CRITICAL_SESSION_STATE_COLUMNS = frozenset({
+    "session_id",
+    "review_status",
+    "hold_state",
+    "content_revision",
+})
+
+_CRITICAL_FINDING_DECISION_COLUMNS = frozenset({
+    "session_id",
+    "engine",
+    "entity_hash",
+    "status",
+    "revision",
+})
+
+_FINDING_DECISION_COLUMNS = (
+    "session_id",
+    "engine",
+    "entity_hash",
+    "status",
+    "decided_by",
+    "decision_source_id",
+    "decided_at",
+    "decision_reason",
+    "revision",
+)
+
+_DURABLE_TABLES = (
+    "policies",
+    "findings_allowlist",
+    "shares",
+    "share_sessions",
+    "session_hold_history",
+    "auto_upload_enrollment",
+    "auto_upload_enrollment_job",
+)
+
+
+class UnsafeIndexRecovery(RuntimeError):
+    """The damaged index cannot be rebuilt automatically without data loss."""
+
+
+def _index_path() -> Path:
+    return Path(str(index_module.INDEX_DB))
+
+
+def _marker_path(database: Path) -> Path:
+    return database.parent / RECOVERY_MARKER_FILENAME
+
+
+def _fsync_directory(directory: Path) -> None:
+    """Persist directory-entry changes where the platform exposes that primitive."""
+
+    if not hasattr(os, "O_DIRECTORY"):
+        return
+    descriptor = os.open(directory, os.O_RDONLY | os.O_DIRECTORY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_marker(database: Path, payload: dict[str, Any]) -> None:
+    marker = _marker_path(database)
+    temporary = marker.with_name(f".{marker.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        with temporary.open("w", encoding="utf-8") as file:
+            json.dump(payload, file, indent=2, sort_keys=True)
+            file.flush()
+            os.fsync(file.fileno())
+        os.replace(temporary, marker)
+        _fsync_directory(marker.parent)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def _load_marker(database: Path) -> dict[str, Any] | None:
+    try:
+        payload = json.loads(_marker_path(database).read_text(encoding="utf-8"))
+    except (OSError, ValueError, json.JSONDecodeError):
+        return None
+    return payload if isinstance(payload, dict) else None
+
+
+def _set_health(payload: dict[str, Any]) -> dict[str, Any]:
+    with _STATE_LOCK:
+        _INDEX_HEALTH.clear()
+        _INDEX_HEALTH.update(payload)
+        return dict(_INDEX_HEALTH)
+
+
+def current_index_health() -> dict[str, Any]:
+    with _STATE_LOCK:
+        return dict(_INDEX_HEALTH)
+
+
+def recovery_marker_exists(path: Path | None = None) -> bool:
+    """Return whether any process has published an index-recovery marker."""
+
+    database = Path(path) if path is not None else _index_path()
+    return _marker_path(database).exists()
+
+
+def synchronize_index_health() -> dict[str, Any]:
+    """Refresh cached health only when another process changed the marker.
+
+    The ordinary request path deliberately avoids rerunning SQLite integrity
+    checks.  A marker transition is rare and is the cross-process signal that
+    an already-running daemon must fail closed or resume after recovery.
+    """
+
+    health = current_index_health()
+    marker_exists = recovery_marker_exists()
+    if (
+        marker_exists
+        and health.get("status") != "rebuilding"
+        and health.get("interrupted_recovery") is not True
+    ):
+        return initialize_index_health()
+    if (
+        not marker_exists
+        and health.get("status") != "rebuilding"
+        and health.get("interrupted_recovery") is True
+    ):
+        return initialize_index_health()
+    return health
+
+
+def begin_guided_rebuild() -> dict[str, Any]:
+    """Atomically reserve the one recovery worker slot."""
+
+    with _STATE_LOCK:
+        if _INDEX_HEALTH.get("status") == "rebuilding":
+            return dict(_INDEX_HEALTH)
+        if _INDEX_HEALTH.get("status") != "recovery_required":
+            raise UnsafeIndexRecovery("The workbench index does not need recovery.")
+        if _INDEX_HEALTH.get("automatic_recovery_available") is not True:
+            raise UnsafeIndexRecovery(
+                "Automatic recovery is not available for this index state."
+            )
+        _INDEX_HEALTH.update({
+            "status": "rebuilding",
+            "stage": "queued",
+            "message": "Starting the safe index recovery...",
+        })
+        return dict(_INDEX_HEALTH)
+
+
+def _read_only_connection(path: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(
+        path.resolve().as_uri() + "?mode=ro",
+        uri=True,
+        timeout=5,
+    )
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    return conn
+
+
+def _health_connection(path: Path) -> sqlite3.Connection:
+    """Open for checks while allowing SQLite's own hot-journal rollback.
+
+    DELETE journaling can leave a rollback journal after process or machine
+    failure. SQLite must briefly have a read/write handle to roll that
+    incomplete transaction back before any reader can inspect the database.
+    ``query_only`` still prevents this health-check connection from issuing
+    application writes. Recovery snapshots use ``_read_only_connection`` and
+    therefore never alter a damaged source or its backup.
+    """
+
+    conn = sqlite3.connect(
+        path.resolve().as_uri() + "?mode=rw",
+        uri=True,
+        timeout=5,
+    )
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA query_only=ON")
+    return conn
+
+
+def _is_storage_or_lock_error(exc: sqlite3.DatabaseError) -> bool:
+    message = str(exc).lower()
+    return any(
+        marker in message
+        for marker in (
+            "database is locked",
+            "database table is locked",
+            "database is busy",
+            "disk i/o error",
+            "unable to open database file",
+            "readonly database",
+            "database or disk is full",
+            "permission denied",
+        )
+    )
+
+
+def _table_names(conn: sqlite3.Connection) -> set[str]:
+    rows = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type = 'table'"
+    ).fetchall()
+    return {str(row[0]) for row in rows}
+
+
+def _table_columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    # Table names come only from the fixed constants above.
+    return {
+        str(row[1])
+        for row in conn.execute(f'PRAGMA table_info("{table}")').fetchall()
+    }
+
+
+def _select_columns(
+    conn: sqlite3.Connection,
+    table: str,
+    requested: tuple[str, ...],
+    *,
+    where: str = "",
+    required: frozenset[str] = frozenset(),
+) -> list[dict[str, Any]]:
+    available = _table_columns(conn, table)
+    missing = required - available
+    if missing:
+        raise sqlite3.DatabaseError(
+            f'{table} is missing recovery column(s): {", ".join(sorted(missing))}'
+        )
+    columns = [column for column in requested if column in available]
+    if not columns:
+        return []
+    sql = f'SELECT {", ".join(columns)} FROM "{table}"'
+    if where:
+        sql += f" WHERE {where}"
+    return [dict(row) for row in conn.execute(sql).fetchall()]
+
+
+def _select_all(conn: sqlite3.Connection, table: str) -> list[dict[str, Any]]:
+    return [dict(row) for row in conn.execute(f'SELECT * FROM "{table}"').fetchall()]
+
+
+def _recovery_snapshot(
+    conn: sqlite3.Connection,
+) -> tuple[dict[str, list[dict[str, Any]]], list[str]]:
+    snapshot: dict[str, list[dict[str, Any]]] = {}
+    errors: list[str] = []
+    try:
+        tables = _table_names(conn)
+    except sqlite3.DatabaseError:
+        return {}, ["database schema"]
+
+    try:
+        if conn.execute("PRAGMA foreign_key_check").fetchone() is not None:
+            errors.append("relational safety state")
+    except sqlite3.DatabaseError:
+        errors.append("relational safety state")
+
+    if "sessions" not in tables:
+        snapshot["sessions"] = []
+        errors.append("session decisions and hold state")
+    else:
+        try:
+            snapshot["sessions"] = _select_columns(
+                conn,
+                "sessions",
+                _SESSION_STATE_COLUMNS,
+                required=_CRITICAL_SESSION_STATE_COLUMNS,
+            )
+        except sqlite3.DatabaseError:
+            snapshot["sessions"] = []
+            errors.append("session decisions and hold state")
+
+    if "findings" in tables:
+        try:
+            snapshot["finding_decisions"] = _select_columns(
+                conn,
+                "findings",
+                _FINDING_DECISION_COLUMNS,
+                where="status != 'open' OR decided_at IS NOT NULL",
+                required=_CRITICAL_FINDING_DECISION_COLUMNS,
+            )
+        except sqlite3.DatabaseError:
+            snapshot["finding_decisions"] = []
+            errors.append("finding decisions")
+    else:
+        snapshot["finding_decisions"] = []
+
+    for table in _DURABLE_TABLES:
+        if table not in tables:
+            snapshot[table] = []
+            continue
+        try:
+            snapshot[table] = _select_all(conn, table)
+        except sqlite3.DatabaseError:
+            snapshot[table] = []
+            errors.append(table.replace("_", " "))
+
+    return snapshot, errors
+
+
+def inspect_index_health(path: Path | None = None) -> dict[str, Any]:
+    database = Path(path) if path is not None else _index_path()
+    base: dict[str, Any] = {
+        "database_path": str(database.resolve()),
+        "sqlite_version": sqlite3.sqlite_version,
+        "journal_mode": index_module.INDEX_JOURNAL_MODE,
+        "automatic_recovery_available": False,
+    }
+    marker = _load_marker(database)
+    if marker is not None:
+        raw_backup = marker.get("backup_path")
+        if isinstance(raw_backup, str) and raw_backup:
+            try:
+                _backup_from_marker(database, marker)
+            except UnsafeIndexRecovery as exc:
+                return {
+                    **base,
+                    "status": "unavailable",
+                    "message": (
+                        "The interrupted-recovery backup is unavailable, so "
+                        "ClawJournal will not replace the current index."
+                    ),
+                    "detail": str(exc),
+                    "automatic_recovery_available": False,
+                    "interrupted_recovery": True,
+                }
+            message = (
+                "A previous index rebuild was interrupted. The original backup "
+                "is still available and recovery can be retried safely."
+            )
+        elif marker.get("stage") == "preparing" and database.is_file():
+            message = (
+                "A previous index rebuild stopped before its backup completed. "
+                "The original index has not been replaced and recovery can be "
+                "retried safely."
+            )
+        else:
+            detail = (
+                "The original index is missing from the preparation stage."
+                if marker.get("stage") == "preparing"
+                else str(_marker_path(database).resolve())
+            )
+            return {
+                **base,
+                "status": "unavailable",
+                "message": (
+                    "The interrupted-recovery record does not identify a safe "
+                    "backup or an untouched preparation stage."
+                ),
+                "detail": detail,
+                "automatic_recovery_available": False,
+                "interrupted_recovery": True,
+            }
+        return {
+            **base,
+            "status": "recovery_required",
+            "message": message,
+            "automatic_recovery_available": True,
+            "backup_path": raw_backup if raw_backup else None,
+            "interrupted_recovery": True,
+        }
+    if _marker_path(database).exists():
+        return {
+            **base,
+            "status": "unavailable",
+            "message": (
+                "The interrupted-recovery record is unreadable, so ClawJournal "
+                "will not guess which backup is authoritative."
+            ),
+            "detail": str(_marker_path(database).resolve()),
+            "automatic_recovery_available": False,
+            "interrupted_recovery": True,
+        }
+    if not database.exists():
+        return {
+            **base,
+            "status": "ready",
+            "message": "A new workbench index will be created.",
+        }
+
+    try:
+        database_size = database.stat().st_size
+    except OSError as exc:
+        return {
+            **base,
+            "status": "unavailable",
+            "message": "The workbench index storage is unavailable.",
+            "detail": str(exc),
+            "automatic_recovery_available": False,
+        }
+    if database_size == 0:
+        return {
+            **base,
+            "status": "recovery_required",
+            "message": "The workbench index is empty and must be rebuilt.",
+            "detail": "The existing index.db file contains no SQLite data.",
+            "automatic_recovery_available": True,
+            "unreadable_state": ["database schema and durable safety state"],
+            "recoverable_state_counts": {},
+        }
+
+    conn: sqlite3.Connection | None = None
+    try:
+        conn = _health_connection(database)
+        journal_row = conn.execute("PRAGMA journal_mode").fetchone()
+        if journal_row:
+            base["journal_mode"] = str(journal_row[0]).lower()
+        checks = [str(row[0]) for row in conn.execute("PRAGMA quick_check(1)")]
+        foreign_key_error = conn.execute("PRAGMA foreign_key_check").fetchone()
+        has_session_table = "sessions" in _table_names(conn)
+        if checks == ["ok"] and foreign_key_error is None and has_session_table:
+            return {
+                **base,
+                "status": "ready",
+                "message": "The workbench index passed its integrity check.",
+            }
+        snapshot, errors = _recovery_snapshot(conn)
+        counts = {name: len(rows) for name, rows in snapshot.items()}
+        detail = checks[0] if checks != ["ok"] and checks else None
+        if foreign_key_error is not None:
+            detail = "The index contains an invalid foreign-key reference."
+        elif not has_session_table:
+            detail = "The index is missing its sessions table."
+        return {
+            **base,
+            "status": "recovery_required",
+            "message": "The workbench index is damaged and must be rebuilt.",
+            "detail": detail or "SQLite integrity check failed.",
+            "automatic_recovery_available": True,
+            "unreadable_state": errors,
+            "recoverable_state_counts": counts,
+        }
+    except sqlite3.DatabaseError as exc:
+        if _is_storage_or_lock_error(exc):
+            return {
+                **base,
+                "status": "unavailable",
+                "message": (
+                    "The workbench index storage is locked or unavailable. "
+                    "No automatic rebuild will be attempted."
+                ),
+                "detail": str(exc),
+                "automatic_recovery_available": False,
+            }
+        errors: list[str] = ["database schema"]
+        counts: dict[str, int] = {}
+        if conn is not None:
+            snapshot, errors = _recovery_snapshot(conn)
+            counts = {name: len(rows) for name, rows in snapshot.items()}
+        return {
+            **base,
+            "status": "recovery_required",
+            "message": "The workbench index is unreadable and must be rebuilt.",
+            "detail": str(exc),
+            "automatic_recovery_available": True,
+            "unreadable_state": errors,
+            "recoverable_state_counts": counts,
+        }
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def initialize_index_health() -> dict[str, Any]:
+    """Inspect once at daemon startup, before any scanner or egress worker."""
+
+    report = inspect_index_health()
+    if report["status"] != "ready":
+        return _set_health(report)
+    try:
+        conn = index_module.open_index()
+        conn.close()
+        report["journal_mode"] = index_module.INDEX_JOURNAL_MODE
+    except (OSError, sqlite3.DatabaseError) as exc:
+        report = {
+            **report,
+            "status": "unavailable",
+            "message": "The workbench index could not be opened safely.",
+            "detail": str(exc),
+            "automatic_recovery_available": False,
+        }
+    return _set_health(report)
+
+
+def _backup_index_files(database: Path) -> tuple[Path, list[Path]]:
+    backup_root = database.parent / "index-backups"
+    backup_root.mkdir(parents=True, exist_ok=True)
+    timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    backup_dir = backup_root / f"index-recovery-{timestamp}-{uuid.uuid4().hex[:8]}"
+    backup_dir.mkdir(parents=False, exist_ok=False)
+    _fsync_directory(backup_root)
+
+    copied: list[Path] = []
+    for source in (
+        database,
+        Path(str(database) + "-wal"),
+        Path(str(database) + "-shm"),
+        Path(str(database) + "-journal"),
+    ):
+        if not source.exists():
+            continue
+        destination = backup_dir / source.name
+        shutil.copy2(source, destination)
+        # Windows does not permit fsync on a read-only descriptor. Open the
+        # completed copy read/write solely to force its bytes to stable storage.
+        with destination.open("r+b") as file:
+            os.fsync(file.fileno())
+        copied.append(destination)
+    if not copied:
+        raise FileNotFoundError(f"No index files were found at {database}")
+    _fsync_directory(backup_dir)
+    return backup_dir, copied
+
+
+def _remove_index_files(database: Path) -> None:
+    for path in (
+        database,
+        Path(str(database) + "-wal"),
+        Path(str(database) + "-shm"),
+        Path(str(database) + "-journal"),
+    ):
+        path.unlink(missing_ok=True)
+
+
+def _backup_from_marker(database: Path, marker: dict[str, Any]) -> tuple[Path, list[Path]]:
+    raw_backup = marker.get("backup_path")
+    if not isinstance(raw_backup, str) or not raw_backup:
+        raise UnsafeIndexRecovery("The interrupted recovery backup path is missing.")
+    backup_dir = Path(raw_backup).resolve()
+    guarded_root = (database.parent / "index-backups").resolve()
+    if not backup_dir.is_relative_to(guarded_root) or not backup_dir.is_dir():
+        raise UnsafeIndexRecovery("The interrupted recovery backup path is invalid.")
+    database_backup = backup_dir / database.name
+    if not database_backup.is_file():
+        raise UnsafeIndexRecovery(
+            "The interrupted recovery database backup is missing."
+        )
+    backups = [database_backup]
+    backups.extend(
+        backup_dir / name
+        for name in (
+            database.name + "-wal",
+            database.name + "-shm",
+            database.name + "-journal",
+        )
+        if (backup_dir / name).is_file()
+    )
+    return backup_dir, backups
+
+
+def _insert_rows(
+    conn: sqlite3.Connection,
+    table: str,
+    rows: list[dict[str, Any]],
+) -> int:
+    if not rows:
+        return 0
+    available = _table_columns(conn, table)
+    inserted = 0
+    for row in rows:
+        values = {key: value for key, value in row.items() if key in available}
+        if not values:
+            continue
+        columns = list(values)
+        placeholders = ", ".join("?" for _ in columns)
+        quoted = ", ".join(f'"{column}"' for column in columns)
+        conn.execute(
+            f'INSERT OR REPLACE INTO "{table}" ({quoted}) VALUES ({placeholders})',
+            [values[column] for column in columns],
+        )
+        inserted += 1
+    return inserted
+
+
+def _filter_rows_with_references(
+    conn: sqlite3.Connection,
+    rows: list[dict[str, Any]],
+    references: tuple[tuple[str, str, str], ...],
+) -> tuple[list[dict[str, Any]], int]:
+    """Drop damaged child rows whose rebuilt parent no longer exists."""
+
+    parent_keys: dict[tuple[str, str], set[Any]] = {}
+    for _child_column, parent_table, parent_column in references:
+        key = (parent_table, parent_column)
+        if key not in parent_keys:
+            parent_keys[key] = {
+                row[0]
+                for row in conn.execute(
+                    f'SELECT "{parent_column}" FROM "{parent_table}"'
+                ).fetchall()
+            }
+    safe: list[dict[str, Any]] = []
+    for row in rows:
+        if all(
+            row.get(child_column) in parent_keys[(parent_table, parent_column)]
+            for child_column, parent_table, parent_column in references
+        ):
+            safe.append(row)
+    return safe, len(rows) - len(safe)
+
+
+def _restore_session_state(
+    conn: sqlite3.Connection,
+    rows: list[dict[str, Any]],
+) -> tuple[int, int, int]:
+    restored = 0
+    needs_review = 0
+    skipped_share_links = 0
+    share_ids = {
+        row[0] for row in conn.execute("SELECT share_id FROM shares").fetchall()
+    }
+    for row in rows:
+        session_id = row.get("session_id")
+        if not session_id:
+            continue
+        raw_share_id = row.get("share_id")
+        share_id = raw_share_id if raw_share_id in share_ids else None
+        if raw_share_id is not None and share_id is None:
+            skipped_share_links += 1
+        current = conn.execute(
+            "SELECT content_revision FROM sessions WHERE session_id = ?",
+            (session_id,),
+        ).fetchone()
+        same_revision = (
+            current is not None
+            and current["content_revision"] == row.get("content_revision")
+        )
+        if current is None:
+            conn.execute(
+                """INSERT INTO sessions (
+                    session_id, project, source, display_title, review_status,
+                    selection_reason, reviewer_notes, reviewed_at, blob_path,
+                    raw_source_path, indexed_at, updated_at, share_id,
+                    hold_state, embargo_until, content_revision
+                ) VALUES (?, ?, ?, ?, 'new', NULL, NULL, NULL, ?, ?, ?, ?, ?,
+                          'pending_review', NULL, ?)""",
+                (
+                    session_id,
+                    row.get("project") or "recovered",
+                    row.get("source") or "recovered",
+                    row.get("display_title") or "Recovered trace",
+                    row.get("blob_path"),
+                    row.get("raw_source_path"),
+                    row.get("indexed_at")
+                    or datetime.now(timezone.utc).isoformat(),
+                    row.get("updated_at"),
+                    share_id,
+                    row.get("content_revision"),
+                ),
+            )
+            needs_review += 1
+            continue
+        if not same_revision:
+            conn.execute(
+                "UPDATE sessions SET review_status = 'new', hold_state = "
+                "'pending_review', embargo_until = NULL WHERE session_id = ?",
+                (session_id,),
+            )
+            needs_review += 1
+            continue
+        hold_state = row.get("hold_state")
+        if hold_state not in index_module.HOLD_STATES:
+            conn.execute(
+                """UPDATE sessions SET
+                    review_status = 'new', selection_reason = ?, reviewer_notes = ?,
+                    reviewed_at = NULL, share_id = ?, hold_state = 'pending_review',
+                    embargo_until = NULL
+                   WHERE session_id = ?""",
+                (
+                    row.get("selection_reason"),
+                    row.get("reviewer_notes"),
+                    share_id,
+                    session_id,
+                ),
+            )
+            needs_review += 1
+            continue
+        conn.execute(
+            """UPDATE sessions SET
+                review_status = ?, selection_reason = ?, reviewer_notes = ?,
+                reviewed_at = ?, share_id = ?, hold_state = ?, embargo_until = ?
+               WHERE session_id = ?""",
+            (
+                row.get("review_status") or "new",
+                row.get("selection_reason"),
+                row.get("reviewer_notes"),
+                row.get("reviewed_at"),
+                share_id,
+                hold_state,
+                row.get("embargo_until"),
+                session_id,
+            ),
+        )
+        restored += 1
+    return restored, needs_review, skipped_share_links
+
+
+def _restore_finding_decisions(
+    conn: sqlite3.Connection,
+    rows: list[dict[str, Any]],
+) -> tuple[int, int]:
+    restored = 0
+    skipped = 0
+    for row in rows:
+        cursor = conn.execute(
+            """UPDATE findings SET status = ?, decided_by = ?,
+                      decision_source_id = ?, decided_at = ?, decision_reason = ?
+                 WHERE session_id = ? AND engine = ? AND entity_hash = ?
+                   AND revision = ?""",
+            (
+                row.get("status"),
+                row.get("decided_by"),
+                row.get("decision_source_id"),
+                row.get("decided_at"),
+                row.get("decision_reason"),
+                row.get("session_id"),
+                row.get("engine"),
+                row.get("entity_hash"),
+                row.get("revision"),
+            ),
+        )
+        if cursor.rowcount:
+            restored += cursor.rowcount
+        else:
+            skipped += 1
+    return restored, skipped
+
+
+def _safe_enrollment_rows(
+    rows: list[dict[str, Any]],
+    warnings: list[str],
+) -> list[dict[str, Any]]:
+    """Normalize older enrollment rows, always removing active run authority."""
+
+    safe: list[dict[str, Any]] = []
+    for original in rows:
+        enrollment = dict(original)
+        try:
+            sources = json.loads(enrollment["enrolled_sources_json"])
+            projects = json.loads(enrollment["enrolled_projects_json"])
+            if (
+                not isinstance(sources, list)
+                or not all(isinstance(item, str) and item for item in sources)
+                or not isinstance(projects, list)
+                or not all(isinstance(item, str) and item for item in projects)
+                or not enrollment.get("enrolled_at")
+                or not enrollment.get("client_enrollment_id")
+            ):
+                raise ValueError("invalid recurring-upload scope")
+            if "enrolled_scope_entries_json" in enrollment:
+                entries = json.loads(enrollment["enrolled_scope_entries_json"])
+                if (
+                    not isinstance(entries, list)
+                    or not all(
+                        isinstance(entry, list)
+                        and len(entry) == 2
+                        and isinstance(entry[0], str)
+                        and isinstance(entry[1], str)
+                        and entry[0] in sources
+                        and entry[1] in projects
+                        for entry in entries
+                    )
+                ):
+                    raise ValueError("invalid recurring-upload scope entries")
+        except (KeyError, TypeError, ValueError, json.JSONDecodeError):
+            warnings.append(
+                "Unreadable automatic-upload state was left disabled in the backup."
+            )
+            continue
+
+        if "enrolled_scope_entries_json" not in enrollment:
+            enrollment["enrolled_scope_entries_json"] = json.dumps(
+                [[source, project] for source in sources for project in projects],
+                separators=(",", ":"),
+            )
+        enrollment.setdefault("singleton_id", 1)
+        generation = enrollment.get("generation")
+        if (
+            not isinstance(generation, int)
+            or isinstance(generation, bool)
+            or generation < 1
+        ):
+            enrollment["generation"] = 1
+        enrollment.setdefault("hook_targets_json", "[]")
+        enrollment.setdefault("consecutive_failures", 0)
+        enrollment.setdefault("revocation_pending", 0)
+        enrollment.setdefault("updated_at", datetime.now(timezone.utc).isoformat())
+        if enrollment.get("mode") != "off":
+            enrollment["mode"] = "paused"
+            enrollment["health"] = "action_required"
+            enrollment["current_run_id"] = None
+            enrollment["current_run_stage"] = None
+            enrollment["next_retry_at"] = None
+            enrollment["last_result_code"] = "index_recovery_review_required"
+            warnings.append(
+                "Automatic uploads were restored paused and must be reviewed."
+            )
+        else:
+            enrollment["health"] = "ready"
+        safe.append(enrollment)
+    return safe
+
+
+def _restore_snapshot(
+    conn: sqlite3.Connection,
+    snapshot: dict[str, list[dict[str, Any]]],
+    *,
+    unreadable_state: list[str],
+) -> tuple[dict[str, int], list[str]]:
+    counts: dict[str, int] = {}
+    warnings: list[str] = []
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        counts["shares"] = _insert_rows(conn, "shares", snapshot.get("shares", []))
+        restored, needs_review, skipped_session_share_links = _restore_session_state(
+            conn, snapshot.get("sessions", [])
+        )
+        counts["session_decisions"] = restored
+        if needs_review:
+            warnings.append(
+                f"{needs_review} trace revision(s) require review before sharing."
+            )
+        if skipped_session_share_links:
+            warnings.append(
+                f"{skipped_session_share_links} orphaned session share link(s) "
+                "remain in the backup."
+            )
+        counts["policies"] = _insert_rows(
+            conn, "policies", snapshot.get("policies", [])
+        )
+        counts["findings_allowlist"] = _insert_rows(
+            conn,
+            "findings_allowlist",
+            snapshot.get("findings_allowlist", []),
+        )
+        hold_history, skipped_history = _filter_rows_with_references(
+            conn,
+            snapshot.get("session_hold_history", []),
+            (("session_id", "sessions", "session_id"),),
+        )
+        counts["hold_history"] = _insert_rows(
+            conn,
+            "session_hold_history",
+            hold_history,
+        )
+        if skipped_history:
+            warnings.append(
+                f"{skipped_history} orphaned hold-history row(s) remain in the backup."
+            )
+        share_sessions, skipped_share_sessions = _filter_rows_with_references(
+            conn,
+            snapshot.get("share_sessions", []),
+            (
+                ("share_id", "shares", "share_id"),
+                ("session_id", "sessions", "session_id"),
+            ),
+        )
+        counts["share_sessions"] = _insert_rows(
+            conn, "share_sessions", share_sessions
+        )
+        if skipped_share_sessions:
+            warnings.append(
+                f"{skipped_share_sessions} orphaned share link(s) remain in the backup."
+            )
+        finding_count, skipped_findings = _restore_finding_decisions(
+            conn, snapshot.get("finding_decisions", [])
+        )
+        counts["finding_decisions"] = finding_count
+        if skipped_findings:
+            warnings.append(
+                f"{skipped_findings} stale finding decision(s) were not reapplied."
+            )
+
+        enrollment_rows = _safe_enrollment_rows(
+            snapshot.get("auto_upload_enrollment", []),
+            warnings,
+        )
+        counts["auto_upload_enrollment"] = _insert_rows(
+            conn, "auto_upload_enrollment", enrollment_rows
+        )
+        # A queued/running enrollment job must never resume from a database that
+        # was rebuilt. The accepted request remains in the backup for diagnosis.
+        if snapshot.get("auto_upload_enrollment_job"):
+            warnings.append(
+                "An unfinished automatic-upload setup was left in the backup."
+            )
+        if unreadable_state:
+            # Losing hold/share history must never silently make a rebuilt
+            # trace eligible for egress. The user can review and release
+            # individual traces after seeing the recovery warning.
+            conn.execute(
+                "UPDATE sessions SET hold_state = 'pending_review', "
+                "embargo_until = NULL, review_status = 'new'"
+            )
+            warnings.append(
+                "Some safety state was unreadable; every rebuilt trace now "
+                "requires review before sharing."
+            )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    return counts, warnings
+
+
+def guided_rebuild(
+    scan_callback: Callable[[], dict[str, Any]],
+) -> dict[str, Any]:
+    """Back up, rebuild, rescan, and restore durable state synchronously."""
+
+    database = _index_path()
+    marker = _load_marker(database)
+    backup_dir: Path | None = None
+    backup_files: list[Path] = []
+    _set_health({
+        **current_index_health(),
+        "status": "rebuilding",
+        "stage": "checking_recovery",
+        "message": "Checking which local decisions can be restored...",
+    })
+
+    raw_backup = marker.get("backup_path") if marker is not None else None
+    if isinstance(raw_backup, str) and raw_backup:
+        backup_dir, backup_files = _backup_from_marker(database, marker)
+        recovery_source = backup_dir / database.name
+    else:
+        marker = dict(marker or {})
+        marker.setdefault("started_at", datetime.now(timezone.utc).isoformat())
+        marker.update({
+            "version": 1,
+            "database_path": str(database.resolve()),
+            "stage": "preparing",
+        })
+        marker.pop("backup_path", None)
+        marker.pop("error", None)
+        # Publish the cross-process gate before reading or copying the source.
+        # A crash in this stage leaves the original untouched; the same marker
+        # tells a retry to create a fresh backup rather than guess.
+        _write_marker(database, marker)
+        recovery_source = database
+
+    snapshot: dict[str, list[dict[str, Any]]] = {}
+    errors: list[str] = []
+    conn: sqlite3.Connection | None = None
+    try:
+        conn = _read_only_connection(recovery_source)
+        snapshot, errors = _recovery_snapshot(conn)
+    except (OSError, sqlite3.DatabaseError):
+        errors = ["database schema and durable safety state"]
+    finally:
+        if conn is not None:
+            conn.close()
+
+    _set_health({
+        **current_index_health(),
+        "status": "rebuilding",
+        "stage": "backing_up",
+        "message": "Backing up the damaged index before changing anything...",
+    })
+    if backup_dir is None:
+        backup_dir, backup_files = _backup_index_files(database)
+        manifest = {
+            "created_at": datetime.now(timezone.utc).isoformat(),
+            "database_path": str(database.resolve()),
+            "files": [path.name for path in backup_files],
+            "unreadable_state": errors,
+            "recoverable_state_counts": {
+                name: len(rows) for name, rows in snapshot.items()
+            },
+        }
+        manifest_path = backup_dir / "recovery-manifest.json"
+        with manifest_path.open("w", encoding="utf-8") as manifest_file:
+            json.dump(manifest, manifest_file, indent=2, sort_keys=True)
+            manifest_file.flush()
+            os.fsync(manifest_file.fileno())
+        _fsync_directory(backup_dir)
+    marker.update({
+        "version": 1,
+        "database_path": str(database.resolve()),
+        "backup_path": str(backup_dir),
+        "stage": "backed_up",
+    })
+    marker.pop("error", None)
+    _write_marker(database, marker)
+
+    previous_recovery_access = index_module._set_index_recovery_access(True)
+    try:
+        _remove_index_files(database)
+        marker["stage"] = "reindexing"
+        _write_marker(database, marker)
+        _set_health({
+            **current_index_health(),
+            "status": "rebuilding",
+            "stage": "reindexing",
+            "message": "Rebuilding the local index from the original session logs...",
+            "backup_path": str(backup_dir),
+        })
+        fresh = index_module.open_index()
+        fresh.close()
+        scan_report = scan_callback()
+        if scan_report.get("ok") is not True:
+            raise RuntimeError("The source-log rescan did not complete cleanly.")
+
+        marker["stage"] = "restoring_state"
+        _write_marker(database, marker)
+        _set_health({
+            **current_index_health(),
+            "status": "rebuilding",
+            "stage": "restoring_state",
+            "message": "Restoring review, hold, sharing, and policy state...",
+        })
+        rebuilt = index_module.open_index()
+        try:
+            restored_counts, warnings = _restore_snapshot(
+                rebuilt,
+                snapshot,
+                unreadable_state=errors,
+            )
+            check = [str(row[0]) for row in rebuilt.execute("PRAGMA quick_check(1)")]
+            if check != ["ok"]:
+                raise sqlite3.DatabaseError(check[0] if check else "integrity check failed")
+            foreign_key_errors = rebuilt.execute("PRAGMA foreign_key_check").fetchall()
+            if foreign_key_errors:
+                raise sqlite3.DatabaseError(
+                    "The rebuilt index failed its foreign-key integrity check."
+                )
+        finally:
+            rebuilt.close()
+    except Exception as exc:
+        logger.exception("Guided workbench-index recovery failed")
+        marker["stage"] = "failed"
+        marker["error"] = str(exc)
+        _write_marker(database, marker)
+        failed = {
+            "database_path": str(database.resolve()),
+            "sqlite_version": sqlite3.sqlite_version,
+            "journal_mode": index_module.INDEX_JOURNAL_MODE,
+            "status": "recovery_required",
+            "message": (
+                "Recovery did not finish. The original index backup is intact "
+                "and the partial rebuild will not be used."
+            ),
+            "detail": str(exc),
+            "backup_path": str(backup_dir),
+            "automatic_recovery_available": True,
+            "interrupted_recovery": True,
+        }
+        _set_health(failed)
+        raise
+    finally:
+        index_module._set_index_recovery_access(previous_recovery_access)
+
+    _marker_path(database).unlink(missing_ok=True)
+    _fsync_directory(database.parent)
+    ready = {
+        "status": "ready",
+        "message": "The workbench index was rebuilt and verified.",
+        "database_path": str(database.resolve()),
+        "sqlite_version": sqlite3.sqlite_version,
+        "journal_mode": index_module.INDEX_JOURNAL_MODE,
+        "automatic_recovery_available": False,
+        "backup_path": str(backup_dir),
+        "restored_state_counts": restored_counts,
+        "warnings": warnings,
+    }
+    return _set_health(ready)

--- a/scripts/install.ps1
+++ b/scripts/install.ps1
@@ -400,16 +400,39 @@ elseif (Test-Path $FeSrcDir) {
     }
 }
 
-$managedBetterleaks = Join-Path $HOME ".clawjournal\bin\betterleaks.exe"
-if (-not $WithSharing -and -not (Get-Command betterleaks -ErrorAction SilentlyContinue) -and -not (Test-Path $managedBetterleaks)) {
+$betterleaksAvailable = $WithSharing
+$trufflehogAvailable = $WithSharing
+if (-not $WithSharing) {
+    # Ask the installed CLI so managed binaries follow CLAWJOURNAL_HOME and
+    # PATH-based installs use the same validation as the share gate. Keep the
+    # installer's own probes from starting a nested background update.
+    $previousNoAutoUpdate = $env:CLAWJOURNAL_NO_AUTO_UPDATE
+    $previousProbeEap = $ErrorActionPreference
+    $env:CLAWJOURNAL_NO_AUTO_UPDATE = '1'
+    $ErrorActionPreference = 'Continue'
+    try {
+        Invoke-ClawJournal betterleaks status --json *> $null
+        $betterleaksAvailable = $LASTEXITCODE -eq 0
+        Invoke-ClawJournal trufflehog status --json *> $null
+        $trufflehogAvailable = $LASTEXITCODE -eq 0
+    } finally {
+        $ErrorActionPreference = $previousProbeEap
+        if ($null -eq $previousNoAutoUpdate) {
+            Remove-Item Env:CLAWJOURNAL_NO_AUTO_UPDATE -ErrorAction SilentlyContinue
+        } else {
+            $env:CLAWJOURNAL_NO_AUTO_UPDATE = $previousNoAutoUpdate
+        }
+    }
+}
+
+if (-not $betterleaksAvailable) {
     Write-Host ""
     Write-Host "[i] Betterleaks is required when sharing exports."
     Write-Host "    Install a pinned, checksum-verified copy: $ClawJournalDisplay betterleaks install"
     Write-Host "    Or re-run: .\scripts\install.ps1 -WithSharing"
 }
 
-$managedTrufflehog = Join-Path $HOME ".clawjournal\bin\trufflehog.exe"
-if (-not $WithSharing -and -not (Get-Command trufflehog -ErrorAction SilentlyContinue) -and -not (Test-Path $managedTrufflehog)) {
+if (-not $trufflehogAvailable) {
     Write-Host ""
     Write-Host "[i] TruffleHog is required when sharing exports."
     Write-Host "    Install a pinned, checksum-verified copy: $ClawJournalDisplay trufflehog install"

--- a/scripts/install_lock.py
+++ b/scripts/install_lock.py
@@ -19,8 +19,19 @@ LOCK_FILENAME = "reinstall.lock"
 LOCK_HELD_ENV = "CLAWJOURNAL_INSTALL_LOCK_HELD"
 
 
+def _state_dir() -> Path:
+    """Resolve the state root without importing the not-yet-installed package."""
+
+    override = os.environ.get("CLAWJOURNAL_HOME", "").strip()
+    return (
+        Path(override).expanduser().resolve()
+        if override
+        else Path.home() / ".clawjournal"
+    )
+
+
 def _lock_path() -> Path:
-    return Path.home() / ".clawjournal" / LOCK_FILENAME
+    return _state_dir() / LOCK_FILENAME
 
 
 def _acquire_lock(path: Path) -> int:

--- a/tests/benchmark/test_api.py
+++ b/tests/benchmark/test_api.py
@@ -266,11 +266,11 @@ class TestFeatures:
         monkeypatch.setattr("clawjournal.config.load_config", lambda: {})
         status, body = _get(api, "/api/features")
         assert status == 200
-        assert body == {"benchmark_tab_enabled": True, "scoring_warmup_declined": False}
+        assert body["benchmark_tab_enabled"] is True
 
     def test_respects_disabled_flag(self, api, monkeypatch):
         monkeypatch.setattr("clawjournal.config.load_config",
                             lambda: {"benchmark_tab_enabled": False})
         status, body = _get(api, "/api/features")
         assert status == 200
-        assert body == {"benchmark_tab_enabled": False, "scoring_warmup_declined": False}
+        assert body["benchmark_tab_enabled"] is False

--- a/tests/events/doctor/test_cli.py
+++ b/tests/events/doctor/test_cli.py
@@ -12,12 +12,14 @@ import pytest
 
 @pytest.fixture
 def isolated_home(monkeypatch, tmp_path):
-    """Run CLI in a subprocess with HOME pointing at a tmp dir."""
+    """Run CLI with isolated agent-home and ClawJournal state roots."""
 
     env = {
         "HOME": str(tmp_path),
+        "USERPROFILE": str(tmp_path),
         "PATH": "/usr/bin:/bin",
         "PYTHONPATH": str(Path(__file__).parent.parent.parent.parent),
+        "CLAWJOURNAL_HOME": str(tmp_path / ".clawjournal"),
         "CLAWJOURNAL_SKIP_TRUFFLEHOG": "1",
     }
     return env

--- a/tests/events/doctor/test_overlay.py
+++ b/tests/events/doctor/test_overlay.py
@@ -26,6 +26,13 @@ def _write(path: Path, text: str) -> None:
     path.write_text(text, encoding="utf-8")
 
 
+def test_overlay_path_follows_configured_state_root(monkeypatch, tmp_path):
+    state_root = tmp_path / "relocated-state"
+    monkeypatch.setattr("clawjournal.config.CONFIG_DIR", state_root)
+
+    assert overlay_mod.overlay_path() == state_root / "capability_overlay.yaml"
+
+
 def test_no_overlay_returns_shipped_matrix():
     matrix = overlay_mod.effective_matrix()
     # Sanity: claude/user_message ships as supported.

--- a/tests/events/doctor/test_probes.py
+++ b/tests/events/doctor/test_probes.py
@@ -10,6 +10,7 @@ import pytest
 from clawjournal.events.doctor import overlay as overlay_mod
 from clawjournal.events.doctor import probes
 from clawjournal.events.schema import ensure_schema as ensure_events_schema
+from clawjournal.workbench import index as index_module
 from clawjournal.workbench.index import open_index
 
 
@@ -38,6 +39,35 @@ def _make_workbench_only(tmp_path: Path) -> None:
         conn.commit()
     finally:
         conn.close()
+
+
+def test_paths_follow_configured_state_root(monkeypatch, tmp_path):
+    state_root = tmp_path / "relocated-state"
+    monkeypatch.setattr("clawjournal.config.CONFIG_DIR", state_root)
+
+    assert probes.config_dir() == state_root
+    assert probes.index_db_path() == state_root / "index.db"
+
+
+def test_readonly_probe_honors_recovery_marker_for_relocated_special_path(tmp_path):
+    database = tmp_path / "state %23#relocated" / "index.db"
+    database.parent.mkdir()
+    conn = sqlite3.connect(database)
+    try:
+        conn.execute("CREATE TABLE sessions (session_id TEXT PRIMARY KEY)")
+        conn.commit()
+    finally:
+        conn.close()
+
+    probe = probes._open_readonly(database)
+    assert probe is not None
+    probes._close_readonly(probe)
+
+    index_module._index_recovery_marker_path(database).write_text(
+        "{}",
+        encoding="utf-8",
+    )
+    assert probes._open_readonly(database) is None
 
 
 def test_fresh_install_returns_zero(monkeypatch, tmp_path):

--- a/tests/events/doctor/test_render.py
+++ b/tests/events/doctor/test_render.py
@@ -126,7 +126,34 @@ def test_partial_suggestion_does_not_reference_nonexistent_inspect_flag():
         matrix_supported_count=11,
         verdict=VERDICT_PARTIAL,
     )
-    text = render.render_human(_base_report(clients=[obs]))
+    text = render.render_human(
+        _base_report(
+            clients=[obs],
+            index_db_path="/relocated/clawjournal/index.db",
+        )
+    )
     assert "Suggested next steps" in text
     assert "--type schema_unknown" not in text
     assert "events inspect <event_id>" in text
+    assert 'sqlite3 "/relocated/clawjournal/index.db"' in text
+
+
+def test_partial_suggestion_quotes_relocated_index_path_with_spaces():
+    obs = ClientObservation(
+        client="claude",
+        client_version="1.45.0",
+        sessions_count=1,
+        event_types_observed=["schema_unknown"],
+        unknown_event_types=[],
+        unsupported_event_types=[],
+        schema_unknown_rows=2,
+        matrix_supported_count=11,
+        verdict=VERDICT_PARTIAL,
+    )
+    text = render.render_human(
+        _base_report(
+            clients=[obs],
+            index_db_path="/private local state/index.db",
+        )
+    )
+    assert 'sqlite3 "/private local state/index.db"' in text

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -146,7 +146,9 @@ class TestEffectiveHoldState:
 
     def test_non_embargo_state_passes_through(self):
         assert effective_hold_state("released", None) == "released"
-        assert effective_hold_state(None, None) == "auto_redacted"
+
+    def test_missing_state_fails_closed(self):
+        assert effective_hold_state(None, None) == "pending_review"
 
 
 class TestFindingsVerb:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,6 +1,10 @@
 """Tests for clawjournal.config — config persistence."""
 
 import json
+import os
+import subprocess
+import sys
+from pathlib import Path
 
 import pytest
 
@@ -22,6 +26,82 @@ def test_clawjournal_home_relocates_the_complete_state_root(tmp_path, monkeypatc
     monkeypatch.setenv("CLAWJOURNAL_HOME", str(state_root))
 
     assert _resolve_config_dir() == state_root.resolve()
+
+
+def test_clawjournal_home_routes_parser_state_without_moving_agent_sources(tmp_path):
+    state_root = tmp_path / "private local state"
+    probe = (
+        "import json\n"
+        "from pathlib import Path\n"
+        "from clawjournal.parsing import parser\n"
+        "print(json.dumps({\n"
+        "    'home': str(Path.home()),\n"
+        "    'workbuddy_import': str(parser.WORKBUDDY_IMPORT_DIR),\n"
+        "    'custom': str(parser.CUSTOM_DIR),\n"
+        "    'claude': str(parser.CLAUDE_DIR),\n"
+        "    'codex': str(parser.CODEX_DIR),\n"
+        "    'workbuddy': str(parser.WORKBUDDY_DIR),\n"
+        "}))\n"
+    )
+    env = os.environ.copy()
+    env["CLAWJOURNAL_HOME"] = str(state_root)
+    repo_root = Path(__file__).resolve().parents[1]
+    existing_pythonpath = env.get("PYTHONPATH")
+    env["PYTHONPATH"] = (
+        str(repo_root)
+        if not existing_pythonpath
+        else os.pathsep.join((str(repo_root), existing_pythonpath))
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-c", probe],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+    paths = json.loads(result.stdout)
+    home = Path(paths["home"])
+
+    assert Path(paths["workbuddy_import"]) == state_root.resolve() / "workbuddy"
+    assert Path(paths["custom"]) == state_root.resolve() / "custom"
+    assert Path(paths["claude"]) == home / ".claude"
+    assert Path(paths["codex"]) == home / ".codex"
+    assert Path(paths["workbuddy"]) == home / "WorkBuddy"
+
+
+@pytest.mark.parametrize(
+    "arguments",
+    (
+        ("trufflehog", "--help"),
+        ("betterleaks", "--help"),
+        ("events", "export", "--help"),
+    ),
+)
+def test_clawjournal_home_percent_is_safe_in_argparse_help(tmp_path, arguments):
+    state_root = tmp_path / "100%safe-state"
+    env = os.environ.copy()
+    env["CLAWJOURNAL_HOME"] = str(state_root)
+    repo_root = Path(__file__).resolve().parents[1]
+    env["PYTHONPATH"] = os.pathsep.join(
+        filter(None, (str(repo_root), env.get("PYTHONPATH")))
+    )
+
+    result = subprocess.run(
+        [sys.executable, "-m", "clawjournal.cli", *arguments],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=True,
+        timeout=30,
+    )
+
+    compact_help = "".join(result.stdout.split())
+    assert "100%safe-state" in compact_help
+    assert "'option_strings'" not in result.stdout
 
 
 class TestAutoUploadProfileProjection:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -10,10 +10,18 @@ from clawjournal.config import (
     _migrate_excluded_projects,
     _migrate_findings_engines,
     _migrate_remove_auto_upload_ui_flag,
+    _resolve_config_dir,
     load_config,
     normalize_excluded_project_names,
     save_config,
 )
+
+
+def test_clawjournal_home_relocates_the_complete_state_root(tmp_path, monkeypatch):
+    state_root = tmp_path / "private local state"
+    monkeypatch.setenv("CLAWJOURNAL_HOME", str(state_root))
+
+    assert _resolve_config_dir() == state_root.resolve()
 
 
 class TestAutoUploadProfileProjection:

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -947,10 +947,18 @@ def test_losing_startup_race_to_another_service_reports_an_error(
     assert calls == []
 
 
-def test_run_server_can_refuse_the_ephemeral_port_fallback() -> None:
-    """`serve` keeps the fallback; the launcher opts out of it."""
+def test_run_server_can_refuse_the_ephemeral_port_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A rejected launch neither falls back nor publishes startup health."""
     from clawjournal.workbench import daemon as daemon_mod
 
+    health_starts = []
+    monkeypatch.setattr(
+        daemon_mod,
+        "begin_index_health_check",
+        lambda: health_starts.append(True),
+    )
     listener = socket.socket()
     listener.bind(("127.0.0.1", 0))
     listener.listen(64)
@@ -962,6 +970,7 @@ def test_run_server_can_refuse_the_ephemeral_port_fallback() -> None:
             )
     finally:
         listener.close()
+    assert health_starts == []
 
 
 def test_status_json_shape(isolated_desktop: Path) -> None:

--- a/tests/test_install_scripts.py
+++ b/tests/test_install_scripts.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import os
+import runpy
 import shutil
 import subprocess
 import sys
@@ -11,6 +12,14 @@ import pytest
 
 
 ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_install_lock_follows_clawjournal_home(monkeypatch, tmp_path):
+    state_root = tmp_path / "private local state"
+    monkeypatch.setenv("CLAWJOURNAL_HOME", str(state_root))
+    namespace = runpy.run_path(str(ROOT / "scripts" / "install_lock.py"))
+
+    assert namespace["_lock_path"]() == state_root.resolve() / "reinstall.lock"
 
 
 def test_posix_installer_supports_managed_sharing_dependencies():
@@ -68,6 +77,15 @@ def test_powershell_installer_supports_managed_sharing_dependencies():
     assert "$RepoDir $script:SyncFrom $script:SyncTo" in script
     assert script.index("record_install_sync") < script.index("pip install")
     assert "--clear-pending" not in script
+
+
+def test_powershell_installer_uses_canonical_scanner_status_for_relocated_state():
+    script = (ROOT / "scripts" / "install.ps1").read_text(encoding="utf-8")
+
+    assert "Invoke-ClawJournal betterleaks status --json" in script
+    assert "Invoke-ClawJournal trufflehog status --json" in script
+    assert "CLAWJOURNAL_NO_AUTO_UPDATE" in script
+    assert 'Join-Path $HOME ".clawjournal\\bin' not in script
 
 
 @pytest.mark.skipif(os.name == "nt", reason="POSIX installer invocation")

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -208,7 +208,11 @@ def test_blocked_all_blocked_aborts(monkeypatch):
 # ---- time-range windows (rolling 24h / 168h) --------------------------------
 
 def _row(fv=None, end_delta_hours=None, **extra):
-    r = {"hold_state": None, "shared_at": None, "ai_failure_value_score": fv}
+    r = {
+        "hold_state": "auto_redacted",
+        "shared_at": None,
+        "ai_failure_value_score": fv,
+    }
     if end_delta_hours is not None:
         r["end_time"] = (datetime.now(timezone.utc) - timedelta(hours=end_delta_hours)).isoformat()
     r.update(extra)

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -7,9 +7,11 @@ import sqlite3
 import time
 import urllib.error
 import zipfile
+from contextlib import nullcontext
 from datetime import datetime, timedelta, timezone
 from http.client import HTTPConnection
 from io import BytesIO
+from pathlib import Path
 from threading import Event, Lock, Thread
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
@@ -330,6 +332,366 @@ def _delete(port, path, *, skip_auth=False):
     resp = conn.getresponse()
     resp_body = resp.read().decode()
     return resp.status, json.loads(resp_body) if resp.getheader("Content-Type", "").startswith("application/json") else resp_body
+
+
+def test_index_recovery_gate_leaves_only_health_probe_available(server):
+    from clawjournal.workbench import index_recovery
+
+    recovery_health = {
+        "status": "recovery_required",
+        "message": "The test index is damaged.",
+        "automatic_recovery_available": True,
+    }
+    index_recovery._set_health(recovery_health)
+    try:
+        status, features = _get(server, "/api/features")
+        assert status == 200
+        assert features["index_health"] == recovery_health
+
+        requests = (
+            _get(server, "/api/stats"),
+            _post(server, "/api/scan"),
+            _patch(server, "/api/findings"),
+            _delete(server, "/api/policies/test-policy"),
+        )
+        for status, body in requests:
+            assert status == 503
+            assert body["code"] == "index_recovery_required"
+    finally:
+        index_recovery._set_health({
+            "status": "ready",
+            "message": "The test index is ready.",
+        })
+
+
+def test_external_recovery_marker_blocks_and_then_resumes_cached_daemon(
+    server,
+    index_setup,
+):
+    from clawjournal.workbench import index as index_module
+    from clawjournal.workbench import index_recovery
+
+    database = Path(index_module.INDEX_DB)
+    backup = index_setup / "index-backups" / "external-recovery"
+    backup.mkdir(parents=True)
+    (backup / "index.db").write_bytes(database.read_bytes())
+    marker = index_setup / index_recovery.RECOVERY_MARKER_FILENAME
+    index_recovery._write_marker(
+        database,
+        {"version": 1, "backup_path": str(backup), "stage": "backed_up"},
+    )
+    index_recovery._set_health({
+        "status": "ready",
+        "message": "Stale ready state from this daemon.",
+    })
+    try:
+        status, features = _get(server, "/api/features")
+        assert status == 200
+        assert features["index_health"]["status"] == "recovery_required"
+        assert features["index_health"]["interrupted_recovery"] is True
+
+        status, body = _get(server, "/api/stats")
+        assert status == 503
+        assert body["code"] == "index_recovery_required"
+
+        marker.unlink()
+        status, features = _get(server, "/api/features")
+        assert status == 200
+        assert features["index_health"]["status"] == "ready"
+        status, _body = _get(server, "/api/stats")
+        assert status == 200
+    finally:
+        marker.unlink(missing_ok=True)
+        index_recovery._set_health({
+            "status": "ready",
+            "message": "The test index is ready.",
+        })
+
+
+def test_index_rebuild_endpoint_still_requires_bearer_auth(server):
+    status, _body = _post(
+        server,
+        "/api/index/rebuild",
+        skip_auth=True,
+    )
+
+    assert status == 401
+
+
+def test_index_rebuild_endpoint_runs_once_and_resumes_scanner(
+    server_with_scanner,
+    monkeypatch,
+):
+    from clawjournal.workbench import daemon, index_recovery
+
+    port, scanner = server_with_scanner
+    resumed = Event()
+    scanner._stop_event = Event()
+    scanner.start = resumed.set
+
+    def rebuild_damaged_index():
+        return index_recovery._set_health({
+            "status": "ready",
+            "message": "The test index was rebuilt.",
+            "backup_path": "test-backup",
+        })
+
+    scanner.rebuild_damaged_index = rebuild_damaged_index
+    monkeypatch.setattr(
+        daemon,
+        "trigger_scoring_warmup",
+        lambda _scanner: {"status": "disabled"},
+    )
+    index_recovery._set_health({
+        "status": "recovery_required",
+        "message": "The test index is damaged.",
+        "automatic_recovery_available": True,
+    })
+    try:
+        status, body = _post(port, "/api/index/rebuild")
+
+        assert status == 202
+        assert body["ok"] is True
+        assert resumed.wait(2)
+        assert index_recovery.current_index_health()["status"] == "ready"
+    finally:
+        thread = daemon._index_recovery_thread
+        if thread is not None:
+            thread.join(timeout=2)
+        index_recovery._set_health({
+            "status": "ready",
+            "message": "The test index is ready.",
+        })
+
+
+def test_index_rebuild_keeps_workers_stopped_when_result_is_not_ready(
+    server_with_scanner,
+    monkeypatch,
+):
+    from clawjournal.workbench import daemon, index_recovery
+
+    port, scanner = server_with_scanner
+    finished = Event()
+    resumed = Event()
+    scanner._stop_event = Event()
+    scanner.start = resumed.set
+
+    def rebuild_damaged_index():
+        try:
+            return index_recovery._set_health({
+                "status": "unavailable",
+                "message": "The rebuilt index could not be opened.",
+                "automatic_recovery_available": False,
+            })
+        finally:
+            finished.set()
+
+    scanner.rebuild_damaged_index = rebuild_damaged_index
+    monkeypatch.setattr(
+        daemon,
+        "trigger_scoring_warmup",
+        lambda _scanner: pytest.fail("warmup must remain stopped"),
+    )
+    index_recovery._set_health({
+        "status": "recovery_required",
+        "message": "The test index is damaged.",
+        "automatic_recovery_available": True,
+    })
+    try:
+        status, body = _post(port, "/api/index/rebuild")
+
+        assert status == 202
+        assert body["ok"] is True
+        assert finished.wait(2)
+        thread = daemon._index_recovery_thread
+        if thread is not None:
+            thread.join(timeout=2)
+        assert not resumed.is_set()
+        assert index_recovery.current_index_health()["status"] == "unavailable"
+    finally:
+        index_recovery._set_health({
+            "status": "ready",
+            "message": "The test index is ready.",
+        })
+
+
+def test_rebuild_skips_when_another_process_already_recovered(
+    monkeypatch,
+):
+    from clawjournal import auto_upload, config
+    from clawjournal.workbench import daemon
+
+    scanner = Scanner()
+    expected = {"status": "ready", "message": "Already recovered."}
+    monkeypatch.setattr(
+        auto_upload,
+        "whole_run_lock",
+        lambda **_kwargs: nullcontext(True),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "_scan_process_lock",
+        lambda **_kwargs: nullcontext(True),
+    )
+    monkeypatch.setattr(
+        config,
+        "auto_upload_egress_lock",
+        lambda: nullcontext(),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "inspect_index_health",
+        lambda: {"status": "ready"},
+    )
+    monkeypatch.setattr(
+        daemon,
+        "initialize_index_health",
+        lambda: expected,
+    )
+    monkeypatch.setattr(
+        daemon,
+        "guided_rebuild",
+        lambda *_args, **_kwargs: pytest.fail("healthy index was rebuilt"),
+    )
+
+    assert scanner.rebuild_damaged_index() == expected
+
+
+def test_rebuild_uses_automatic_upload_lock_order(monkeypatch):
+    from clawjournal import auto_upload, config
+    from clawjournal.workbench import daemon
+
+    events: list[str] = []
+
+    class RecordingContext:
+        def __init__(self, name, result=None):
+            self.name = name
+            self.result = result
+
+        def __enter__(self):
+            events.append(f"enter:{self.name}")
+            return self.result
+
+        def __exit__(self, *_args):
+            events.append(f"exit:{self.name}")
+
+    def whole_run_lock(*, blocking=False):
+        assert blocking is True
+        return RecordingContext("whole_run", True)
+
+    scanner = Scanner()
+    scanner._scan_lock = RecordingContext("local_scan")
+    monkeypatch.setattr(auto_upload, "whole_run_lock", whole_run_lock)
+    monkeypatch.setattr(
+        daemon,
+        "_scan_process_lock",
+        lambda **_kwargs: RecordingContext("process_scan", True),
+    )
+    monkeypatch.setattr(
+        config,
+        "auto_upload_egress_lock",
+        lambda: RecordingContext("egress"),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "inspect_index_health",
+        lambda: {"status": "recovery_required"},
+    )
+    monkeypatch.setattr(
+        daemon,
+        "guided_rebuild",
+        lambda *_args, **_kwargs: events.append("rebuild") or {"status": "ready"},
+    )
+
+    assert scanner.rebuild_damaged_index() == {"status": "ready"}
+    assert events == [
+        "enter:whole_run",
+        "enter:local_scan",
+        "enter:process_scan",
+        "enter:egress",
+        "rebuild",
+        "exit:egress",
+        "exit:process_scan",
+        "exit:local_scan",
+        "exit:whole_run",
+    ]
+
+
+def test_rebuild_stops_when_automatic_upload_lock_is_unavailable(monkeypatch):
+    from clawjournal import auto_upload
+    from clawjournal.workbench import daemon
+
+    scanner = Scanner()
+    monkeypatch.setattr(
+        auto_upload,
+        "whole_run_lock",
+        lambda **_kwargs: nullcontext(False),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "_scan_process_lock",
+        lambda **_kwargs: pytest.fail("scan lock must not be entered"),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "guided_rebuild",
+        lambda *_args, **_kwargs: pytest.fail("rebuild must not start"),
+    )
+
+    with pytest.raises(ScanBusyError, match="could not be paused"):
+        scanner.rebuild_damaged_index()
+
+
+def test_rebuild_ignores_serve_source_filter_for_complete_rescan(monkeypatch):
+    from clawjournal import auto_upload, config
+    from clawjournal.workbench import daemon
+
+    scanner = Scanner(source_filter="claude")
+    observed_filters: list[str | None] = []
+    scanner._scan_once_report = lambda **_kwargs: (
+        observed_filters.append(scanner.source_filter) or {"ok": True}
+    )
+    monkeypatch.setattr(
+        auto_upload,
+        "whole_run_lock",
+        lambda **_kwargs: nullcontext(True),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "_scan_process_lock",
+        lambda **_kwargs: nullcontext(True),
+    )
+    monkeypatch.setattr(
+        config,
+        "auto_upload_egress_lock",
+        lambda: nullcontext(),
+    )
+    monkeypatch.setattr(
+        daemon,
+        "inspect_index_health",
+        lambda: {"status": "recovery_required"},
+    )
+    monkeypatch.setattr(
+        daemon,
+        "guided_rebuild",
+        lambda callback: callback(),
+    )
+
+    assert scanner.rebuild_damaged_index() == {"ok": True}
+    assert observed_filters == [None]
+    assert scanner.source_filter == "claude"
+
+
+def test_index_recovery_worker_blocks_graceful_reexec(monkeypatch):
+    from clawjournal.workbench import daemon
+
+    monkeypatch.setattr(
+        daemon,
+        "_index_recovery_thread",
+        SimpleNamespace(is_alive=lambda: True),
+    )
+
+    assert daemon._background_workers_active() is True
 
 
 @pytest.mark.parametrize(
@@ -4163,7 +4525,11 @@ def test_finalized_ai_manifest_requires_complete_nested_coverage():
     assert not _manifest_is_finalized_for_upload(legacy, ai_pii=True)
 
 
-def test_finalize_blocks_rules_only_fallback_when_ai_configured(tmp_path, monkeypatch):
+def test_finalize_blocks_rules_only_fallback_when_ai_configured(
+    tmp_path,
+    monkeypatch,
+    index_setup,
+):
     from clawjournal.workbench import daemon
 
     (tmp_path / "sessions.jsonl").write_text("{}\n", encoding="utf-8")

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -11,6 +11,7 @@ from clawjournal.workbench.index import (
     add_policy,
     backfill_session_keys,
     create_share,
+    effective_hold_state,
     get_effective_share_settings,
     get_dashboard_analytics,
     get_share,
@@ -33,6 +34,11 @@ from clawjournal.workbench.index import (
     update_session,
     upsert_sessions,
 )
+
+
+@pytest.mark.parametrize("damaged_state", [None, "", "unknown-state"])
+def test_effective_hold_state_fails_closed_for_invalid_values(damaged_state):
+    assert effective_hold_state(damaged_state, None) == "pending_review"
 
 
 @pytest.fixture

--- a/tests/workbench/test_index_recovery.py
+++ b/tests/workbench/test_index_recovery.py
@@ -1,0 +1,871 @@
+"""Tests for the startup integrity guard and guided index recovery."""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from threading import Thread
+
+import pytest
+
+from clawjournal.workbench import index as index_module
+from clawjournal.workbench import index_recovery
+
+
+@pytest.fixture
+def recovery_install(tmp_path, monkeypatch) -> Path:
+    """Redirect every index artifact used by recovery to one temp root."""
+
+    install_dir = tmp_path / "state"
+    monkeypatch.setattr(index_module, "CONFIG_DIR", install_dir)
+    monkeypatch.setattr(index_module, "INDEX_DB", install_dir / "index.db")
+    monkeypatch.setattr(index_module, "BLOBS_DIR", install_dir / "blobs")
+    index_recovery._set_health(
+        {"status": "ready", "message": "Test index is ready."}
+    )
+    yield install_dir
+    index_recovery._set_health(
+        {"status": "ready", "message": "Test index is ready."}
+    )
+
+
+def _session(content: str = "Fix the recovery bug") -> dict:
+    return {
+        "session_id": "session-recovery",
+        "project": "recovery-project",
+        "source": "claude",
+        "model": "claude-sonnet-4",
+        "start_time": "2026-07-30T00:00:00+00:00",
+        "end_time": "2026-07-30T00:10:00+00:00",
+        "messages": [
+            {"role": "user", "content": content, "tool_uses": []},
+            {"role": "assistant", "content": "Done.", "tool_uses": []},
+        ],
+        "stats": {
+            "user_messages": 1,
+            "assistant_messages": 1,
+            "tool_uses": 0,
+            "input_tokens": 100,
+            "output_tokens": 25,
+        },
+    }
+
+
+def _scan_one_session() -> dict[str, object]:
+    conn = index_module.open_index()
+    try:
+        index_module.upsert_sessions(conn, [_session()])
+    finally:
+        conn.close()
+    return {"ok": True}
+
+
+def _add_recovery_finding(conn: sqlite3.Connection, *, decided: bool) -> None:
+    revision = conn.execute(
+        "SELECT content_revision FROM sessions WHERE session_id = ?",
+        ("session-recovery",),
+    ).fetchone()[0]
+    conn.execute(
+        """INSERT INTO findings (
+            finding_id, session_id, engine, rule, entity_hash, field,
+            offset, length, status, decided_by, decided_at,
+            decision_reason, revision, created_at
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        (
+            "finding-recovery",
+            "session-recovery",
+            "test-engine",
+            "test-rule",
+            "hash:test-entity",
+            "content",
+            0,
+            4,
+            "ignored" if decided else "open",
+            "user" if decided else None,
+            "2026-07-30T00:20:00+00:00" if decided else None,
+            "Known test value" if decided else None,
+            revision,
+            "2026-07-30T00:15:00+00:00",
+        ),
+    )
+    conn.commit()
+
+
+def _scan_one_session_with_finding() -> dict[str, object]:
+    conn = index_module.open_index()
+    try:
+        index_module.upsert_sessions(conn, [_session()])
+        _add_recovery_finding(conn, decided=False)
+    finally:
+        conn.close()
+    return {"ok": True}
+
+
+def test_initialize_new_index_uses_delete_journal(recovery_install):
+    report = index_recovery.initialize_index_health()
+
+    assert report["status"] == "ready"
+    assert report["journal_mode"] == "delete"
+    assert (recovery_install / "index.db").is_file()
+
+    conn = sqlite3.connect(recovery_install / "index.db")
+    try:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+    finally:
+        conn.close()
+
+
+def test_initialize_healthy_wal_index_converts_to_delete(recovery_install):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    legacy = index_module.open_index()
+    try:
+        assert legacy.execute("PRAGMA journal_mode=WAL").fetchone()[0] == "wal"
+        legacy.execute("CREATE TABLE legacy_row (value TEXT)")
+        legacy.execute("INSERT INTO legacy_row VALUES ('preserved')")
+        legacy.commit()
+    finally:
+        legacy.close()
+
+    report = index_recovery.initialize_index_health()
+
+    assert report["status"] == "ready"
+    assert report["journal_mode"] == "delete"
+    conn = sqlite3.connect(database)
+    try:
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0] == "delete"
+        assert conn.execute("SELECT value FROM legacy_row").fetchone()[0] == "preserved"
+    finally:
+        conn.close()
+
+
+def test_non_sqlite_index_is_recoverable(recovery_install):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    database.write_bytes(b"not a sqlite database")
+
+    report = index_recovery.inspect_index_health()
+
+    assert report["status"] == "recovery_required"
+    assert report["automatic_recovery_available"] is True
+    assert report["unreadable_state"]
+
+
+def test_locked_index_is_not_misclassified_as_corruption(
+    recovery_install,
+    monkeypatch,
+):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    seed = sqlite3.connect(database)
+    try:
+        seed.execute("CREATE TABLE placeholder (value TEXT)")
+        seed.commit()
+    finally:
+        seed.close()
+
+    def locked_connection(_path):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(
+        index_recovery,
+        "_health_connection",
+        locked_connection,
+    )
+
+    report = index_recovery.inspect_index_health()
+
+    assert report["status"] == "unavailable"
+    assert report["automatic_recovery_available"] is False
+
+
+def test_health_check_rolls_back_hot_delete_journal(recovery_install):
+    database = recovery_install / "index.db"
+    conn = index_module.open_index()
+    try:
+        conn.execute("CREATE TABLE hot_journal_probe (id TEXT, value TEXT)")
+        conn.executemany(
+            "INSERT INTO hot_journal_probe VALUES (?, ?)",
+            [(str(index), "a" * 4000) for index in range(50)],
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    child = """
+import os
+import sqlite3
+import sys
+
+conn = sqlite3.connect(sys.argv[1])
+conn.execute("PRAGMA journal_mode=DELETE")
+conn.execute("PRAGMA synchronous=FULL")
+conn.execute("PRAGMA cache_size=1")
+conn.execute("BEGIN IMMEDIATE")
+conn.execute("UPDATE hot_journal_probe SET value = replace(value, 'a', 'b')")
+os._exit(0)
+"""
+    subprocess.run(
+        [sys.executable, "-c", child, str(database)],
+        check=True,
+        env={**os.environ},
+    )
+    journal = Path(str(database) + "-journal")
+    assert journal.is_file()
+    assert journal.stat().st_size > 0
+
+    report = index_recovery.inspect_index_health()
+
+    assert report["status"] == "ready"
+    assert not journal.exists()
+    verified = sqlite3.connect(database)
+    try:
+        assert verified.execute(
+            "SELECT DISTINCT substr(value, 1, 1) FROM hot_journal_probe"
+        ).fetchall() == [("a",)]
+    finally:
+        verified.close()
+
+
+def test_malformed_recovery_marker_fails_closed(recovery_install):
+    marker = recovery_install / index_recovery.RECOVERY_MARKER_FILENAME
+    marker.parent.mkdir(parents=True)
+    marker.write_text("not-json", encoding="utf-8")
+
+    report = index_recovery.inspect_index_health()
+
+    assert report["status"] == "unavailable"
+    assert report["automatic_recovery_available"] is False
+    assert report["interrupted_recovery"] is True
+
+
+def test_marker_with_missing_backup_fails_closed(recovery_install):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    database.write_bytes(b"damaged source")
+    index_recovery._write_marker(
+        database,
+        {
+            "version": 1,
+            "stage": "backed_up",
+            "backup_path": str(recovery_install / "missing-backup"),
+        },
+    )
+
+    report = index_recovery.inspect_index_health()
+
+    assert report["status"] == "unavailable"
+    assert report["automatic_recovery_available"] is False
+    assert report["interrupted_recovery"] is True
+
+
+def test_marker_with_only_sidecar_backup_fails_closed(recovery_install):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    database.write_bytes(b"damaged source")
+    backup = recovery_install / "index-backups" / "sidecar-only"
+    backup.mkdir(parents=True)
+    (backup / "index.db-wal").write_bytes(b"orphaned wal")
+    index_recovery._write_marker(
+        database,
+        {"version": 1, "stage": "backed_up", "backup_path": str(backup)},
+    )
+
+    report = index_recovery.inspect_index_health()
+
+    assert report["status"] == "unavailable"
+    assert report["automatic_recovery_available"] is False
+    assert "database backup is missing" in report["detail"]
+
+
+def test_recovery_marker_blocks_direct_index_access(recovery_install):
+    conn = index_module.open_index()
+    conn.close()
+    database = recovery_install / "index.db"
+    index_recovery._write_marker(
+        database,
+        {"version": 1, "stage": "preparing"},
+    )
+
+    with pytest.raises(sqlite3.DatabaseError, match="unfinished recovery"):
+        index_module.open_index()
+
+    outcomes: list[str] = []
+    previous = index_module._set_index_recovery_access(True)
+    try:
+        allowed = index_module.open_index()
+        allowed.close()
+
+        def open_from_other_thread() -> None:
+            try:
+                unexpected = index_module.open_index()
+            except sqlite3.DatabaseError:
+                outcomes.append("blocked")
+            else:
+                unexpected.close()
+                outcomes.append("opened")
+
+        thread = Thread(target=open_from_other_thread)
+        thread.start()
+        thread.join(timeout=2)
+    finally:
+        index_module._set_index_recovery_access(previous)
+
+    assert outcomes == ["blocked"]
+    with pytest.raises(sqlite3.DatabaseError, match="unfinished recovery"):
+        index_module.open_index()
+
+
+def test_interrupted_preparing_stage_retries_from_untouched_index(
+    recovery_install,
+):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    original = b"damaged but untouched before backup"
+    database.write_bytes(original)
+    index_recovery._write_marker(
+        database,
+        {"version": 1, "stage": "preparing"},
+    )
+
+    report = index_recovery.inspect_index_health()
+    assert report["status"] == "recovery_required"
+    assert report["backup_path"] is None
+    assert "has not been replaced" in report["message"]
+
+    result = index_recovery.guided_rebuild(_scan_one_session)
+
+    assert (Path(result["backup_path"]) / "index.db").read_bytes() == original
+
+
+def test_preparing_marker_without_original_index_is_unavailable(
+    recovery_install,
+):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    index_recovery._write_marker(
+        database,
+        {"version": 1, "stage": "preparing"},
+    )
+
+    report = index_recovery.inspect_index_health()
+
+    assert report["status"] == "unavailable"
+    assert report["automatic_recovery_available"] is False
+    assert "original index is missing" in report["detail"]
+
+
+def test_snapshot_treats_missing_critical_session_columns_as_unreadable():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute(
+            "CREATE TABLE sessions ("
+            "session_id TEXT PRIMARY KEY, review_status TEXT, "
+            "content_revision TEXT)"
+        )
+
+        snapshot, errors = index_recovery._recovery_snapshot(conn)
+    finally:
+        conn.close()
+
+    assert snapshot["sessions"] == []
+    assert errors == ["session decisions and hold state"]
+
+
+def test_snapshot_treats_missing_critical_finding_columns_as_unreadable():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute(
+            "CREATE TABLE sessions ("
+            "session_id TEXT PRIMARY KEY, review_status TEXT, "
+            "hold_state TEXT, content_revision TEXT)"
+        )
+        conn.execute(
+            "CREATE TABLE findings ("
+            "session_id TEXT, engine TEXT, entity_hash TEXT, status TEXT)"
+        )
+
+        snapshot, errors = index_recovery._recovery_snapshot(conn)
+    finally:
+        conn.close()
+
+    assert snapshot["sessions"] == []
+    assert snapshot["finding_decisions"] == []
+    assert errors == ["finding decisions"]
+
+
+def test_snapshot_without_sessions_keeps_other_readable_state():
+    conn = sqlite3.connect(":memory:")
+    conn.row_factory = sqlite3.Row
+    try:
+        conn.execute(
+            "CREATE TABLE policies ("
+            "policy_id TEXT PRIMARY KEY, policy_type TEXT NOT NULL, "
+            "value TEXT NOT NULL, reason TEXT, created_at TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO policies VALUES (?, ?, ?, ?, ?)",
+            (
+                "policy-recovery",
+                "redact_string",
+                "keep-this-policy",
+                "Readable despite session damage",
+                "2026-07-30T00:00:00+00:00",
+            ),
+        )
+
+        snapshot, errors = index_recovery._recovery_snapshot(conn)
+    finally:
+        conn.close()
+
+    assert snapshot["sessions"] == []
+    assert snapshot["policies"][0]["value"] == "keep-this-policy"
+    assert errors == ["session decisions and hold state"]
+
+
+def test_existing_database_without_sessions_requires_recovery(recovery_install):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    conn = sqlite3.connect(database)
+    try:
+        conn.execute(
+            "CREATE TABLE policies ("
+            "policy_id TEXT PRIMARY KEY, policy_type TEXT NOT NULL, "
+            "value TEXT NOT NULL, reason TEXT, created_at TEXT NOT NULL)"
+        )
+        conn.execute(
+            "INSERT INTO policies VALUES "
+            "('policy-recovery', 'redact_string', 'preserve-me', NULL, 'now')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    report = index_recovery.inspect_index_health()
+
+    assert report["status"] == "recovery_required"
+    assert report["recoverable_state_counts"]["policies"] == 1
+    assert "sessions table" in report["detail"]
+
+
+def test_zero_byte_index_is_backed_up_before_rebuild(recovery_install):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    database.touch()
+
+    report = index_recovery.inspect_index_health()
+    assert report["status"] == "recovery_required"
+    assert report["automatic_recovery_available"] is True
+
+    result = index_recovery.guided_rebuild(_scan_one_session)
+
+    backup = Path(result["backup_path"]) / "index.db"
+    assert backup.is_file()
+    assert backup.stat().st_size == 0
+    rebuilt = index_module.open_index()
+    try:
+        row = rebuilt.execute(
+            "SELECT review_status, hold_state FROM sessions"
+        ).fetchone()
+        assert tuple(row) == ("new", "pending_review")
+    finally:
+        rebuilt.close()
+
+
+def test_marker_transition_refreshes_cached_health(recovery_install):
+    conn = index_module.open_index()
+    conn.close()
+    database = recovery_install / "index.db"
+    backup = recovery_install / "index-backups" / "external-recovery"
+    backup.mkdir(parents=True)
+    (backup / "index.db").write_bytes(database.read_bytes())
+    index_recovery._write_marker(
+        database,
+        {
+            "version": 1,
+            "backup_path": str(backup),
+            "stage": "backed_up",
+        },
+    )
+    index_recovery._set_health({"status": "ready", "message": "cached"})
+
+    blocked = index_recovery.synchronize_index_health()
+    assert blocked["status"] == "recovery_required"
+    assert blocked["interrupted_recovery"] is True
+
+    (recovery_install / index_recovery.RECOVERY_MARKER_FILENAME).unlink()
+    resumed = index_recovery.synchronize_index_health()
+    assert resumed["status"] == "ready"
+
+
+def test_legacy_enrollment_scope_is_restored_paused():
+    warnings: list[str] = []
+    rows = index_recovery._safe_enrollment_rows(
+        [{
+            "singleton_id": 1,
+            "mode": "enabled",
+            "health": "ready",
+            "generation": 2,
+            "enrolled_at": "2026-07-30T00:00:00+00:00",
+            "client_enrollment_id": "legacy-client",
+            "enrolled_sources_json": '["claude"]',
+            "enrolled_projects_json": '["project-a"]',
+        }],
+        warnings,
+    )
+
+    assert rows[0]["mode"] == "paused"
+    assert rows[0]["health"] == "action_required"
+    assert rows[0]["enrolled_scope_entries_json"] == '[["claude","project-a"]]'
+    assert warnings == [
+        "Automatic uploads were restored paused and must be reviewed."
+    ]
+
+
+def test_invalid_exact_enrollment_scope_is_left_disabled_in_backup():
+    warnings: list[str] = []
+    rows = index_recovery._safe_enrollment_rows(
+        [{
+            "mode": "enabled",
+            "enrolled_at": "2026-07-30T00:00:00+00:00",
+            "client_enrollment_id": "invalid-client",
+            "enrolled_sources_json": '["claude"]',
+            "enrolled_projects_json": '["project-a"]',
+            "enrolled_scope_entries_json": '[["codex","project-b"]]',
+        }],
+        warnings,
+    )
+
+    assert rows == []
+    assert warnings == [
+        "Unreadable automatic-upload state was left disabled in the backup."
+    ]
+
+
+def test_backup_copies_database_and_all_sqlite_sidecars(recovery_install):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    expected = {
+        "index.db": b"database-bytes",
+        "index.db-wal": b"wal-bytes",
+        "index.db-shm": b"shm-bytes",
+        "index.db-journal": b"journal-bytes",
+    }
+    for name, payload in expected.items():
+        (database.parent / name).write_bytes(payload)
+
+    backup_dir, copied = index_recovery._backup_index_files(database)
+
+    assert {path.name for path in copied} == set(expected)
+    assert {
+        name: (backup_dir / name).read_bytes() for name in expected
+    } == expected
+    assert {
+        name: (database.parent / name).read_bytes() for name in expected
+    } == expected
+
+
+def test_guided_rebuild_restores_readable_user_state(recovery_install):
+    conn = index_module.open_index()
+    try:
+        index_module.upsert_sessions(conn, [_session()])
+        index_module.update_session(
+            conn,
+            "session-recovery",
+            status="approved",
+            notes="Keep this review note",
+            reason="Useful recovery trace",
+        )
+        index_module.set_hold_state(
+            conn,
+            "session-recovery",
+            "pending_review",
+            changed_by="user",
+            reason="Do not share yet",
+        )
+        policy_id = index_module.add_policy(
+            conn,
+            "redact_string",
+            "private-recovery-value",
+            reason="User-authored rule",
+        )
+    finally:
+        conn.close()
+
+    result = index_recovery.guided_rebuild(_scan_one_session)
+
+    assert result["status"] == "ready"
+    backup_dir = Path(result["backup_path"])
+    assert (backup_dir / "index.db").is_file()
+    manifest = json.loads((backup_dir / "recovery-manifest.json").read_text())
+    assert manifest["unreadable_state"] == []
+    assert not (recovery_install / index_recovery.RECOVERY_MARKER_FILENAME).exists()
+
+    rebuilt = index_module.open_index()
+    try:
+        row = rebuilt.execute(
+            "SELECT review_status, reviewer_notes, selection_reason, hold_state "
+            "FROM sessions WHERE session_id = ?",
+            ("session-recovery",),
+        ).fetchone()
+        assert dict(row) == {
+            "review_status": "approved",
+            "reviewer_notes": "Keep this review note",
+            "selection_reason": "Useful recovery trace",
+            "hold_state": "pending_review",
+        }
+        assert rebuilt.execute(
+            "SELECT COUNT(*) FROM session_hold_history WHERE session_id = ?",
+            ("session-recovery",),
+        ).fetchone()[0] >= 2
+        assert rebuilt.execute(
+            "SELECT value FROM policies WHERE policy_id = ?", (policy_id,)
+        ).fetchone()[0] == "private-recovery-value"
+    finally:
+        rebuilt.close()
+
+
+@pytest.mark.parametrize("damaged_hold", [None, "", "unknown-state"])
+def test_rebuild_fails_closed_for_invalid_hold_state(
+    recovery_install,
+    damaged_hold,
+):
+    conn = index_module.open_index()
+    try:
+        index_module.upsert_sessions(conn, [_session()])
+        index_module.update_session(
+            conn,
+            "session-recovery",
+            status="approved",
+            notes="Preserve this non-safety note",
+        )
+        conn.execute(
+            "UPDATE sessions SET hold_state = ? WHERE session_id = ?",
+            (damaged_hold, "session-recovery"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    result = index_recovery.guided_rebuild(_scan_one_session)
+
+    assert any("require review" in item for item in result["warnings"])
+    rebuilt = index_module.open_index()
+    try:
+        row = rebuilt.execute(
+            "SELECT review_status, reviewer_notes, hold_state, embargo_until "
+            "FROM sessions WHERE session_id = ?",
+            ("session-recovery",),
+        ).fetchone()
+        assert tuple(row) == (
+            "new",
+            "Preserve this non-safety note",
+            "pending_review",
+            None,
+        )
+    finally:
+        rebuilt.close()
+
+
+def test_rebuild_restores_share_and_findings_but_pauses_automatic_uploads(
+    recovery_install,
+):
+    conn = index_module.open_index()
+    try:
+        index_module.upsert_sessions(conn, [_session()])
+        index_module.update_session(conn, "session-recovery", status="approved")
+        _add_recovery_finding(conn, decided=True)
+        share_id = index_module.create_share(conn, ["session-recovery"])
+        conn.execute(
+            "UPDATE shares SET status = 'shared', shared_at = ? WHERE share_id = ?",
+            ("2026-07-30T00:30:00+00:00", share_id),
+        )
+        conn.commit()
+        index_module.save_auto_upload_enrollment(
+            conn,
+            mode="enabled",
+            health="ready",
+            generation=1,
+            enrolled_at="2026-07-30T00:00:00+00:00",
+            client_enrollment_id="client-recovery",
+            enrolled_sources=("claude",),
+            enrolled_projects=("recovery-project",),
+            server_enrollment_id="server-recovery",
+            authorization_revision=1,
+            recurring_authorization_version="recurring-v2",
+            retention_version="retention-v1",
+            ownership_certification_version="ownership-v1",
+            server_scope_hash="scope-hash",
+            egress_profile_hash="profile-hash",
+            current_run_id="run-before-corruption",
+            current_run_stage="scanning",
+            next_retry_at="2026-07-31T00:00:00+00:00",
+        )
+        index_module.save_auto_upload_enrollment_job(
+            conn,
+            job_id="job-before-corruption",
+            state="queued",
+            request={"source": "claude"},
+            current_stage="queued",
+        )
+    finally:
+        conn.close()
+
+    result = index_recovery.guided_rebuild(_scan_one_session_with_finding)
+
+    assert any("Automatic uploads were restored paused" in item for item in result["warnings"])
+    assert any("setup was left in the backup" in item for item in result["warnings"])
+    rebuilt = index_module.open_index()
+    try:
+        enrollment = index_module.get_auto_upload_enrollment(rebuilt)
+        assert enrollment is not None
+        assert enrollment["mode"] == "paused"
+        assert enrollment["health"] == "action_required"
+        assert enrollment["current_run_id"] is None
+        assert enrollment["current_run_stage"] is None
+        assert enrollment["next_retry_at"] is None
+        assert enrollment["last_result_code"] == "index_recovery_review_required"
+        assert index_module.get_auto_upload_enrollment_job(rebuilt) is None
+        share = rebuilt.execute(
+            "SELECT status, shared_at FROM shares WHERE share_id = ?",
+            (share_id,),
+        ).fetchone()
+        assert tuple(share) == ("shared", "2026-07-30T00:30:00+00:00")
+        assert rebuilt.execute(
+            "SELECT COUNT(*) FROM share_sessions WHERE share_id = ?",
+            (share_id,),
+        ).fetchone()[0] == 1
+        finding = rebuilt.execute(
+            "SELECT status, decided_by, decision_reason FROM findings "
+            "WHERE finding_id = 'finding-recovery'"
+        ).fetchone()
+        assert tuple(finding) == ("ignored", "user", "Known test value")
+    finally:
+        rebuilt.close()
+
+
+def test_unreadable_state_rebuild_marks_every_trace_pending_review(
+    recovery_install,
+):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    damaged_bytes = b"this is not sqlite"
+    database.write_bytes(damaged_bytes)
+
+    result = index_recovery.guided_rebuild(_scan_one_session)
+
+    assert result["status"] == "ready"
+    assert any("requires review" in warning for warning in result["warnings"])
+    backup_dir = Path(result["backup_path"])
+    assert (backup_dir / "index.db").read_bytes() == damaged_bytes
+
+    conn = index_module.open_index()
+    try:
+        row = conn.execute(
+            "SELECT review_status, hold_state, embargo_until FROM sessions"
+        ).fetchone()
+        assert dict(row) == {
+            "review_status": "new",
+            "hold_state": "pending_review",
+            "embargo_until": None,
+        }
+        assert conn.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert conn.execute("PRAGMA quick_check(1)").fetchone()[0] == "ok"
+    finally:
+        conn.close()
+
+
+def test_foreign_key_damage_is_rebuilt_without_orphan_rows(recovery_install):
+    database = recovery_install / "index.db"
+    conn = index_module.open_index()
+    try:
+        index_module.upsert_sessions(conn, [_session()])
+        index_module.update_session(conn, "session-recovery", status="approved")
+    finally:
+        conn.close()
+
+    damaged = sqlite3.connect(database)
+    try:
+        damaged.execute("PRAGMA foreign_keys=OFF")
+        damaged.execute(
+            """INSERT INTO session_hold_history (
+                history_id, session_id, from_state, to_state,
+                changed_by, changed_at
+            ) VALUES ('orphan-history', 'missing-session', NULL,
+                      'pending_review', 'test', '2026-07-30T00:00:00+00:00')"""
+        )
+        damaged.execute(
+            """INSERT INTO share_sessions (
+                share_id, session_id, added_at
+            ) VALUES ('missing-share', 'missing-session',
+                      '2026-07-30T00:00:00+00:00')"""
+        )
+        damaged.execute(
+            "UPDATE sessions SET share_id = 'missing-share' "
+            "WHERE session_id = 'session-recovery'"
+        )
+        damaged.commit()
+    finally:
+        damaged.close()
+
+    report = index_recovery.inspect_index_health()
+    assert report["status"] == "recovery_required"
+    assert "relational safety state" in report["unreadable_state"]
+
+    result = index_recovery.guided_rebuild(_scan_one_session)
+
+    assert any("orphaned hold-history" in item for item in result["warnings"])
+    assert any("orphaned share link" in item for item in result["warnings"])
+    assert any("orphaned session share link" in item for item in result["warnings"])
+    assert any("every rebuilt trace" in item for item in result["warnings"])
+    rebuilt = index_module.open_index()
+    try:
+        assert rebuilt.execute("PRAGMA foreign_key_check").fetchall() == []
+        assert rebuilt.execute(
+            "SELECT hold_state FROM sessions WHERE session_id = ?",
+            ("session-recovery",),
+        ).fetchone()[0] == "pending_review"
+    finally:
+        rebuilt.close()
+
+
+def test_failed_rebuild_marker_survives_and_retry_uses_original_backup(
+    recovery_install,
+):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    damaged_bytes = b"unreadable original index"
+    database.write_bytes(damaged_bytes)
+
+    with pytest.raises(RuntimeError, match="rescan did not complete"):
+        index_recovery.guided_rebuild(lambda: {"ok": False})
+
+    with pytest.raises(sqlite3.DatabaseError, match="unfinished recovery"):
+        index_module.open_index()
+
+    marker_path = recovery_install / index_recovery.RECOVERY_MARKER_FILENAME
+    marker = json.loads(marker_path.read_text())
+    backup_dir = Path(marker["backup_path"])
+    assert marker["stage"] == "failed"
+    assert (backup_dir / "index.db").read_bytes() == damaged_bytes
+    assert index_recovery.inspect_index_health()["interrupted_recovery"] is True
+
+    result = index_recovery.guided_rebuild(_scan_one_session)
+
+    assert result["status"] == "ready"
+    assert Path(result["backup_path"]) == backup_dir
+    assert not marker_path.exists()
+    conn = index_module.open_index()
+    try:
+        assert conn.execute(
+            "SELECT hold_state FROM sessions WHERE session_id = ?",
+            ("session-recovery",),
+        ).fetchone()[0] == "pending_review"
+    finally:
+        conn.close()

--- a/tests/workbench/test_index_recovery_concurrency.py
+++ b/tests/workbench/test_index_recovery_concurrency.py
@@ -1,0 +1,366 @@
+"""Concurrency regressions for the backup-first workbench index recovery."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from clawjournal import auto_upload as auto_upload_module
+from clawjournal import config as config_module
+from clawjournal.workbench import index as index_module
+from clawjournal.workbench import index_recovery
+
+
+@pytest.fixture
+def recovery_state(tmp_path, monkeypatch) -> Path:
+    """Keep the index, marker, blobs, and config inside one temporary root."""
+
+    state = tmp_path / "state"
+    monkeypatch.setattr(index_module, "CONFIG_DIR", state)
+    monkeypatch.setattr(index_module, "INDEX_DB", state / "index.db")
+    monkeypatch.setattr(index_module, "BLOBS_DIR", state / "blobs")
+    monkeypatch.setattr(config_module, "CONFIG_DIR", state)
+    monkeypatch.setattr(config_module, "CONFIG_FILE", state / "config.json")
+    index_module._set_index_recovery_access(False)
+    index_recovery._set_health(
+        {"status": "ready", "message": "The test index is ready."}
+    )
+    yield state
+    index_module._set_index_recovery_access(False)
+    index_recovery._set_health(
+        {"status": "ready", "message": "The test index is ready."}
+    )
+
+
+def _require_recovery(database: Path, **extra: object) -> None:
+    health: dict[str, object] = {
+        "status": "recovery_required",
+        "message": "The test index needs recovery.",
+        "database_path": str(database.resolve()),
+        "automatic_recovery_available": True,
+    }
+    health.update(extra)
+    index_recovery._set_health(health)
+
+
+def _marker_path(state: Path) -> Path:
+    return state / index_recovery.RECOVERY_MARKER_FILENAME
+
+
+def test_begin_guided_rebuild_publishes_durable_marker_before_return(
+    recovery_state,
+):
+    database = recovery_state / "index.db"
+    database.parent.mkdir(parents=True)
+    database.write_bytes(b"damaged index bytes")
+    _require_recovery(database)
+
+    report = index_recovery.begin_guided_rebuild()
+
+    marker_path = _marker_path(recovery_state)
+    assert report["status"] == "rebuilding"
+    assert marker_path.is_file()
+    marker = json.loads(marker_path.read_text(encoding="utf-8"))
+    assert marker["database_path"] == str(database.resolve())
+    assert isinstance(marker.get("stage"), str)
+
+
+def test_connection_lease_file_preallocates_every_windows_lock_slot(
+    recovery_state,
+):
+    lease = index_module._open_index_lease_file()
+    lease.close()
+
+    assert index_module._index_connection_lease_path().stat().st_size >= (
+        index_module._INDEX_CONNECTION_LEASE_SLOTS
+    )
+
+
+def test_startup_health_fails_closed_when_connection_lease_is_unavailable(
+    recovery_state,
+    monkeypatch,
+):
+    conn = index_module.open_index()
+    conn.close()
+
+    def lease_denied(*_args, **_kwargs):
+        raise PermissionError("connection lease denied")
+
+    monkeypatch.setattr(index_module, "_open_index_lease_file", lease_denied)
+
+    report = index_recovery.initialize_index_health()
+
+    assert report["status"] == "unavailable"
+    assert report["automatic_recovery_available"] is False
+    assert "connection lease denied" in report["detail"]
+
+
+def test_begin_guided_rebuild_preserves_verified_retry_backup(recovery_state):
+    database = recovery_state / "index.db"
+    database.parent.mkdir(parents=True)
+    database.write_bytes(b"partial rebuilt index")
+    backup = recovery_state / "index-backups" / "known-good"
+    backup.mkdir(parents=True)
+    (backup / "index.db").write_bytes(b"original index bytes")
+    index_recovery._write_marker(
+        database,
+        {
+            "version": 1,
+            "database_path": str(database.resolve()),
+            "backup_path": str(backup),
+            "stage": "failed",
+            "error": "previous rescan failed",
+        },
+    )
+    _require_recovery(
+        database,
+        interrupted_recovery=True,
+        backup_path=str(backup),
+    )
+
+    index_recovery.begin_guided_rebuild()
+
+    marker = json.loads(_marker_path(recovery_state).read_text(encoding="utf-8"))
+    assert marker["backup_path"] == str(backup)
+    assert (Path(marker["backup_path"]) / "index.db").read_bytes() == (
+        b"original index bytes"
+    )
+
+
+def test_guided_rebuild_fails_closed_for_active_writer_then_retries(
+    recovery_state,
+    monkeypatch,
+):
+    database = recovery_state / "index.db"
+    seed = index_module.open_index()
+    try:
+        seed.execute(
+            "CREATE TABLE recovery_concurrency_probe "
+            "(id INTEGER PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        seed.execute(
+            "INSERT INTO recovery_concurrency_probe VALUES (1, 'committed')"
+        )
+        seed.commit()
+    finally:
+        seed.close()
+
+    real_exclusive = index_recovery._exclusive_source_connection
+    real_backup = index_recovery._backup_index_files
+    real_remove = index_recovery._remove_index_files
+    backup_calls: list[Path] = []
+    remove_calls: list[Path] = []
+
+    def fast_exclusive(path: Path) -> sqlite3.Connection:
+        conn = sqlite3.connect(
+            path.resolve().as_uri() + "?mode=rw",
+            uri=True,
+            timeout=0.05,
+            isolation_level=None,
+        )
+        conn.row_factory = sqlite3.Row
+        conn.execute("PRAGMA busy_timeout=50")
+        try:
+            conn.execute("BEGIN EXCLUSIVE")
+        except Exception:
+            conn.close()
+            raise
+        return conn
+
+    def observed_backup(path: Path):
+        backup_calls.append(path)
+        return real_backup(path)
+
+    def observed_remove(path: Path):
+        remove_calls.append(path)
+        return real_remove(path)
+
+    monkeypatch.setattr(
+        index_recovery,
+        "_exclusive_source_connection",
+        fast_exclusive,
+    )
+    monkeypatch.setattr(index_recovery, "_backup_index_files", observed_backup)
+    monkeypatch.setattr(index_recovery, "_remove_index_files", observed_remove)
+
+    writer = sqlite3.connect(database, timeout=0.1, isolation_level=None)
+    try:
+        writer.execute("BEGIN IMMEDIATE")
+        writer.execute(
+            "UPDATE recovery_concurrency_probe SET value = 'uncommitted' "
+            "WHERE id = 1"
+        )
+
+        with pytest.raises(index_recovery.UnsafeIndexRecovery, match="still in use"):
+            index_recovery.guided_rebuild(lambda: {"ok": True})
+
+        assert backup_calls == []
+        assert remove_calls == []
+        assert database.is_file()
+        assert _marker_path(recovery_state).is_file()
+    finally:
+        writer.rollback()
+        writer.close()
+
+    unchanged = sqlite3.connect(database)
+    try:
+        assert unchanged.execute(
+            "SELECT value FROM recovery_concurrency_probe WHERE id = 1"
+        ).fetchone()[0] == "committed"
+    finally:
+        unchanged.close()
+
+    monkeypatch.setattr(
+        index_recovery,
+        "_exclusive_source_connection",
+        real_exclusive,
+    )
+    result = index_recovery.guided_rebuild(lambda: {"ok": True})
+
+    assert result["status"] == "ready"
+    assert Path(result["backup_path"], "index.db").is_file()
+    assert not _marker_path(recovery_state).exists()
+
+
+def test_guided_rebuild_waits_for_guarded_connection_before_backup(
+    recovery_state,
+    monkeypatch,
+):
+    live = index_module.open_index()
+    backup_started = threading.Event()
+    real_backup = index_recovery._backup_index_files
+    result: dict[str, object] = {}
+
+    def observed_backup(path: Path):
+        backup_started.set()
+        return real_backup(path)
+
+    def rebuild() -> None:
+        try:
+            result["value"] = index_recovery.guided_rebuild(lambda: {"ok": True})
+        except BaseException as exc:  # surface worker errors in the main thread
+            result["error"] = exc
+
+    monkeypatch.setattr(index_recovery, "_backup_index_files", observed_backup)
+    worker = threading.Thread(target=rebuild)
+    worker.start()
+    try:
+        deadline = time.monotonic() + 2
+        while not _marker_path(recovery_state).exists() and time.monotonic() < deadline:
+            time.sleep(0.01)
+        assert _marker_path(recovery_state).exists()
+        assert not backup_started.wait(0.1)
+    finally:
+        live.close()
+    worker.join(timeout=5)
+
+    assert not worker.is_alive()
+    assert "error" not in result
+    assert result["value"]["status"] == "ready"
+    assert backup_started.is_set()
+
+
+def test_save_config_does_not_touch_index_while_recovery_marker_exists(
+    recovery_state,
+    monkeypatch,
+):
+    database = recovery_state / "index.db"
+    conn = index_module.open_index()
+    conn.close()
+    config_module.CONFIG_FILE.write_text(
+        json.dumps({"excluded_projects": []}),
+        encoding="utf-8",
+    )
+    index_recovery._write_marker(
+        database,
+        {
+            "version": 1,
+            "database_path": str(database.resolve()),
+            "stage": "draining",
+        },
+    )
+    profile_stamp_calls: list[sqlite3.Connection] = []
+    monkeypatch.setattr(
+        config_module,
+        "mark_auto_upload_profile_changed",
+        lambda connection: profile_stamp_calls.append(connection) or True,
+    )
+
+    saved = config_module.save_config({"excluded_projects": ["claude:private"]})
+
+    assert saved is True
+    assert json.loads(config_module.CONFIG_FILE.read_text(encoding="utf-8"))[
+        "excluded_projects"
+    ] == ["claude:private"]
+    assert profile_stamp_calls == []
+
+
+def test_save_config_keeps_success_after_connection_lease_oserror(
+    recovery_state,
+    monkeypatch,
+    capsys,
+):
+    conn = index_module.open_index()
+    conn.close()
+    config_module.CONFIG_FILE.write_text(
+        json.dumps({"excluded_projects": []}),
+        encoding="utf-8",
+    )
+
+    def lease_denied(**_kwargs):
+        raise PermissionError("connection lease denied")
+
+    monkeypatch.setattr(index_module, "open_existing_index", lease_denied)
+
+    saved = config_module.save_config({"excluded_projects": ["claude:private"]})
+
+    assert saved is True
+    assert json.loads(config_module.CONFIG_FILE.read_text(encoding="utf-8"))[
+        "excluded_projects"
+    ] == ["claude:private"]
+    assert "could not pause automatic upload" in capsys.readouterr().err
+
+
+def test_auto_upload_preview_fails_soft_when_connection_lease_is_unavailable(
+    recovery_state,
+    monkeypatch,
+):
+    conn = index_module.open_index()
+    conn.close()
+
+    def lease_denied(**_kwargs):
+        raise PermissionError("connection lease denied")
+
+    monkeypatch.setattr(index_module, "open_existing_index", lease_denied)
+
+    result = auto_upload_module.preview(refresh=False)
+
+    assert result["ok"] is False
+    assert result["code"] == "index_upgrade_required"
+
+
+def test_hook_direct_open_refuses_index_guarded_by_recovery_marker(
+    recovery_state,
+):
+    database = recovery_state / "index.db"
+    conn = index_module.open_index()
+    conn.close()
+    index_recovery._write_marker(
+        database,
+        {
+            "version": 1,
+            "database_path": str(database.resolve()),
+            "stage": "draining",
+        },
+    )
+
+    hook_connection = auto_upload_module._open_existing_hook_index()
+    if hook_connection is not None:
+        hook_connection.close()
+
+    assert hook_connection is None

--- a/tests/workbench/test_index_recovery_events.py
+++ b/tests/workbench/test_index_recovery_events.py
@@ -1,0 +1,767 @@
+"""Execution-recorder coverage for the guided workbench-index rebuild."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from clawjournal.capture.cursors import ensure_schema as ensure_capture_schema
+from clawjournal.events.cost.schema import ensure_cost_schema
+from clawjournal.events.export.schema import ensure_export_schema
+from clawjournal.events.incidents.schema import ensure_incidents_schema
+from clawjournal.events.schema import ensure_schema as ensure_events_schema
+from clawjournal.events.search.schema import ensure_search_schema
+from clawjournal.events.view import ensure_view_schema
+from clawjournal.events.view import write_hook_override
+from clawjournal.workbench import index as index_module
+from clawjournal.workbench import index_recovery
+
+
+PARENT_ID = 40
+CHILD_ID = 10
+PARENT_KEY = "claude:project:session-recovery"
+CHILD_KEY = "claude:project:child-recovery"
+PARENT_SOURCE = "C:/recovery/project/session-recovery.jsonl"
+CHILD_SOURCE = "C:/recovery/project/child-recovery.jsonl"
+TS = "2026-07-30T10:00:00Z"
+
+
+@pytest.fixture
+def recovery_install_events(tmp_path, monkeypatch) -> Path:
+    """Keep the source, rebuilt database, and recovery backup test-local."""
+
+    install_dir = tmp_path / "state"
+    monkeypatch.setattr(index_module, "CONFIG_DIR", install_dir)
+    monkeypatch.setattr(index_module, "INDEX_DB", install_dir / "index.db")
+    monkeypatch.setattr(index_module, "BLOBS_DIR", install_dir / "blobs")
+    index_recovery._set_health(
+        {"status": "ready", "message": "Test index is ready."}
+    )
+    yield install_dir
+    index_recovery._set_health(
+        {"status": "ready", "message": "Test index is ready."}
+    )
+
+
+def _workbench_session() -> dict:
+    return {
+        "session_id": "session-recovery",
+        "project": "recovery-project",
+        "source": "claude",
+        "raw_source_path": PARENT_SOURCE,
+        "model": "claude-sonnet-4",
+        "start_time": "2026-07-30T10:00:00Z",
+        "end_time": "2026-07-30T10:10:00Z",
+        "messages": [
+            {"role": "user", "content": "Recover recorder data", "tool_uses": []},
+            {"role": "assistant", "content": "Recovered.", "tool_uses": []},
+        ],
+        "stats": {
+            "user_messages": 1,
+            "assistant_messages": 1,
+            "tool_uses": 0,
+            "input_tokens": 100,
+            "output_tokens": 25,
+        },
+    }
+
+
+def _recovery_scan() -> dict[str, object]:
+    conn = index_module.open_index()
+    try:
+        index_module.upsert_sessions(conn, [_workbench_session()])
+        # Exercise the post-recorder bridge instead of relying on upsert's
+        # path-derived session key.
+        conn.execute(
+            "UPDATE sessions SET session_key = NULL WHERE session_id = ?",
+            ("session-recovery",),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+    return {"ok": True}
+
+
+def _assistant_usage(cache_read: int, *, marker: str | None = None) -> str:
+    payload = {
+        "type": "assistant",
+        "message": {
+            "model": "claude-opus-4-6",
+            "usage": {
+                "input_tokens": 1_000,
+                "output_tokens": 50,
+                "cache_read_input_tokens": cache_read,
+            },
+        },
+    }
+    if marker is not None:
+        payload["recovery_marker"] = marker
+    return json.dumps(payload, sort_keys=True)
+
+
+def _command_raw(tool_id: str) -> str:
+    return json.dumps(
+        {
+            "type": "assistant",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": tool_id,
+                        "name": "Bash",
+                        "input": {"command": "npm test"},
+                    }
+                ]
+            },
+        },
+        sort_keys=True,
+    )
+
+
+def _result_raw(tool_id: str) -> str:
+    return json.dumps(
+        {
+            "type": "user",
+            "message": {
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_id,
+                        "content": [
+                            {
+                                "type": "text",
+                                "text": "FAIL auth.test.ts\nTests: 1 failed, 0 passed",
+                            }
+                        ],
+                    }
+                ]
+            },
+        },
+        sort_keys=True,
+    )
+
+
+def _event_row(
+    event_id: int,
+    session_id: int,
+    event_type: str,
+    event_key: str,
+    event_at: str,
+    source_path: str,
+    source_offset: int,
+    raw_json: str,
+) -> tuple:
+    return (
+        event_id,
+        session_id,
+        event_type,
+        event_key,
+        event_at,
+        TS,
+        "claude-jsonl",
+        source_path,
+        source_offset,
+        0,
+        "claude",
+        "high",
+        "none",
+        raw_json,
+    )
+
+
+def _seed_source_index(conn: sqlite3.Connection) -> None:
+    index_module.upsert_sessions(conn, [_workbench_session()])
+    index_module.update_session(
+        conn,
+        "session-recovery",
+        status="approved",
+        notes="Keep the recorder review",
+        reason="Recorder recovery fixture",
+    )
+    index_module.set_hold_state(
+        conn,
+        "session-recovery",
+        "pending_review",
+        changed_by="user",
+        reason="Do not share during recovery",
+    )
+
+    ensure_capture_schema(conn)
+    ensure_events_schema(conn)
+    ensure_view_schema(conn)
+    ensure_export_schema(conn)
+    ensure_cost_schema(conn)
+    ensure_incidents_schema(conn)
+    ensure_search_schema(conn)
+    conn.commit()
+
+    # The child has the lower rowid, so an unordered bulk copy encounters it
+    # before its parent. Recovery must still restore the self-FK correctly.
+    conn.execute(
+        """INSERT INTO event_sessions (
+               id, session_key, parent_session_key, parent_session_id,
+               client, client_version, started_at, ended_at, status
+           ) VALUES (?, ?, NULL, NULL, 'claude', '1.0', ?, ?, 'ended')""",
+        (PARENT_ID, PARENT_KEY, TS, "2026-07-30T10:10:00Z"),
+    )
+    conn.execute(
+        """INSERT INTO event_sessions (
+               id, session_key, parent_session_key, parent_session_id,
+               client, client_version, started_at, ended_at, status
+           ) VALUES (?, ?, ?, ?, 'claude', '1.0', ?, ?, 'ended')""",
+        (
+            CHILD_ID,
+            CHILD_KEY,
+            PARENT_KEY,
+            PARENT_ID,
+            "2026-07-30T10:01:00Z",
+            "2026-07-30T10:09:00Z",
+        ),
+    )
+
+    events = [
+        _event_row(
+            100,
+            PARENT_ID,
+            "assistant_message",
+            "assistant:usage-1",
+            "2026-07-30T10:00:00Z",
+            PARENT_SOURCE,
+            0,
+            _assistant_usage(10_000, marker="recoveryneedle"),
+        ),
+        _event_row(
+            101,
+            PARENT_ID,
+            "assistant_message",
+            "assistant:usage-2",
+            "2026-07-30T10:00:01Z",
+            PARENT_SOURCE,
+            1,
+            _assistant_usage(100),
+        ),
+    ]
+    for index in range(3):
+        tool_id = f"loop-{index}"
+        event_id = 200 + (index * 2)
+        events.extend(
+            [
+                _event_row(
+                    event_id,
+                    CHILD_ID,
+                    "command_start",
+                    f"command_start:{tool_id}",
+                    f"2026-07-30T10:01:0{index * 2}Z",
+                    CHILD_SOURCE,
+                    index * 2,
+                    _command_raw(tool_id),
+                ),
+                _event_row(
+                    event_id + 1,
+                    CHILD_ID,
+                    "tool_result",
+                    f"tool_result:{tool_id}",
+                    f"2026-07-30T10:01:0{index * 2 + 1}Z",
+                    CHILD_SOURCE,
+                    index * 2 + 1,
+                    _result_raw(tool_id),
+                ),
+            ]
+        )
+    conn.executemany(
+        """INSERT INTO events (
+               id, session_id, type, event_key, event_at, ingested_at,
+               source, source_path, source_offset, seq, client, confidence,
+               lossiness, raw_json
+           ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
+        events,
+    )
+
+    conn.execute(
+        """INSERT INTO event_overrides (
+               session_id, event_key, type, source, confidence, lossiness,
+               event_at, payload_json, origin, created_at, write_seq
+           ) VALUES (?, ?, 'assistant_message', 'hook', 'high', 'none',
+                     ?, ?, 'hook:recovery-test', ?, 7)""",
+        (
+            PARENT_ID,
+            "assistant:usage-1",
+            "2026-07-30T10:00:00Z",
+            '{"precise":true}',
+            TS,
+        ),
+    )
+    conn.execute(
+        """INSERT INTO event_source_snippets (
+               source_path, source_offset, seq, text, imported_at
+           ) VALUES (?, 17, 0, ?, ?)""",
+        (
+            "/imported/redacted/session.jsonl",
+            '{"redacted":"snippet-recovery"}',
+            TS,
+        ),
+    )
+    conn.executemany(
+        """INSERT INTO capture_cursors (
+               consumer_id, source_path, inode, last_offset, last_modified,
+               client, first_seen, last_seen
+           ) VALUES ('events', ?, ?, ?, 1234.5, 'claude', ?, ?)""",
+        [
+            (PARENT_SOURCE, 111, 901, TS, TS),
+            (CHILD_SOURCE, 222, 902, TS, TS),
+        ],
+    )
+
+    # Seed the derived rows and their old cursors as a realistic source. The
+    # recovery path may rebuild these tables, but the recovered semantics and
+    # new cursor frontiers must remain complete.
+    conn.executemany(
+        """INSERT INTO token_usage (
+               event_id, session_id, model, input, output, cache_read,
+               data_source, pricing_table_version, event_at
+           ) VALUES (?, ?, 'claude-opus-4-6', 1000, 50, ?, 'api',
+                     'source-pricing', ?)""",
+        [
+            (100, PARENT_ID, 10_000, "2026-07-30T10:00:00Z"),
+            (101, PARENT_ID, 100, "2026-07-30T10:00:01Z"),
+        ],
+    )
+    conn.execute(
+        """INSERT INTO cost_anomalies (
+               id, session_id, turn_event_id, kind, confidence,
+               evidence_json, created_at
+           ) VALUES (1, ?, 101, 'cache_read_collapse', 'high', '{}', ?)""",
+        (PARENT_ID, TS),
+    )
+    conn.execute(
+        "INSERT INTO cost_ingest_state VALUES ('cost_ledger', 205)"
+    )
+    conn.execute(
+        """INSERT INTO incidents (
+               id, session_id, kind, first_event_id, last_event_id,
+               evidence_json, count, confidence, created_at
+           ) VALUES (1, ?, 'loop_exact_repeat', 200, 204, '{}', 3, 'high', ?)""",
+        (CHILD_ID, TS),
+    )
+    conn.execute(
+        """INSERT INTO loop_ingest_state (
+               consumer_id, last_event_id, last_override_write_seq,
+               last_override_created_at, last_override_session_id,
+               last_override_event_key
+           ) VALUES ('loop_detector', 205, 7, ?, ?, 'assistant:usage-1')""",
+        (TS, PARENT_ID),
+    )
+
+    conn.execute(
+        """INSERT INTO benchmarks (
+               benchmark_id, window_start, window_end, generated_at,
+               status, backend, payload_json
+           ) VALUES ('benchmark-recovery', ?, ?, ?, 'ready', 'test-backend', ?)""",
+        (
+            "2026-07-20T00:00:00Z",
+            "2026-07-27T00:00:00Z",
+            TS,
+            '{"title":"Recovery benchmark"}',
+        ),
+    )
+    conn.execute(
+        """INSERT INTO benchmark_tasks (
+               task_id, benchmark_id, title, readiness, points
+           ) VALUES ('benchmark-task-recovery', 'benchmark-recovery',
+                     'Preserve recorder state', 'ready', 5)"""
+    )
+    conn.execute(
+        """INSERT INTO benchmark_exports (
+               export_id, benchmark_id, kind, path, created_at,
+               redaction_summary_json
+           ) VALUES ('benchmark-export-recovery', 'benchmark-recovery',
+                     'markdown', '/tmp/recovery.md', ?, '{}')""",
+        (TS,),
+    )
+
+    # Deliberately stale FTS state must not be copied from the backup.
+    conn.execute("INSERT INTO events_fts(events_fts) VALUES('delete-all')")
+    conn.commit()
+    assert conn.execute(
+        "SELECT COUNT(*) FROM events_fts_docsize"
+    ).fetchone()[0] == 0
+
+
+def test_guided_rebuild_restores_execution_recorder_and_benchmarks(
+    recovery_install_events,
+):
+    source = index_module.open_index()
+    try:
+        _seed_source_index(source)
+    finally:
+        source.close()
+
+    result = index_recovery.guided_rebuild(_recovery_scan)
+
+    assert result["status"] == "ready"
+    assert result["warnings"] == []
+    assert Path(result["backup_path"], "index.db").is_file()
+    counts = result["restored_state_counts"]
+    assert {
+        key: counts[key]
+        for key in (
+            "event_sessions",
+            "events",
+            "event_overrides",
+            "event_source_snippets",
+            "event_capture_cursors",
+            "token_usage",
+            "cost_anomalies",
+            "incidents",
+            "benchmarks",
+            "benchmark_tasks",
+            "benchmark_exports",
+        )
+    } == {
+        "event_sessions": 2,
+        "events": 8,
+        "event_overrides": 1,
+        "event_source_snippets": 1,
+        "event_capture_cursors": 2,
+        "token_usage": 2,
+        "cost_anomalies": 1,
+        "incidents": 1,
+        "benchmarks": 1,
+        "benchmark_tasks": 1,
+        "benchmark_exports": 1,
+    }
+
+    rebuilt = index_module.open_index()
+    try:
+        assert [row[0] for row in rebuilt.execute("PRAGMA quick_check(1)")] == [
+            "ok"
+        ]
+        assert rebuilt.execute("PRAGMA foreign_key_check").fetchall() == []
+
+        sessions = rebuilt.execute(
+            "SELECT id, session_key, parent_session_key, parent_session_id "
+            "FROM event_sessions ORDER BY id"
+        ).fetchall()
+        assert [tuple(row) for row in sessions] == [
+            (CHILD_ID, CHILD_KEY, PARENT_KEY, PARENT_ID),
+            (PARENT_ID, PARENT_KEY, None, None),
+        ]
+        assert [row[0] for row in rebuilt.execute(
+            "SELECT id FROM events ORDER BY id"
+        )] == [100, 101, 200, 201, 202, 203, 204, 205]
+
+        override = rebuilt.execute(
+            "SELECT session_id, event_key, payload_json, write_seq "
+            "FROM event_overrides"
+        ).fetchone()
+        assert tuple(override) == (
+            PARENT_ID,
+            "assistant:usage-1",
+            '{"precise":true}',
+            7,
+        )
+        snippet = rebuilt.execute(
+            "SELECT source_path, source_offset, seq, text "
+            "FROM event_source_snippets"
+        ).fetchone()
+        assert tuple(snippet) == (
+            "/imported/redacted/session.jsonl",
+            17,
+            0,
+            '{"redacted":"snippet-recovery"}',
+        )
+
+        token_rows = rebuilt.execute(
+            "SELECT event_id, session_id, model, input, cache_read, data_source, "
+            "pricing_table_version "
+            "FROM token_usage ORDER BY event_id"
+        ).fetchall()
+        assert [tuple(row) for row in token_rows] == [
+            (
+                100,
+                PARENT_ID,
+                "claude-opus-4-6",
+                1_000,
+                10_000,
+                "api",
+                "source-pricing",
+            ),
+            (
+                101,
+                PARENT_ID,
+                "claude-opus-4-6",
+                1_000,
+                100,
+                "api",
+                "source-pricing",
+            ),
+        ]
+        assert rebuilt.execute(
+            "SELECT kind FROM cost_anomalies"
+        ).fetchone()[0] == "cache_read_collapse"
+        incident = rebuilt.execute(
+            "SELECT session_id, kind, first_event_id, last_event_id, count "
+            "FROM incidents"
+        ).fetchone()
+        assert tuple(incident) == (
+            CHILD_ID,
+            "loop_exact_repeat",
+            200,
+            204,
+            3,
+        )
+
+        capture_rows = rebuilt.execute(
+            "SELECT source_path, inode, last_offset FROM capture_cursors "
+            "WHERE consumer_id = 'events' ORDER BY source_path"
+        ).fetchall()
+        assert [tuple(row) for row in capture_rows] == [
+            (CHILD_SOURCE, 222, 902),
+            (PARENT_SOURCE, 111, 901),
+        ]
+        assert rebuilt.execute(
+            "SELECT last_event_id FROM cost_ingest_state "
+            "WHERE consumer_id = 'cost_ledger'"
+        ).fetchone()[0] == 205
+        loop_cursor = rebuilt.execute(
+            "SELECT last_event_id, last_override_write_seq, "
+            "last_override_session_id, last_override_event_key "
+            "FROM loop_ingest_state WHERE consumer_id = 'loop_detector'"
+        ).fetchone()
+        assert tuple(loop_cursor) == (
+            205,
+            7,
+            PARENT_ID,
+            "assistant:usage-1",
+        )
+
+        assert rebuilt.execute(
+            "SELECT COUNT(*) FROM events_fts_docsize"
+        ).fetchone()[0] == 8
+        assert [row[0] for row in rebuilt.execute(
+            "SELECT rowid FROM events_fts WHERE events_fts MATCH 'recoveryneedle'"
+        )] == [100]
+
+        workbench = rebuilt.execute(
+            "SELECT review_status, reviewer_notes, hold_state, session_key "
+            "FROM sessions WHERE session_id = 'session-recovery'"
+        ).fetchone()
+        assert tuple(workbench) == (
+            "approved",
+            "Keep the recorder review",
+            "pending_review",
+            PARENT_KEY,
+        )
+        benchmark = rebuilt.execute(
+            "SELECT status, backend, payload_json FROM benchmarks "
+            "WHERE benchmark_id = 'benchmark-recovery'"
+        ).fetchone()
+        assert tuple(benchmark) == (
+            "ready",
+            "test-backend",
+            '{"title":"Recovery benchmark"}',
+        )
+        assert rebuilt.execute(
+            "SELECT title FROM benchmark_tasks "
+            "WHERE task_id = 'benchmark-task-recovery'"
+        ).fetchone()[0] == "Preserve recorder state"
+        assert rebuilt.execute(
+            "SELECT path FROM benchmark_exports "
+            "WHERE export_id = 'benchmark-export-recovery'"
+        ).fetchone()[0] == "/tmp/recovery.md"
+    finally:
+        rebuilt.close()
+
+
+def test_malformed_recorder_stays_in_backup_without_downgrading_review_state(
+    recovery_install_events,
+):
+    source = index_module.open_index()
+    try:
+        index_module.upsert_sessions(source, [_workbench_session()])
+        index_module.update_session(
+            source,
+            "session-recovery",
+            status="approved",
+            notes="Keep this approval",
+        )
+        source.execute(
+            "CREATE TABLE event_sessions ("
+            "id INTEGER PRIMARY KEY, session_key TEXT NOT NULL, client TEXT NOT NULL)"
+        )
+        # Deliberately omit raw_json, a required recovery column.
+        source.execute(
+            "CREATE TABLE events ("
+            "id INTEGER PRIMARY KEY, session_id INTEGER NOT NULL, type TEXT NOT NULL, "
+            "ingested_at TEXT NOT NULL, source TEXT NOT NULL, source_path TEXT NOT NULL, "
+            "source_offset INTEGER NOT NULL, client TEXT NOT NULL, "
+            "confidence TEXT NOT NULL, lossiness TEXT NOT NULL)"
+        )
+        source.execute(
+            "INSERT INTO event_sessions VALUES (1, 'broken:session', 'claude')"
+        )
+        source.execute(
+            "INSERT INTO events VALUES "
+            "(1, 1, 'assistant_message', ?, 'claude-jsonl', 'broken.jsonl', "
+            "0, 'claude', 'high', 'none')",
+            (TS,),
+        )
+        source.execute("DROP TABLE benchmark_exports")
+        source.execute("DROP TABLE benchmark_tasks")
+        source.execute("DROP TABLE benchmarks")
+        source.execute("CREATE TABLE benchmarks (benchmark_id TEXT PRIMARY KEY)")
+        source.execute("INSERT INTO benchmarks VALUES ('broken-benchmark')")
+        source.commit()
+    finally:
+        source.close()
+
+    result = index_recovery.guided_rebuild(_recovery_scan)
+
+    assert result["status"] == "ready"
+    assert any(
+        "Execution-recorder state could not be restored" in warning
+        for warning in result["warnings"]
+    )
+    assert any(
+        "Historical benchmark state could not be restored" in warning
+        for warning in result["warnings"]
+    )
+    rebuilt = index_module.open_index()
+    try:
+        review = rebuilt.execute(
+            "SELECT review_status, reviewer_notes FROM sessions "
+            "WHERE session_id = 'session-recovery'"
+        ).fetchone()
+        assert tuple(review) == ("approved", "Keep this approval")
+        assert rebuilt.execute("SELECT COUNT(*) FROM events").fetchone()[0] == 0
+    finally:
+        rebuilt.close()
+
+
+def test_failed_override_restore_resets_loop_frontier_for_future_hooks(
+    recovery_install_events,
+):
+    source = index_module.open_index()
+    try:
+        _seed_source_index(source)
+        source.execute("DROP TABLE event_overrides")
+        source.execute(
+            "CREATE TABLE event_overrides ("
+            "session_id INTEGER NOT NULL, event_key TEXT NOT NULL, type TEXT NOT NULL, "
+            "source TEXT NOT NULL, confidence TEXT NOT NULL, lossiness TEXT NOT NULL, "
+            "event_at TEXT, origin TEXT, created_at TEXT NOT NULL, "
+            "write_seq INTEGER NOT NULL DEFAULT 0, "
+            "PRIMARY KEY (session_id, event_key))"
+        )
+        source.commit()
+    finally:
+        source.close()
+
+    result = index_recovery.guided_rebuild(_recovery_scan)
+
+    assert any(
+        "overrides could not be restored" in warning
+        for warning in result["warnings"]
+    )
+    assert any(
+        "override cursor was reset" in warning
+        for warning in result["warnings"]
+    )
+    rebuilt = index_module.open_index()
+    try:
+        assert rebuilt.execute("SELECT COUNT(*) FROM incidents").fetchone()[0] == 1
+        cursor = rebuilt.execute(
+            "SELECT last_override_write_seq, last_override_created_at, "
+            "last_override_session_id, last_override_event_key "
+            "FROM loop_ingest_state WHERE consumer_id = 'loop_detector'"
+        ).fetchone()
+        assert tuple(cursor) == (0, None, 0, "")
+
+        assert write_hook_override(
+            rebuilt,
+            session_key=PARENT_KEY,
+            event_key="future-hook",
+            event_type="assistant_message",
+            source="hook",
+            confidence="high",
+            lossiness="none",
+            event_at="2026-07-30T10:20:00Z",
+            payload_json='{"future":true}',
+            origin="hook:after-recovery",
+        )
+        rebuilt.commit()
+        assert rebuilt.execute(
+            "SELECT write_seq FROM event_overrides "
+            "WHERE event_key = 'future-hook'"
+        ).fetchone()[0] == 1
+    finally:
+        rebuilt.close()
+
+
+def test_legacy_overrides_reset_loop_frontier_before_sequence_backfill(
+    recovery_install_events,
+):
+    source = index_module.open_index()
+    try:
+        _seed_source_index(source)
+        source.execute("DROP TABLE event_overrides")
+        source.execute(
+            "CREATE TABLE event_overrides ("
+            "session_id INTEGER NOT NULL, event_key TEXT NOT NULL, type TEXT NOT NULL, "
+            "source TEXT NOT NULL, confidence TEXT NOT NULL, lossiness TEXT NOT NULL, "
+            "event_at TEXT, payload_json TEXT NOT NULL, origin TEXT, "
+            "created_at TEXT NOT NULL, PRIMARY KEY (session_id, event_key))"
+        )
+        source.execute(
+            "INSERT INTO event_overrides ("
+            "session_id, event_key, type, source, confidence, lossiness, event_at, "
+            "payload_json, origin, created_at) VALUES "
+            "(?, 'assistant:usage-1', 'assistant_message', 'hook', 'high', "
+            "'none', ?, '{\"precise\":true}', 'hook:legacy', ?)",
+            (PARENT_ID, "2026-07-30T10:00:00Z", TS),
+        )
+        source.commit()
+    finally:
+        source.close()
+
+    result = index_recovery.guided_rebuild(_recovery_scan)
+
+    assert any(
+        "override cursor was reset" in warning
+        for warning in result["warnings"]
+    )
+    rebuilt = index_module.open_index()
+    try:
+        cursor = rebuilt.execute(
+            "SELECT last_override_write_seq, last_override_created_at, "
+            "last_override_session_id, last_override_event_key "
+            "FROM loop_ingest_state WHERE consumer_id = 'loop_detector'"
+        ).fetchone()
+        assert tuple(cursor) == (0, None, 0, "")
+        assert rebuilt.execute(
+            "SELECT write_seq FROM event_overrides "
+            "WHERE event_key = 'assistant:usage-1'"
+        ).fetchone()[0] == 1
+
+        assert write_hook_override(
+            rebuilt,
+            session_key=PARENT_KEY,
+            event_key="future-legacy-hook",
+            event_type="assistant_message",
+            source="hook",
+            confidence="high",
+            lossiness="none",
+            event_at="2026-07-30T10:20:00Z",
+            payload_json='{\"future\":true}',
+            origin="hook:after-legacy-recovery",
+        )
+        rebuilt.commit()
+        assert rebuilt.execute(
+            "SELECT write_seq FROM event_overrides "
+            "WHERE event_key = 'future-legacy-hook'"
+        ).fetchone()[0] == 2
+    finally:
+        rebuilt.close()


### PR DESCRIPTION
## Summary

- move the workbench index from WAL to SQLite's rollback journal mode and support relocating the complete state root with CLAWJOURNAL_HOME
- run startup integrity and foreign-key checks, recover hot journals normally, and fail closed when the index is damaged or unavailable
- add a one-click, backup-first rebuild that rescans every source and restores readable review, hold, policy, finding, share, and enrollment state safely
- block daemon APIs, CLI index access, scanning, and automatic uploads while recovery is active
- add the recovery UI, documentation, and regression coverage for interrupted, partial, and cross-process recovery cases

## Verification

- python -m pytest tests/workbench/test_daemon.py -q (247 passed)
- combined index, recovery, config, and automatic-upload suite (304 passed)
- npx vitest run --reporter=dot --maxWorkers=1 --no-file-parallelism (99 passed)
- npm run build
- targeted ESLint and Python compile checks

Fixes #171