### PR TITLE
fix(share): lower and fade submission success chime

### DIFF
--- a/clawjournal/web/frontend/src/views/Share/successChime.test.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.test.ts
@@ -62,7 +62,7 @@ describe('success sound', () => {
     expect(sound.play).toHaveBeenCalledOnce();
     expect(sound.currentTime).toBe(0);
     expect(sound.loop).toBe(false);
-    expect(sound.volume).toBe(0.15);
+    expect(sound.volume).toBe(0.1);
 
     vi.advanceTimersByTime(1500);
     expect(sound.pause).not.toHaveBeenCalled();
@@ -76,15 +76,15 @@ describe('success sound', () => {
     expect(sound.pause).not.toHaveBeenCalled();
     vi.advanceTimersByTime(1);
     expect(sound.pause).not.toHaveBeenCalled();
-    expect(sound.volume).toBe(0.15);
+    expect(sound.volume).toBe(0.1);
     vi.advanceTimersByTime(250);
     expect(sound.pause).not.toHaveBeenCalled();
     expect(sound.volume).toBeGreaterThan(0);
-    expect(sound.volume).toBeLessThan(0.15);
+    expect(sound.volume).toBeLessThan(0.1);
     vi.advanceTimersByTime(250);
     expect(sound.pause).toHaveBeenCalledOnce();
     expect(sound.currentTime).toBe(0);
-    expect(sound.volume).toBe(0.15);
+    expect(sound.volume).toBe(0.1);
   });
 
   it('stops silent playback when submission does not succeed', async () => {
@@ -107,7 +107,7 @@ describe('success sound', () => {
     expect(sound.pause).toHaveBeenCalledOnce();
     expect(sound.currentTime).toBe(0);
     expect(sound.loop).toBe(false);
-    expect(sound.volume).toBe(0.15);
+    expect(sound.volume).toBe(0.1);
   });
 
   it('does not restart playback after cancellation wins a priming race', async () => {

--- a/clawjournal/web/frontend/src/views/Share/successChime.test.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.test.ts
@@ -77,11 +77,13 @@ describe('success sound', () => {
     vi.advanceTimersByTime(1);
     expect(sound.pause).not.toHaveBeenCalled();
     expect(sound.volume).toBe(0.05);
-    vi.advanceTimersByTime(250);
+    vi.advanceTimersByTime(1000);
     expect(sound.pause).not.toHaveBeenCalled();
-    expect(sound.volume).toBeGreaterThan(0);
-    expect(sound.volume).toBeLessThan(0.05);
-    vi.advanceTimersByTime(250);
+    expect(sound.volume).toBeCloseTo(0.0125);
+    vi.advanceTimersByTime(999);
+    expect(sound.pause).not.toHaveBeenCalled();
+    expect(sound.volume).toBeLessThan(0.00001);
+    vi.advanceTimersByTime(1);
     expect(sound.pause).toHaveBeenCalledOnce();
     expect(sound.currentTime).toBe(0);
     expect(sound.volume).toBe(0.05);

--- a/clawjournal/web/frontend/src/views/Share/successChime.test.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.test.ts
@@ -62,7 +62,7 @@ describe('success sound', () => {
     expect(sound.play).toHaveBeenCalledOnce();
     expect(sound.currentTime).toBe(0);
     expect(sound.loop).toBe(false);
-    expect(sound.volume).toBe(0.1);
+    expect(sound.volume).toBe(0.05);
 
     vi.advanceTimersByTime(1500);
     expect(sound.pause).not.toHaveBeenCalled();
@@ -76,15 +76,15 @@ describe('success sound', () => {
     expect(sound.pause).not.toHaveBeenCalled();
     vi.advanceTimersByTime(1);
     expect(sound.pause).not.toHaveBeenCalled();
-    expect(sound.volume).toBe(0.1);
+    expect(sound.volume).toBe(0.05);
     vi.advanceTimersByTime(250);
     expect(sound.pause).not.toHaveBeenCalled();
     expect(sound.volume).toBeGreaterThan(0);
-    expect(sound.volume).toBeLessThan(0.1);
+    expect(sound.volume).toBeLessThan(0.05);
     vi.advanceTimersByTime(250);
     expect(sound.pause).toHaveBeenCalledOnce();
     expect(sound.currentTime).toBe(0);
-    expect(sound.volume).toBe(0.1);
+    expect(sound.volume).toBe(0.05);
   });
 
   it('stops silent playback when submission does not succeed', async () => {
@@ -107,7 +107,7 @@ describe('success sound', () => {
     expect(sound.pause).toHaveBeenCalledOnce();
     expect(sound.currentTime).toBe(0);
     expect(sound.loop).toBe(false);
-    expect(sound.volume).toBe(0.1);
+    expect(sound.volume).toBe(0.05);
   });
 
   it('does not restart playback after cancellation wins a priming race', async () => {

--- a/clawjournal/web/frontend/src/views/Share/successChime.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.ts
@@ -1,5 +1,5 @@
 const SUCCESS_SOUND_URL = '/sounds/submission-success.mp3';
-const SUCCESS_CHIME_VOLUME = 0.1;
+const SUCCESS_CHIME_VOLUME = 0.05;
 const SUCCESS_CHIME_HOLD_MS = 1500;
 const SUCCESS_CHIME_FADE_MS = 500;
 const SUCCESS_CHIME_FADE_STEP_MS = 25;

--- a/clawjournal/web/frontend/src/views/Share/successChime.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.ts
@@ -1,7 +1,7 @@
 const SUCCESS_SOUND_URL = '/sounds/submission-success.mp3';
 const SUCCESS_CHIME_VOLUME = 0.05;
 const SUCCESS_CHIME_HOLD_MS = 1500;
-const SUCCESS_CHIME_FADE_MS = 500;
+const SUCCESS_CHIME_FADE_MS = 2000;
 const SUCCESS_CHIME_FADE_STEP_MS = 25;
 
 let successSound: HTMLAudioElement | null = null;
@@ -51,7 +51,9 @@ function schedulePlaybackStop(sound: HTMLAudioElement) {
       try {
         const elapsed = Date.now() - fadeStartedAt;
         const progress = Math.min(1, elapsed / SUCCESS_CHIME_FADE_MS);
-        sound.volume = initialVolume * (1 - progress);
+        const remaining = 1 - progress;
+        // Ease into silence so the final pause happens below an audible level.
+        sound.volume = initialVolume * remaining * remaining;
         if (progress >= 1) {
           stopPlaybackTimer = null;
           finishPlayback(sound);

--- a/clawjournal/web/frontend/src/views/Share/successChime.ts
+++ b/clawjournal/web/frontend/src/views/Share/successChime.ts
@@ -1,5 +1,5 @@
 const SUCCESS_SOUND_URL = '/sounds/submission-success.mp3';
-const SUCCESS_CHIME_VOLUME = 0.15;
+const SUCCESS_CHIME_VOLUME = 0.1;
 const SUCCESS_CHIME_HOLD_MS = 1500;
 const SUCCESS_CHIME_FADE_MS = 500;
 const SUCCESS_CHIME_FADE_STEP_MS = 25;


### PR DESCRIPTION
## Summary

- reduce the hosted submission success chime from 15% volume to 5%
- replace the brief 500 ms linear fade with a two-second quadratic taper
- update the chime tests to pin the quieter playback and gradual fade behavior

## Why

The successful-submission cue can still sound too prominent at the current 15% level, and its short linear fade can end with an audible cut. The new taper reduces the sound to an effectively inaudible level before pausing playback, while preserving the existing Safari-compatible priming and cancellation behavior.

## Impact

Successful hosted submissions retain their audible confirmation at one-third of the previous peak volume. After the initial 1.5-second hold, the chime fades smoothly for two seconds instead of stopping abruptly. No submission, redaction, upload, or visual celebration behavior changes.

## Validation

- `npm test -- src/views/Share/successChime.test.ts` — 4 passed
- `npm test` — 89 passed
- `npx eslint src/views/Share/successChime.ts src/views/Share/successChime.test.ts` — passed
- `npm run build` — passed
