### PR TITLE
Bound automatic-upload status polling

### DIFF
--- a/clawjournal/web/frontend/src/api.test.ts
+++ b/clawjournal/web/frontend/src/api.test.ts
@@ -103,6 +103,7 @@ describe('automatic-upload API normalization', () => {
 
     expect(fetchMock).toHaveBeenCalledWith('/api/auto-upload/status', {
       headers: {},
+      signal: expect.any(AbortSignal),
     });
     expect(status.scope).toEqual({
       sources: ['claude', 'codex'],
@@ -128,6 +129,23 @@ describe('automatic-upload API normalization', () => {
         last_observed_at: null,
       },
     ]);
+  });
+
+  it('bounds an unresponsive automatic-upload status request', async () => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn().mockImplementation(
+      (_url: string, init: RequestInit) => new Promise((_resolve, reject) => {
+        init.signal?.addEventListener('abort', () => reject(new DOMException('aborted', 'AbortError')));
+      }),
+    ));
+
+    const assertion = expect(api.autoUpload.status()).rejects.toMatchObject({
+      status: 408,
+      message: 'Automatic-upload status timed out',
+    });
+    await vi.advanceTimersByTimeAsync(15_000);
+    await assertion;
+    vi.useRealTimers();
   });
 
   it('tracks accepted enrollment requests and reads their local progress', async () => {

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -48,6 +48,7 @@ export class ApiError extends Error {
 // seconds for the daemon to serialize the report and the browser to receive it.
 // A wedged daemon or dropped response still gets a finite browser deadline.
 export const REDACTION_REPORT_TIMEOUT_MS = 200_000;
+export const AUTO_UPLOAD_STATUS_TIMEOUT_MS = 15_000;
 
 declare global {
   interface Window {
@@ -360,8 +361,25 @@ export const api = {
 
   autoUpload: {
     async status(): Promise<AutoUploadStatus> {
-      const status = await request<Partial<AutoUploadStatus>>('/auto-upload/status');
-      return normalizeAutoUploadStatus(status);
+      const controller = new AbortController();
+      const timeout = globalThis.setTimeout(
+        () => controller.abort(),
+        AUTO_UPLOAD_STATUS_TIMEOUT_MS,
+      );
+      try {
+        const status = await request<Partial<AutoUploadStatus>>(
+          '/auto-upload/status',
+          { signal: controller.signal },
+        );
+        return normalizeAutoUploadStatus(status);
+      } catch (error) {
+        if (controller.signal.aborted) {
+          throw new ApiError(408, 'Automatic-upload status timed out');
+        }
+        throw error;
+      } finally {
+        globalThis.clearTimeout(timeout);
+      }
     },
 
     async preview(opts?: { refresh?: boolean }): Promise<AutoUploadCandidateReport> {

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
@@ -637,6 +637,27 @@ describe('AutoUploadPanel status and controls', () => {
     expect(statusSpy).toHaveBeenCalledTimes(2);
   });
 
+  it('does not overlap transient status polls when the daemon is slow', async () => {
+    vi.useFakeTimers();
+    const running = status({ mode: 'enabled', overlay: 'running' });
+    const slowPoll = deferred<AutoUploadStatus>();
+    const statusSpy = vi.spyOn(api.autoUpload, 'status')
+      .mockResolvedValueOnce(running)
+      .mockReturnValue(slowPoll.promise);
+
+    renderControl(<AutoUploadPanel />);
+    await act(flushPromises);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+      await flushPromises();
+    });
+    expect(statusSpy).toHaveBeenCalledTimes(2);
+
+    slowPoll.resolve(running);
+    await act(flushPromises);
+  });
+
   it('does not let an older poll overwrite a pause response', async () => {
     const enabled = status({ mode: 'enabled', run_now_allowed: true });
     const paused = status({ mode: 'paused' });

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.tsx
@@ -860,6 +860,7 @@ function SummaryItem({ label, value }: { label: string; value: string }) {
 
 export function AutoUploadOffer({ manualReceiptId }: { manualReceiptId: string | null }) {
   const [status, setStatus] = useState<AutoUploadStatus | null>(null);
+  const statusInFlightRef = useRef(false);
   // Dismissal is scoped to the receipt it was shown for: "Not now" on one
   // share must not suppress the offer after every future manual share.
   const [dismissedReceipt, setDismissedReceipt] = useState<string | null>(() => {
@@ -872,20 +873,18 @@ export function AutoUploadOffer({ manualReceiptId }: { manualReceiptId: string |
   const dismissed = manualReceiptId !== null && dismissedReceipt === manualReceiptId;
 
   const loadStatus = useCallback(() => {
-    if (!manualReceiptId || dismissed) return;
+    if (!manualReceiptId || dismissed || statusInFlightRef.current) return;
+    statusInFlightRef.current = true;
     api.autoUpload.status()
       .then(setStatus)
-      .catch(() => { /* The optional offer disappears if capability/status is unavailable. */ });
+      .catch(() => { /* The optional offer disappears if capability/status is unavailable. */ })
+      .finally(() => { statusInFlightRef.current = false; });
   }, [dismissed, manualReceiptId]);
 
   useEffect(() => {
     if (!manualReceiptId || dismissed) return;
-    let cancelled = false;
-    api.autoUpload.status()
-      .then(next => { if (!cancelled) setStatus(next); })
-      .catch(() => { /* The optional offer disappears if capability/status is unavailable. */ });
-    return () => { cancelled = true; };
-  }, [dismissed, manualReceiptId]);
+    loadStatus();
+  }, [dismissed, loadStatus, manualReceiptId]);
 
   useEffect(() => {
     if (status?.overlay !== 'enrollment_pending') return;
@@ -946,6 +945,7 @@ export function AutoUploadPanel() {
   const [preview, setPreview] = useState<AutoUploadCandidateReport | null>(null);
   const [previewLoading, setPreviewLoading] = useState(false);
   const busyRef = useRef(false);
+  const statusInFlightRef = useRef(false);
   const statusGenerationRef = useRef(0);
   const statusRequestRef = useRef(0);
 
@@ -957,7 +957,8 @@ export function AutoUploadPanel() {
   }, []);
 
   const loadStatus = useCallback(async (quiet = false) => {
-    if (busyRef.current) return;
+    if (busyRef.current || statusInFlightRef.current) return;
+    statusInFlightRef.current = true;
     const generation = statusGenerationRef.current;
     const requestId = statusRequestRef.current + 1;
     statusRequestRef.current = requestId;
@@ -973,6 +974,8 @@ export function AutoUploadPanel() {
         || generation !== statusGenerationRef.current
         || requestId !== statusRequestRef.current) return;
       if (!quiet) setLoadError(errorMessage(error, 'Could not load automatic-upload status.'));
+    } finally {
+      statusInFlightRef.current = false;
     }
   }, []);
 


### PR DESCRIPTION
## Summary
- stop automatic-upload status polls from overlapping when the daemon is slow
- abort a stuck status request after 15 seconds
- preserve the existing background behavior without adding user prompts or controls
- add regression coverage for timeouts and slow polling

## Tests
- npm test -- --reporter=dot src/api.test.ts src/components/AutoUploadControls.test.tsx
- npm run build
- npx eslint src/api.ts src/api.test.ts src/components/AutoUploadControls.tsx src/components/AutoUploadControls.test.tsx