### PR TITLE
fix: add bounded one-shot workbench opener

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,25 @@ jobs:
           tests/test_install_scripts.py
           tests/workbench/test_update_restart.py
           -v
+      - name: One-shot workbench open (native Windows)
+        run: >-
+          python -m pytest
+          tests/test_desktop.py::test_port_probe_requires_a_valid_health_challenge_response
+          tests/test_desktop.py::test_wait_for_workbench_uses_a_fixed_deadline
+          tests/test_desktop.py::test_browser_open_attempt_is_bounded_and_called_once
+          tests/test_desktop.py::test_launch_reuses_live_workbench
+          tests/test_desktop.py::test_launch_starts_daemon_then_scans_and_opens_exactly_once
+          tests/test_desktop.py::test_update_restart_launch_suppresses_launch_only_actions
+          tests/test_desktop.py::test_launch_timeout_terminates_child_and_reports_command_log_and_output
+          tests/test_desktop.py::test_launch_early_exit_terminates_child_and_reports_exit_code
+          tests/test_desktop.py::test_spawn_workbench_daemon_uses_windows_detached_creation_flags
+          tests/test_desktop.py::test_occupied_unknown_port_is_not_opened_or_replaced
+          tests/test_desktop.py::test_losing_the_startup_race_does_not_spawn_a_duplicate
+          tests/test_desktop.py::test_losing_startup_race_to_another_service_reports_an_error
+          tests/test_desktop.py::test_run_server_can_refuse_the_ephemeral_port_fallback
+          tests/test_cli.py::TestWorkbenchSourceChoices::test_open_dispatches_to_one_shot_desktop_controller
+          tests/test_cli.py::TestWorkbenchSourceChoices::test_serve_hidden_no_port_fallback_flag_is_forwarded
+          -v
 
   smoke:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ For the complete details, see [PRIVACY.md](PRIVACY.md).
 These are the main commands:
 
 ```bash
-clawjournal serve                        # open the local workbench
+clawjournal open                         # open the local workbench, then return
 clawjournal skill --preview              # preview lessons + one evidence-backed weekly focus
 clawjournal share --interactive --weekly --no-score # guided sharing without AI scoring
 clawjournal status                       # check your setup
@@ -175,6 +175,13 @@ clawjournal --help                       # see every command
 ```
 
 If `clawjournal` is not found, use the full command printed by the installer.
+
+`clawjournal open` starts or reuses the local workbench, waits briefly for it to
+be ready, opens your browser, and then returns. `clawjournal serve` is the
+foreground, long-running daemon command for manual process management and
+debugging; agents and scripts should not wait for it to exit. On a remote or
+headless machine, use `clawjournal serve --remote` in a dedicated terminal or
+background process and follow the SSH tunnel instructions it prints.
 
 `clawjournal skill` uses one optional AI distill call to propose up to five
 coding-agent lessons. Its preview names one human-facing weekly focus only when a
