### PR TITLE
Make bundle export destinations behave as specified

### DIFF
--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -1669,8 +1669,8 @@ def _run_bundle_view(args) -> None:
         conn.close()
 
 
-def _write_bundle_zip(export_dir: Path) -> Path:
-    zip_path = export_dir.with_name(f"{export_dir.name}.zip")
+def _write_bundle_zip(export_dir: Path, zip_path: Path | None = None) -> Path:
+    zip_path = zip_path or export_dir.with_name(f"{export_dir.name}.zip")
     with zipfile.ZipFile(zip_path, "w", zipfile.ZIP_DEFLATED) as zf:
         for name in (
             "sessions.jsonl",
@@ -1744,11 +1744,21 @@ def _run_bundle_export(args) -> None:
             print("Bundle contains sessions outside the confirmed source scope.")
             sys.exit(1)
 
+        output_path = args.output
+        requested_zip_path: Path | None = None
+        if (
+            getattr(args, "zip", False) is True
+            and output_path
+            and Path(output_path).suffix.lower() == ".zip"
+        ):
+            requested_zip_path = Path(output_path).expanduser().resolve()
+            output_path = str(requested_zip_path.with_suffix(""))
+
         export_dir, manifest = export_share_to_disk(
             conn,
             share_id,
             share,
-            output_path=args.output,
+            output_path=output_path,
             custom_strings=settings["custom_strings"],
             extra_usernames=settings["extra_usernames"],
             excluded_projects=settings["excluded_projects"],
@@ -1756,7 +1766,7 @@ def _run_bundle_export(args) -> None:
             allowlist_entries=settings["allowlist_entries"],
         )
         if export_dir is None:
-            print("Output path must be under home directory or /tmp.")
+            print("Output path must not be a filesystem root directory.")
             sys.exit(1)
 
         if manifest.get("blocked"):
@@ -1797,7 +1807,7 @@ def _run_bundle_export(args) -> None:
             files.append("sessions.training.jsonl")
 
         if getattr(args, "zip", False) is True:
-            zip_path = _write_bundle_zip(export_dir)
+            zip_path = _write_bundle_zip(export_dir, requested_zip_path)
 
         if getattr(args, "json", False):
             result = {
@@ -4824,7 +4834,13 @@ def main() -> None:
 
     be = sub.add_parser("bundle-export", help="Export bundle to disk as JSONL + manifest")
     be.add_argument("share_id", help="Bundle ID (or prefix)")
-    be.add_argument("--output", "-o", type=str, default=None, help="Custom output directory")
+    be.add_argument(
+        "--output",
+        "-o",
+        type=str,
+        default=None,
+        help="Output directory, or the archive path when used with --zip and a .zip suffix",
+    )
     be.add_argument("--training-format", action="store_true",
                     help="Also produce a training-format JSONL (turn-based, cleaned)")
     be.add_argument("--zip", action="store_true", help="Also write an uploadable zip")

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -6064,7 +6064,7 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                 allowlist_entries=settings["allowlist_entries"],
             )
             if export_dir is None:
-                _json_response(self, {"error": "output_path must be under home directory or /tmp"}, 400)
+                _json_response(self, {"error": "output_path must not be a filesystem root directory"}, 400)
                 return
 
             if manifest.get("blocked"):

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -6210,8 +6210,10 @@ def export_share_to_disk(
     """
     if output_path:
         export_dir = Path(output_path).resolve()
-        home = Path.home().resolve()
-        if not export_dir.is_relative_to(home) and not export_dir.is_relative_to(Path("/tmp").resolve()):
+        # The caller explicitly selected this local destination. Keep the one
+        # dangerous ambiguity out: never place our fixed filenames directly in
+        # a filesystem root where they could collide with unrelated files.
+        if export_dir == Path(export_dir.anchor):
             return None, {}
     else:
         export_dir = CONFIG_DIR / "shares" / share_id

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1256,17 +1256,17 @@ class TestBundleExport:
         captured = capsys.readouterr()
         assert "--ai-pii-review only applies when building the uploadable zip" in captured.err
 
-    def test_export_zip_appends_suffix_to_output_directory(self, bundle_index, tmp_path, capsys):
+    def test_export_zip_path_is_used_as_the_archive_destination(self, bundle_index, tmp_path, capsys):
         from clawjournal.workbench.index import create_share, open_index
         conn = open_index()
         bundle_id = create_share(conn, ["sess-0"])
         conn.close()
 
-        output_dir = Path("/tmp") / f"clawjournal-manual-export-{bundle_id}.zip"
+        output_zip = tmp_path / f"clawjournal-manual-export-{bundle_id}.zip"
         from clawjournal.cli import _run_bundle_export
         args = MagicMock(
             share_id=bundle_id,
-            output=str(output_dir),
+            output=str(output_zip),
             json=True,
             zip=True,
             training_format=False,
@@ -1275,13 +1275,12 @@ class TestBundleExport:
             _run_bundle_export(args)
             output = json.loads(capsys.readouterr().out)
 
-            resolved_output_dir = output_dir.resolve()
-            assert Path(output["export_path"]) == resolved_output_dir
-            assert Path(output["zip_path"]) == resolved_output_dir.with_name(f"{resolved_output_dir.name}.zip")
-            assert Path(output["zip_path"]).is_file()
+            assert Path(output["export_path"]) == output_zip.with_suffix("").resolve()
+            assert Path(output["zip_path"]) == output_zip.resolve()
+            assert output_zip.is_file()
         finally:
-            shutil.rmtree(output_dir, ignore_errors=True)
-            output_dir.with_name(f"{output_dir.name}.zip").unlink(missing_ok=True)
+            shutil.rmtree(output_zip.with_suffix(""), ignore_errors=True)
+            output_zip.unlink(missing_ok=True)
 
     def test_export_redacts_custom_strings(self, tmp_path, monkeypatch, capsys):
         """Bundle export applies redact_strings from config."""


### PR DESCRIPTION
## Summary
- allow explicit local export destinations outside home and /tmp while still rejecting filesystem roots
- treat --output something.zip --zip as the requested archive path
- avoid creating a .zip directory followed by a .zip.zip archive
- keep the existing single --output option and directory behavior

## Tests
- python -m pytest tests/test_cli.py::TestBundleExport::test_export_zip_path_is_used_as_the_archive_destination tests/workbench/test_share_gates.py -q