### PR TITLE
fix(workbench): repair stale costs after token recovery

### DIFF
--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -2579,11 +2579,38 @@ def _resolve_estimated_cost(
     """Choose which cost value to persist during session upsert.
 
     Completed sessions (with end_time) keep their first stored estimate so
-    dashboard totals stay stable. Ongoing sessions recompute as they grow.
+    dashboard totals stay stable. Ongoing sessions recompute as they grow. A
+    completed session whose zero cost came from zeroed parser token stats gets
+    one narrow exception when a later parse recovers non-zero token counts.
     """
     if existing is not None:
         preserved_cost = existing["estimated_cost_usd"]
-        if preserved_cost is not None and end_time is not None:
+        recovered_zeroed_tokens = (
+            preserved_cost == 0.0
+            and all(
+                (existing[column] or 0) == 0
+                for column in (
+                    "input_tokens",
+                    "output_tokens",
+                    "cache_read_tokens",
+                    "cache_creation_tokens",
+                )
+            )
+            and any(
+                (value or 0) > 0
+                for value in (
+                    input_tokens,
+                    output_tokens,
+                    cache_read_tokens,
+                    cache_creation_tokens,
+                )
+            )
+        )
+        if (
+            preserved_cost is not None
+            and end_time is not None
+            and not recovered_zeroed_tokens
+        ):
             return preserved_cost
 
     return estimate_cost(
@@ -2718,7 +2745,8 @@ def upsert_sessions(
             "ai_value_badges, ai_risk_badges, "
             "ai_effort_estimate, ai_summary, "
             "share_id, session_key, parent_session_id, subagent_session_ids, "
-            "estimated_cost_usd, end_time, content_revision "
+            "estimated_cost_usd, input_tokens, output_tokens, "
+            "cache_read_tokens, cache_creation_tokens, end_time, content_revision "
             "FROM sessions WHERE session_id = ?",
             (session_id,),
         ).fetchone()

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -179,12 +179,60 @@ class TestUpsertSessions:
         upsert_sessions(index_conn, [_make_session()])
 
         monkeypatch.setattr("clawjournal.workbench.index.estimate_cost", lambda *_args, **_kwargs: 56.78)
-        upsert_sessions(index_conn, [_make_session()])
+        reparsed = _make_session()
+        reparsed["stats"]["input_tokens"] = 999
+        upsert_sessions(index_conn, [reparsed])
 
         row = index_conn.execute(
             "SELECT estimated_cost_usd FROM sessions WHERE session_id = 'sess-1'"
         ).fetchone()
         assert row["estimated_cost_usd"] == pytest.approx(12.34)
+
+    def test_upsert_repairs_zero_cost_when_completed_tokens_recovered(
+        self, index_conn, monkeypatch
+    ):
+        def fake_estimate(
+            _model,
+            input_tokens,
+            output_tokens,
+            *,
+            cache_read_tokens=0,
+            cache_creation_tokens=0,
+        ):
+            return (
+                input_tokens
+                + output_tokens
+                + cache_read_tokens
+                + cache_creation_tokens
+            ) / 100
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.estimate_cost", fake_estimate
+        )
+        zeroed = _make_session()
+        zeroed["stats"].update({
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
+        })
+        upsert_sessions(index_conn, [zeroed])
+
+        recovered = _make_session()
+        recovered["stats"].update({
+            "cache_read_tokens": 200,
+            "cache_creation_tokens": 50,
+        })
+        stats = {}
+        upsert_sessions(index_conn, [recovered], stats=stats)
+
+        row = index_conn.execute(
+            "SELECT input_tokens, output_tokens, cache_read_tokens, "
+            "cache_creation_tokens, estimated_cost_usd FROM sessions "
+            "WHERE session_id = 'sess-1'"
+        ).fetchone()
+        assert tuple(row) == (500, 100, 200, 50, pytest.approx(8.5))
+        assert stats == {"inserted": 0, "updated": 0, "unchanged": 1}
 
     def test_upsert_recomputes_estimated_cost_for_ongoing_session(self, index_conn, monkeypatch):
         monkeypatch.setattr("clawjournal.workbench.index.estimate_cost", lambda *_args, **_kwargs: 1.23)


### PR DESCRIPTION
## Summary

- Recompute a completed session's frozen zero cost only when all four stored token buckets were zero and a later parse recovers non-zero usage.
- Preserve the existing completed-session cost freeze for every other reparse.
- Add regression coverage for token-only metadata recovery without invalidating the content revision.

## Context

Follow-up to #178. That change restores token counts for segmented Claude/Codex sessions, but already-indexed completed sessions could retain the zero cost calculated from the old zeroed token stats.

## Testing

- 104 workbench index and revision-tracking tests passed.
- 6 targeted Claude/Codex segmentation tests passed.

Closes #182