### PR TITLE
Enforce cross-platform client and frontend checks

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,13 @@ jobs:
           tests/test_cli.py::TestWorkbenchSourceChoices::test_open_dispatches_to_one_shot_desktop_controller
           tests/test_cli.py::TestWorkbenchSourceChoices::test_serve_hidden_no_port_fallback_flag_is_forwarded
           -v
+      - name: Cross-platform capture and scanner installers
+        run: >-
+          python -m pytest
+          tests/capture
+          tests/redaction/test_betterleaks_install.py
+          tests/redaction/test_trufflehog_install.py
+          -v
 
   smoke:
     runs-on: ubuntu-latest
@@ -67,6 +74,8 @@ jobs:
       - working-directory: clawjournal/web/frontend
         run: |
           npm ci
+          npm run lint
+          npm test -- --reporter=dot
           npm run build
       - run: test -f clawjournal/web/frontend/dist/index.html
       - run: python -m pip wheel . --no-deps --no-build-isolation -w /tmp/clawjournal-wheelcheck

--- a/clawjournal/web/frontend/eslint.config.js
+++ b/clawjournal/web/frontend/eslint.config.js
@@ -20,6 +20,10 @@ export default defineConfig([
       globals: globals.browser,
     },
     rules: {
+      'react-refresh/only-export-components': ['error', {
+        allowConstantExport: true,
+        allowExportNames: ['LABELS', 'useToast'],
+      }],
       'react-hooks/immutability': 'off',
       'react-hooks/refs': 'off',
       'react-hooks/set-state-in-effect': 'off',

--- a/clawjournal/web/frontend/src/components/RedactionReportPanel.tsx
+++ b/clawjournal/web/frontend/src/components/RedactionReportPanel.tsx
@@ -75,7 +75,7 @@ export function RedactionReportPanel({ sessionId, onScrollToMessage }: Redaction
     }
   };
 
-  const handleAllowExact = async (index: number) => {
+  const handleAllowExact = async () => {
     if (!allowText.trim()) return;
     try {
       await api.allowlist.add({
@@ -244,7 +244,7 @@ export function RedactionReportPanel({ sessionId, onScrollToMessage }: Redaction
                 />
                 <div style={{ display: 'flex', gap: 6, marginTop: 6 }}>
                   <button
-                    onClick={() => handleAllowExact(i)}
+                    onClick={handleAllowExact}
                     disabled={!allowText.trim()}
                     style={{
                       padding: '4px 12px', fontSize: 12, fontWeight: 600,

--- a/clawjournal/web/frontend/src/views/Dashboard.tsx
+++ b/clawjournal/web/frontend/src/views/Dashboard.tsx
@@ -207,13 +207,11 @@ export function Dashboard() {
 
   if (!data) return null;
 
-  const { summary, weekly_activity, by_outcome_label, by_value_label, by_risk_level, by_task_type, by_model, by_agent, tokens_by_source, by_quality_score, by_failure_value_score = [], resolve_rate, resolve_rate_previous, read_edit_ratio, top_tools, avg_interrupts } = data;
+  const { summary, weekly_activity, by_outcome_label, by_value_label, by_task_type, by_model, by_agent, tokens_by_source, by_quality_score, by_failure_value_score = [], resolve_rate, resolve_rate_previous, read_edit_ratio, top_tools, avg_interrupts } = data;
 
   // Sort outcomes by count descending
   const sortedOutcomes = [...by_outcome_label].sort((a, b) => b.count - a.count);
   const sortedValues = [...by_value_label].sort((a, b) => b.count - a.count);
-  const sortedRisks = [...by_risk_level].sort((a, b) => b.count - a.count);
-
   const weeklyMax = Math.max(...(weekly_activity || []).map(w => w.count), 0);
   const modelMax = Math.max(...by_model.map(m => m.count), 0);
   const agentMax = Math.max(...(by_agent || []).map(a => a.count), 0);
@@ -221,7 +219,6 @@ export function Dashboard() {
   const totalSessions = summary.total_sessions;
   const outcomeMax = Math.max(...sortedOutcomes.map(b => b.count), 0);
   const valueMax = Math.max(...sortedValues.map(b => b.count), 0);
-  const riskMax = Math.max(...sortedRisks.map(b => b.count), 0);
   const tokenSources = tokens_by_source.filter(s => s.input_tokens > 0 || s.output_tokens > 0);
   const tokenSourceMax = Math.max(...tokenSources.map(s => Math.max(s.input_tokens, s.output_tokens)), 0);
 

--- a/clawjournal/web/frontend/src/views/Policies.tsx
+++ b/clawjournal/web/frontend/src/views/Policies.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import type { Policy } from '../types.ts';
 import { api } from '../api.ts';
@@ -37,7 +37,7 @@ export function Policies() {
   const [loading, setLoading] = useState(true);
   const [deleteTarget, setDeleteTarget] = useState<Policy | null>(null);
 
-  async function loadPolicies() {
+  const loadPolicies = useCallback(async () => {
     try {
       const data = await api.policies.list();
       setPolicies(data);
@@ -46,11 +46,11 @@ export function Policies() {
     } finally {
       setLoading(false);
     }
-  }
+  }, [toast]);
 
   useEffect(() => {
     loadPolicies();
-  }, []);
+  }, [loadPolicies]);
 
   async function handleAdd() {
     if (!newValue.trim()) return;

--- a/clawjournal/web/frontend/src/views/SessionDetail.tsx
+++ b/clawjournal/web/frontend/src/views/SessionDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState, useRef, useCallback } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { api } from '../api.ts';
-import type { SessionDetail as SessionDetailType, Message, ToolUse } from '../types.ts';
+import type { SessionDetail as SessionDetailType, Message } from '../types.ts';
 import { BadgeChip } from '../components/BadgeChip.tsx';
 import { Spinner } from '../components/Spinner.tsx';
 import { useToast } from '../components/Toast.tsx';

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,3 +53,6 @@ exclude = ["clawjournal.web*"]
 
 [project.optional-dependencies]
 dev = ["pytest", "tomli; python_version < '3.11'"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]

--- a/tests/capture/test_discovery.py
+++ b/tests/capture/test_discovery.py
@@ -370,7 +370,7 @@ def test_local_agent_matching_native_session_is_still_surfaced(isolated_homedir)
     (proj / "dup.jsonl").write_text("{}\n")
 
     files = list(discovery.iter_source_files(source_filter="claude"))
-    paths = sorted(str(f.path.relative_to(isolated_homedir)) for f in files)
+    paths = sorted(f.path.relative_to(isolated_homedir).as_posix() for f in files)
     assert paths == [
         "claude/projects/-Users-me-shared/dup.jsonl",
         "local_agent/11111111-2222-3333-4444-555555555555/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/local_dup/.claude/projects/-sessions-proc/dup.jsonl",
@@ -435,7 +435,7 @@ def test_duplicate_local_agent_wrappers_same_cli_session_id_are_both_surfaced(
     (proj_two / "dup-cli.jsonl").write_text("{}\n")
 
     files = list(discovery.iter_source_files(source_filter="claude"))
-    paths = sorted(str(f.path.relative_to(isolated_homedir)) for f in files)
+    paths = sorted(f.path.relative_to(isolated_homedir).as_posix() for f in files)
     assert paths == [
         "local_agent/11111111-2222-3333-4444-555555555555/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/local_one/.claude/projects/-sessions-proc/dup-cli.jsonl",
         "local_agent/11111111-2222-3333-4444-555555555555/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee/local_two/.claude/projects/-sessions-proc/dup-cli.jsonl",
@@ -911,4 +911,4 @@ def test_size_bytes_matches_file_size(isolated_homedir):
     proj.mkdir(parents=True)
     (proj / "s.jsonl").write_text("{}\n")
     files = list(discovery.iter_source_files(source_filter="claude"))
-    assert all(f.size_bytes == 3 for f in files)
+    assert all(f.size_bytes == f.path.stat().st_size for f in files)

--- a/tests/redaction/test_betterleaks_install.py
+++ b/tests/redaction/test_betterleaks_install.py
@@ -72,7 +72,9 @@ def install_env(tmp_path, monkeypatch):
     flavor (zip for windows keys).
     """
     config_dir = tmp_path / ".clawjournal"
+    target = config_dir / "bin" / "betterleaks"
     monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+    monkeypatch.setattr(betterleaks_install, "managed_binary_path", lambda: target)
     monkeypatch.setattr(betterleaks_install, "platform_key", lambda: "testos_x64")
     monkeypatch.setattr(
         betterleaks_install, "_verify_installed_binary", lambda path: PINNED
@@ -106,7 +108,7 @@ def install_env(tmp_path, monkeypatch):
     state["pin_checksum"] = pin_checksum
     state["set_platform"] = set_platform
     state["config_dir"] = config_dir
-    state["target"] = config_dir / "bin" / betterleaks.managed_binary_path().name
+    state["target"] = target
     return state
 
 

--- a/tests/redaction/test_trufflehog_install.py
+++ b/tests/redaction/test_trufflehog_install.py
@@ -59,7 +59,9 @@ def install_env(tmp_path, monkeypatch):
     table to that payload.
     """
     config_dir = tmp_path / ".clawjournal"
+    target = config_dir / "bin" / "trufflehog"
     monkeypatch.setattr("clawjournal.config.CONFIG_DIR", config_dir)
+    monkeypatch.setattr(trufflehog_install, "managed_binary_path", lambda: target)
     monkeypatch.setattr(trufflehog_install, "platform_key", lambda: "testos_amd64")
     monkeypatch.setattr(
         trufflehog_install, "_verify_installed_binary", lambda path: "3.95.5"
@@ -92,7 +94,7 @@ def install_env(tmp_path, monkeypatch):
     state["serve"] = serve
     state["pin_checksum"] = pin_checksum
     state["config_dir"] = config_dir
-    state["target"] = config_dir / "bin" / trufflehog.managed_binary_path().name
+    state["target"] = target
     return state
 
 
@@ -411,7 +413,7 @@ class TestVerifyInstalledBinary:
     def test_parses_version_banner(self, monkeypatch):
         version, seen = self._run(monkeypatch, stdout="trufflehog 3.95.5\n")
         assert version == "3.95.5"
-        assert seen["argv"] == ["/x/trufflehog", "--version"]
+        assert seen["argv"] == [str(Path("/x/trufflehog")), "--version"]
         # Scrubbed env, not the parent's (None would inherit API keys).
         assert isinstance(seen["env"], dict)
 


### PR DESCRIPTION
## Summary
- keep pytest collection scoped to this repository's test suite
- make capture and managed-scanner installer tests platform-neutral, then run them on Windows CI
- run frontend lint and component tests in CI and clear the existing lint failures

## Verification
- python -m pytest tests/capture tests/redaction/test_betterleaks_install.py tests/redaction/test_trufflehog_install.py -q (163 passed, 2 skipped)
- python -m pytest --collect-only -q (3790 collected; independent clawjournal-share repo excluded)
- npm run lint
- npm test -- --reporter=dot (108 passed)
- npm run build