### PR TITLE
fix(workbench): make bulk session review responsive

### DIFF
--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -272,6 +272,17 @@ export const api = {
       });
     },
 
+    bulkStatus(sessionIds: string[], status: 'approved' | 'blocked'): Promise<{
+      updated_ids: string[];
+      missing_ids: string[];
+    }> {
+      return request('/session-status/bulk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ session_ids: sessionIds, status }),
+      });
+    },
+
     findings(id: string, opts: { groupBy?: 'entity'; status?: FindingStatus } = {}): Promise<{ total: number; entities?: FindingEntityGroup[]; findings?: Finding[] }> {
       const params: Record<string, string> = {};
       if (opts.groupBy) params.group_by = opts.groupBy;

--- a/clawjournal/web/frontend/src/views/Inbox.test.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.test.tsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { api } from '../api.ts';
@@ -61,6 +61,38 @@ function session(id: string): Session {
   };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function stats(total: number) {
+  return {
+    total,
+    by_status: { new: total },
+    by_source: { codex: total },
+    by_project: { 'project-a': total },
+    by_task_type: { testing: total },
+  };
+}
+
+function renderInbox(sessions: Session[]) {
+  vi.spyOn(api.sessions, 'list').mockResolvedValue(sessions);
+  const statsSpy = vi.spyOn(api, 'stats').mockResolvedValue(stats(sessions.length));
+  localStorage.setItem('cj.gettingStartedGuideV2Dismissed', '1');
+  render(
+    <MemoryRouter>
+      <ToastProvider><Inbox /></ToastProvider>
+    </MemoryRouter>,
+  );
+  return { statsSpy };
+}
+
 afterEach(() => {
   vi.restoreAllMocks();
 });
@@ -104,4 +136,228 @@ describe('Inbox selection defaults', () => {
     expect(second).not.toBeChecked();
     expect(screen.queryByText(/selected$/)).not.toBeInTheDocument();
   });
+});
+
+describe('Inbox bulk status updates', () => {
+  it('shows immediate progress, closes the dialog, and prevents duplicate approval requests', async () => {
+    const pending = deferred<{ updated_ids: string[]; missing_ids: string[] }>();
+    const bulkStatus = vi.spyOn(api.sessions, 'bulkStatus').mockReturnValue(pending.promise);
+    const { statsSpy } = renderInbox([session('one'), session('two')]);
+
+    await screen.findByRole('checkbox', { name: 'Select session: Session one' });
+    await waitFor(() => expect(statsSpy).toHaveBeenCalledTimes(1));
+    const statsRefresh = deferred<ReturnType<typeof stats>>();
+    statsSpy.mockReturnValueOnce(statsRefresh.promise);
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    const confirmButton = within(screen.getByRole('dialog')).getByRole('button', { name: 'Approve' });
+    fireEvent.click(confirmButton);
+    // Exercise the synchronous guard with the old DOM reference: React may not
+    // have committed the modal close between two browser click events.
+    fireEvent.click(confirmButton);
+
+    expect(bulkStatus).toHaveBeenCalledTimes(1);
+    expect(bulkStatus).toHaveBeenCalledWith(['one', 'two'], 'approved');
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.getByRole('status')).toHaveTextContent('Approving 2 sessions…');
+    expect(screen.queryByRole('button', { name: 'Approve' })).not.toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Select session: Session one' })).toBeDisabled();
+    fireEvent.click(screen.getAllByTitle('Filter by Testing')[0]);
+    expect(api.sessions.list).toHaveBeenCalledTimes(1);
+
+    pending.resolve({ updated_ids: ['one', 'two'], missing_ids: [] });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('checkbox', { name: 'Select session: Session one' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByText('2 sessions approved')).toBeInTheDocument();
+    expect(screen.queryByRole('status')).not.toBeInTheDocument();
+    expect(statsSpy).toHaveBeenCalledTimes(2);
+    statsRefresh.resolve(stats(0));
+  });
+
+  it('keeps a missing session selected while removing the sessions the server skipped', async () => {
+    const pending = deferred<{ updated_ids: string[]; missing_ids: string[] }>();
+    vi.spyOn(api.sessions, 'bulkStatus').mockReturnValue(pending.promise);
+    renderInbox([session('one'), session('two')]);
+
+    await screen.findByRole('checkbox', { name: 'Select session: Session one' });
+    fireEvent.click(screen.getByRole('button', { name: 'Skip' }));
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Skip' }));
+
+    expect(screen.getByRole('status')).toHaveTextContent('Skipping 2 sessions…');
+    pending.resolve({ updated_ids: ['one'], missing_ids: ['two'] });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('checkbox', { name: 'Select session: Session one' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('checkbox', { name: 'Select session: Session two' })).toBeChecked();
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+    expect(screen.getByText('1 session skipped')).toBeInTheDocument();
+    expect(screen.getByText('1 session could not be updated; visible items remain selected')).toBeInTheDocument();
+  });
+
+  it('keeps the submitted sessions selected when the request fails', async () => {
+    const pending = deferred<{ updated_ids: string[]; missing_ids: string[] }>();
+    vi.spyOn(api.sessions, 'bulkStatus').mockReturnValue(pending.promise);
+    const { statsSpy } = renderInbox([session('one'), session('two')]);
+
+    await screen.findByRole('checkbox', { name: 'Select session: Session one' });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Approve' }));
+    pending.reject(new Error('network unavailable'));
+
+    await screen.findByText('Failed to update sessions: network unavailable');
+    expect(screen.getByRole('checkbox', { name: 'Select session: Session one' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Select session: Session two' })).toBeChecked();
+    expect(screen.getByText('2 selected')).toBeInTheDocument();
+    expect(screen.queryByText(/sessions approved$/)).not.toBeInTheDocument();
+    expect(statsSpy).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores a stale list response while a bulk update is pending', async () => {
+    const staleList = deferred<Session[]>();
+    vi.spyOn(api.sessions, 'list')
+      .mockResolvedValueOnce([session('one'), session('two')])
+      .mockReturnValueOnce(staleList.promise);
+    vi.spyOn(api, 'stats').mockResolvedValue(stats(2));
+    const pending = deferred<{ updated_ids: string[]; missing_ids: string[] }>();
+    vi.spyOn(api.sessions, 'bulkStatus').mockReturnValue(pending.promise);
+    localStorage.setItem('cj.gettingStartedGuideV2Dismissed', '1');
+    render(
+      <MemoryRouter>
+        <ToastProvider><Inbox /></ToastProvider>
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('checkbox', { name: 'Select session: Session one' });
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    fireEvent.change(screen.getByRole('combobox', { name: 'Sort sessions' }), {
+      target: { value: 'start_time:desc' },
+    });
+    await waitFor(() => expect(api.sessions.list).toHaveBeenCalledTimes(2));
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Approve' }));
+
+    expect(screen.getByRole('combobox', { name: 'Sort sessions' })).toBeDisabled();
+    expect(screen.getByRole('combobox', { name: 'Sessions per page' })).toBeDisabled();
+    pending.resolve({ updated_ids: ['one', 'two'], missing_ids: [] });
+    await waitFor(() => {
+      expect(screen.queryByRole('checkbox', { name: 'Select session: Session one' })).not.toBeInTheDocument();
+    });
+
+    await act(async () => {
+      staleList.resolve([session('one'), session('two')]);
+      await staleList.promise;
+    });
+    expect(screen.queryByRole('checkbox', { name: 'Select session: Session one' })).not.toBeInTheDocument();
+  });
+
+  it('refills from the first page without reselecting a deliberately excluded row', async () => {
+    const initialSessions = Array.from({ length: 11 }, (_, index) => session(`s${index + 1}`));
+    const list = vi.spyOn(api.sessions, 'list')
+      .mockResolvedValueOnce(initialSessions)
+      .mockResolvedValueOnce([session('s10'), session('s11')]);
+    vi.spyOn(api, 'stats').mockResolvedValue(stats(initialSessions.length));
+    vi.spyOn(api.sessions, 'bulkStatus').mockImplementation(async ids => ({
+      updated_ids: ids,
+      missing_ids: [],
+    }));
+    localStorage.setItem('cj.gettingStartedGuideV2Dismissed', '1');
+    render(
+      <MemoryRouter>
+        <ToastProvider><Inbox /></ToastProvider>
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('checkbox', { name: 'Select session: Session s1' });
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Select session: Session s10' }));
+    expect(screen.getByText('9 selected')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Approve' }));
+
+    const nextSession = await screen.findByRole('checkbox', {
+      name: 'Select session: Session s11',
+    });
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('checkbox', { name: 'Select session: Session s10' })).not.toBeChecked();
+    expect(nextSession).toBeChecked();
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+    expect(screen.queryByText('Every session has been reviewed.')).not.toBeInTheDocument();
+  });
+
+  it('keeps new rows unselected after Clear opts out of automatic selection', async () => {
+    const initialSessions = Array.from({ length: 11 }, (_, index) => session(`s${index + 1}`));
+    vi.spyOn(api.sessions, 'list')
+      .mockResolvedValueOnce(initialSessions)
+      .mockResolvedValueOnce(initialSessions.slice(1));
+    vi.spyOn(api, 'stats').mockResolvedValue(stats(initialSessions.length));
+    vi.spyOn(api.sessions, 'bulkStatus').mockImplementation(async ids => ({
+      updated_ids: ids,
+      missing_ids: [],
+    }));
+    localStorage.setItem('cj.gettingStartedGuideV2Dismissed', '1');
+    render(
+      <MemoryRouter>
+        <ToastProvider><Inbox /></ToastProvider>
+      </MemoryRouter>,
+    );
+
+    const firstSession = await screen.findByRole('checkbox', {
+      name: 'Select session: Session s1',
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'Clear' }));
+    fireEvent.click(firstSession);
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Approve' }));
+
+    const nextSession = await screen.findByRole('checkbox', {
+      name: 'Select session: Session s11',
+    });
+    expect(screen.getByRole('checkbox', { name: 'Select session: Session s2' })).not.toBeChecked();
+    expect(nextSession).not.toBeChecked();
+    expect(screen.queryByText(/selected$/)).not.toBeInTheDocument();
+  });
+
+  it('splits over-limit selections and preserves a later failed chunk for retry', async () => {
+    const allSessions = Array.from({ length: 101 }, (_, index) => session(`s${index + 1}`));
+    vi.spyOn(api.sessions, 'list').mockImplementation(async (params = {}) => {
+      const start = params.offset ?? 0;
+      return allSessions.slice(start, start + (params.limit ?? 50));
+    });
+    vi.spyOn(api, 'stats').mockResolvedValue(stats(allSessions.length));
+    const bulkStatus = vi.spyOn(api.sessions, 'bulkStatus').mockImplementation(async ids => {
+      if (ids.length === 1) throw new Error('second chunk failed');
+      return { updated_ids: ids, missing_ids: [] };
+    });
+    localStorage.setItem('cj.gettingStartedGuideV2Dismissed', '1');
+    render(
+      <MemoryRouter>
+        <ToastProvider><Inbox /></ToastProvider>
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('checkbox', { name: 'Select session: Session s1' });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Sessions per page' }), {
+      target: { value: '100' },
+    });
+    await screen.findByText('100 selected');
+    fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+    await screen.findByText('101 selected');
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Approve' }));
+
+    await waitFor(() => expect(bulkStatus).toHaveBeenCalledTimes(2));
+    expect(bulkStatus.mock.calls[0][0]).toHaveLength(100);
+    expect(bulkStatus.mock.calls[1][0]).toHaveLength(1);
+    expect(bulkStatus.mock.calls[0][1]).toBe('approved');
+    expect(bulkStatus.mock.calls[1][1]).toBe('approved');
+    await waitFor(() => {
+      expect(screen.queryByRole('checkbox', { name: 'Select session: Session s1' })).not.toBeInTheDocument();
+    });
+    expect(screen.getByRole('checkbox', { name: 'Select session: Session s101' })).toBeChecked();
+    expect(screen.getByText('1 selected')).toBeInTheDocument();
+    expect(screen.getByText('100 sessions approved')).toBeInTheDocument();
+    expect(screen.getByText('1 session could not be updated; visible items remain selected')).toBeInTheDocument();
+  }, 15_000);
 });

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -15,6 +15,7 @@ import { colors, selectStyle, btnPrimary, btnDanger, btnSecondary } from '../the
 // chips wrapping across the viewport.
 const TYPE_CHIP_PREVIEW_LIMIT = 6;
 const GETTING_STARTED_DISMISSED_KEY = 'cj.gettingStartedGuideV2Dismissed';
+const BULK_STATUS_BATCH_SIZE = 100;
 
 function failureBadge(score: number | null): string {
   if (score == null) return '\u2014';
@@ -162,6 +163,14 @@ export function Inbox() {
 
   // Bulk selection
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [bulkUpdate, setBulkUpdate] = useState<{
+    action: 'approved' | 'blocked';
+    ids: string[];
+  } | null>(null);
+  // State updates do not become visible until the next render. Keep a
+  // synchronous guard as well so a double click cannot submit the same batch
+  // twice while React is closing the confirmation dialog.
+  const bulkUpdateInFlightRef = useRef(false);
 
   // Keyboard navigation
   const [focusIndex, setFocusIndex] = useState(-1);
@@ -182,7 +191,10 @@ export function Inbox() {
   const loadingIdsRef = useRef<Set<string>>(new Set());
 
   // Confirm dialog
-  const [confirm, setConfirm] = useState<{ action: string; ids: string[] } | null>(null);
+  const [confirm, setConfirm] = useState<{
+    action: 'approved' | 'blocked';
+    ids: string[];
+  } | null>(null);
 
   const loadStats = useCallback(async () => {
     try {
@@ -191,7 +203,13 @@ export function Inbox() {
     } catch { /* ignore */ }
   }, []);
 
-  const loadSessions = useCallback(async (currentOffset: number, append: boolean) => {
+  const loadSessions = useCallback(async (
+    currentOffset: number,
+    append: boolean,
+    preserveDeselectedIds?: ReadonlySet<string>,
+    preserveSelectedIds?: ReadonlySet<string>,
+  ) => {
+    if (bulkUpdateInFlightRef.current) return;
     const requestSeq = loadRequestSeqRef.current + 1;
     loadRequestSeqRef.current = requestSeq;
     setLoading(true);
@@ -223,7 +241,17 @@ export function Inbox() {
           return next;
         });
       } else {
-        setSelectedIds(new Set(visibleRows.map((session) => session.session_id)));
+        setSelectedIds(new Set(
+          visibleRows
+            .filter(session => (
+              preserveSelectedIds?.has(session.session_id)
+              || (
+                selectNewRowsRef.current
+                && !preserveDeselectedIds?.has(session.session_id)
+              )
+            ))
+            .map(session => session.session_id),
+        ));
       }
       setOffset(currentOffset);
       setHasMore(data.length > pageSize);
@@ -278,23 +306,116 @@ export function Inbox() {
     }
   }, [focusIndex]);
 
-  const handleBulkAction = async (action: 'approved' | 'blocked') => {
-    const ids = [...selectedIds];
+  const handleBulkAction = async (
+    action: 'approved' | 'blocked',
+    ids: string[],
+  ) => {
+    if (bulkUpdateInFlightRef.current || ids.length === 0) return;
+    bulkUpdateInFlightRef.current = true;
+    // Ignore any list response that started before this write. Otherwise a
+    // slow "Load more" response could restore rows after they were approved.
+    loadRequestSeqRef.current += 1;
+    setLoading(false);
     const verb = action === 'approved' ? 'approved' : 'skipped';
-    // Per-item settle so one failed update doesn't strand the rest: remove only
-    // the ones that actually succeeded and keep the failures selected.
-    const results = await Promise.allSettled(ids.map(id => api.sessions.update(id, { status: action })));
-    const okIds = new Set(ids.filter((_, i) => results[i].status === 'fulfilled'));
-    const failed = ids.length - okIds.size;
-    setSessions(prev => prev.filter(s => !okIds.has(s.session_id)));
-    setSelectedIds(prev => new Set([...prev].filter(id => !okIds.has(id))));
-    loadStats();
+    const requestedIds = new Set(ids);
+    const deselectedVisibleIds = new Set(
+      sessionsRef.current
+        .filter(session => !requestedIds.has(session.session_id))
+        .map(session => session.session_id),
+    );
+    let shouldReloadSessions = false;
+    let unresolvedSubmittedIds = new Set<string>();
+    // Close the modal immediately and replace the toolbar actions with a
+    // durable progress message. Success is only announced after the server
+    // confirms which rows were updated.
     setConfirm(null);
-    if (okIds.size > 0) {
-      toast(`${okIds.size} session${okIds.size > 1 ? 's' : ''} ${verb}`, 'success');
-    }
-    if (failed > 0) {
-      toast(`${failed} session${failed > 1 ? 's' : ''} failed to update`, 'error');
+    setBulkUpdate({ action, ids });
+
+    try {
+      const updatedIds = new Set<string>();
+      let completedBatchCount = 0;
+      let firstRequestError: unknown = null;
+
+      // The daemon caps each atomic update at 100 rows. Loaded pages can exceed
+      // that after "Load more", so split only when necessary and preserve the
+      // outcome of every completed batch if a later request fails.
+      for (let start = 0; start < ids.length; start += BULK_STATUS_BATCH_SIZE) {
+        const batchIds = ids.slice(start, start + BULK_STATUS_BATCH_SIZE);
+        try {
+          const result = await api.sessions.bulkStatus(batchIds, action);
+          completedBatchCount += 1;
+          result.updated_ids.forEach(id => {
+            if (requestedIds.has(id)) updatedIds.add(id);
+          });
+        } catch (error) {
+          firstRequestError ??= error;
+        }
+      }
+
+      if (completedBatchCount === 0 && firstRequestError) {
+        throw firstRequestError;
+      }
+
+      const unresolvedIds = ids.filter(id => !updatedIds.has(id));
+      unresolvedSubmittedIds = new Set(unresolvedIds);
+      shouldReloadSessions = updatedIds.size > 0 && hasMore;
+      const visibleIds = new Set(
+        sessionsRef.current.map(session => session.session_id),
+      );
+
+      setSessions(prev => prev.filter(s => !updatedIds.has(s.session_id)));
+      setSelectedIds(prev => {
+        const next = new Set([...prev].filter(id => !updatedIds.has(id)));
+        unresolvedIds.forEach(id => {
+          if (visibleIds.has(id)) next.add(id);
+        });
+        return next;
+      });
+
+      if (updatedIds.size > 0) {
+        toast(`${updatedIds.size} session${updatedIds.size > 1 ? 's' : ''} ${verb}`, 'success');
+      }
+      if (unresolvedIds.length > 0) {
+        toast(
+          `${unresolvedIds.length} session${unresolvedIds.length === 1 ? '' : 's'} could not be updated; visible items remain selected`,
+          'error',
+        );
+      }
+    } catch (error) {
+      // A request-level failure has no confirmed successes. Preserve the exact
+      // submitted selection still visible in the current filter so retrying is
+      // a single click without creating hidden selections from an old view.
+      const visibleIds = new Set(
+        sessionsRef.current.map(session => session.session_id),
+      );
+      setSelectedIds(prev => {
+        const next = new Set(prev);
+        ids.forEach(id => {
+          if (visibleIds.has(id)) next.add(id);
+        });
+        return next;
+      });
+      const detail = error instanceof Error && error.message
+        ? `: ${error.message}`
+        : '';
+      toast(`Failed to update sessions${detail}`, 'error');
+    } finally {
+      bulkUpdateInFlightRef.current = false;
+      setBulkUpdate(null);
+      // Stats are supplemental. Do not keep the primary interaction in its
+      // pending state while a slower refresh waits on the database or network.
+      void loadStats();
+      if (shouldReloadSessions) {
+        // Removing rows changes the offset basis. Refill from the first page so
+        // the next unreviewed rows are not skipped, while retaining deliberate
+        // deselections from the page the user just acted on.
+        void loadSessions(
+          0,
+          false,
+          deselectedVisibleIds,
+          unresolvedSubmittedIds,
+        );
+      }
     }
   };
 
@@ -407,7 +528,13 @@ export function Inbox() {
               cursor: 'text',
             }}
           />
-          <select value={sort} onChange={e => setSort(e.target.value)} style={selectStyle}>
+          <select
+            value={sort}
+            onChange={e => setSort(e.target.value)}
+            disabled={bulkUpdate !== null}
+            aria-label="Sort sessions"
+            style={selectStyle}
+          >
             <option value="ai_failure_value_score:desc">Most instructive failures</option>
             <option value="ai_quality_score:desc">Highest productivity</option>
             <option value="start_time:desc">Newest first</option>
@@ -416,6 +543,7 @@ export function Inbox() {
           <select
             value={pageSize}
             onChange={e => setPageSize(Number(e.target.value))}
+            disabled={bulkUpdate !== null}
             aria-label="Sessions per page"
             style={selectStyle}
           >
@@ -441,31 +569,48 @@ export function Inbox() {
         <GettingStartedGuide stats={stats} onDismiss={dismissGettingStartedGuide} />
       )}
 
-      {selectedIds.size > 0 && (
+      {(bulkUpdate !== null || selectedIds.size > 0) && (
         <div style={{
           display: 'flex', alignItems: 'center', gap: 10,
           padding: '8px 12px', marginBottom: 8,
           background: colors.primary50, border: `1px solid ${colors.primary200}`, borderRadius: 8,
+          opacity: bulkUpdate ? 0.85 : 1,
         }}>
           <span style={{ fontSize: 13, fontWeight: 600, color: colors.gray800 }}>
-            {selectedIds.size} selected
+            {bulkUpdate ? `${bulkUpdate.ids.length} submitted` : `${selectedIds.size} selected`}
           </span>
-          <button onClick={toggleSelectAll} style={{ ...btnSecondary, padding: '4px 10px', fontSize: 12 }}>
-            {selectedIds.size === sessions.length ? 'Clear' : 'Select all'}
-          </button>
-          <div style={{ flex: 1 }} />
-          <button
-            onClick={() => setConfirm({ action: 'approved', ids: [...selectedIds] })}
-            style={{ ...btnPrimary, padding: '4px 12px', fontSize: 12, fontWeight: 600 }}
-          >
-            Approve
-          </button>
-          <button
-            onClick={() => setConfirm({ action: 'blocked', ids: [...selectedIds] })}
-            style={{ ...btnDanger, padding: '4px 12px', fontSize: 12, fontWeight: 600 }}
-          >
-            Skip
-          </button>
+          {bulkUpdate ? (
+            <>
+              <div style={{ flex: 1 }} />
+              <span
+                role="status"
+                aria-live="polite"
+                style={{ fontSize: 13, fontWeight: 600, color: colors.primary500 }}
+              >
+                {bulkUpdate.action === 'approved' ? 'Approving' : 'Skipping'}{' '}
+                {bulkUpdate.ids.length} session{bulkUpdate.ids.length > 1 ? 's' : ''}…
+              </span>
+            </>
+          ) : (
+            <>
+              <button onClick={toggleSelectAll} style={{ ...btnSecondary, padding: '4px 10px', fontSize: 12 }}>
+                {selectedIds.size === sessions.length ? 'Clear' : 'Select all'}
+              </button>
+              <div style={{ flex: 1 }} />
+              <button
+                onClick={() => setConfirm({ action: 'approved', ids: [...selectedIds] })}
+                style={{ ...btnPrimary, padding: '4px 12px', fontSize: 12, fontWeight: 600 }}
+              >
+                Approve
+              </button>
+              <button
+                onClick={() => setConfirm({ action: 'blocked', ids: [...selectedIds] })}
+                style={{ ...btnDanger, padding: '4px 12px', fontSize: 12, fontWeight: 600 }}
+              >
+                Skip
+              </button>
+            </>
+          )}
         </div>
       )}
 
@@ -474,6 +619,7 @@ export function Inbox() {
           <select
             value={sourceFilter || ''}
             onChange={e => setSourceFilter(e.target.value || null)}
+            disabled={bulkUpdate !== null}
             style={selectStyle}
           >
             <option value="">All sources</option>
@@ -484,6 +630,7 @@ export function Inbox() {
           <select
             value={recoveryFilter || ''}
             onChange={e => setRecoveryFilter(e.target.value || null)}
+            disabled={bulkUpdate !== null}
             style={selectStyle}
           >
             <option value="">All recovery</option>
@@ -495,6 +642,7 @@ export function Inbox() {
           <select
             value={attributionFilter || ''}
             onChange={e => setAttributionFilter(e.target.value || null)}
+            disabled={bulkUpdate !== null}
             style={selectStyle}
           >
             <option value="">All attribution</option>
@@ -507,6 +655,7 @@ export function Inbox() {
           <select
             value={modeFilter || ''}
             onChange={e => setModeFilter(e.target.value || null)}
+            disabled={bulkUpdate !== null}
             style={selectStyle}
           >
             <option value="">All modes</option>
@@ -526,6 +675,7 @@ export function Inbox() {
           <select
             value={projectFilter || ''}
             onChange={e => setProjectFilter(e.target.value || null)}
+            disabled={bulkUpdate !== null}
             style={selectStyle}
           >
             <option value="">All projects</option>
@@ -541,6 +691,7 @@ export function Inbox() {
         <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 10 }}>
           <button
             onClick={() => setTypeFilter(null)}
+            disabled={bulkUpdate !== null}
             style={{
               padding: '4px 12px',
               borderRadius: 9999,
@@ -561,6 +712,7 @@ export function Inbox() {
               <button
                 key={type}
                 onClick={() => setTypeFilter(active ? null : type)}
+                disabled={bulkUpdate !== null}
                 style={{
                   padding: '4px 12px',
                   borderRadius: 9999,
@@ -630,6 +782,7 @@ export function Inbox() {
           {hasActiveFilter && (
             <button
               onClick={clearAllFilters}
+              disabled={bulkUpdate !== null}
               style={{
                 display: 'inline-block', padding: '7px 18px', background: colors.primary500, color: colors.white,
                 borderRadius: '6px', fontSize: '13px', fontWeight: 600, border: 'none', cursor: 'pointer',
@@ -681,10 +834,11 @@ export function Inbox() {
                 <input
                   type="checkbox"
                   checked={isSelected}
+                  disabled={bulkUpdate !== null}
                   aria-label={`Select session: ${s.display_title || 'Untitled'}`}
                   onClick={e => e.stopPropagation()}
                   onChange={() => toggleSelect(s.session_id)}
-                  style={{ flexShrink: 0, cursor: 'pointer' }}
+                  style={{ flexShrink: 0, cursor: bulkUpdate ? 'wait' : 'pointer' }}
                 />
                 {/* Failure + productivity scores */}
                 <div style={{
@@ -726,9 +880,15 @@ export function Inbox() {
                           color: typeColor(s.task_type),
                           fontWeight: 600,
                           flexShrink: 0,
-                          cursor: 'pointer',
+                          cursor: bulkUpdate ? 'wait' : 'pointer',
                         }}
-                        onClick={(e) => { e.stopPropagation(); setTypeFilter(s.task_type); }}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          if (!bulkUpdateInFlightRef.current) {
+                            setTypeFilter(s.task_type);
+                          }
+                        }}
+                        aria-disabled={bulkUpdate !== null}
                         title={`Filter by ${LABELS[s.task_type] ?? s.task_type}`}
                       >
                         {LABELS[s.task_type] ?? s.task_type.replace(/_/g, ' ')}
@@ -803,7 +963,7 @@ export function Inbox() {
         <div style={{ textAlign: 'center', marginTop: '8px' }}>
           <button
             onClick={() => { void loadSessions(offset + pageSize, true); }}
-            disabled={loading}
+            disabled={loading || bulkUpdate !== null}
             style={{
               padding: '5px 18px', background: colors.gray100, color: colors.gray700, border: `1px solid ${colors.gray300}`,
               borderRadius: '4px', fontSize: '13px', cursor: 'pointer',
@@ -823,7 +983,7 @@ export function Inbox() {
         message={`This will ${confirm?.action === 'approved' ? 'approve' : 'skip'} ${confirm?.ids.length ?? 0} session${(confirm?.ids.length ?? 0) > 1 ? 's' : ''}.`}
         confirmLabel={confirm?.action === 'approved' ? 'Approve' : 'Skip'}
         variant={confirm?.action === 'blocked' ? 'danger' : 'primary'}
-        onConfirm={() => confirm && handleBulkAction(confirm.action as 'approved' | 'blocked')}
+        onConfirm={() => confirm && handleBulkAction(confirm.action, confirm.ids)}
         onCancel={() => setConfirm(null)}
       />
     </div>

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -64,6 +64,7 @@ from .index import (
     add_policy,
     already_shared_revision_blockers,
     apply_share_redactions,
+    bulk_update_review_status,
     create_share,
     export_share_to_disk,
     FAILURE_VALUE_SOURCE_SCOPE,
@@ -4026,7 +4027,9 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         parsed = urlparse(self.path)
         path = parsed.path.rstrip("/")
 
-        if path.startswith("/api/sessions/") and path.endswith("/score"):
+        if path == "/api/session-status/bulk":
+            self._handle_bulk_update_review_status()
+        elif path.startswith("/api/sessions/") and path.endswith("/score"):
             session_id = _api_session_id(path, suffix="/score")
             self._handle_score_session(session_id)
         elif path.startswith("/api/sessions/") and path.endswith("/scan"):
@@ -4269,6 +4272,70 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                 _json_response(self, {"ok": True})
             else:
                 _json_response(self, {"error": "Session not found"}, 404)
+        finally:
+            conn.close()
+
+    def _handle_bulk_update_review_status(self) -> None:
+        body = _read_body(self)
+        if not isinstance(body, dict):
+            _json_response(self, {"error": "Request body must be an object"}, 400)
+            return
+
+        session_ids = body.get("session_ids")
+        status = body.get("status")
+        if not isinstance(session_ids, list) or not (
+            1 <= len(session_ids) <= 100
+        ):
+            _json_response(
+                self,
+                {"error": "session_ids must be an array containing 1-100 entries"},
+                400,
+            )
+            return
+        if any(
+            not isinstance(session_id, str) or not session_id
+            for session_id in session_ids
+        ):
+            _json_response(
+                self,
+                {"error": "session_ids must contain non-empty strings"},
+                400,
+            )
+            return
+        if not isinstance(status, str) or status not in {"approved", "blocked"}:
+            _json_response(
+                self,
+                {"error": "status must be 'approved' or 'blocked'"},
+                400,
+            )
+            return
+
+        conn = open_index()
+        try:
+            try:
+                updated_ids, missing_ids = bulk_update_review_status(
+                    conn,
+                    session_ids,
+                    status,
+                )
+            except ValueError as exc:
+                _json_response(self, {"error": str(exc)}, 400)
+                return
+            except Exception:
+                logger.exception("Could not update review statuses in bulk")
+                _json_response(
+                    self,
+                    {"error": "Could not update review statuses"},
+                    500,
+                )
+                return
+            _json_response(
+                self,
+                {
+                    "updated_ids": updated_ids,
+                    "missing_ids": missing_ids,
+                },
+            )
         finally:
             conn.close()
 

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -3179,6 +3179,83 @@ def update_session(
     return True
 
 
+REVIEW_BULK_STATUSES = frozenset({"approved", "blocked"})
+REVIEW_BULK_LIMIT = 100
+
+
+def bulk_update_review_status(
+    conn: sqlite3.Connection,
+    session_ids: Sequence[str],
+    status: str,
+) -> tuple[list[str], list[str]]:
+    """Set one review status for a bounded set of sessions atomically.
+
+    Duplicate IDs are collapsed while preserving request order. Existing
+    sessions are returned in ``updated_ids`` and unknown sessions in
+    ``missing_ids``. As with :func:`update_session`, ``updated_at`` advances
+    for every existing row while ``reviewed_at`` advances only when the review
+    status actually changes.
+    """
+    if not isinstance(status, str) or status not in REVIEW_BULK_STATUSES:
+        raise ValueError("status must be 'approved' or 'blocked'")
+    if (
+        isinstance(session_ids, (str, bytes))
+        or not isinstance(session_ids, Sequence)
+        or not (
+            1 <= len(session_ids) <= REVIEW_BULK_LIMIT
+        )
+    ):
+        raise ValueError(
+            f"session_ids must contain 1-{REVIEW_BULK_LIMIT} entries"
+        )
+    if any(
+        not isinstance(session_id, str) or not session_id
+        for session_id in session_ids
+    ):
+        raise ValueError("session_ids must contain non-empty strings")
+
+    requested_ids = list(dict.fromkeys(session_ids))
+    placeholders = ", ".join("?" for _ in requested_ids)
+    now = _now_iso()
+
+    if conn.in_transaction:
+        raise RuntimeError(
+            "bulk review status updates require a connection without "
+            "an active transaction"
+        )
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        rows = conn.execute(
+            f"SELECT session_id FROM sessions WHERE session_id IN ({placeholders})",
+            requested_ids,
+        ).fetchall()
+        found_ids = {str(row["session_id"]) for row in rows}
+        updated_ids = [
+            session_id for session_id in requested_ids if session_id in found_ids
+        ]
+        missing_ids = [
+            session_id for session_id in requested_ids if session_id not in found_ids
+        ]
+
+        if updated_ids:
+            update_placeholders = ", ".join("?" for _ in updated_ids)
+            conn.execute(
+                "UPDATE sessions SET "
+                "review_status = ?, "
+                "reviewed_at = CASE "
+                "WHEN review_status = ? THEN reviewed_at ELSE ? END, "
+                "updated_at = ? "
+                f"WHERE session_id IN ({update_placeholders})",
+                (status, status, now, now, *updated_ids),
+            )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+    return updated_ids, missing_ids
+
+
 # ---------------------------------------------------------------------------
 # Hold-state lifecycle
 # ---------------------------------------------------------------------------

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -1309,6 +1309,74 @@ class TestSessionsAPI:
         status, detail = _get(server, "/api/sessions/sess-0")
         assert detail["review_status"] == "approved"
 
+    def test_bulk_route_does_not_shadow_a_session_id(self, server):
+        conn = open_index()
+        try:
+            upsert_sessions(conn, [{
+                "session_id": "bulk-status",
+                "project": "test-project",
+                "source": "codex",
+                "messages": [],
+                "stats": {},
+            }])
+        finally:
+            conn.close()
+
+        status, data = _post(
+            server,
+            "/api/sessions/bulk-status",
+            {"status": "approved"},
+        )
+
+        assert status == 200
+        assert data["ok"] is True
+        assert _get(
+            server,
+            "/api/sessions/bulk-status",
+        )[1]["review_status"] == "approved"
+
+    def test_bulk_update_review_status_deduplicates_and_reports_missing(self, server):
+        status, data = _post(
+            server,
+            "/api/session-status/bulk",
+            {
+                "session_ids": [
+                    "sess-1",
+                    "missing-session",
+                    "sess-0",
+                    "sess-1",
+                ],
+                "status": "approved",
+            },
+        )
+
+        assert status == 200
+        assert data == {
+            "updated_ids": ["sess-1", "sess-0"],
+            "missing_ids": ["missing-session"],
+        }
+        assert _get(server, "/api/sessions/sess-0")[1]["review_status"] == "approved"
+        assert _get(server, "/api/sessions/sess-1")[1]["review_status"] == "approved"
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {},
+            {"session_ids": [], "status": "approved"},
+            {"session_ids": ["sess-0"] * 101, "status": "approved"},
+            {"session_ids": ["sess-0", 1], "status": "approved"},
+            {"session_ids": ["sess-0"], "status": "new"},
+            {"session_ids": ["sess-0"], "status": []},
+            {"session_ids": ["sess-0"], "status": {}},
+            {"session_ids": ["sess-0"], "status": None},
+        ],
+    )
+    def test_bulk_update_review_status_validates_request(self, server, body):
+        status, data = _post(server, "/api/session-status/bulk", body)
+
+        assert status == 400
+        assert "error" in data
+
     def test_skipped_session_stays_out_of_new_queue_after_reindex(self, server):
         status, data = _post(server, "/api/sessions/sess-0", {"status": "blocked"})
         assert status == 200

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -10,6 +10,7 @@ from clawjournal.workbench.index import (
     _migrate_bundles_to_shares,
     add_policy,
     backfill_session_keys,
+    bulk_update_review_status,
     create_share,
     get_effective_share_settings,
     get_dashboard_analytics,
@@ -705,6 +706,135 @@ class TestUpdateSession:
 
     def test_not_found(self, index_conn):
         assert update_session(index_conn, "nope", status="blocked") is False
+
+
+class TestBulkUpdateReviewStatus:
+    def test_updates_existing_rows_and_preserves_reviewed_at_when_unchanged(
+        self, index_conn, monkeypatch
+    ):
+        upsert_sessions(index_conn, [
+            _make_session("already-approved"),
+            _make_session("needs-approval"),
+        ])
+        index_conn.execute(
+            "UPDATE sessions SET review_status = 'approved', "
+            "reviewed_at = 'old-review-time', updated_at = 'old-update-time' "
+            "WHERE session_id = 'already-approved'"
+        )
+        index_conn.commit()
+        monkeypatch.setattr(
+            "clawjournal.workbench.index._now_iso",
+            lambda: "2026-07-31T12:00:00+00:00",
+        )
+
+        updated_ids, missing_ids = bulk_update_review_status(
+            index_conn,
+            ["already-approved", "needs-approval"],
+            "approved",
+        )
+
+        assert updated_ids == ["already-approved", "needs-approval"]
+        assert missing_ids == []
+        rows = {
+            row["session_id"]: row
+            for row in index_conn.execute(
+                "SELECT session_id, review_status, reviewed_at, updated_at "
+                "FROM sessions"
+            ).fetchall()
+        }
+        assert rows["already-approved"]["review_status"] == "approved"
+        assert rows["already-approved"]["reviewed_at"] == "old-review-time"
+        assert (
+            rows["already-approved"]["updated_at"]
+            == "2026-07-31T12:00:00+00:00"
+        )
+        assert rows["needs-approval"]["review_status"] == "approved"
+        assert (
+            rows["needs-approval"]["reviewed_at"]
+            == "2026-07-31T12:00:00+00:00"
+        )
+
+    def test_deduplicates_ids_and_reports_missing_in_request_order(self, index_conn):
+        upsert_sessions(index_conn, [
+            _make_session("first"),
+            _make_session("second"),
+        ])
+
+        updated_ids, missing_ids = bulk_update_review_status(
+            index_conn,
+            ["second", "missing", "second", "first", "missing"],
+            "blocked",
+        )
+
+        assert updated_ids == ["second", "first"]
+        assert missing_ids == ["missing"]
+
+    @pytest.mark.parametrize(
+        ("session_ids", "status"),
+        [
+            ([], "approved"),
+            (["session"] * 101, "approved"),
+            ([""], "approved"),
+            (["session"], "new"),
+            (["session"], []),
+            (["session"], {}),
+            (["session"], None),
+        ],
+    )
+    def test_rejects_invalid_input(self, index_conn, session_ids, status):
+        with pytest.raises(ValueError):
+            bulk_update_review_status(index_conn, session_ids, status)
+
+    def test_rolls_back_every_row_if_the_update_fails(self, index_conn):
+        upsert_sessions(index_conn, [
+            _make_session("first"),
+            _make_session("second"),
+        ])
+        index_conn.executescript(
+            """
+            CREATE TRIGGER reject_second_bulk_review
+            BEFORE UPDATE OF review_status ON sessions
+            WHEN NEW.session_id = 'second'
+            BEGIN
+                SELECT RAISE(ABORT, 'reject second');
+            END;
+            """
+        )
+        index_conn.commit()
+
+        with pytest.raises(sqlite3.IntegrityError, match="reject second"):
+            bulk_update_review_status(
+                index_conn,
+                ["first", "second"],
+                "approved",
+            )
+
+        rows = index_conn.execute(
+            "SELECT session_id, review_status FROM sessions "
+            "WHERE session_id IN ('first', 'second') ORDER BY session_id"
+        ).fetchall()
+        assert [(row["session_id"], row["review_status"]) for row in rows] == [
+            ("first", "new"),
+            ("second", "new"),
+        ]
+
+    def test_rejects_an_existing_caller_transaction(self, index_conn):
+        upsert_sessions(index_conn, [_make_session("first")])
+        index_conn.execute(
+            "UPDATE sessions SET reviewer_notes = 'caller-owned' "
+            "WHERE session_id = 'first'"
+        )
+
+        with pytest.raises(RuntimeError, match="active transaction"):
+            bulk_update_review_status(index_conn, ["first"], "approved")
+
+        index_conn.rollback()
+        row = index_conn.execute(
+            "SELECT review_status, reviewer_notes FROM sessions "
+            "WHERE session_id = 'first'"
+        ).fetchone()
+        assert row["review_status"] == "new"
+        assert row["reviewer_notes"] is None
 
 
 class TestStats:


### PR DESCRIPTION
## Summary

- replace per-session review requests with a bounded atomic bulk status endpoint
- show immediate Approving or Skipping progress and prevent duplicate submissions
- preserve failed selections, ignore stale list responses, and refill pagination without overriding user deselections

## Validation

- 108 targeted backend tests passed
- 96 frontend tests passed
- changed-file ESLint and TypeScript checks passed
- production frontend build passed

Fixes #174