@@ -208,7 +215,7 @@ Set-Location "$HOME\clawjournal"
 powershell -ExecutionPolicy Bypass -File .\scripts\install.ps1 -WithFrontend -WithSharing
 ```
 
-When installation finishes, use the exact `clawjournal serve` command it prints, then open [http://localhost:8384](http://localhost:8384).
+When installation finishes, run `clawjournal open`. It starts or reuses the local workbench, opens [http://localhost:8384](http://localhost:8384), and returns once the launch attempt finishes.
 
 Re-running the installer safely updates an existing install to the latest published version. It never overwrites your local changes; if your checkout can't be updated cleanly, it says why and installs the code you already have.
 

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3968,9 +3968,12 @@ def _requested_subcommand(argv: list[str] | None = None) -> str | None:
 def _should_auto_update(argv: list[str] | None = None) -> bool:
     """Return False for commands where a pre-parse update changes semantics.
 
-    Suppresses in two cases:
+    Suppresses in these cases:
       - The user explicitly invoked `clawjournal selfupdate` — let
         that command be the only updater for this invocation.
+      - A one-shot workbench controller is about to start a `serve` child.
+        The child must pin its imported backend/frontend pair before it starts
+        the updater, so the parent must not race an update ahead of that pin.
       - The user invoked help/version (`-h`, `--help`, `--version`)
         with no real subcommand — argparse prints and exits, so a
         background fetch is wasted work that surprises the user.
@@ -3985,7 +3988,14 @@ def _should_auto_update(argv: list[str] | None = None) -> bool:
             return True
         # All tokens were flags — no subcommand. Skip when any are help/version.
         return not any(t in _AUTO_UPDATE_SKIP_FLAGS for t in tokens)
-    return command != "selfupdate"
+    if command in {"selfupdate", "open"}:
+        return False
+    # `desktop launch` has no options of its own, so its subcommand is the
+    # final token. Avoid mistaking an unrelated global option value named
+    # "launch" for the desktop action.
+    if command == "desktop" and tokens[-1:] == ["launch"]:
+        return False
+    return True
 
 
 def _should_pin_frontend(
@@ -3999,7 +4009,7 @@ def _should_pin_frontend(
       - a wheel install has no checkout for the updater to fast-forward, so
         there is nothing to defend against (and `_package_repo_root` is the
         same gate `daemon_startup_head` already uses);
-      - `desktop status` / `desktop stop` exit without binding a socket;
+      - one-shot `open` and all `desktop` commands exit without serving;
       - `--reload` opts out on purpose — picking up rebuilds is the dev
         supervisor's whole job.
     """
@@ -4008,8 +4018,8 @@ def _should_pin_frontend(
     tokens = (sys.argv if argv is None else argv)[1:]
     if "--reload" in tokens:
         return False
-    if _requested_subcommand(argv) == "desktop":
-        return "launch" in tokens
+    if _requested_subcommand(argv) in {"open", "desktop"}:
+        return False
     return True
 
 
@@ -4019,7 +4029,7 @@ def main() -> None:
     # updater can fast-forward the checkout or rebuild dist/.
     daemon_startup_head: str | None = None
     daemon_frontend_snapshot: Any = None
-    if _requested_subcommand() in {"serve", "desktop"}:
+    if _requested_subcommand() == "serve":
         try:
             from .selfupdate import _package_repo_root, _rev_parse
 
@@ -4554,6 +4564,10 @@ def main() -> None:
     desktop_sub.add_parser("launch", help="Open the workbench and request a fresh scan")
 
     # Workbench commands
+    sub.add_parser(
+        "open",
+        help="Start or reuse the local workbench, open it, and return when ready",
+    )
     serve_parser = sub.add_parser("serve", help="Start the workbench daemon + web UI")
     serve_parser.add_argument("--port", type=int, default=8384, help="Port (default: 8384)")
     serve_parser.add_argument("--no-browser", action="store_true", help="Don't open browser")
@@ -4564,6 +4578,11 @@ def main() -> None:
     serve_parser.add_argument("--reload", action="store_true",
                               help="Dev: restart the server automatically when backend "
                                    "(*.py) files change")
+    serve_parser.add_argument(
+        "--no-port-fallback",
+        action="store_true",
+        help=argparse.SUPPRESS,
+    )
 
     scan_parser = sub.add_parser("scan", help="One-shot index sessions into local workbench DB")
     scan_parser.add_argument("--source", choices=WORKBENCH_SOURCE_CHOICES, default=None,
@@ -4948,10 +4967,15 @@ def main() -> None:
     args = parser.parse_args()
     command = args.command or "export"
 
+    if command == "open":
+        from .desktop import run_open_command
+        exit_code = run_open_command()
+        if exit_code:
+            raise SystemExit(exit_code)
+        return
+
     if command == "desktop":
         from .desktop import run_desktop_command
-        args.daemon_startup_head = daemon_startup_head
-        args.daemon_frontend_snapshot = daemon_frontend_snapshot
         exit_code = run_desktop_command(args)
         if exit_code:
             raise SystemExit(exit_code)
@@ -4999,6 +5023,7 @@ def main() -> None:
             open_browser=open_browser,
             source_filter=args.source,
             remote=args.remote,
+            allow_port_fallback=not args.no_port_fallback,
             startup_head=daemon_startup_head,
             frontend_snapshot=daemon_frontend_snapshot,
         )

--- a/clawjournal/desktop.py
+++ b/clawjournal/desktop.py
@@ -24,6 +24,7 @@ import struct
 import subprocess
 import sys
 import threading
+import time
 import urllib.error
 import urllib.request
 import webbrowser
@@ -88,6 +89,10 @@ ICON_SIZE = 256
 # every HTTP request, so the log needs a ceiling to stay bounded over months.
 LOG_MAX_BYTES = 1_000_000
 DESKTOP_COMMAND_TIMEOUT_SECONDS = 30.0
+WORKBENCH_START_TIMEOUT_SECONDS = 30.0
+WORKBENCH_POLL_INTERVAL_SECONDS = 0.25
+WORKBENCH_LOG_TAIL_BYTES = 8_192
+BROWSER_OPEN_TIMEOUT_SECONDS = 5.0
 # Shared environment contract with workbench.daemon.RESTART_CHILD_ENV.  Keep
 # this lightweight launcher independent of importing the full daemon merely
 # to detect its own post-update re-exec.
@@ -1105,12 +1110,214 @@ def _request_scan(port: int) -> None:
         pass
 
 
+def _open_browser_once(
+    url: str,
+    *,
+    timeout_seconds: float = BROWSER_OPEN_TIMEOUT_SECONDS,
+) -> bool:
+    """Make one bounded browser-open attempt.
+
+    Some custom ``BROWSER`` commands wait for the browser process to exit.
+    Keep that platform integration from extending the one-shot controller to
+    the browser's lifetime.
+    """
+    finished = threading.Event()
+    result = False
+
+    def _open() -> None:
+        nonlocal result
+        try:
+            result = bool(webbrowser.open(url))
+        except Exception:
+            result = False
+        finally:
+            finished.set()
+
+    threading.Thread(
+        target=_open,
+        name="clawjournal-browser-open",
+        daemon=True,
+    ).start()
+    if not finished.wait(max(0.0, timeout_seconds)):
+        return False
+    return result
+
+
+def _trigger_self_update() -> None:
+    """Restore the hourly update trigger only after daemon readiness is safe."""
+    try:
+        from .selfupdate import maybe_self_update
+
+        maybe_self_update()
+    except Exception:
+        # Auto-update is always best-effort and must not fail an open request.
+        pass
+
+
+def _render_command(command: list[str]) -> str:
+    if os.name == "nt":
+        return subprocess.list2cmdline(command)
+    return shlex.join(command)
+
+
+def _workbench_daemon_command(port: int) -> list[str]:
+    return _command(
+        "serve",
+        "--port",
+        str(port),
+        "--no-browser",
+        "--no-port-fallback",
+    )
+
+
+def _detached_process_kwargs(log_stream: Any) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": log_stream,
+        "stderr": subprocess.STDOUT,
+        "close_fds": True,
+        # Do not let a caller's project directory shadow the installed
+        # `clawjournal` package resolved by `python -m`.
+        "cwd": str(_state_dir()),
+    }
+    if os.name == "nt":
+        kwargs["creationflags"] = (
+            getattr(subprocess, "CREATE_NEW_PROCESS_GROUP", 0x00000200)
+            | getattr(subprocess, "DETACHED_PROCESS", 0x00000008)
+        )
+    else:
+        kwargs["start_new_session"] = True
+    return kwargs
+
+
+def _spawn_workbench_daemon(
+    port: int,
+) -> tuple[subprocess.Popen[Any], list[str], int]:
+    """Start a strict-port daemon detached from this one-shot controller."""
+    log_path = _log_file()
+    command = _workbench_daemon_command(port)
+    try:
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        _trim_log()
+        with log_path.open("ab", buffering=0) as log_stream:
+            header = (
+                f"\n[{_now().isoformat(timespec='seconds')}] "
+                f"Starting: {_render_command(command)}\n"
+            ).encode("utf-8", "replace")
+            log_stream.write(header)
+            log_offset = log_stream.tell()
+            process = subprocess.Popen(
+                command,
+                **_detached_process_kwargs(log_stream),
+            )
+    except OSError as exc:
+        raise DesktopError(
+            "Could not start the ClawJournal workbench.\n"
+            f"Executable: {command[0]}\n"
+            f"Startup command: {_render_command(command)}\n"
+            f"Error: {exc}\n"
+            f"Log: {log_path}\n"
+            "Fix the reported error, then run `clawjournal open` again."
+        ) from exc
+    return process, command, log_offset
+
+
+def _wait_for_workbench(
+    process: subprocess.Popen[Any],
+    port: int,
+    timeout_seconds: float,
+) -> bool:
+    """Wait only for authenticated readiness, never for daemon completion."""
+    deadline = time.monotonic() + max(0.0, timeout_seconds)
+    while True:
+        port_state = _workbench_port_state(port)
+        if port_state == _PORT_WORKBENCH:
+            return True
+        if process.poll() is not None and port_state == _PORT_FREE:
+            return False
+        # If our strict-bind child exited while the port is occupied, another
+        # launcher may have bound ClawJournal but not started serving requests
+        # yet. Keep authenticating it within the original deadline. A foreign
+        # listener present before spawn was already rejected by launch().
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            return False
+        time.sleep(min(WORKBENCH_POLL_INTERVAL_SECONDS, remaining))
+
+
+def _terminate_process(process: subprocess.Popen[Any]) -> None:
+    if process.poll() is not None:
+        return
+    try:
+        process.terminate()
+        process.wait(timeout=2.0)
+    except subprocess.TimeoutExpired:
+        try:
+            process.kill()
+            process.wait(timeout=2.0)
+        except (OSError, subprocess.TimeoutExpired):
+            pass
+    except OSError:
+        pass
+
+
+def _read_launch_log_tail(offset: int) -> str:
+    try:
+        log_path = _log_file()
+        size = log_path.stat().st_size
+        start = max(offset, size - WORKBENCH_LOG_TAIL_BYTES)
+        with log_path.open("rb") as handle:
+            handle.seek(start)
+            raw = handle.read()
+    except OSError:
+        return ""
+    if start > offset:
+        newline = raw.find(b"\n")
+        raw = raw[newline + 1:] if newline >= 0 else raw
+    return raw.decode("utf-8", "replace").strip()
+
+
+def _startup_error(
+    *,
+    port: int,
+    process: subprocess.Popen[Any],
+    command: list[str],
+    log_offset: int,
+    timeout_seconds: float,
+    timed_out: bool,
+) -> DesktopError:
+    returncode = process.poll()
+    if timed_out:
+        reason = (
+            f"The workbench did not become ready within "
+            f"{timeout_seconds:g} seconds on port {port}."
+        )
+    else:
+        reason = (
+            f"The workbench process exited before it became ready "
+            f"(exit code {returncode})."
+        )
+    lines = [
+        reason,
+        f"Executable: {command[0]}",
+        f"Startup command: {_render_command(command)}",
+        f"Log: {_log_file()}",
+    ]
+    tail = _read_launch_log_tail(log_offset)
+    if tail:
+        lines.extend(("Last startup output:", tail))
+    lines.append(
+        "Review the startup output, fix the reported error, then run "
+        "`clawjournal open` again."
+    )
+    return DesktopError("\n".join(lines))
+
+
 def launch(
     *,
-    startup_head: str | None = None,
-    frontend_snapshot: Any = None,
-) -> None:
-    """Open the workbench and ensure a scan happens, reusing a live daemon."""
+    startup_timeout: float = WORKBENCH_START_TIMEOUT_SECONDS,
+) -> str:
+    """Start or reuse the workbench, open it once, and return after readiness."""
     # pythonw.exe gives Windows a true no-console launcher. Preserve diagnostics
     # by supplying streams before logging and the daemon are initialized.
     _trim_log()
@@ -1131,36 +1338,48 @@ def launch(
     if port_state == _PORT_WORKBENCH:
         if not is_restart_child:
             _request_scan(port)
-            webbrowser.open(url)
-        return
+            _open_browser_once(url)
+        _trigger_self_update()
+        return url
     if port_state == _PORT_OCCUPIED:
         raise _occupied_port_error(port)
 
-    from .pricing import ensure_pricing_fresh
-    from .workbench.daemon import run_server
-
-    ensure_pricing_fresh()
+    process: subprocess.Popen[Any] | None = None
     try:
-        run_server(
-            port=port,
-            open_browser=not is_restart_child,
-            allow_port_fallback=False,
-            startup_head=startup_head,
-            frontend_snapshot=frontend_snapshot,
-        )
-    except OSError as exc:
-        # Another click won the race between the probe above and the bind.
-        # Verify that the winner is ClawJournal before joining it; another
-        # local service must never be opened under the ClawJournal name.
-        port_state = _workbench_port_state(port)
-        if port_state == _PORT_WORKBENCH:
-            if not is_restart_child:
-                _request_scan(port)
-                webbrowser.open(url)
-            return
-        if port_state == _PORT_OCCUPIED:
-            raise _occupied_port_error(port) from exc
-        raise DesktopError(f"Could not start the workbench on port {port}: {exc}") from exc
+        process, command, log_offset = _spawn_workbench_daemon(port)
+        ready = _wait_for_workbench(process, port, startup_timeout)
+    except BaseException:
+        if process is not None:
+            _terminate_process(process)
+        raise
+    if not ready:
+        # Give a daemon that crossed the readiness boundary exactly at the
+        # deadline one final authenticated chance before stopping our child.
+        final_state = _workbench_port_state(port)
+        if final_state == _PORT_WORKBENCH:
+            ready = True
+        else:
+            timed_out = process.poll() is None
+            _terminate_process(process)
+            final_state = _workbench_port_state(port)
+            if final_state == _PORT_WORKBENCH:
+                ready = True
+            elif final_state == _PORT_OCCUPIED and process.poll() is not None:
+                raise _occupied_port_error(port)
+            else:
+                raise _startup_error(
+                    port=port,
+                    process=process,
+                    command=command,
+                    log_offset=log_offset,
+                    timeout_seconds=startup_timeout,
+                    timed_out=timed_out,
+                )
+    if not is_restart_child:
+        _request_scan(port)
+        _open_browser_once(url)
+    _trigger_self_update()
+    return url
 
 
 def _remove_file(path: Path) -> None:
@@ -1244,14 +1463,20 @@ def run_desktop_command(args: Any) -> int:
             print(json.dumps(status(), indent=2))
             return 0
         if args.desktop_command == "launch":
-            launch(
-                startup_head=getattr(args, "daemon_startup_head", None),
-                frontend_snapshot=getattr(
-                    args, "daemon_frontend_snapshot", None
-                ),
-            )
+            launch()
             return 0
     except DesktopError as exc:
         print(f"[x] {exc}", file=sys.stderr)
         return 1
     raise DesktopError(f"Unknown desktop command: {args.desktop_command}")
+
+
+def run_open_command() -> int:
+    """CLI adapter for the bounded, one-shot local workbench opener."""
+    try:
+        url = launch()
+    except DesktopError as exc:
+        print(f"[x] {exc}", file=sys.stderr)
+        return 1
+    print(f"[ok] Workbench ready: {url}")
+    return 0

--- a/clawjournal/desktop.py
+++ b/clawjournal/desktop.py
@@ -101,6 +101,8 @@ _UPDATE_RESTART_CHILD_ENV = "CLAWJOURNAL_RESTART_CHILD"
 _PORT_FREE = "free"
 _PORT_WORKBENCH = "workbench"
 _PORT_OCCUPIED = "occupied"
+_IPV4_LOOPBACK_HOST = "127.0.0.1"
+_BROWSER_LOOPBACK_HOST = "localhost"
 _NOTE_OPENED_LOCK = threading.Lock()
 _NOTE_OPENED_THREAD_LOCK = threading.Lock()
 _note_opened_thread: threading.Thread | None = None
@@ -1063,30 +1065,44 @@ def _daemon_port_is_open(port: int) -> bool:
     return _daemon_port_is_open(port)
 
 
-def _workbench_port_state(port: int) -> str:
-    """Classify the configured port without mistaking another service for us."""
-    if not _daemon_port_is_open(port):
-        return _PORT_FREE
-
+def _workbench_health_matches(port: int, host: str) -> bool:
+    """Authenticate a loopback endpoint without sending it the API token."""
     token = ensure_api_token(_config_dir())
     challenge = secrets.token_hex(HEALTH_CHALLENGE_BYTES)
     request = urllib.request.Request(
-        f"http://127.0.0.1:{port}/.well-known/clawjournal?challenge={challenge}",
+        f"http://{host}:{port}/.well-known/clawjournal?challenge={challenge}",
     )
     try:
         with urllib.request.urlopen(request, timeout=0.75) as response:
             payload = json.loads(response.read().decode("utf-8"))
     except (OSError, urllib.error.URLError, json.JSONDecodeError, UnicodeDecodeError):
-        return _PORT_OCCUPIED
+        return False
     expected_proof = api_health_proof(token, challenge)
-    if (
+    return bool(
         isinstance(payload, dict)
         and payload.get("service") == "clawjournal"
         and isinstance(payload.get("proof"), str)
         and secrets.compare_digest(payload["proof"], expected_proof)
-    ):
+    )
+
+
+def _workbench_port_state(port: int) -> str:
+    """Classify the configured port without mistaking another service for us."""
+    if not _daemon_port_is_open(port):
+        return _PORT_FREE
+    if _workbench_health_matches(port, _IPV4_LOOPBACK_HOST):
         return _PORT_WORKBENCH
     return _PORT_OCCUPIED
+
+
+def _workbench_browser_url(port: int) -> str:
+    """Preserve the localhost origin only when that exact endpoint is ours."""
+    if _workbench_health_matches(port, _BROWSER_LOOPBACK_HOST):
+        return f"http://{_BROWSER_LOOPBACK_HOST}:{port}/"
+    # This helper is called only after the primary IPv4 listener passed the
+    # authenticated health check. A failed localhost proof can therefore mean
+    # that an unrelated service owns the preferred ::1 endpoint.
+    return f"http://{_IPV4_LOOPBACK_HOST}:{port}/"
 
 
 def _occupied_port_error(port: int) -> DesktopError:
@@ -1333,13 +1349,9 @@ def launch(
         note_opened()
     config = load_config()
     port = int(config.get("daemon_port") or 8384)
-    # Open the exact IPv4 endpoint authenticated by _workbench_port_state().
-    # The daemon's best-effort ::1 companion may be unavailable because a
-    # different local service already owns that port; using localhost here
-    # could otherwise send the browser to that unrelated IPv6 listener.
-    url = f"http://127.0.0.1:{port}/"
     port_state = _workbench_port_state(port)
     if port_state == _PORT_WORKBENCH:
+        url = _workbench_browser_url(port)
         if not is_restart_child:
             _request_scan(port)
             _open_browser_once(url)
@@ -1379,6 +1391,7 @@ def launch(
                     timeout_seconds=startup_timeout,
                     timed_out=timed_out,
                 )
+    url = _workbench_browser_url(port)
     if not is_restart_child:
         _request_scan(port)
         _open_browser_once(url)

--- a/clawjournal/desktop.py
+++ b/clawjournal/desktop.py
@@ -1333,7 +1333,11 @@ def launch(
         note_opened()
     config = load_config()
     port = int(config.get("daemon_port") or 8384)
-    url = f"http://localhost:{port}/"
+    # Open the exact IPv4 endpoint authenticated by _workbench_port_state().
+    # The daemon's best-effort ::1 companion may be unavailable because a
+    # different local service already owns that port; using localhost here
+    # could otherwise send the browser to that unrelated IPv6 listener.
+    url = f"http://127.0.0.1:{port}/"
     port_state = _workbench_port_state(port)
     if port_state == _PORT_WORKBENCH:
         if not is_restart_child:

--- a/skills/clawjournal-setup/SKILL.md
+++ b/skills/clawjournal-setup/SKILL.md
@@ -133,8 +133,11 @@ powershell -ExecutionPolicy Bypass -File "$HOME\clawjournal\scripts\install.ps1"
 Then start the workbench:
 
 ```bash
