### PR TITLE
fix(parsing): preserve token stats across append-only segmentation

### DIFF
--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -2468,27 +2468,22 @@ def _parse_claude_session_file(
                 tool_result_map,
             )
             if capture_raw_offsets and len(messages) > before_messages:
+                added_messages = len(messages) - before_messages
                 raw_message_start_offsets.extend(
-                    [int(parse_snapshot["record_start"])]
-                    * (len(messages) - before_messages)
+                    [int(parse_snapshot["record_start"])] * added_messages
                 )
                 raw_message_end_offsets.extend(
-                    [int(parse_snapshot["record_end"])]
-                    * (len(messages) - before_messages)
+                    [int(parse_snapshot["record_end"])] * added_messages
                 )
-            if capture_raw_offsets:
-                token_snapshot = (
+                # Cumulative totals as of each message. Claude bills usage on
+                # the same entry that carries the assistant message, so an
+                # entry that adds no message never moves these counters.
+                raw_message_token_snapshots.extend([(
                     stats["input_tokens"],
                     stats["output_tokens"],
                     stats["cache_read_tokens"],
                     stats["cache_creation_tokens"],
-                )
-                if len(messages) > before_messages:
-                    raw_message_token_snapshots.extend(
-                        [token_snapshot] * (len(messages) - before_messages)
-                    )
-                elif raw_message_token_snapshots:
-                    raw_message_token_snapshots[-1] = token_snapshot
+                )] * added_messages)
     except OSError:
         if strict_jsonl:
             raise
