### PR TITLE
Show project scope before one-click confirmation

### DIFF
--- a/clawjournal/web/frontend/src/views/Settings.test.tsx
+++ b/clawjournal/web/frontend/src/views/Settings.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../api.ts';
+import type { WorkbenchConfig } from '../types.ts';
+import { ToastProvider } from '../components/Toast.tsx';
+import { Settings } from './Settings.tsx';
+
+vi.mock('../components/AutoUploadControls.tsx', () => ({ AutoUploadPanel: () => null }));
+
+const config: WorkbenchConfig = {
+  source: null,
+  projects_confirmed: false,
+  ai_pii_review_enabled: false,
+  scorer_backend: null,
+  scorer_backend_confirmed_at: null,
+  benchmark_tab_enabled: true,
+  scoring_warmup_declined: true,
+  source_choices: ['claude'],
+  scorer_backend_choices: ['claude'],
+  scorer_backend_detected: null,
+};
+
+function renderSettings() {
+  return render(<ToastProvider><Settings /></ToastProvider>);
+}
+
+describe('project confirmation', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('shows the exact included and excluded projects before one-step confirmation', async () => {
+    vi.spyOn(api.config, 'get').mockResolvedValue(config);
+    const update = vi.spyOn(api.config, 'update').mockResolvedValue({ ...config, projects_confirmed: true });
+    vi.spyOn(api, 'projects').mockResolvedValue([
+      { project: 'customer-app', source: 'claude', session_count: 4, total_tokens: 100, excluded: false },
+      { project: 'private-notes', source: 'codex', session_count: 2, total_tokens: 50, excluded: true },
+    ]);
+
+    renderSettings();
+
+    expect(await screen.findByText('customer-app')).toBeInTheDocument();
+    expect(screen.getByText('private-notes')).toBeInTheDocument();
+    expect(screen.getByText('Included')).toBeInTheDocument();
+    expect(screen.getByText('Excluded')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm reviewed projects' }));
+    await waitFor(() => expect(update).toHaveBeenCalledWith({ confirm_projects: true }));
+    expect(await screen.findByText(/Projects confirmed/)).toBeInTheDocument();
+  });
+
+  it('does not allow blind confirmation when the project list cannot load', async () => {
+    vi.spyOn(api.config, 'get').mockResolvedValue(config);
+    vi.spyOn(api, 'projects').mockRejectedValue(new Error('offline'));
+
+    renderSettings();
+
+    expect(await screen.findByText(/Could not load the project list/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Confirm reviewed projects' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Try again' })).toBeInTheDocument();
+  });
+});

--- a/clawjournal/web/frontend/src/views/Settings.tsx
+++ b/clawjournal/web/frontend/src/views/Settings.tsx
@@ -1,6 +1,6 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { api } from '../api.ts';
-import type { WorkbenchConfig } from '../types.ts';
+import type { ProjectSummary, WorkbenchConfig } from '../types.ts';
 import { useToast } from '../components/Toast.tsx';
 import { AutoUploadPanel } from '../components/AutoUploadControls.tsx';
 import { colors, selectStyle, btnPrimary } from '../theme.ts';