-~/.clawjournal-venv/bin/clawjournal serve
+~/.clawjournal-venv/bin/clawjournal open
 ```
+
+This starts or reuses the local daemon, waits a bounded time for readiness, opens
+the browser, and then returns. Do not wait for a foreground daemon to exit.
 
 Tell the user: "Your workbench is open at localhost:8384. Everything is 100% local. Use the Inbox to triage traces, Search to find sessions, and Bundles to assemble exports."
 
@@ -146,7 +149,10 @@ Tell the user: "Your workbench is open at localhost:8384. Everything is 100% loc
 
 Parse the JSON and present traces as a numbered list. Then guide triage interactively.
 
-**For remote VMs:** `clawjournal serve --remote` prints the SSH tunnel command.
+**For remote VMs:** use `clawjournal serve --remote` in a dedicated terminal or
+background process and follow the SSH tunnel command it prints. `serve` is a
+foreground, long-running daemon command; do not wait for it to exit before
+continuing the setup conversation.
 
 ## 5. Done
 

--- a/skills/clawjournal/SKILL.md
+++ b/skills/clawjournal/SKILL.md
@@ -91,12 +91,18 @@ Ask:
 If user chooses the UI:
 
 ```bash
-clawjournal serve
+clawjournal open
 ```
+
+This starts or reuses the local daemon, waits a bounded time for readiness, opens
+the browser, and then returns. Continue the conversation after the command
+returns; do not wait for a foreground daemon to exit.
 
 Tell user: "Workbench is open at localhost:8384. Triage sessions in the Inbox, then come back and say 'share' when ready."
 
-For remote VMs: `clawjournal serve --remote` prints the SSH tunnel command.
+For remote VMs: use `clawjournal serve --remote` in a dedicated terminal or
+background process and follow the SSH tunnel command it prints. `serve` is a
+foreground, long-running daemon command; do not wait for it to exit.
 
 When user returns, continue to Step 2.
 
@@ -214,10 +220,11 @@ Map the user's index numbers to session_ids from the inbox JSON output.
 ### Full Review (web UI)
 
 ```bash