@@ -3119,6 +3114,19 @@ def _build_codex_tool_result_map(
     return result
 
 
+def _codex_token_snapshot(state: _CodexParseState) -> tuple[int, int, int, int]:
+    """Cumulative (input, output, cache_read, cache_creation) totals so far.
+
+    Codex rollouts report no cache-creation counter, so that slot stays zero.
+    """
+    return (
+        state.max_input_tokens,
+        state.max_output_tokens,
+        state.max_cached_tokens,
+        0,
+    )
+
+
 def _parse_codex_session_file(
     filepath: Path,
     anonymizer: Anonymizer,
@@ -3220,12 +3228,7 @@ def _parse_codex_session_file(
                 # Cumulative totals as of each message. A token_count arriving
                 # between messages belongs to the response it concludes, so it
                 # updates the latest message's snapshot in place.
-                token_snapshot = (
-                    state.max_input_tokens,
-                    state.max_output_tokens,
-                    state.max_cached_tokens,
-                    0,
-                )
+                token_snapshot = _codex_token_snapshot(state)
                 if len(state.messages) > before_messages:
                     raw_message_token_snapshots.extend(
                         [token_snapshot] * (len(state.messages) - before_messages)
@@ -3261,13 +3264,7 @@ def _parse_codex_session_file(
             * (len(state.messages) - before_flush)
         )
         raw_message_token_snapshots.extend(
-            [(
-                state.max_input_tokens,
-                state.max_output_tokens,
-                state.max_cached_tokens,
-                0,
-            )]
-            * (len(state.messages) - before_flush)
+            [_codex_token_snapshot(state)] * (len(state.messages) - before_flush)
         )
 
     if state.metadata["model"] is None:

--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -1919,6 +1919,7 @@ def _finalize_append_only_segments(
     offsets = session.pop("_raw_message_end_offsets", None)
     start_offsets = session.pop("_raw_message_start_offsets", None)
     raw_source_size = session.pop("_raw_source_size", None)
+    token_snapshots = session.pop("_raw_message_token_snapshots", None)
     if not isinstance(offsets, list):
         return [session]
     segments = segment_append_only_session(
@@ -1926,6 +1927,7 @@ def _finalize_append_only_segments(
         offsets,
         message_start_offsets=start_offsets,
         raw_source_size=raw_source_size,
+        message_token_snapshots=token_snapshots,
     )
     if len(segments) <= 1:
         return [session]
@@ -2448,6 +2450,7 @@ def _parse_claude_session_file(
     parse_snapshot: dict[str, Any] = {}
     raw_message_start_offsets: list[int] = []
     raw_message_end_offsets: list[int] = []
+    raw_message_token_snapshots: list[tuple[int, int, int, int]] = []
     try:
         for entry in _iter_jsonl(
             filepath,
@@ -2473,6 +2476,19 @@ def _parse_claude_session_file(
                     [int(parse_snapshot["record_end"])]
                     * (len(messages) - before_messages)
                 )
+            if capture_raw_offsets:
+                token_snapshot = (
+                    stats["input_tokens"],
+                    stats["output_tokens"],
+                    stats["cache_read_tokens"],
+                    stats["cache_creation_tokens"],
+                )
+                if len(messages) > before_messages:
+                    raw_message_token_snapshots.extend(
+                        [token_snapshot] * (len(messages) - before_messages)
+                    )
+                elif raw_message_token_snapshots:
+                    raw_message_token_snapshots[-1] = token_snapshot
     except OSError:
         if strict_jsonl:
             raise
@@ -2489,6 +2505,7 @@ def _parse_claude_session_file(
     if result is not None and capture_raw_offsets:
         result["_raw_message_start_offsets"] = raw_message_start_offsets
         result["_raw_message_end_offsets"] = raw_message_end_offsets
+        result["_raw_message_token_snapshots"] = raw_message_token_snapshots
         result["_raw_source_size"] = parse_snapshot.get("file_size")
     return result
 
@@ -3146,6 +3163,7 @@ def _parse_codex_session_file(
     parse_snapshot: dict[str, Any] = {}
     raw_message_start_offsets: list[int] = []
     raw_message_end_offsets: list[int] = []
+    raw_message_token_snapshots: list[tuple[int, int, int, int]] = []
     try:
         for entry in _iter_jsonl(
             filepath,
@@ -3198,6 +3216,22 @@ def _parse_codex_session_file(
                     raw_message_end_offsets.extend(
                         [int(parse_snapshot["record_end"])] * added_messages
                     )
+            if capture_raw_offsets:
+                # Cumulative totals as of each message. A token_count arriving
+                # between messages belongs to the response it concludes, so it
+                # updates the latest message's snapshot in place.
+                token_snapshot = (
+                    state.max_input_tokens,
+                    state.max_output_tokens,
+                    state.max_cached_tokens,
+                    0,
+                )
+                if len(state.messages) > before_messages:
+                    raw_message_token_snapshots.extend(
+                        [token_snapshot] * (len(state.messages) - before_messages)
+                    )
+                elif raw_message_token_snapshots:
+                    raw_message_token_snapshots[-1] = token_snapshot
     except OSError:
         if strict_jsonl:
             raise
@@ -3226,6 +3260,15 @@ def _parse_codex_session_file(
             [int(parse_snapshot.get("file_size") or 0)]
             * (len(state.messages) - before_flush)
         )
+        raw_message_token_snapshots.extend(
+            [(
+                state.max_input_tokens,
+                state.max_output_tokens,
+                state.max_cached_tokens,
+                0,
+            )]
+            * (len(state.messages) - before_flush)
+        )
 
     if state.metadata["model"] is None:
         model_provider = state.metadata.get("model_provider")
@@ -3240,6 +3283,7 @@ def _parse_codex_session_file(
     if result is not None and capture_raw_offsets:
         result["_raw_message_start_offsets"] = raw_message_start_offsets
         result["_raw_message_end_offsets"] = raw_message_end_offsets
+        result["_raw_message_token_snapshots"] = raw_message_token_snapshots
         result["_raw_source_size"] = parse_snapshot.get("file_size")
     return result
 

--- a/clawjournal/parsing/segmenter.py
+++ b/clawjournal/parsing/segmenter.py
@@ -42,6 +42,7 @@ def segment_append_only_session(
     *,
     message_start_offsets: list[int] | None = None,
     raw_source_size: int | None = None,
+    message_token_snapshots: list[tuple[int, int, int, int]] | None = None,
     max_messages: int = APPEND_ONLY_MAX_MESSAGES,
     max_user_messages: int = APPEND_ONLY_MAX_USER_MESSAGES,
     max_text_bytes: int = APPEND_ONLY_MAX_TEXT_BYTES,
@@ -54,6 +55,11 @@ def segment_append_only_session(
     confirms the raw boundary. Appending later records can therefore only
     extend the active tail or create new segments; it never changes an
     already-closed segment.
+
+    ``message_token_snapshots`` carries the cumulative
+    (input, output, cache_read, cache_creation) token totals as of each
+    message; each child's stats get the delta over its message range so the
+    file-level totals partition across segments instead of being dropped.
     """
 
     messages = session.get("messages", [])
@@ -84,6 +90,10 @@ def segment_append_only_session(
         for index, offset in enumerate(message_start_offsets)
     ):
         return [session]
+
+    token_snapshots = _validated_token_snapshots(
+        message_token_snapshots, len(messages)
+    )
 
     boundaries: list[int] = []
     segment_start = 0
@@ -132,6 +142,9 @@ def segment_append_only_session(
     children: list[dict[str, Any]] = []
     for segment_index, (start, end) in enumerate(zip(starts, ends)):
         segment_messages = messages[start:end]
+        segment_stats = _compute_stats(segment_messages)
+        if token_snapshots is not None:
+            segment_stats.update(_segment_token_deltas(token_snapshots, start, end))
         raw_segment_start = 0 if start == 0 else message_start_offsets[start]
         raw_segment_end = (
             message_start_offsets[end]
@@ -173,7 +186,7 @@ def segment_append_only_session(
             "start_time": _first_timestamp(segment_messages),
             "end_time": _last_timestamp(segment_messages),
             "messages": segment_messages,
-            "stats": _compute_stats(segment_messages),
+            "stats": segment_stats,
         })
         if segment_index == 0:
             child.pop("parent_session_id", None)
@@ -667,6 +680,45 @@ def _same_project(path_a: str, path_b: str) -> bool:
     if prefix_a and prefix_b:
         return prefix_a == prefix_b
     return path_a == path_b
+
+
+_TOKEN_SNAPSHOT_FIELDS = (
+    "input_tokens",
+    "output_tokens",
+    "cache_read_tokens",
+    "cache_creation_tokens",
+)
+
+
+def _validated_token_snapshots(
+    snapshots: Any, message_count: int
+) -> list[tuple[int, int, int, int]] | None:
+    """Return the snapshots only when they align 1:1 with the messages."""
+    if not isinstance(snapshots, list) or len(snapshots) != message_count:
+        return None
+    for snapshot in snapshots:
+        if not isinstance(snapshot, (list, tuple)) or len(snapshot) != len(
+            _TOKEN_SNAPSHOT_FIELDS
+        ):
+            return None
+        if any(
+            not isinstance(value, int) or isinstance(value, bool) or value < 0
+            for value in snapshot
+        ):
+            return None
+    return snapshots
+
+
+def _segment_token_deltas(
+    snapshots: list[tuple[int, int, int, int]], start: int, end: int
+) -> dict[str, int]:
+    """Token totals accrued across messages[start:end], from cumulative snapshots."""
+    previous = snapshots[start - 1] if start else (0, 0, 0, 0)
+    last = snapshots[end - 1]
+    return {
+        field: max(0, int(last[index]) - int(previous[index]))
+        for index, field in enumerate(_TOKEN_SNAPSHOT_FIELDS)
+    }
 
 
 def _compute_stats(messages: list[dict]) -> dict[str, int]:

--- a/clawjournal/parsing/segmenter.py
+++ b/clawjournal/parsing/segmenter.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import json
 import re
+from collections.abc import Sequence
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -42,7 +43,7 @@ def segment_append_only_session(
     *,
     message_start_offsets: list[int] | None = None,
     raw_source_size: int | None = None,
-    message_token_snapshots: list[tuple[int, int, int, int]] | None = None,
+    message_token_snapshots: list[Sequence[int]] | None = None,
     max_messages: int = APPEND_ONLY_MAX_MESSAGES,
     max_user_messages: int = APPEND_ONLY_MAX_USER_MESSAGES,
     max_text_bytes: int = APPEND_ONLY_MAX_TEXT_BYTES,
@@ -60,6 +61,8 @@ def segment_append_only_session(
     (input, output, cache_read, cache_creation) token totals as of each
     message; each child's stats get the delta over its message range so the
     file-level totals partition across segments instead of being dropped.
+    Snapshots that do not line up with the messages are ignored, leaving the
+    children with the zeroed token counts they had before.
     """
 
     messages = session.get("messages", [])
@@ -160,6 +163,9 @@ def segment_append_only_session(
                 "messages",
                 "stats",
                 "_raw_message_end_offsets",
+                "_raw_message_start_offsets",
+                "_raw_message_token_snapshots",
+                "_raw_source_size",
                 "_raw_source_fingerprint",
             }
         }
@@ -692,8 +698,13 @@ _TOKEN_SNAPSHOT_FIELDS = (
 
 def _validated_token_snapshots(
     snapshots: Any, message_count: int
-) -> list[tuple[int, int, int, int]] | None:
-    """Return the snapshots only when they align 1:1 with the messages."""
+) -> list[Sequence[int]] | None:
+    """Return the snapshots only when they align 1:1 with the messages.
+
+    Elements may be lists rather than tuples: a session dict that round-trips
+    through JSON loses the tuple type, and dropping token stats for that reason
+    alone would be a silent regression.
+    """
     if not isinstance(snapshots, list) or len(snapshots) != message_count:
         return None
     for snapshot in snapshots:
@@ -710,13 +721,15 @@ def _validated_token_snapshots(
 
 
 def _segment_token_deltas(
-    snapshots: list[tuple[int, int, int, int]], start: int, end: int
+    snapshots: list[Sequence[int]], start: int, end: int
 ) -> dict[str, int]:
     """Token totals accrued across messages[start:end], from cumulative snapshots."""
     previous = snapshots[start - 1] if start else (0, 0, 0, 0)
     last = snapshots[end - 1]
+    # Both parsers accumulate monotonically, so the clamp only guards against a
+    # caller handing us snapshots that go backwards.
     return {
-        field: max(0, int(last[index]) - int(previous[index]))
+        field: max(0, last[index] - previous[index])
         for index, field in enumerate(_TOKEN_SNAPSHOT_FIELDS)
     }
 
@@ -729,6 +742,8 @@ def _compute_stats(messages: list[dict]) -> dict[str, int]:
         "tool_uses": 0,
         "input_tokens": 0,
         "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_creation_tokens": 0,
     }
     for msg in messages:
         role = msg.get("role")

--- a/tests/parsing/test_parser.py
+++ b/tests/parsing/test_parser.py
@@ -1185,6 +1185,152 @@ class TestDiscoverProjects:
             "assistant",
         ]
 
+    def test_codex_parser_captures_per_message_token_snapshots(
+        self, tmp_path, mock_anonymizer
+    ):
+        """token_count events land on the message they conclude, so segmenting
+        the trace later can recover per-segment token deltas."""
+        session_file = tmp_path / "rollout-token-snapshots.jsonl"
+
+        def token_count(input_tokens, cached, output):
+            return {
+                "timestamp": "2026-07-28T07:13:24.000Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": input_tokens,
+                            "cached_input_tokens": cached,
+                            "output_tokens": output,
+                        }
+                    },
+                },
+            }
+
+        lines = [
+            {
+                "timestamp": "2026-07-28T07:13:20.000Z",
+                "type": "session_meta",
+                "payload": {"id": "session-tokens", "cwd": "/repo"},
+            },
+            {
+                "timestamp": "2026-07-28T07:13:21.000Z",
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": "question one"},
+            },
+            {
+                "timestamp": "2026-07-28T07:13:22.000Z",
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "answer one"},
+            },
+            token_count(100, 20, 10),
+            {
+                "timestamp": "2026-07-28T07:13:25.000Z",
+                "type": "event_msg",
+                "payload": {"type": "user_message", "message": "question two"},
+            },
+            {
+                "timestamp": "2026-07-28T07:13:26.000Z",
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "answer two"},
+            },
+            token_count(300, 50, 40),
+        ]
+        session_file.write_text(
+            "\n".join(json.dumps(line) for line in lines) + "\n",
+            encoding="utf-8",
+        )
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+            capture_raw_offsets=True,
+        )
+
+        assert result is not None
+        assert len(result["messages"]) == 4
+        # Cumulative (non-cached input, output, cache_read, cache_creation)
+        # as of each message; the count that concludes a response is folded
+        # into that assistant message, not the following user message.
+        assert result["_raw_message_token_snapshots"] == [
+            (0, 0, 0, 0),
+            (80, 10, 20, 0),
+            (80, 10, 20, 0),
+            (250, 40, 50, 0),
+        ]
+        assert result["stats"]["input_tokens"] == 250
+        assert result["stats"]["output_tokens"] == 40
+        assert result["stats"]["cache_read_tokens"] == 50
+
+    def test_claude_parser_captures_per_message_token_snapshots(
+        self, tmp_path, mock_anonymizer
+    ):
+        session_file = tmp_path / "claude-token-snapshots.jsonl"
+        lines = [
+            {
+                "type": "user",
+                "timestamp": "2026-07-28T07:13:20.000Z",
+                "cwd": "/repo",
+                "sessionId": "claude-tokens",
+                "message": {"content": "question one"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-07-28T07:13:21.000Z",
+                "message": {
+                    "model": "claude-opus-5",
+                    "content": [{"type": "text", "text": "answer one"}],
+                    "usage": {
+                        "input_tokens": 100,
+                        "output_tokens": 10,
+                        "cache_read_input_tokens": 5,
+                        "cache_creation_input_tokens": 2,
+                    },
+                },
+            },
+            {
+                "type": "user",
+                "timestamp": "2026-07-28T07:13:22.000Z",
+                "message": {"content": "question two"},
+            },
+            {
+                "type": "assistant",
+                "timestamp": "2026-07-28T07:13:23.000Z",
+                "message": {
+                    "model": "claude-opus-5",
+                    "content": [{"type": "text", "text": "answer two"}],
+                    "usage": {
+                        "input_tokens": 200,
+                        "output_tokens": 30,
+                        "cache_read_input_tokens": 7,
+                        "cache_creation_input_tokens": 3,
+                    },
+                },
+            },
+        ]
+        session_file.write_text(
+            "\n".join(json.dumps(line) for line in lines) + "\n",
+            encoding="utf-8",
+        )
+
+        result = _parse_claude_session_file(
+            session_file,
+            mock_anonymizer,
+            capture_raw_offsets=True,
+        )
+
+        assert result is not None
+        assert len(result["messages"]) == 4
+        assert result["_raw_message_token_snapshots"] == [
+            (0, 0, 0, 0),
+            (100, 10, 5, 2),
+            (100, 10, 5, 2),
+            (300, 40, 12, 5),
+        ]
+
     def test_discover_opencode_projects(self, tmp_path, monkeypatch):
         self._disable_codex(tmp_path, monkeypatch)
         db_path = tmp_path / "opencode.db"

--- a/tests/parsing/test_parser.py
+++ b/tests/parsing/test_parser.py
@@ -3100,6 +3100,10 @@ def test_long_claude_session_checkpoint_includes_interstitial_tool_result(
     assert sessions[0]["messages"][-1]["tool_uses"][0]["output"] == {
         "text": "result-19"
     }
+    # Each turn bills 1 input / 1 output token, so the per-segment deltas must
+    # partition the 21 turns instead of being reset to zero by _compute_stats.
+    assert [session["stats"]["input_tokens"] for session in sessions] == [20, 1]
+    assert [session["stats"]["output_tokens"] for session in sessions] == [20, 1]
 
 
 def _make_wrapper_json(

--- a/tests/parsing/test_segmenter.py
+++ b/tests/parsing/test_segmenter.py
@@ -127,6 +127,90 @@ class TestAppendOnlySegmentation:
         assert result[1]["raw_source_start_offset"] is None
         assert result[1]["raw_source_end_offset"] is None
 
+    def test_token_snapshots_split_into_per_segment_deltas(self):
+        messages = [
+            _user("question one"),
+            _assistant("answer one"),
+            _user("question two"),
+            _assistant("answer two"),
+            _user("question three"),
+        ]
+        session = _session(messages, session_id="growing", source="codex")
+        session["stats"]["input_tokens"] = 500
+        session["stats"]["output_tokens"] = 80
+        # Cumulative (input, output, cache_read, cache_creation) after each
+        # message, mirroring what the parsers capture alongside raw offsets.
+        snapshots = [
+            (100, 10, 5, 0),
+            (200, 30, 5, 0),
+            (200, 30, 5, 0),
+            (500, 80, 25, 0),
+            (500, 80, 25, 0),
+        ]
+
+        result = segment_append_only_session(
+            session,
+            [10, 20, 30, 40, 55],
+            message_start_offsets=[0, 10, 20, 30, 50],
+            raw_source_size=55,
+            message_token_snapshots=snapshots,
+            max_messages=2,
+            max_user_messages=99,
+            max_text_bytes=999_999,
+            max_raw_bytes=999_999,
+        )
+
+        assert [item["session_id"] for item in result] == [
+            "growing",
+            "growing_seg-0001",
+            "growing_seg-0002",
+        ]
+        per_segment = [
+            (
+                item["stats"]["input_tokens"],
+                item["stats"]["output_tokens"],
+                item["stats"]["cache_read_tokens"],
+                item["stats"]["cache_creation_tokens"],
+            )
+            for item in result
+        ]
+        assert per_segment == [
+            (200, 30, 5, 0),
+            (300, 50, 20, 0),
+            (0, 0, 0, 0),
+        ]
+        # Deltas partition the file totals: nothing double-counted or lost.
+        assert sum(tokens[0] for tokens in per_segment) == 500
+        assert sum(tokens[1] for tokens in per_segment) == 80
+        assert result[0]["stats"]["user_messages"] == 1
+        assert result[0]["stats"]["assistant_messages"] == 1
+
+    def test_invalid_token_snapshots_are_ignored(self):
+        messages = [
+            _user("question one"),
+            _assistant("answer one"),
+            _user("question two"),
+            _assistant("answer two"),
+            _user("question three"),
+        ]
+        session = _session(messages, session_id="growing", source="codex")
+
+        result = segment_append_only_session(
+            session,
+            [10, 20, 30, 40, 55],
+            message_start_offsets=[0, 10, 20, 30, 50],
+            raw_source_size=55,
+            message_token_snapshots=[(100, 10, 5, 0)],  # wrong length
+            max_messages=2,
+            max_user_messages=99,
+            max_text_bytes=999_999,
+            max_raw_bytes=999_999,
+        )
+
+        assert len(result) == 3
+        assert all(item["stats"]["input_tokens"] == 0 for item in result)
+        assert all(item["stats"]["output_tokens"] == 0 for item in result)
+
 
 # ---------------------------------------------------------------------------
 # Time gap detection


### PR DESCRIPTION
Splitting a growing Claude/Codex trace into bounded checkpoints rebuilt each child's stats with _compute_stats, which hardcodes token counts to zero — every segmented session (including segment 0, which keeps the parent id) lost its input/output/cache token totals in the index.

Capture cumulative per-message token snapshots in both parsers alongside the existing raw-offset arrays, and hand them to
segment_append_only_session so each segment gets the token delta over its message range. A token_count arriving between messages is folded into the response it concludes. Deltas partition the file-level totals exactly; missing or misaligned snapshots fall back to the previous behavior.