@@ -35,12 +35,24 @@ export function Settings() {
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showAdvanced, setShowAdvanced] = useState(false);
+  const [projects, setProjects] = useState<ProjectSummary[] | null>(null);
+  const [projectError, setProjectError] = useState<string | null>(null);
+
+  const loadProjects = useCallback(async () => {
+    setProjectError(null);
+    try {
+      setProjects(await api.projects());
+    } catch (e) {
+      setProjectError(e instanceof Error ? e.message : 'Could not load projects');
+    }
+  }, []);
 
   useEffect(() => {
     api.config.get()
       .then(setCfg)
       .catch(e => setError(e instanceof Error ? e.message : 'Could not load settings'));
-  }, []);
+    loadProjects();
+  }, [loadProjects]);
 
   async function save(patch: ConfigPatch) {
     setSaving(true);
@@ -85,15 +97,53 @@ export function Settings() {
           Confirms you’ve reviewed which project folders are included (after applying any
           exclusions). Required before export.
         </p>
+        {projectError ? (
+          <div style={{ marginBottom: 12, fontSize: 12.5, color: colors.red700 }}>
+            Could not load the project list.{' '}
+            <button
+              type="button"
+              onClick={loadProjects}
+              style={{ border: 0, padding: 0, background: 'none', color: colors.red700, textDecoration: 'underline', cursor: 'pointer' }}
+            >
+              Try again
+            </button>
+          </div>
+        ) : projects === null ? (
+          <p style={{ margin: '0 0 12px', fontSize: 12.5, color: colors.gray500 }}>Loading projects...</p>
+        ) : (
+          <div style={{ border: `1px solid ${colors.gray200}`, borderRadius: 8, marginBottom: 12, maxHeight: 220, overflowY: 'auto' }}>
+            {projects.length === 0 ? (
+              <p style={{ margin: 0, padding: '10px 12px', fontSize: 12.5, color: colors.gray500 }}>
+                No indexed projects found yet.
+              </p>
+            ) : projects.map(project => (
+              <div
+                key={`${project.source}:${project.project}`}
+                style={{ display: 'flex', alignItems: 'center', gap: 8, padding: '8px 10px', borderBottom: `1px solid ${colors.gray100}`, fontSize: 12.5 }}
+              >
+                <span aria-hidden="true" style={{ color: project.excluded ? colors.gray400 : colors.green500 }}>
+                  {project.excluded ? '○' : '✓'}
+                </span>
+                <span style={{ flex: 1, minWidth: 0, overflowWrap: 'anywhere', color: project.excluded ? colors.gray500 : colors.gray800 }}>
+                  {project.project}
+                </span>
+                <span style={{ color: colors.gray400 }}>{project.source}</span>
+                <span style={{ color: project.excluded ? colors.gray500 : colors.green500, fontWeight: 600 }}>
+                  {project.excluded ? 'Excluded' : 'Included'}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
         {cfg.projects_confirmed ? (
           <span style={{ fontSize: 13, color: colors.green500, fontWeight: 600 }}>✓ Projects confirmed</span>
         ) : (
           <button
             style={{ ...btnPrimary, fontWeight: 600 }}
-            disabled={saving}
+            disabled={saving || projects === null || projectError !== null}
             onClick={() => save({ confirm_projects: true })}
           >
-            Confirm all projects
+            Confirm reviewed projects
           </button>
         )}
       </div>

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -4888,16 +4888,28 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
     def _handle_projects(self) -> None:
         conn = open_index()
         try:
+            settings = get_effective_share_settings(conn, load_config())
+            source_filter = settings.get("source_filter")
+            if source_filter is None:
+                allowed_sources = None
+            elif isinstance(source_filter, str):
+                allowed_sources = {source_filter}
+            else:
+                allowed_sources = set(source_filter)
             rows = conn.execute(
                 "SELECT project, source, COUNT(*) as session_count, "
                 "SUM(input_tokens + output_tokens) as total_tokens "
                 "FROM sessions GROUP BY project, source ORDER BY project"
             ).fetchall()
-            settings = get_effective_share_settings(conn, load_config())
             excluded_projects = settings["excluded_projects"]
             projects = []
             for row in rows:
                 project = dict(row)
+                if (
+                    allowed_sources is not None
+                    and project["source"] not in allowed_sources
+                ):
+                    continue
                 project["excluded"] = session_matches_excluded_projects(
                     project,
                     excluded_projects,

--- a/tests/workbench/test_daemon_config.py
+++ b/tests/workbench/test_daemon_config.py
@@ -86,6 +86,41 @@ class TestGetConfig:
 
 
 class TestProjects:
+    @pytest.mark.parametrize(
+        ("source", "expected_sources"),
+        [
+            ("all", {"claude", "codex", "openclaw"}),
+            ("both", {"claude", "codex"}),
+            ("codex", {"codex"}),
+        ],
+    )
+    def test_lists_only_projects_in_manual_export_source_scope(
+        self,
+        api,
+        source,
+        expected_sources,
+    ):
+        save_config({"source": source})
+        conn = open_index()
+        try:
+            upsert_sessions(conn, [
+                {
+                    "session_id": f"{session_source}-session",
+                    "project": f"{session_source}:project",
+                    "source": session_source,
+                    "messages": [{"role": "user", "content": session_source}],
+                    "stats": {"input_tokens": 10, "output_tokens": 5},
+                }
+                for session_source in ("claude", "codex", "openclaw")
+            ])
+        finally:
+            conn.close()
+
+        status, body = _get(api, "/api/projects")
+
+        assert status == 200
+        assert {row["source"] for row in body} == expected_sources
+
     def test_marks_projects_excluded_by_effective_share_policy(self, api):
         save_config({"excluded_projects": ["claude:private-project"]})
         conn = open_index()


### PR DESCRIPTION
## Summary
- show the exact included and excluded projects in the existing Settings confirmation card
- keep the normal flow to a single confirmation click
- prevent blind confirmation if the project list failed to load, with an inline retry
- cover included/excluded rendering, confirmation, and failure behavior

## Verification
- npm test -- --reporter=dot (110 passed)
- npm run build
- npx eslint src/views/Settings.tsx src/views/Settings.test.tsx