-clawjournal serve
+clawjournal open
 ```
 
-Opens a browser at `localhost:8384` with:
+Starts or reuses the local workbench, opens a browser at `localhost:8384`, and
+returns after a bounded readiness check. The workbench includes:
 - **Inbox**: Trace cards with value/risk/outcome badges and one-click triage
 - **Search**: Full-text search across all session transcripts
 - **Session Detail**: Three-pane view (timeline | transcript | metadata)
@@ -329,6 +336,7 @@ clawjournal export [--no-push] [--no-thinking] [--pii-review --pii-apply]
 clawjournal confirm --full-name "NAME" --attest-full-name "..." --attest-sensitive "..." --attest-manual-scan "..."
 
 # Workbench
+clawjournal open
 clawjournal serve [--port 8384] [--no-browser] [--remote]
 ```
 
@@ -336,5 +344,6 @@ clawjournal serve [--port 8384] [--no-browser] [--remote]
 
 - **`--exclude`, `--redact`, `--redact-usernames` APPEND** — they never overwrite. Safe to call repeatedly.
 - **`clawjournal inbox --json`** is the preferred way for agents to read trace data.
-- **`clawjournal serve`** opens a browser automatically. Use `--no-browser` to suppress.
+- **`clawjournal open`** is the local UI command for agents: it starts or reuses the daemon, opens the browser, and returns after a bounded readiness check.
+- **`clawjournal serve`** is a foreground, long-running daemon command. Use it only when explicitly managing the process (including `--remote`); do not wait for it to exit.
 - **Everything is local by default** — nothing leaves the machine unless the user explicitly submits from the workbench or uses a configured self-hosted ingest command.

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1485,6 +1485,28 @@ class TestScanOutput:
 
 
 class TestWorkbenchSourceChoices:
+    def test_open_dispatches_to_one_shot_desktop_controller(
+        self, monkeypatch, capsys
+    ):
+        from clawjournal import desktop
+
+        calls = []
+        monkeypatch.setattr(
+            "clawjournal.cli._should_auto_update", lambda argv=None: False
+        )
+
+        def launch(**kwargs):
+            calls.append(kwargs)
+            return "http://localhost:8384/"
+
+        monkeypatch.setattr(desktop, "launch", launch)
+        monkeypatch.setattr(sys, "argv", ["clawjournal", "open"])
+
+        main()
+
+        assert calls == [{}]
+        assert "Workbench ready: http://localhost:8384/" in capsys.readouterr().out
+
     def test_scan_accepts_cursor_source(self, monkeypatch):
         seen = {}
         monkeypatch.setattr("clawjournal.cli._run_scan", lambda source_filter=None: seen.setdefault("source", source_filter))
@@ -1505,6 +1527,33 @@ class TestWorkbenchSourceChoices:
         main()
 
         assert seen["source_filter"] == "aider"
+
+    def test_serve_hidden_no_port_fallback_flag_is_forwarded(self, monkeypatch):
+        seen = {}
+        monkeypatch.setattr(
+            "clawjournal.cli._should_auto_update", lambda argv=None: False
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.run_server",
+            lambda **kwargs: seen.update(kwargs),
+        )
+        monkeypatch.setattr(
+            sys,
+            "argv",
+            [
+                "clawjournal",
+                "serve",
+                "--port",
+                "9384",
+                "--no-browser",
+                "--no-port-fallback",
+            ],
+        )
+
+        main()
+
+        assert seen["port"] == 9384
+        assert seen["allow_port_fallback"] is False
 
     def test_recent_accepts_copilot_source(self, monkeypatch):
         seen = {}

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -51,6 +51,7 @@ def isolated_desktop(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> Path:
     monkeypatch.setattr(desktop, "_desktop_dir", lambda _platform: desktop_dir)
     monkeypatch.setattr(desktop, "_platform", lambda: "linux")
     monkeypatch.setattr(desktop, "_frontend_available", lambda: True)
+    monkeypatch.setattr(desktop, "_trigger_self_update", lambda: None)
     monkeypatch.setattr(desktop.shutil, "which", lambda _name: None)
     monkeypatch.setattr(
         desktop,
@@ -550,6 +551,61 @@ def test_port_probe_requires_a_valid_health_challenge_response(
     assert desktop._workbench_port_state(8384) == desktop._PORT_OCCUPIED
 
 
+class _FakeWorkbenchProcess:
+    def __init__(self, returncode: int | None = None) -> None:
+        self.returncode = returncode
+        self.pid = 4321
+
+    def poll(self) -> int | None:
+        return self.returncode
+
+
+def test_wait_for_workbench_uses_a_fixed_deadline(
+    isolated_desktop: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    process = _FakeWorkbenchProcess()
+    now = [100.0]
+    sleeps: list[float] = []
+
+    monkeypatch.setattr(
+        desktop, "_workbench_port_state", lambda _port: desktop._PORT_FREE
+    )
+    monkeypatch.setattr(desktop.time, "monotonic", lambda: now[0])
+
+    def advance(seconds: float) -> None:
+        sleeps.append(seconds)
+        now[0] += seconds
+
+    monkeypatch.setattr(desktop.time, "sleep", advance)
+
+    assert desktop._wait_for_workbench(process, 8384, 0.6) is False
+    assert sum(sleeps) == pytest.approx(0.6)
+    assert max(sleeps) <= desktop.WORKBENCH_POLL_INTERVAL_SECONDS
+    assert now[0] == pytest.approx(100.6)
+
+
+def test_browser_open_attempt_is_bounded_and_called_once(
+    isolated_desktop: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    release = threading.Event()
+    calls: list[str] = []
+
+    def blocking_open(url: str) -> bool:
+        calls.append(url)
+        release.wait(1.0)
+        return True
+
+    monkeypatch.setattr(desktop.webbrowser, "open", blocking_open)
+    try:
+        assert desktop._open_browser_once(
+            "http://localhost:8384/",
+            timeout_seconds=0.01,
+        ) is False
+        assert calls == ["http://localhost:8384/"]
+    finally:
+        release.set()
+
+
 def test_launch_reuses_live_workbench(
     isolated_desktop: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -563,6 +619,9 @@ def test_launch_reuses_live_workbench(
     )
     monkeypatch.setattr(desktop, "_request_scan", lambda port: calls.append(("scan", port)))
     monkeypatch.setattr(desktop.webbrowser, "open", lambda url: calls.append(("browser", url)))
+    monkeypatch.setattr(
+        desktop, "_trigger_self_update", lambda: calls.append("selfupdate")
+    )
 
     desktop.launch()
 
@@ -570,39 +629,198 @@ def test_launch_reuses_live_workbench(
         "opened",
         ("scan", 9001),
         ("browser", "http://localhost:9001/"),
+        "selfupdate",
     ]
 
 
-def test_update_restart_launch_suppresses_launch_only_actions(
+def test_launch_starts_daemon_then_scans_and_opens_exactly_once(
     isolated_desktop: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     calls: list[object] = []
-    captured: dict[str, object] = {}
-    frontend_snapshot = object()
-    monkeypatch.setenv(desktop._UPDATE_RESTART_CHILD_ENV, "1")
+    process = _FakeWorkbenchProcess()
+    command = ["python", "-m", "clawjournal.cli", "serve"]
+
     monkeypatch.setattr(desktop, "note_opened", lambda: calls.append("opened"))
     monkeypatch.setattr(desktop, "load_config", lambda: {"daemon_port": 9001})
     monkeypatch.setattr(
         desktop, "_workbench_port_state", lambda _port: desktop._PORT_FREE
     )
     monkeypatch.setattr(
+        desktop,
+        "_spawn_workbench_daemon",
+        lambda port: (process, command, 0),
+    )
+
+    def wait_for_workbench(proc, port, timeout_seconds):
+        calls.append(("wait", proc, port, timeout_seconds))
+        return True
+
+    monkeypatch.setattr(desktop, "_wait_for_workbench", wait_for_workbench)
+    monkeypatch.setattr(desktop, "_request_scan", lambda port: calls.append(("scan", port)))
+    monkeypatch.setattr(
         desktop.webbrowser, "open", lambda url: calls.append(("browser", url))
     )
-    monkeypatch.setattr("clawjournal.pricing.ensure_pricing_fresh", lambda: None)
     monkeypatch.setattr(
-        "clawjournal.workbench.daemon.run_server",
-        lambda **kwargs: captured.update(kwargs),
+        desktop, "_trigger_self_update", lambda: calls.append("selfupdate")
+    )
+    monkeypatch.setattr(
+        desktop,
+        "_terminate_process",
+        lambda _proc: pytest.fail("a ready daemon must not be terminated"),
     )
 
-    desktop.launch(
-        startup_head="a" * 40,
-        frontend_snapshot=frontend_snapshot,
+    desktop.launch(startup_timeout=4.5)
+
+    assert calls == [
+        "opened",
+        ("wait", process, 9001, 4.5),
+        ("scan", 9001),
+        ("browser", "http://localhost:9001/"),
+        "selfupdate",
+    ]
+
+
+def test_update_restart_launch_suppresses_launch_only_actions(
+    isolated_desktop: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    process = _FakeWorkbenchProcess()
+    calls: list[object] = []
+
+    monkeypatch.setenv(desktop._UPDATE_RESTART_CHILD_ENV, "1")
+    monkeypatch.setattr(desktop, "load_config", lambda: {"daemon_port": 9001})
+    monkeypatch.setattr(
+        desktop, "_workbench_port_state", lambda _port: desktop._PORT_FREE
+    )
+    monkeypatch.setattr(
+        desktop,
+        "_spawn_workbench_daemon",
+        lambda port: calls.append(("spawn", port))
+        or (process, ["clawjournal", "serve"], 0),
+    )
+    monkeypatch.setattr(
+        desktop,
+        "_wait_for_workbench",
+        lambda proc, port, timeout: calls.append(("wait", proc, port, timeout))
+        or True,
+    )
+    monkeypatch.setattr(desktop, "note_opened", lambda: calls.append("opened"))
+    monkeypatch.setattr(desktop, "_request_scan", lambda port: calls.append(("scan", port)))
+    monkeypatch.setattr(
+        desktop.webbrowser, "open", lambda url: calls.append(("browser", url))
     )
 
-    assert calls == []
-    assert captured["open_browser"] is False
-    assert captured["startup_head"] == "a" * 40
-    assert captured["frontend_snapshot"] is frontend_snapshot
+    desktop.launch(startup_timeout=4.5)
+
+    assert calls == [
+        ("spawn", 9001),
+        ("wait", process, 9001, 4.5),
+    ]
+
+
+def test_launch_timeout_terminates_child_and_reports_command_log_and_output(
+    isolated_desktop: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    process = _FakeWorkbenchProcess()
+    command = [
+        "python",
+        "-m",
+        "clawjournal.cli",
+        "serve",
+        "--port",
+        "9002",
+        "--no-browser",
+    ]
+    log = desktop._log_file()
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("startup stalled while opening the index\n", encoding="utf-8")
+    terminated: list[object] = []
+
+    monkeypatch.setattr(desktop, "load_config", lambda: {"daemon_port": 9002})
+    monkeypatch.setattr(desktop, "_workbench_port_state", lambda _port: desktop._PORT_FREE)
+    monkeypatch.setattr(
+        desktop,
+        "_spawn_workbench_daemon",
+        lambda _port: (process, command, 0),
+    )
+
+    def time_out(_proc, _port, timeout_seconds):
+        assert timeout_seconds == 2.5
+        return False
+
+    monkeypatch.setattr(desktop, "_wait_for_workbench", time_out)
+    monkeypatch.setattr(
+        desktop, "_terminate_process", lambda proc: terminated.append(proc)
+    )
+
+    with pytest.raises(desktop.DesktopError) as exc_info:
+        desktop.launch(startup_timeout=2.5)
+
+    message = str(exc_info.value)
+    assert terminated == [process]
+    assert "startup stalled while opening the index" in message
+    assert "clawjournal.cli" in message
+    assert str(log) in message
+
+
+def test_launch_early_exit_terminates_child_and_reports_exit_code(
+    isolated_desktop: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    process = _FakeWorkbenchProcess(returncode=7)
+    command = ["python", "-m", "clawjournal.cli", "serve", "--port", "9003"]
+    log = desktop._log_file()
+    log.parent.mkdir(parents=True, exist_ok=True)
+    log.write_text("fatal: daemon could not bind\n", encoding="utf-8")
+    terminated: list[object] = []
+
+    monkeypatch.setattr(desktop, "load_config", lambda: {"daemon_port": 9003})
+    monkeypatch.setattr(desktop, "_workbench_port_state", lambda _port: desktop._PORT_FREE)
+    monkeypatch.setattr(
+        desktop,
+        "_spawn_workbench_daemon",
+        lambda _port: (process, command, 0),
+    )
+    monkeypatch.setattr(desktop, "_wait_for_workbench", lambda *_args: False)
+    monkeypatch.setattr(
+        desktop, "_terminate_process", lambda proc: terminated.append(proc)
+    )
+
+    with pytest.raises(desktop.DesktopError) as exc_info:
+        desktop.launch(startup_timeout=30)
+
+    message = str(exc_info.value)
+    assert terminated == [process]
+    assert "7" in message
+    assert "fatal: daemon could not bind" in message
+    assert str(log) in message
+
+
+def test_spawn_workbench_daemon_uses_windows_detached_creation_flags(
+    isolated_desktop: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    captured: dict[str, object] = {}
+    process = _FakeWorkbenchProcess()
+
+    def popen(command, **kwargs):
+        captured["command"] = command
+        captured.update(kwargs)
+        return process
+
+    monkeypatch.setattr(desktop.os, "name", "nt")
+    monkeypatch.setattr(desktop.subprocess, "Popen", popen)
+
+    spawned, command, log_offset = desktop._spawn_workbench_daemon(9384)
+
+    assert spawned is process
+    assert captured["command"] == command
+    assert "serve" in command
+    assert command[command.index("--port") + 1] == "9384"
+    assert "--no-browser" in command
+    assert "--no-port-fallback" in command
+    assert captured["cwd"] == str(desktop._state_dir())
+    assert captured["cwd"] != str(isolated_desktop)
+    assert int(captured["creationflags"]) & 0x00000208 == 0x00000208
+    assert "start_new_session" not in captured
+    assert log_offset > 0
 
 
 def test_occupied_unknown_port_is_not_opened_or_replaced(
@@ -620,10 +838,10 @@ def test_occupied_unknown_port_is_not_opened_or_replaced(
     monkeypatch.setattr(desktop, "_request_scan", lambda p: calls.append(("scan", p)))
     monkeypatch.setattr(desktop.webbrowser, "open", lambda u: calls.append(("browser", u)))
 
-    def must_not_run(**kwargs: object) -> None:
+    def must_not_spawn(_port: int):
         raise AssertionError("started a second daemon against a live port")
 
-    monkeypatch.setattr("clawjournal.workbench.daemon.run_server", must_not_run)
+    monkeypatch.setattr(desktop, "_spawn_workbench_daemon", must_not_spawn)
     try:
         assert desktop._workbench_port_state(port) == desktop._PORT_OCCUPIED
         with pytest.raises(desktop.DesktopError, match="another local service"):
@@ -640,18 +858,23 @@ def test_losing_the_startup_race_does_not_spawn_a_duplicate(
 ) -> None:
     """Two fast clicks: the loser must join the winner, not take a random port."""
     calls: list[object] = []
+    process = _FakeWorkbenchProcess(returncode=1)
     monkeypatch.setattr(desktop, "load_config", lambda: {"daemon_port": 8384})
-    states = iter((desktop._PORT_FREE, desktop._PORT_WORKBENCH))
+    states = iter((
+        desktop._PORT_FREE,
+        desktop._PORT_OCCUPIED,
+        desktop._PORT_OCCUPIED,
+        desktop._PORT_WORKBENCH,
+    ))
     monkeypatch.setattr(desktop, "_workbench_port_state", lambda _p: next(states))
+    monkeypatch.setattr(desktop.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(desktop, "_request_scan", lambda p: calls.append(("scan", p)))
     monkeypatch.setattr(desktop.webbrowser, "open", lambda u: calls.append(("browser", u)))
-    monkeypatch.setattr("clawjournal.pricing.ensure_pricing_fresh", lambda *a, **k: None)
-
-    def bind_conflict(**kwargs: object) -> None:
-        assert kwargs["allow_port_fallback"] is False
-        raise OSError(48, "Address already in use")
-
-    monkeypatch.setattr("clawjournal.workbench.daemon.run_server", bind_conflict)
+    monkeypatch.setattr(
+        desktop,
+        "_spawn_workbench_daemon",
+        lambda _port: (process, ["clawjournal", "serve"], 0),
+    )
     desktop.launch()
 
     assert calls == [("scan", 8384), ("browser", "http://localhost:8384/")]
@@ -661,14 +884,22 @@ def test_losing_startup_race_to_another_service_reports_an_error(
     isolated_desktop: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     calls: list[object] = []
+    process = _FakeWorkbenchProcess(returncode=1)
     monkeypatch.setattr(desktop, "load_config", lambda: {"daemon_port": 8384})
-    states = iter((desktop._PORT_FREE, desktop._PORT_OCCUPIED))
+    states = iter((
+        desktop._PORT_FREE,
+        desktop._PORT_OCCUPIED,
+        desktop._PORT_OCCUPIED,
+        desktop._PORT_OCCUPIED,
+    ))
+    times = iter((0.0, 30.0))
     monkeypatch.setattr(desktop, "_workbench_port_state", lambda _p: next(states))
+    monkeypatch.setattr(desktop.time, "monotonic", lambda: next(times))
     monkeypatch.setattr(desktop.webbrowser, "open", lambda u: calls.append(("browser", u)))
-    monkeypatch.setattr("clawjournal.pricing.ensure_pricing_fresh", lambda *a, **k: None)
     monkeypatch.setattr(
-        "clawjournal.workbench.daemon.run_server",
-        lambda **_kwargs: (_ for _ in ()).throw(OSError(48, "Address already in use")),
+        desktop,
+        "_spawn_workbench_daemon",
+        lambda _port: (process, ["clawjournal", "serve"], 0),
     )
 
     with pytest.raises(desktop.DesktopError, match="another local service"):

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -551,6 +551,33 @@ def test_port_probe_requires_a_valid_health_challenge_response(
     assert desktop._workbench_port_state(8384) == desktop._PORT_OCCUPIED
 
 
+def test_browser_url_preserves_an_authenticated_localhost_origin(
+    isolated_desktop: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    calls: list[tuple[int, str]] = []
+
+    def health_matches(port: int, host: str) -> bool:
+        calls.append((port, host))
+        return True
+
+    monkeypatch.setattr(desktop, "_workbench_health_matches", health_matches)
+
+    assert desktop._workbench_browser_url(8384) == "http://localhost:8384/"
+    assert calls == [(8384, "localhost")]
+
+
+def test_browser_url_falls_back_when_localhost_is_not_authenticated(
+    isolated_desktop: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        desktop,
+        "_workbench_health_matches",
+        lambda _port, _host: False,
+    )
+
+    assert desktop._workbench_browser_url(8384) == "http://127.0.0.1:8384/"
+
+
 class _FakeWorkbenchProcess:
     def __init__(self, returncode: int | None = None) -> None:
         self.returncode = returncode
@@ -617,18 +644,21 @@ def test_launch_reuses_live_workbench(
         "_workbench_port_state",
         lambda port: desktop._PORT_WORKBENCH if port == 9001 else desktop._PORT_FREE,
     )
+    monkeypatch.setattr(
+        desktop, "_workbench_browser_url", lambda _port: "http://localhost:9001/"
+    )
     monkeypatch.setattr(desktop, "_request_scan", lambda port: calls.append(("scan", port)))
     monkeypatch.setattr(desktop.webbrowser, "open", lambda url: calls.append(("browser", url)))
     monkeypatch.setattr(
         desktop, "_trigger_self_update", lambda: calls.append("selfupdate")
     )
 
-    assert desktop.launch() == "http://127.0.0.1:9001/"
+    assert desktop.launch() == "http://localhost:9001/"
 
     assert calls == [
         "opened",
         ("scan", 9001),
-        ("browser", "http://127.0.0.1:9001/"),
+        ("browser", "http://localhost:9001/"),
         "selfupdate",
     ]
 
@@ -644,6 +674,9 @@ def test_launch_starts_daemon_then_scans_and_opens_exactly_once(
     monkeypatch.setattr(desktop, "load_config", lambda: {"daemon_port": 9001})
     monkeypatch.setattr(
         desktop, "_workbench_port_state", lambda _port: desktop._PORT_FREE
+    )
+    monkeypatch.setattr(
+        desktop, "_workbench_browser_url", lambda _port: "http://localhost:9001/"
     )
     monkeypatch.setattr(
         desktop,
@@ -669,13 +702,13 @@ def test_launch_starts_daemon_then_scans_and_opens_exactly_once(
         lambda _proc: pytest.fail("a ready daemon must not be terminated"),
     )
 
-    assert desktop.launch(startup_timeout=4.5) == "http://127.0.0.1:9001/"
+    assert desktop.launch(startup_timeout=4.5) == "http://localhost:9001/"
 
     assert calls == [
         "opened",
         ("wait", process, 9001, 4.5),
         ("scan", 9001),
-        ("browser", "http://127.0.0.1:9001/"),
+        ("browser", "http://localhost:9001/"),
         "selfupdate",
     ]
 
@@ -690,6 +723,9 @@ def test_update_restart_launch_suppresses_launch_only_actions(
     monkeypatch.setattr(desktop, "load_config", lambda: {"daemon_port": 9001})
     monkeypatch.setattr(
         desktop, "_workbench_port_state", lambda _port: desktop._PORT_FREE
+    )
+    monkeypatch.setattr(
+        desktop, "_workbench_browser_url", lambda _port: "http://localhost:9001/"
     )
     monkeypatch.setattr(
         desktop,
@@ -870,6 +906,9 @@ def test_losing_the_startup_race_does_not_spawn_a_duplicate(
     monkeypatch.setattr(desktop.time, "sleep", lambda _seconds: None)
     monkeypatch.setattr(desktop, "_request_scan", lambda p: calls.append(("scan", p)))
     monkeypatch.setattr(desktop.webbrowser, "open", lambda u: calls.append(("browser", u)))
+    monkeypatch.setattr(
+        desktop, "_workbench_browser_url", lambda _port: "http://127.0.0.1:8384/"
+    )
     monkeypatch.setattr(
         desktop,
         "_spawn_workbench_daemon",

--- a/tests/test_desktop.py
+++ b/tests/test_desktop.py
@@ -623,12 +623,12 @@ def test_launch_reuses_live_workbench(
         desktop, "_trigger_self_update", lambda: calls.append("selfupdate")
     )
 
-    desktop.launch()
+    assert desktop.launch() == "http://127.0.0.1:9001/"
 
     assert calls == [
         "opened",
         ("scan", 9001),
-        ("browser", "http://localhost:9001/"),
+        ("browser", "http://127.0.0.1:9001/"),
         "selfupdate",
     ]
 
@@ -669,13 +669,13 @@ def test_launch_starts_daemon_then_scans_and_opens_exactly_once(
         lambda _proc: pytest.fail("a ready daemon must not be terminated"),
     )
 
-    desktop.launch(startup_timeout=4.5)
+    assert desktop.launch(startup_timeout=4.5) == "http://127.0.0.1:9001/"
 
     assert calls == [
         "opened",
         ("wait", process, 9001, 4.5),
         ("scan", 9001),
-        ("browser", "http://localhost:9001/"),
+        ("browser", "http://127.0.0.1:9001/"),
         "selfupdate",
     ]
 
@@ -875,9 +875,9 @@ def test_losing_the_startup_race_does_not_spawn_a_duplicate(
         "_spawn_workbench_daemon",
         lambda _port: (process, ["clawjournal", "serve"], 0),
     )
-    desktop.launch()
+    assert desktop.launch() == "http://127.0.0.1:8384/"
 
-    assert calls == [("scan", 8384), ("browser", "http://localhost:8384/")]
+    assert calls == [("scan", 8384), ("browser", "http://127.0.0.1:8384/")]
 
 
 def test_losing_startup_race_to_another_service_reports_an_error(

--- a/tests/test_selfupdate.py
+++ b/tests/test_selfupdate.py
@@ -557,6 +557,11 @@ def test_cli_selfupdate_command_skips_pre_parse_auto_update():
     from clawjournal.cli import _should_auto_update
 
     assert _should_auto_update(["clawjournal", "selfupdate", "--check"]) is False
+    assert _should_auto_update(["clawjournal", "open"]) is False
+    assert _should_auto_update(["clawjournal", "desktop", "launch"]) is False
+    assert _should_auto_update(
+        ["clawjournal", "--repo", "launch", "desktop", "status"]
+    ) is True
     assert _should_auto_update(["clawjournal", "status"]) is True
 
 

--- a/tests/workbench/test_update_restart.py
+++ b/tests/workbench/test_update_restart.py
@@ -116,7 +116,10 @@ def test_no_snapshot_when_the_tree_keeps_changing_mid_capture(tmp_path, monkeypa
     [
         (Path("/repo"), ["clawjournal", "serve"], True),
         (Path("/repo"), ["clawjournal", "serve", "--port", "8384"], True),
-        (Path("/repo"), ["clawjournal", "desktop", "launch"], True),
+        # These are one-shot controllers; the detached `serve` child pins its
+        # own imported frontend/backend pair.
+        (Path("/repo"), ["clawjournal", "desktop", "launch"], False),
+        (Path("/repo"), ["clawjournal", "open"], False),
         # No checkout to fast-forward: a wheel install's dist/ never moves.
         (None, ["clawjournal", "serve"], False),
         # Never binds a socket, so it has nothing to keep serving.


### PR DESCRIPTION
## Summary

- add a one-shot `clawjournal open` command that starts or reuses the local workbench and returns after authenticated readiness
- detach cold-start daemons with strict port binding, bounded startup/browser waits, cleanup, and actionable launcher-log diagnostics
- route the desktop launcher, README, and agent skills through the bounded open path while keeping `serve` explicitly foreground
- add native Windows coverage for reuse, startup, timeout, process flags, port conflicts, and launch races

## Safety notes

- a challenge-response health probe prevents opening an unrelated localhost service
- the detached child cannot fall back to an undiscoverable random port and starts outside the callers project directory
- self-update still runs only after the daemon has pinned a matching backend/frontend revision

## Tests

- relevant desktop, CLI, and restart suite: 235 passed
- self-update/install/restart suite: 101 passed, 20 skipped
- native Windows PR subset: 15 passed
- `python -m compileall -q clawjournal`
- `git diff --check`

Fixes #173