### PR TITLE
feat(skill): add opt-in SessionStart lessons nudge

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,8 @@ These are the main commands:
 ```bash
 clawjournal open                         # open the local workbench, then return
 clawjournal skill --preview              # preview lessons + one evidence-backed weekly focus
+clawjournal skill --install-nudge        # opt in to a stale-lessons SessionStart reminder
+clawjournal skill --uninstall-nudge      # disable that reminder and its context output
 clawjournal share --interactive --weekly --no-score # guided sharing without AI scoring
 clawjournal status                       # check your setup
 clawjournal selfupdate --check           # see whether a newer version is available
@@ -200,6 +202,14 @@ no rule also passes its focus safeguards. The spotlight framing and aggregate
 evidence are not installed into agent instructions; the underlying lesson remains in
 the proposed skill set. It does not claim to assess your personality or performance
 at work.
+
+The stale-lessons nudge is **off by default**. If you opt in with
+`clawjournal skill --install-nudge`, a due reminder includes aggregate counts of
+new sessions and sessions with failure evidence in agent context, so those counts
+also reach the model provider when the agent starts. It does not include session
+text, run distillation, or install lessons automatically. The count follows your
+confirmed source/project exclusions and hold/embargo boundaries. Disable it at any
+time with `clawjournal skill --uninstall-nudge`.
 
 The terminal guide keeps the essential selection, redaction, consent, and destination safeguards in a simpler interface.
 

--- a/clawjournal/agent_hooks.py
+++ b/clawjournal/agent_hooks.py
@@ -8,6 +8,10 @@ only owns agent configuration and the small, injectable hook dispatch seam.
 The module entry point binds the local due check and detached runner lazily;
 injected adapters keep that boundary directly testable. The hook process never
 packages or uploads a trace itself.
+
+Besides the silent auto-upload check, the entry point may print ONE bounded
+lessons-refresh nudge line (:mod:`clawjournal.skill.due`) suggesting a manual
+``clawjournal skill --preview`` — never running it.
 """
 
 from __future__ import annotations
@@ -491,6 +495,7 @@ def main(
     due_check: DueCheck | None = None,
     spawn_runner: RunnerSpawner | None = None,
     record_observed: ObservationRecorder | None = None,
+    nudge_emitter: Callable[[str], bool] | None = None,
 ) -> int:
     """Lightweight module entrypoint used by agent hook configuration."""
 
@@ -514,13 +519,31 @@ def main(
             # not-due and the agent session continues without spawning.
             due_check = hook_session_start_check
             spawn_runner = spawn_scheduled_runner
+            if nudge_emitter is None:
+                try:
+                    from .skill.due import emit_session_start_nudge
+
+                    nudge_emitter = emit_session_start_nudge
+                except Exception:
+                    # The nudge is optional garnish; a broken import must never
+                    # break the auto-upload check or the agent session.
+                    nudge_emitter = None
         run_session_start(
             client=args.client,
             due_check=due_check,
             spawn_runner=spawn_runner,
             record_observed=record_observed,
         )
-    # No output: SessionStart must never inject scheduler text into a trace.
+        # The auto-upload scheduler stays silent (its state must never reach a
+        # trace). The lessons-refresh nudge is the ONE deliberate exception: at
+        # most one printed line, bounded + fail-open + cooldown-limited, and it
+        # only ever *suggests* `clawjournal skill --preview` — nothing runs
+        # automatically (plan §16 CH-1).
+        if nudge_emitter is not None:
+            try:
+                nudge_emitter(args.client)
+            except Exception:
+                pass
     return 0
 
 

--- a/clawjournal/auto_upload.py
+++ b/clawjournal/auto_upload.py
@@ -1090,6 +1090,92 @@ def _restore_hook_files(snapshots: Mapping[Path, str | None]) -> None:
             atomic_write_text(path, previous, parents=True)
 
 
+def _enrollment_hook_targets(
+    enrollment: Mapping[str, Any] | None,
+) -> set[AgentName] | None:
+    """Return the hooks currently owned by recurring upload.
+
+    A durable first-enable intent owns its selected hooks while hosted setup is
+    in flight even though its mode is still ``off``.  This prevents a racing
+    nudge uninstall from removing the hook between local setup and the final
+    enrollment commit.  ``None`` means corrupt/unknown state and callers must
+    preserve every hook conservatively.
+    """
+    if enrollment is None:
+        return set()
+    mode = enrollment.get("mode")
+    if mode not in ("off", "enabled", "paused"):
+        return None
+    owns_hooks = mode in ("enabled", "paused") or (
+        mode == "off"
+        and enrollment.get("last_result_code") == "enrollment_pending"
+    )
+    if not owns_hooks:
+        return set()
+    raw_targets = enrollment.get("hook_targets")
+    if not isinstance(raw_targets, list):
+        return None
+    targets = set(raw_targets)
+    supported = set(SUPPORTED_HOOK_TARGETS)
+    if not targets or not targets <= supported:
+        return None
+    return targets  # type: ignore[return-value]
+
+
+def _current_auto_upload_hook_targets(
+    conn: sqlite3.Connection,
+) -> set[AgentName] | None:
+    try:
+        return _enrollment_hook_targets(get_auto_upload_enrollment(conn))
+    except Exception:
+        return None
+
+
+def _reconcile_shared_hooks(
+    conn: sqlite3.Connection,
+    *,
+    upload_targets: Sequence[AgentName] | None = None,
+) -> list[dict[str, Any]]:
+    """Make hook files match the union of upload and nudge ownership.
+
+    Callers hold :func:`control_mutation_lock`; keeping the marker/DB reads and
+    hook writes inside that one short critical section prevents either feature
+    from restoring or deleting the other's hook. Unknown ownership suppresses
+    deletion but never authorizes creating a missing hook.
+    """
+    from .skill.due import nudge_hook_ownership
+
+    owned_by_upload = (
+        set(upload_targets)
+        if upload_targets is not None
+        else _current_auto_upload_hook_targets(conn)
+    )
+    owned_by_nudge = nudge_hook_ownership(conn)
+    desired: set[str] = set()
+    if owned_by_upload is not None:
+        desired.update(owned_by_upload)
+    if owned_by_nudge is True:
+        desired.update(SUPPORTED_HOOK_TARGETS)
+
+    results: list[dict[str, Any]] = []
+    if desired:
+        hook_agent = "all" if len(desired) > 1 else next(iter(desired))
+        results = install_hooks(agent=hook_agent)
+        if not all(result.get("configured") for result in results):
+            raise AutoUploadError(
+                "hook_install_failed",
+                "A selected SessionStart hook could not be installed.",
+            )
+    # Unknown ownership is conservative only in the non-destructive direction:
+    # never delete a possibly-owned hook, but also never install a missing hook
+    # without a known owner authorizing that target.
+    if owned_by_upload is not None and owned_by_nudge is not None:
+        for target in SUPPORTED_HOOK_TARGETS:
+            if target not in desired:
+                uninstall_agent_hook(target)
+    return results
+
+
 def _reconcile_explicit_pause_after_reauthorization(
     conn: sqlite3.Connection,
     *,
@@ -1173,6 +1259,24 @@ def _reconcile_explicit_pause_after_reauthorization(
                     last_result_code="credential_store_failed",
                 )
                 raise
+        try:
+            _reconcile_shared_hooks(conn)
+        except Exception as exc:
+            try:
+                update_auto_upload_enrollment(
+                    conn,
+                    expected_generation=reconciled_generation,
+                    health="action_required",
+                    last_result_code="hook_update_failed",
+                )
+            except Exception:
+                pass
+            raise AutoUploadError(
+                "hook_update_failed",
+                "The paused enrollment was reconciled, but its SessionStart "
+                "hooks could not be updated safely.",
+                retryable=True,
+            ) from exc
         return True
 
 
@@ -1676,13 +1780,14 @@ def enable(
                     last_result_code="enrollment_pending",
                 )
 
-        if background_job_id is None:
-            persist_intent()
-        else:
-            # Disable deletes the job under this same control lock.  Once this
-            # block publishes an Off intent, the existing generation CAS makes
-            # every later Disable win safely even if hosted I/O has begun.
-            with control_mutation_lock():
+        # Publishing hook ownership is a local control mutation too. Serialize
+        # both synchronous and queued intents so a nudge command cannot observe
+        # a half-published pending target set.
+        with control_mutation_lock():
+            if background_job_id is not None:
+                # Disable deletes the job under this same control lock. Once
+                # this block publishes an Off intent, the generation CAS makes
+                # every later Disable win even if hosted I/O has begun.
                 queued_job = get_auto_upload_enrollment_job(conn)
                 if (
                     queued_job is None
@@ -1693,7 +1798,7 @@ def enable(
                     raise ControlChanged(
                         "The queued automatic-upload setup was cancelled."
                     )
-                persist_intent()
+            persist_intent()
 
         snapshots: dict[Path, str | None] = {}
         committed = False
@@ -1719,17 +1824,12 @@ def enable(
         # secret in config.
         sent_identity_kind: str | None = None
         try:
-            snapshots = _snapshot_hook_files(SUPPORTED_HOOK_TARGETS)
-            hook_agent = "all" if len(targets) > 1 else targets[0]
-            hook_results = install_hooks(agent=hook_agent)
-            if not all(result.get("configured") for result in hook_results):
-                raise AutoUploadError(
-                    "hook_install_failed",
-                    "A selected SessionStart hook could not be installed.",
-                )
-            for target in SUPPORTED_HOOK_TARGETS:
-                if target not in targets:
-                    uninstall_agent_hook(target)
+            # Only the local snapshot/install mutation is serialized. Hosted
+            # enrollment I/O below deliberately runs without the control lock
+            # so Disable and nudge controls remain responsive.
+            with control_mutation_lock():
+                snapshots = _snapshot_hook_files(SUPPORTED_HOOK_TARGETS)
+                _reconcile_shared_hooks(conn, upload_targets=targets)
 
             if updating and not rotating_credentials:
                 assert credentials is not None
@@ -2069,6 +2169,10 @@ def enable(
                     )
                 write_credentials(credential_record)
                 committed = True
+                # Re-read the nudge marker after hosted I/O and reconcile the
+                # final union while the enrollment commit is still ordered
+                # against nudge install/uninstall.
+                _reconcile_shared_hooks(conn)
         except Exception as exc:
             current_after_failure = get_auto_upload_enrollment(conn)
             if (
@@ -2120,14 +2224,22 @@ def enable(
                         delete_credentials()
                 except CredentialStoreError:
                     pass
-            if (
-                current_after_failure is not None
-                and int(current_after_failure.get("generation", 0)) == generation
-            ):
-                try:
-                    _restore_hook_files(snapshots)
-                except OSError:
-                    pass
+            try:
+                with control_mutation_lock():
+                    hook_owner = get_auto_upload_enrollment(conn)
+                    if (
+                        hook_owner is not None
+                        and int(hook_owner.get("generation", 0)) == generation
+                    ):
+                        _restore_hook_files(snapshots)
+                    # A nudge command may have completed while hosted I/O was
+                    # in flight. Rebuild from its CURRENT marker after any
+                    # snapshot restore so that restore cannot erase its hook.
+                    _reconcile_shared_hooks(conn)
+            except Exception:
+                # Preserve the original enrollment error. The failure tail
+                # retries reconciliation after final DB compensation.
+                pass
             fresh_recovery = (
                 response.get("recovery_token")
                 if isinstance(response, dict)
@@ -2237,11 +2349,17 @@ def enable(
                 )
 
             if committed:
-                return AutoUploadError(
-                    "status_failed",
-                    "Enrollment succeeded, but its status could not be rendered.",
-                    retryable=True,
-                ).as_result()
+                try:
+                    with control_mutation_lock():
+                        _reconcile_shared_hooks(conn)
+                except Exception:
+                    return AutoUploadError(
+                        "hook_update_failed",
+                        "Enrollment succeeded, but its SessionStart hooks could "
+                        "not be reconciled safely.",
+                        retryable=True,
+                    ).as_result()
+                return status(conn=conn)
 
             # If the server created an enrollment but local persistence failed,
             # revoke with recovery authority.  A failed revoke retains only the
@@ -2468,6 +2586,14 @@ def enable(
                     revocation_pending=False,
                     last_result_code=error.code,
                 )
+            try:
+                with control_mutation_lock():
+                    _reconcile_shared_hooks(conn)
+            except Exception:
+                # The primary enrollment error remains authoritative. A later
+                # Enable/Disable/nudge command will retry the idempotent hook
+                # reconciliation under the same lock.
+                pass
             return error.as_result()
         if background_job_id is None:
             # A user may recover an action-required background attempt through
@@ -2705,6 +2831,7 @@ def disable() -> dict[str, Any]:
 
     conn = open_index()
     try:
+        hook_error = False
         # Establish Off and strip active authority as one ordered local phase.
         # Hosted revocation stays outside the lock; every later DB write is a
         # CAS against the generation this Disable owns.
@@ -2792,11 +2919,8 @@ def disable() -> dict[str, Any]:
                 return AutoUploadError(
                     "credential_store_failed", str(exc)
                 ).as_result()
-
-        hook_error = False
-        for target in SUPPORTED_HOOK_TARGETS:
             try:
-                uninstall_agent_hook(target)
+                _reconcile_shared_hooks(conn)
             except Exception:
                 hook_error = True
 

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -4683,6 +4683,13 @@ def main() -> None:
     skill_p.add_argument("--no-score", action="store_true", help="Skip scoring unscored sessions in the window")
     skill_p.add_argument("--score-limit", type=int, default=25,
                          help="Max unscored sessions to score this run (cost bound; default 25)")
+    skill_p.add_argument("--install-nudge", action="store_true",
+                         help="Opt in to a SessionStart reminder that sends aggregate new-session "
+                              "and failure-evidence counts through agent context to the model "
+                              "provider when lessons go stale; it never runs anything itself")
+    skill_p.add_argument("--uninstall-nudge", action="store_true",
+                         help="Disable the stale-lessons reminder and its agent-context output "
+                              "(the shared hook remains only if automatic uploads need it)")
     skill_p.add_argument("--reject", metavar="FINGERPRINT",
                          help="Reject a rule by fingerprint so it is never re-proposed")
     skill_p.add_argument("--skip-preflight", action="store_true",

--- a/clawjournal/cli_skill.py
+++ b/clawjournal/cli_skill.py
@@ -17,6 +17,7 @@ from difflib import SequenceMatcher
 from typing import Any
 
 from .skill import distill as _distill
+from .skill import due as _due
 from .skill import focus as _focus
 from .skill import install as _install
 from .skill import render as _render
@@ -591,6 +592,83 @@ def _ensure_corpus(window_days: int, *, do_scan: bool, do_score: bool,
 
 # --- IO / CLI ---------------------------------------------------------------
 
+
+def _run_nudge_hook_command(*, install: bool) -> None:
+    """Enable or disable the opt-in stale-lessons SessionStart nudge."""
+    from . import auto_upload as _auto_upload
+    from .agent_hooks import SUPPORTED_AGENTS
+    from .workbench.index import open_index
+
+    conn = open_index()
+    try:
+        with _auto_upload.control_mutation_lock():
+            previous_ownership = _due.nudge_hook_ownership(conn)
+            if previous_ownership is None:
+                raise RuntimeError("Nudge hook ownership could not be read safely.")
+            snapshots = _auto_upload._snapshot_hook_files(SUPPORTED_AGENTS)
+            try:
+                _due.set_nudge_hook_requested(conn, install)
+                upload_targets = _auto_upload._current_auto_upload_hook_targets(conn)
+                results = _auto_upload._reconcile_shared_hooks(conn)
+            except Exception:
+                rollback_errors: list[Exception] = []
+                try:
+                    _auto_upload._restore_hook_files(snapshots)
+                except Exception as rollback_error:
+                    rollback_errors.append(rollback_error)
+                try:
+                    _due.set_nudge_hook_requested(conn, previous_ownership)
+                except Exception as rollback_error:
+                    rollback_errors.append(rollback_error)
+                if rollback_errors:
+                    raise RuntimeError(
+                        "Nudge hook update failed and its prior marker/files could "
+                        "not be restored safely."
+                    ) from rollback_errors[0]
+                raise
+
+        if install:
+            for result in results:
+                state = "updated" if result.get("changed") else "already installed"
+                print(
+                    f"  - {result['agent']}: SessionStart hook {state} "
+                    f"({result['path']})"
+                )
+            print(
+                "Stale-lessons nudge enabled (opt-in). When lessons go stale, it "
+                "prints aggregate new-session and failure-evidence counts into "
+                "agent context (and therefore to the model provider), plus a "
+                "suggestion to run `clawjournal skill --preview`. Nothing runs "
+                "automatically. Disable any time with `clawjournal skill "
+                "--uninstall-nudge`."
+            )
+            return
+
+        if upload_targets is None:
+            print(
+                "Nudge disabled. SessionStart hook ownership could not be read, "
+                "so the shared hooks were preserved conservatively."
+            )
+            return
+
+        removed = [agent for agent in SUPPORTED_AGENTS if agent not in upload_targets]
+        kept = [agent for agent in SUPPORTED_AGENTS if agent in upload_targets]
+        if kept and removed:
+            print(
+                "Nudge disabled; removed the shared hook for "
+                f"{', '.join(removed)} and kept {', '.join(kept)} for automatic uploads."
+            )
+        elif kept:
+            print(
+                "Nudge disabled. The shared SessionStart hooks stay installed for "
+                "automatic uploads; disable those to remove them."
+            )
+        else:
+            print("Nudge disabled; SessionStart hook removed for all supported agents.")
+    finally:
+        conn.close()
+
+
 def _ascii_safe(text: str) -> str:
     """Downgrade the glyphs we print when the console can't encode them (e.g. cp1252)."""
     enc = getattr(sys.stdout, "encoding", None) or "utf-8"
@@ -767,6 +845,16 @@ def run_skill(args) -> None:
               if hit else f"No rule with fingerprint {args.reject}.")
         return
 
+    # The nudge owns the shared hook explicitly and never runs the distiller.
+    if getattr(args, "install_nudge", False) or getattr(args, "uninstall_nudge", False):
+        if getattr(args, "install_nudge", False) and getattr(args, "uninstall_nudge", False):
+            print("--install-nudge and --uninstall-nudge are mutually exclusive")
+            sys.exit(2)
+        _run_nudge_hook_command(
+            install=bool(getattr(args, "install_nudge", False))
+        )
+        return
+
     from .config import load_config
     cfg = load_config()  # read the config ONCE and thread it through preflight/scan/select
 
@@ -798,6 +886,13 @@ def run_skill(args) -> None:
         res = generate_skill(conn, window_days=window_days, backend=backend, model=model, effort=effort,
                              sources=_config_sources(cfg),
                              excluded_projects=_config_excluded_projects(cfg, conn), cfg=cfg)
+        # A completed empty or gate-blocked run is still conscious activity.
+        # Record it before those early exits so the SessionStart nudge does not
+        # immediately nag after the user already tried to refresh the skill.
+        try:
+            _due.record_skill_run(conn)
+        except Exception:
+            pass
         _print_preview(res)
         # Persist NOTHING when the gate fails: a rule the render-time gate flags would
         # otherwise be stored as 'proposed', reloaded by load_kept every run, and
@@ -837,6 +932,7 @@ def run_skill(args) -> None:
         # the next run mislabels every rule [NEW] and the trend snapshot is lost.
         installed: list[str] = []
         failures: list[str] = []
+        offer_nudge_tip = False
         for name, fn, payload in (("claude", _install.install_claude, res.skill_md),
                                   ("codex", _install.install_codex, res.region)):
             if name not in targets:
@@ -862,6 +958,10 @@ def run_skill(args) -> None:
             except Exception as exc:
                 print(f"note: installed to disk, but failed to record state "
                       f"({exc.__class__.__name__}); the next run may re-propose these rules.")
+            try:
+                offer_nudge_tip = not _due.nudge_hook_requested(conn)
+            except Exception:
+                offer_nudge_tip = False
         else:
             _persist_seen()  # nothing landed -> at least keep 'seen' state for next run
     finally:
@@ -874,6 +974,11 @@ def run_skill(args) -> None:
         print("\nNote: these lessons reach your model provider when your agent loads them "
               "(that's how any skill/CLAUDE.md works) — nothing is uploaded to us.")
         print("Re-run weekly (`clawjournal skill`) to keep them fresh.")
+        if offer_nudge_tip:
+            print("Tip (opt-in): `clawjournal skill --install-nudge` adds a stale-lessons "
+                  "reminder. Its aggregate new-session/failure-evidence counts enter agent "
+                  "context and therefore reach the model provider; disable any time with "
+                  "`clawjournal skill --uninstall-nudge`.")
     if failures:
         print("\nInstall problems (fix and re-run):")
         for f in failures:

--- a/clawjournal/skill/due.py
+++ b/clawjournal/skill/due.py
@@ -1,0 +1,438 @@
+"""Distill-due nudge for the ``SessionStart`` hook (plan §16 CH-1).
+
+Distillation is manual by design (the LLM egress must stay user-initiated), but
+a manual-only cadence goes stale in practice. This module computes a *cheap,
+bounded, fail-open* "is a lessons refresh due?" decision from the existing index
+DB and, when due, emits ONE printed line from the agent hook — a Claude Code
+``SessionStart`` hook's stdout is surfaced into the session, so the agent can
+suggest ``clawjournal skill --preview`` to the user. Nothing is ever run
+automatically: the nudge is text, the distill call and install remain manual
+and confirmed.
+
+Only users who have already run the skill pipeline are nudged (the anchor is
+``skill_rules`` state plus a run marker); a fresh install nudges nobody. The
+printed counts reach agent context (and therefore the model provider when the
+agent loads them), so they honor the same boundaries as the corpus itself:
+hold-state gated via ``_release_blocked_ids`` and scoped to the confirmed
+sources/projects — the nudge never advertises, even in aggregate, sessions the
+suggested run could not select.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Any, Callable
+
+from ..workbench.index import (
+    FAILURE_VALUE_SOURCE_SCOPE,
+    SHAREABLE_HOLD_STATES,
+    session_matches_excluded_projects,
+)
+from .select import _parse_start_time, _release_blocked_ids
+
+# Never nudge within a week of the last skill run. After two weeks, sufficient
+# new activity is enough; in between, failure evidence or an unusually large
+# session burst must also justify the nudge.
+NUDGE_MIN_DAYS = 7.0
+NUDGE_STALE_DAYS = 14.0
+NUDGE_MIN_NEW_SESSIONS = 5
+NUDGE_BURST_SESSIONS = 25
+NUDGE_FAILURE_SESSIONS = 3
+NUDGE_COOLDOWN_DAYS = 3.0   # an emitted nudge suppresses repeats across sessions
+
+# Scanning is paged and bounded. SQL removes source/project/hold-state rows
+# before LIMIT; the smaller set of Python-only legacy filters is checked page by
+# page. The scan stops early once the count settles every threshold; a count
+# that is a floor rather than a total is reported as "N+".
+_PAGE_SIZE = 100
+_SCAN_BUDGET = 2000
+
+_STATE_TABLE = "skill_nudge_state"
+_LAST_NUDGED_KEY = "last_nudged_at"
+_LAST_RUN_KEY = "last_skill_run_at"
+_HOOK_REQUESTED_KEY = "nudge_hook_requested_at"
+
+
+@dataclass(frozen=True)
+class DueStatus:
+    due: bool
+    reason: str
+    message: str = ""
+    new_sessions: int = 0
+    failure_sessions: int = 0
+    days_since: float | None = None
+
+
+def _parse_ts(value: Any) -> datetime | None:
+    if not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    return parsed if parsed.tzinfo else parsed.replace(tzinfo=timezone.utc)
+
+
+def _read_state_ts(conn: sqlite3.Connection, key: str) -> datetime | None:
+    try:
+        row = conn.execute(
+            f"SELECT value FROM {_STATE_TABLE} WHERE key = ?", (key,)
+        ).fetchone()
+    except sqlite3.Error:   # table absent until the first write — that's fine
+        return None
+    return _parse_ts(row[0] if row else None)
+
+
+def _write_state_ts(conn: sqlite3.Connection, key: str, now: datetime) -> None:
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {_STATE_TABLE} (key TEXT PRIMARY KEY, value TEXT)"
+    )
+    conn.execute(
+        f"INSERT INTO {_STATE_TABLE} (key, value) VALUES (?, ?) "
+        "ON CONFLICT(key) DO UPDATE SET value = excluded.value",
+        (key, now.isoformat()),
+    )
+
+
+def record_skill_run(conn: sqlite3.Connection, *, now: datetime | None = None) -> None:
+    """Record a conscious ``clawjournal skill`` run as nudge-anchor activity.
+
+    A run that ends rule-less (empty distill, gate block) never touches
+    ``skill_rules``, so without this the anchor would stay stale and the nudge
+    would re-nag every cooldown about a pipeline the user just tried.
+    """
+    _write_state_ts(conn, _LAST_RUN_KEY, now or datetime.now(timezone.utc))
+    conn.commit()
+
+
+def nudge_hook_requested(conn: sqlite3.Connection) -> bool:
+    """True when the user explicitly enabled the nudge via ``--install-nudge``."""
+    return _read_state_ts(conn, _HOOK_REQUESTED_KEY) is not None
+
+
+def nudge_hook_ownership(conn: sqlite3.Connection) -> bool | None:
+    """Read hook ownership strictly: ``None`` means the DB answer is unknown."""
+    try:
+        table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (_STATE_TABLE,),
+        ).fetchone()
+        if table is None:
+            return False
+        row = conn.execute(
+            f"SELECT value FROM {_STATE_TABLE} WHERE key = ?",
+            (_HOOK_REQUESTED_KEY,),
+        ).fetchone()
+        if row is None:
+            return False
+        return True if _parse_ts(row[0]) is not None else None
+    except sqlite3.Error:
+        return None
+
+
+def set_nudge_hook_requested(
+    conn: sqlite3.Connection, requested: bool, *, now: datetime | None = None
+) -> None:
+    """Durable marker that the user explicitly owns the SessionStart hook.
+
+    The hook file is shared with the auto-upload scheduler; this flag is what
+    lets each feature's teardown know the other still needs it.
+    """
+    if requested:
+        _write_state_ts(conn, _HOOK_REQUESTED_KEY, now or datetime.now(timezone.utc))
+    else:
+        # An absent table means there is no marker to clear.  Every other
+        # SQLite failure is material: swallowing a failed DELETE would make the
+        # CLI claim the nudge was disabled while the durable opt-in remained.
+        table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = ?",
+            (_STATE_TABLE,),
+        ).fetchone()
+        if table is not None:
+            conn.execute(
+                f"DELETE FROM {_STATE_TABLE} WHERE key = ?", (_HOOK_REQUESTED_KEY,)
+            )
+    conn.commit()
+
+
+def _scope_and_exclusions(
+    conn: sqlite3.Connection,
+) -> tuple[list[str], list[str], str | None]:
+    """Read the exact confirmed scope without warnings or implicit migration.
+
+    The nudge must advertise activity the suggested ``clawjournal skill`` run
+    can actually see: mirroring ``cli_skill._config_sources`` /
+    ``_config_excluded_projects`` keeps the count from touting sessions the
+    corpus scope would then drop.  Unlike the interactive CLI, a SessionStart
+    hook must not call ``load_config``: its warning includes the config path and
+    becomes agent context on hosts that surface hook stderr.  Any unreadable or
+    unconfirmed scope therefore fails closed to no nudge.
+    """
+    try:
+        from ..config import CONFIG_FILE, DEFAULT_CONFIG, source_scope_sources
+
+        raw = json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+        if not isinstance(raw, dict):
+            return [], [], "scope-unavailable"
+        cfg = {**DEFAULT_CONFIG, **raw}
+    except (OSError, json.JSONDecodeError, TypeError, ValueError):
+        return [], [], "scope-unavailable"
+
+    if cfg.get("projects_confirmed") is not True:
+        return [], [], "scope-unconfirmed"
+    source = cfg.get("source")
+    excluded_config = cfg.get("excluded_projects", [])
+    if (
+        (source is not None and not isinstance(source, str))
+        or not isinstance(excluded_config, list)
+        or any(not isinstance(value, str) for value in excluded_config)
+    ):
+        return [], [], "scope-unavailable"
+
+    try:
+        scope = source_scope_sources(source)
+        sources = (
+            list(scope) if scope is not None else list(FAILURE_VALUE_SOURCE_SCOPE)
+        )
+        from ..workbench.index import get_effective_share_settings
+
+        excluded = list(
+            get_effective_share_settings(conn, cfg).get("excluded_projects") or []
+        )
+    except Exception:
+        return [], [], "scope-unavailable"
+    return sources, excluded, None
+
+
+def distill_due_on_connection(conn: sqlite3.Connection, now: datetime) -> DueStatus:
+    """Decide due-ness on an open index connection. Cheap reads only.
+
+    The anchor is the last skill activity — MAX over ``installed_at`` (real
+    install) and ``last_seen_at`` (a ``--preview`` run bumps it via
+    ``upsert_seen``) — so a user who consciously previewed recently is not
+    nagged again for a full cycle.
+    """
+    # The nudge is opt-in: the SessionStart hook file is shared with the
+    # auto-upload scheduler, so hook presence alone is not consent. Only an
+    # explicit `clawjournal skill --install-nudge` enables it, and
+    # `--uninstall-nudge` disables it even while the hook stays installed for
+    # uploads.
+    if not nudge_hook_requested(conn):
+        return DueStatus(False, "nudge-not-enabled")
+    # A rule-less run (empty distill / gate block) writes only the run marker;
+    # it still counts as conscious skill activity, including when it was the
+    # FIRST run and ``skill_rules`` has no row (or no table) yet.
+    last_run = _read_state_ts(conn, _LAST_RUN_KEY)
+    anchors = [last_run] if last_run is not None else []
+    try:
+        table = conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'skill_rules'"
+        ).fetchone()
+        if table is not None:
+            row = conn.execute(
+                "WITH timestamps(value) AS ("
+                "  SELECT installed_at FROM skill_rules WHERE installed_at IS NOT NULL "
+                "  UNION ALL "
+                "  SELECT last_seen_at FROM skill_rules WHERE last_seen_at IS NOT NULL"
+                "), latest(value) AS ("
+                "  SELECT value FROM timestamps WHERE julianday(value) IS NOT NULL "
+                "  ORDER BY julianday(value) DESC LIMIT 1"
+                ") "
+                "SELECT EXISTS("
+                "  SELECT 1 FROM timestamps WHERE julianday(value) IS NULL"
+                ") AS invalid, latest.value FROM (SELECT 1) LEFT JOIN latest ON 1 = 1"
+            ).fetchone()
+            if row[0]:
+                # A malformed timestamp might represent more recent activity.
+                # Never choose an older anchor and nudge early merely because
+                # corrupted state cannot be ordered.
+                return DueStatus(False, "skill-state-unavailable")
+            if row[1]:
+                parsed = _parse_ts(row[1])
+                if parsed is None:
+                    return DueStatus(False, "skill-state-unavailable")
+                anchors.append(parsed)
+    except sqlite3.Error:
+        return DueStatus(False, "skill-state-unavailable")
+    if not anchors:
+        return DueStatus(False, "never-distilled")
+    anchor = max(anchors)
+    days_since = max(0.0, (now - anchor).total_seconds() / 86400)
+    if days_since < NUDGE_MIN_DAYS:
+        return DueStatus(False, "fresh", days_since=days_since)
+
+    last_nudged = _read_state_ts(conn, _LAST_NUDGED_KEY)
+    if last_nudged is not None and (
+        (now - last_nudged).total_seconds() / 86400 < NUDGE_COOLDOWN_DAYS
+    ):
+        return DueStatus(False, "cooldown", days_since=days_since)
+
+    # Activity since the anchor, in the same source/project scope the suggested
+    # run would use. The SQL is a cheap narrowing pass (the GLOB drops obvious
+    # non-ISO strings like 'unknown' that compare greater than any anchor); the
+    # precise instant check happens on the parsed timestamp below, bounding both
+    # ends like select.py so malformed ISO-lookalikes ('9999-99-99garbage') and
+    # future-dated rows can never count as new activity forever.
+    sources, excluded, scope_error = _scope_and_exclusions(conn)
+    if scope_error is not None:
+        return DueStatus(False, scope_error, days_since=days_since)
+    placeholders = ",".join("?" for _ in sources)
+    # The FULL hold gate is expressible in SQL — `release_gate_blockers` decides
+    # purely on `effective_hold_state`, i.e. shareable states plus an embargo
+    # whose `embargo_until` has passed. Encoding it here means no held or
+    # actively-embargoed row consumes the scan budget at all (they used to, and
+    # 2000 of them starved six real sessions). `_release_blocked_ids` still runs
+    # on the survivors as the authoritative check.
+    hold_states = sorted(SHAREABLE_HOLD_STATES)
+    hold_placeholders = ",".join("?" for _ in hold_states)
+    hold_clause = (
+        f"AND (hold_state IN ({hold_placeholders}) OR hold_state IS NULL "
+        "OR (hold_state = 'embargoed' AND embargo_until IS NOT NULL "
+        "AND julianday(embargo_until) IS NOT NULL "
+        "AND julianday(embargo_until) <= julianday(?))) "
+    )
+    exclusion_clause = ""
+    exclusion_params: list[str] = []
+    if excluded:
+        ex_placeholders = ",".join("?" for _ in excluded)
+        exclusion_clause = (
+            f" AND project NOT IN ({ex_placeholders})"
+            f" AND (source || ':' || project) NOT IN ({ex_placeholders})"
+        )
+        exclusion_params = [*excluded, *excluded]
+    # Lexical time bounds are WIDENED by 2 days (> the ~14h max UTC-offset skew)
+    # exactly as select.py does: a raw string compare on mixed-offset timestamps
+    # would otherwise drop genuinely in-window rows (a -12:00 session read as
+    # out of range). The precise instant check happens on the parsed value.
+    lex_lo = (anchor - timedelta(days=2)).isoformat()
+    lex_hi = (now + timedelta(days=2)).isoformat()
+    sql = (
+        "SELECT session_id, project, source, start_time, "
+        "ai_failure_value_score, ai_outcome_badge "
+        "FROM sessions WHERE review_status != 'segmented' "
+        f"AND source IN ({placeholders}) "
+        f"{hold_clause}"
+        "AND start_time > ? AND start_time <= ? "
+        "AND start_time GLOB '[0-9][0-9][0-9][0-9]-[0-9][0-9]-[0-9][0-9]*' "
+        f"{exclusion_clause}"
+        f"ORDER BY start_time DESC LIMIT {_PAGE_SIZE} OFFSET ?"
+    )
+    base_params = [*sources, *hold_states, now.isoformat(), lex_lo, lex_hi,
+                   *exclusion_params]
+    # Page rather than cap: the filters SQL cannot express (precise timestamp
+    # parse and legacy claude: project forms) would otherwise
+    # run after a single LIMIT and let a pile of ineligible rows hide real
+    # activity behind the first page. The remaining work is bounded by
+    # _SCAN_BUDGET rows and stops as soon as the count settles every threshold.
+    kept: list[Any] = []
+    scanned = 0
+    budget_exhausted = False
+    while scanned < _SCAN_BUDGET and len(kept) < NUDGE_BURST_SESSIONS:
+        page = conn.execute(sql, [*base_params, scanned]).fetchall()
+        if not page:
+            break
+        scanned += len(page)
+        page_kept = []
+        for r in page:
+            parsed = _parse_start_time(r["start_time"])
+            if parsed is None or not (anchor < parsed <= now):
+                continue
+            if excluded and session_matches_excluded_projects(
+                    {"project": r["project"], "source": r["source"]}, excluded):
+                continue
+            page_kept.append(r)
+        # Hold-state gate: the nudge line reaches agent context (and so the
+        # model provider), so even aggregate counts must not derive from
+        # held/embargoed sessions — mirror the corpus egress gate rather than
+        # counting sessions selection could never use. Applied per page so an
+        # active embargo cannot occupy the budget either.
+        if page_kept:
+            blocked = _release_blocked_ids(
+                conn, [r["session_id"] for r in page_kept], now=now)
+            page_kept = [r for r in page_kept if r["session_id"] not in blocked]
+        kept.extend(page_kept)
+        if len(page) < _PAGE_SIZE:
+            break   # exhausted the matching rows
+    else:
+        budget_exhausted = scanned >= _SCAN_BUDGET
+    # The count is a FLOOR whenever scanning stopped early — either the budget
+    # ran out, or enough rows accumulated to settle every threshold (which can
+    # also happen on a short final page, so this must not be tied to the loop
+    # exit path).
+    saturated = budget_exhausted or len(kept) >= NUDGE_BURST_SESSIONS
+    if len(kept) > NUDGE_BURST_SESSIONS:
+        kept = kept[:NUDGE_BURST_SESSIONS]
+    new_sessions = len(kept)
+    if new_sessions < NUDGE_MIN_NEW_SESSIONS:
+        return DueStatus(False, "quiet", new_sessions=new_sessions, days_since=days_since)
+    failure_sessions = sum(
+        1 for r in kept
+        if (r["ai_failure_value_score"] is not None and r["ai_failure_value_score"] >= 3)
+        or (r["ai_outcome_badge"] or "") in ("failed", "abandoned")
+    )
+
+    if not (
+        failure_sessions >= NUDGE_FAILURE_SESSIONS
+        or new_sessions >= NUDGE_BURST_SESSIONS
+        or days_since >= NUDGE_STALE_DAYS
+    ):
+        return DueStatus(False, "waiting", new_sessions=new_sessions,
+                         failure_sessions=failure_sessions, days_since=days_since)
+
+    fail_part = (f", {failure_sessions} with failure evidence"
+                 if failure_sessions else "")
+    shown = f"{new_sessions}+" if saturated else str(new_sessions)
+    message = (
+        f"ClawJournal lessons refresher: {shown} new sessions since the "
+        f"last clawjournal-lessons refresh {int(days_since)}d ago{fail_part}. "
+        "Suggest running `clawjournal skill --preview` to refresh the skill "
+        "(the user reviews before install; nothing runs automatically)."
+    )
+    return DueStatus(True, "due", message=message, new_sessions=new_sessions,
+                     failure_sessions=failure_sessions, days_since=days_since)
+
+
+def emit_session_start_nudge(
+    client: str,
+    *,
+    now: datetime | None = None,
+    conn_factory: Callable[[], sqlite3.Connection | None] | None = None,
+    printer: Callable[[str], Any] = print,
+) -> bool:
+    """Print the one-line nudge when due; record it so repeats cool down.
+
+    Fail-open everywhere: a missing/busy DB, a locked write, or any parse error
+    must never delay or break an agent session start. The nudge is recorded
+    BEFORE printing so a write failure cannot spam a nudge every session.
+    """
+    del client   # same decision for every agent surface, kept for the hook seam
+    clock = now or datetime.now(timezone.utc)
+    try:
+        if conn_factory is None:
+            from ..auto_upload import _open_existing_hook_index
+            conn_factory = _open_existing_hook_index
+        conn = conn_factory()
+        if conn is None:
+            return False
+        try:
+            conn.execute("BEGIN IMMEDIATE")
+            status = distill_due_on_connection(conn, clock)
+            if status.due:
+                _write_state_ts(conn, _LAST_NUDGED_KEY, clock)
+                conn.commit()
+            else:
+                conn.rollback()
+        except sqlite3.Error:
+            conn.rollback()
+            return False
+        finally:
+            conn.close()
+    except Exception:
+        return False
+    if status.due:
+        printer(status.message)
+        return True
+    return False

--- a/tests/skill/test_due.py
+++ b/tests/skill/test_due.py
@@ -1,0 +1,816 @@
+"""Distill-due nudge (plan §16 CH-1): cheap, bounded, fail-open, never auto-runs."""
+
+import sqlite3
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from clawjournal.skill import store as _store
+from clawjournal.skill.due import (
+    NUDGE_BURST_SESSIONS,
+    distill_due_on_connection,
+    emit_session_start_nudge,
+)
+
+NOW = datetime(2026, 8, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _seed_skill_state(conn, *, installed_days_ago=15.0, last_seen_days_ago=None,
+                      nudge_enabled=True):
+    """Insert one skill_rules row anchoring the user's last skill activity."""
+    from clawjournal.config import load_config, save_config
+    from clawjournal.skill.due import set_nudge_hook_requested
+
+    cfg = load_config()
+    cfg["projects_confirmed"] = True
+    save_config(cfg)
+    if nudge_enabled:   # the nudge is opt-in via `skill --install-nudge`
+        set_nudge_hook_requested(conn, True, now=NOW - timedelta(days=30))
+    _store.ensure_table(conn)
+    installed = (NOW - timedelta(days=installed_days_ago)).isoformat()
+    seen = (NOW - timedelta(days=last_seen_days_ago)).isoformat() \
+        if last_seen_days_ago is not None else installed
+    conn.execute(
+        "INSERT INTO skill_rules (fingerprint, kind, guidance, state, "
+        "installed_at, last_seen_at) VALUES ('fp1', 'avoid', 'g', 'kept', ?, ?)",
+        (installed, seen),
+    )
+    conn.commit()
+
+
+def _seed_sessions(conn, ins, n, *, failures=0, days_ago=2.0):
+    start = (NOW - timedelta(days=days_ago)).isoformat()
+    for i in range(n):
+        ins(conn, f"s{i}", start_time=start,
+            fvs=4 if i < failures else None,
+            learning="x" if i < failures else None)
+
+
+def test_nudge_requires_explicit_opt_in(index_conn, ins):
+    # the SessionStart hook is shared with auto-upload, so hook presence is not
+    # consent: without --install-nudge the check is inert (Codex re-review)
+    _seed_skill_state(index_conn, installed_days_ago=15, nudge_enabled=False)
+    _seed_sessions(index_conn, ins, 6)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "nudge-not-enabled"
+
+
+def test_uninstall_nudge_silences_an_installed_hook(index_conn, ins):
+    # --uninstall-nudge may leave the shared hook installed for uploads; the
+    # nudge itself must still stop firing
+    from clawjournal.skill.due import set_nudge_hook_requested
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    _seed_sessions(index_conn, ins, 6)
+    assert distill_due_on_connection(index_conn, NOW).due
+    set_nudge_hook_requested(index_conn, False)
+    lines: list[str] = []
+    assert emit_session_start_nudge(
+        "claude", now=NOW, conn_factory=lambda: index_conn,
+        printer=lines.append) is False
+    assert lines == []
+
+
+def test_never_distilled_is_never_nudged(index_conn):
+    # opted in, but no skill_rules rows yet (never ran the pipeline)
+    from clawjournal.skill.due import set_nudge_hook_requested
+    set_nudge_hook_requested(index_conn, True, now=NOW)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "never-distilled"
+
+
+def test_fresh_install_not_due(index_conn, ins):
+    _seed_skill_state(index_conn, installed_days_ago=3)
+    _seed_sessions(index_conn, ins, 30)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "fresh"
+
+
+def test_preview_run_counts_as_activity(index_conn, ins):
+    # installed long ago but the user ran --preview 2d ago (last_seen bumped)
+    _seed_skill_state(index_conn, installed_days_ago=40, last_seen_days_ago=2)
+    _seed_sessions(index_conn, ins, 30)
+    assert not distill_due_on_connection(index_conn, NOW).due
+
+
+def test_skill_anchor_uses_latest_instant_across_mixed_offsets(index_conn, ins):
+    """A lexically newer timestamp can be an older actual instant."""
+    from clawjournal.config import load_config, save_config
+    from clawjournal.skill.due import set_nudge_hook_requested
+
+    cfg = load_config()
+    cfg["projects_confirmed"] = True
+    save_config(cfg)
+    set_nudge_hook_requested(index_conn, True, now=NOW - timedelta(days=30))
+    _store.ensure_table(index_conn)
+    actual_latest = (NOW - timedelta(days=6)).astimezone(
+        timezone(timedelta(hours=-12))
+    ).isoformat()
+    lexical_latest_but_actually_old = (NOW - timedelta(days=7)).astimezone(
+        timezone(timedelta(hours=14))
+    ).isoformat()
+    assert lexical_latest_but_actually_old > actual_latest
+    index_conn.executemany(
+        "INSERT INTO skill_rules (fingerprint, kind, guidance, state, "
+        "installed_at, last_seen_at) VALUES (?, 'avoid', 'g', 'kept', ?, ?)",
+        [
+            ("fp-latest", actual_latest, actual_latest),
+            ("fp-older", lexical_latest_but_actually_old,
+             lexical_latest_but_actually_old),
+        ],
+    )
+    index_conn.commit()
+    _seed_sessions(index_conn, ins, 6, failures=3)
+
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "fresh"
+    assert status.days_since == pytest.approx(6.0)
+
+
+def test_malformed_skill_anchor_fails_silent(index_conn):
+    from clawjournal.skill.due import set_nudge_hook_requested
+
+    set_nudge_hook_requested(index_conn, True, now=NOW - timedelta(days=30))
+    _store.ensure_table(index_conn)
+    index_conn.execute(
+        "INSERT INTO skill_rules (fingerprint, kind, guidance, state, "
+        "installed_at, last_seen_at) VALUES "
+        "('fp-bad', 'avoid', 'g', 'kept', 'not-a-time', NULL)"
+    )
+    index_conn.commit()
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "skill-state-unavailable"
+
+
+def test_stale_with_activity_is_due(index_conn, ins):
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    _seed_sessions(index_conn, ins, 6)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and status.new_sessions == 6
+    assert "clawjournal skill --preview" in status.message
+    assert "6 new sessions" in status.message
+
+
+def test_quiet_window_not_due(index_conn, ins):
+    _seed_skill_state(index_conn, installed_days_ago=20)
+    _seed_sessions(index_conn, ins, 3)   # below NUDGE_MIN_NEW_SESSIONS
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "quiet"
+
+
+def test_between_min_and_stale_needs_an_event(index_conn, ins):
+    # 8 days: staleness alone isn't enough — a failure event or a burst is needed
+    _seed_skill_state(index_conn, installed_days_ago=8)
+    _seed_sessions(index_conn, ins, 6)
+    assert distill_due_on_connection(index_conn, NOW).reason == "waiting"
+
+    # failure evidence crosses the event bar
+    for i in range(3):
+        index_conn.execute(
+            "UPDATE sessions SET ai_failure_value_score = 4, ai_learning_summary='x' "
+            "WHERE session_id = ?", (f"s{i}",))
+    index_conn.commit()
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and status.failure_sessions == 3
+    assert "failure evidence" in status.message
+
+
+def test_burst_of_sessions_is_an_event(index_conn, ins):
+    _seed_skill_state(index_conn, installed_days_ago=8)
+    _seed_sessions(index_conn, ins, NUDGE_BURST_SESSIONS)
+    assert distill_due_on_connection(index_conn, NOW).due
+
+
+def test_sessions_before_anchor_do_not_count(index_conn, ins):
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    _seed_sessions(index_conn, ins, 30, days_ago=20)   # all predate the install
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "quiet"
+
+
+def test_out_of_scope_sources_do_not_count(index_conn, ins):
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    start = (NOW - timedelta(days=2)).isoformat()
+    for i in range(10):
+        ins(index_conn, f"cur{i}", source="cursor", start_time=start)
+    assert distill_due_on_connection(index_conn, NOW).reason == "quiet"
+
+
+def test_emit_prints_once_then_cools_down(index_conn, ins):
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    _seed_sessions(index_conn, ins, 6)
+    lines: list[str] = []
+    emitted = emit_session_start_nudge(
+        "claude", now=NOW, conn_factory=lambda: index_conn, printer=lines.append)
+    assert emitted and len(lines) == 1
+    # the emit closed the connection; reopen for the second check
+    from clawjournal.workbench.index import open_index
+    conn2 = open_index()
+    try:
+        status = distill_due_on_connection(conn2, NOW + timedelta(hours=6))
+        assert not status.due and status.reason == "cooldown"
+    finally:
+        conn2.close()
+
+
+def test_emit_fails_open_without_db():
+    assert emit_session_start_nudge("claude", now=NOW, conn_factory=lambda: None) is False
+
+
+def test_emit_fails_open_on_factory_error():
+    def boom():
+        raise RuntimeError("no db")
+    assert emit_session_start_nudge("claude", now=NOW, conn_factory=boom) is False
+
+
+def test_not_due_prints_nothing(index_conn):
+    lines: list[str] = []
+    assert emit_session_start_nudge(
+        "claude", now=NOW, conn_factory=lambda: index_conn, printer=lines.append) is False
+    assert lines == []
+
+
+# --- hook lifecycle (decoupled from auto-upload enrollment) -------------------
+
+def test_install_nudge_command_sets_flag_and_installs(index_conn, monkeypatch, capsys):
+    from clawjournal.cli_skill import _run_nudge_hook_command
+    from clawjournal.skill.due import nudge_hook_requested
+    calls: list[str] = []
+    def install(agent):
+        calls.append(agent)
+        return [
+            {"agent": "claude", "changed": True, "path": "p1", "configured": True},
+            {"agent": "codex", "changed": False, "path": "p2", "configured": True},
+        ]
+
+    monkeypatch.setattr("clawjournal.auto_upload._snapshot_hook_files", lambda _targets: {})
+    monkeypatch.setattr("clawjournal.auto_upload.install_hooks", install)
+    _run_nudge_hook_command(install=True)
+    assert calls == ["all"]
+    assert nudge_hook_requested(index_conn) is True
+    out = capsys.readouterr().out
+    assert "Nothing runs automatically" in out
+    assert "model provider" in out and "failure-evidence counts" in out
+
+
+def test_install_nudge_rolls_back_marker_when_hook_install_fails(
+    index_conn, monkeypatch
+):
+    from clawjournal.cli_skill import _run_nudge_hook_command
+    from clawjournal.skill.due import nudge_hook_requested
+
+    monkeypatch.setattr("clawjournal.auto_upload._snapshot_hook_files", lambda _targets: {})
+    monkeypatch.setattr("clawjournal.auto_upload._restore_hook_files", lambda _snapshot: None)
+    monkeypatch.setattr(
+        "clawjournal.auto_upload.install_hooks",
+        lambda agent: (_ for _ in ()).throw(OSError("write denied")),
+    )
+    with pytest.raises(OSError, match="write denied"):
+        _run_nudge_hook_command(install=True)
+    assert nudge_hook_requested(index_conn) is False
+
+
+def test_failed_hook_refresh_preserves_preexisting_nudge_marker(
+    index_conn, monkeypatch
+):
+    from clawjournal.cli_skill import _run_nudge_hook_command
+    from clawjournal.skill.due import nudge_hook_requested, set_nudge_hook_requested
+
+    set_nudge_hook_requested(index_conn, True, now=NOW)
+    monkeypatch.setattr("clawjournal.auto_upload._snapshot_hook_files", lambda _targets: {})
+    monkeypatch.setattr("clawjournal.auto_upload._restore_hook_files", lambda _snapshot: None)
+    monkeypatch.setattr(
+        "clawjournal.auto_upload.install_hooks",
+        lambda agent: (_ for _ in ()).throw(OSError("write denied")),
+    )
+    with pytest.raises(OSError, match="write denied"):
+        _run_nudge_hook_command(install=True)
+    assert nudge_hook_requested(index_conn) is True
+
+
+def test_uninstall_nudge_keeps_only_hooks_uploads_own(index_conn, monkeypatch, capsys):
+    from clawjournal.cli_skill import _run_nudge_hook_command
+    from clawjournal.skill import due as due_mod
+    due_mod.set_nudge_hook_requested(index_conn, True, now=NOW)
+    removed: list[str] = []
+    monkeypatch.setattr("clawjournal.auto_upload._snapshot_hook_files", lambda _targets: {})
+    monkeypatch.setattr(
+        "clawjournal.auto_upload.install_hooks",
+        lambda agent: [{"agent": agent, "configured": True, "changed": False, "path": agent}],
+    )
+    monkeypatch.setattr("clawjournal.auto_upload.uninstall_agent_hook",
+                        lambda agent: removed.append(agent))
+    monkeypatch.setattr("clawjournal.auto_upload.get_auto_upload_enrollment",
+                        lambda conn: {"mode": "enabled", "hook_targets": ["claude"]})
+    _run_nudge_hook_command(install=False)
+    assert removed == ["codex"]
+    assert due_mod.nudge_hook_requested(index_conn) is False
+    out = capsys.readouterr().out
+    assert "kept claude" in out and "removed the shared hook for codex" in out
+
+
+def test_uninstall_nudge_removes_hook_when_uploads_do_not(index_conn, monkeypatch, capsys):
+    from clawjournal.cli_skill import _run_nudge_hook_command
+    removed: list[str] = []
+    monkeypatch.setattr("clawjournal.auto_upload._snapshot_hook_files", lambda _targets: {})
+    monkeypatch.setattr("clawjournal.auto_upload.uninstall_agent_hook",
+                        lambda agent: removed.append(agent))
+    monkeypatch.setattr("clawjournal.auto_upload.get_auto_upload_enrollment",
+                        lambda conn: None)
+    _run_nudge_hook_command(install=False)
+    assert removed == ["claude", "codex"]
+    assert "hook removed" in capsys.readouterr().out
+
+
+def test_reconcile_shared_hooks_respects_nudge_flag(index_conn, monkeypatch):
+    from clawjournal import auto_upload
+    from clawjournal.skill import due as due_mod
+    installed: list[str] = []
+    removed: list[str] = []
+    monkeypatch.setattr(
+        auto_upload, "install_hooks",
+        lambda agent: installed.append(agent) or [
+            {"configured": True, "agent": agent}
+        ],
+    )
+    monkeypatch.setattr(auto_upload, "uninstall_agent_hook", removed.append)
+
+    auto_upload._reconcile_shared_hooks(index_conn, upload_targets=[])
+    assert installed == [] and removed == ["claude", "codex"]
+
+    removed.clear()
+    due_mod.set_nudge_hook_requested(index_conn, True, now=NOW)
+    auto_upload._reconcile_shared_hooks(index_conn, upload_targets=[])
+    assert installed == ["all"] and removed == []
+
+
+def test_unknown_nudge_ownership_neither_creates_nor_removes_hooks(
+    index_conn, monkeypatch
+):
+    from clawjournal import auto_upload
+    installed: list[str] = []
+    removed: list[str] = []
+    monkeypatch.setattr(auto_upload, "install_hooks", lambda agent: installed.append(agent))
+    monkeypatch.setattr(auto_upload, "uninstall_agent_hook", removed.append)
+    monkeypatch.setattr(
+        "clawjournal.skill.due.nudge_hook_ownership", lambda conn: None
+    )
+    auto_upload._reconcile_shared_hooks(index_conn, upload_targets=[])
+    assert installed == [] and removed == []
+
+
+def test_unknown_upload_ownership_neither_creates_nor_removes_hooks(
+    index_conn, monkeypatch
+):
+    from clawjournal import auto_upload
+
+    installed: list[str] = []
+    removed: list[str] = []
+    monkeypatch.setattr(auto_upload, "install_hooks", lambda agent: installed.append(agent))
+    monkeypatch.setattr(auto_upload, "uninstall_agent_hook", removed.append)
+    monkeypatch.setattr(
+        auto_upload, "get_auto_upload_enrollment",
+        lambda conn: (_ for _ in ()).throw(sqlite3.OperationalError("busy")),
+    )
+    auto_upload._reconcile_shared_hooks(index_conn)
+    assert installed == [] and removed == []
+
+
+def test_pending_enable_intent_owns_exact_hook_targets():
+    from clawjournal.auto_upload import _enrollment_hook_targets
+
+    assert _enrollment_hook_targets({
+        "mode": "off",
+        "last_result_code": "enrollment_pending",
+        "hook_targets": ["claude"],
+    }) == {"claude"}
+
+
+@pytest.mark.parametrize(
+    "enrollment",
+    [
+        {"mode": "enabled", "hook_targets": []},
+        {"mode": "paused", "hook_targets": []},
+        {"mode": "off", "last_result_code": "enrollment_pending", "hook_targets": []},
+        {"mode": "future-mode", "hook_targets": ["claude"]},
+    ],
+)
+def test_corrupt_active_enrollment_ownership_preserves_without_creating(
+    index_conn, monkeypatch, enrollment
+):
+    from clawjournal import auto_upload
+
+    assert auto_upload._enrollment_hook_targets(enrollment) is None
+    installed: list[str] = []
+    removed: list[str] = []
+    monkeypatch.setattr(auto_upload, "get_auto_upload_enrollment", lambda conn: enrollment)
+    monkeypatch.setattr(auto_upload, "install_hooks", lambda agent: installed.append(agent))
+    monkeypatch.setattr(auto_upload, "uninstall_agent_hook", removed.append)
+    auto_upload._reconcile_shared_hooks(index_conn)
+    assert installed == [] and removed == []
+
+
+def test_malformed_nudge_marker_preserves_without_creating(index_conn, monkeypatch):
+    from clawjournal import auto_upload
+    from clawjournal.skill.due import (
+        nudge_hook_ownership,
+        nudge_hook_requested,
+        set_nudge_hook_requested,
+    )
+
+    set_nudge_hook_requested(index_conn, True, now=NOW)
+    index_conn.execute(
+        "UPDATE skill_nudge_state SET value = 'truncated' "
+        "WHERE key = 'nudge_hook_requested_at'"
+    )
+    index_conn.commit()
+    assert nudge_hook_requested(index_conn) is False
+    assert nudge_hook_ownership(index_conn) is None
+    installed: list[str] = []
+    removed: list[str] = []
+    monkeypatch.setattr(auto_upload, "install_hooks", lambda agent: installed.append(agent))
+    monkeypatch.setattr(auto_upload, "uninstall_agent_hook", removed.append)
+    auto_upload._reconcile_shared_hooks(index_conn, upload_targets=[])
+    assert installed == [] and removed == []
+
+
+def test_skill_rules_table_present_but_empty_is_never_distilled(index_conn):
+    from clawjournal.skill.due import set_nudge_hook_requested
+    set_nudge_hook_requested(index_conn, True, now=NOW)
+    _store.ensure_table(index_conn)   # table exists, no rows (e.g. everything rejected)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "never-distilled"
+
+
+def test_unparseable_start_time_never_counts_as_activity(index_conn, ins):
+    # 'unknown' compares lexicographically greater than any ISO anchor; select.py
+    # excludes such rows from the corpus and the nudge must not count them either
+    # (else it re-nudges forever about sessions the run can never use).
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    for i in range(6):
+        ins(index_conn, f"bad{i}", start_time="unknown")
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "quiet"
+
+
+def test_confirmed_source_scope_bounds_the_count(index_conn, ins):
+    # a user scoped to claude must not be nudged about codex-only activity the
+    # suggested `clawjournal skill` run would then exclude from selection
+    from clawjournal.config import load_config, save_config
+    cfg = load_config()
+    cfg["source"] = "claude"
+    save_config(cfg)
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    _seed_sessions(index_conn, ins, 6)   # default source=codex
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "quiet"
+
+
+def test_excluded_projects_do_not_count(index_conn, ins):
+    # config `--exclude proj` normalizes to claude:proj — same semantics as the
+    # select/export gates, so only the matching claude sessions stop counting
+    from clawjournal.config import load_config, save_config
+    cfg = load_config()
+    cfg["excluded_projects"] = ["proj"]
+    save_config(cfg)
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    start = (NOW - timedelta(days=2)).isoformat()
+    for i in range(6):
+        ins(index_conn, f"c{i}", source="claude", project="proj", start_time=start)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "quiet"
+
+
+def test_held_sessions_do_not_count(index_conn, ins):
+    # the nudge line reaches agent context, so even aggregate counts must honor
+    # the hold-state gate (Codex review, PR #181)
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    start = (NOW - timedelta(days=2)).isoformat()
+    for i in range(6):
+        ins(index_conn, f"h{i}", start_time=start, hold_state="pending_review")
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "quiet"
+
+
+def test_malformed_iso_lookalike_start_time_never_counts(index_conn, ins):
+    # '9999-99-99garbage' passes the GLOB prefix but must fail the precise
+    # parse; future-dated rows are bounded out too
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    for i in range(3):
+        ins(index_conn, f"m{i}", start_time="9999-99-99garbage")
+    for i in range(3):
+        ins(index_conn, f"f{i}", start_time="2027-01-01T00:00:00+00:00")
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "quiet"
+
+
+def test_held_rows_cannot_crowd_out_eligible_ones(index_conn, ins):
+    # the row cap is applied AFTER the cheap eligibility filters, so a pile of
+    # held sessions can no longer hide real activity (Codex re-review)
+    from clawjournal.skill.due import _PAGE_SIZE
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    start_old = (NOW - timedelta(days=5)).isoformat()
+    for i in range(_PAGE_SIZE * 3):
+        ins(index_conn, f"held{i}", start_time=start_old, hold_state="pending_review")
+    start_new = (NOW - timedelta(days=1)).isoformat()
+    for i in range(6):
+        ins(index_conn, f"ok{i}", start_time=start_new)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and status.new_sessions == 6
+
+
+def test_future_dated_rows_cannot_crowd_out_eligible_ones(index_conn, ins):
+    # both time bounds are applied before the cap, so a pile of future-dated
+    # rows can't consume it (Codex re-review round 2)
+    from clawjournal.skill.due import _PAGE_SIZE
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    future = (NOW + timedelta(days=400)).isoformat()
+    for i in range(_PAGE_SIZE * 3):
+        ins(index_conn, f"fut{i}", start_time=future)
+    start = (NOW - timedelta(days=1)).isoformat()
+    for i in range(6):
+        ins(index_conn, f"ok{i}", start_time=start)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and status.new_sessions == 6
+
+
+def test_excluded_project_rows_cannot_crowd_out_eligible_ones(index_conn, ins):
+    from clawjournal.config import load_config, save_config
+    from clawjournal.skill.due import _PAGE_SIZE
+    cfg = load_config()
+    cfg["excluded_projects"] = ["secret"]
+    save_config(cfg)
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    old = (NOW - timedelta(days=5)).isoformat()
+    for i in range(_PAGE_SIZE * 3):
+        ins(index_conn, f"ex{i}", source="claude", project="secret", start_time=old)
+    recent = (NOW - timedelta(days=1)).isoformat()
+    for i in range(6):
+        ins(index_conn, f"ok{i}", source="claude", project="fine", start_time=recent)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and status.new_sessions == 6
+
+
+def test_active_embargo_rows_cannot_crowd_out_eligible_ones(index_conn, ins):
+    # an ACTIVE embargo is only detectable via the release gate, i.e. after SQL;
+    # paging (not a single LIMIT) keeps such rows from consuming the budget
+    from clawjournal.skill.due import _PAGE_SIZE
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    recent = (NOW - timedelta(days=1)).isoformat()
+    future = (NOW + timedelta(days=30)).isoformat()
+    for i in range(_PAGE_SIZE * 3):
+        ins(index_conn, f"emb{i}", start_time=recent, hold_state="embargoed")
+    index_conn.execute("UPDATE sessions SET embargo_until = ?", (future,))
+    older = (NOW - timedelta(days=5)).isoformat()
+    for i in range(6):
+        ins(index_conn, f"ok{i}", start_time=older)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and status.new_sessions == 6
+
+
+def test_legacy_claude_exclusion_rows_cannot_crowd_out_eligible_ones(index_conn, ins):
+    # the legacy `claude:<long-path>` exclusion form is resolved in Python, so
+    # those rows also survive SQL and must not consume the budget either
+    from clawjournal.config import load_config, save_config
+    from clawjournal.skill.due import _PAGE_SIZE
+    cfg = load_config()
+    cfg["excluded_projects"] = ["claude:Users-kai-code-my-proj"]
+    save_config(cfg)
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    recent = (NOW - timedelta(days=1)).isoformat()
+    for i in range(_PAGE_SIZE * 3):
+        ins(index_conn, f"leg{i}", source="claude", project="claude:my-proj",
+            start_time=recent)
+    older = (NOW - timedelta(days=5)).isoformat()
+    for i in range(6):
+        ins(index_conn, f"ok{i}", source="claude", project="claude:other",
+            start_time=older)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and status.new_sessions == 6
+
+
+def test_expired_embargo_counts_again(index_conn, ins):
+    # an embargo that has lapsed is shareable again; the SQL prefilter must not
+    # hard-exclude it before the release gate can resolve that
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    start = (NOW - timedelta(days=2)).isoformat()
+    # The wall-clock representation sorts AFTER NOW even though the instant is
+    # four hours in the past. SQL must compare instants, not ISO text.
+    past = (NOW - timedelta(hours=4)).astimezone(
+        timezone(timedelta(hours=14))
+    ).isoformat()
+    for i in range(6):
+        ins(index_conn, f"emb{i}", start_time=start, hold_state="embargoed")
+    index_conn.execute("UPDATE sessions SET embargo_until = ?", (past,))
+    index_conn.commit()
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and status.new_sessions == 6
+
+
+def test_active_embargo_still_does_not_count(index_conn, ins):
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    start = (NOW - timedelta(days=2)).isoformat()
+    future = (NOW + timedelta(days=30)).isoformat()
+    for i in range(6):
+        ins(index_conn, f"emb{i}", start_time=start, hold_state="embargoed")
+    index_conn.execute("UPDATE sessions SET embargo_until = ?", (future,))
+    index_conn.commit()
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "quiet"
+
+
+def test_active_embargoes_do_not_consume_the_scan_budget(index_conn, ins):
+    # the full hold gate is expressed in SQL, so held rows are never scanned at
+    # all — 2000 of them used to starve the six real sessions behind them
+    from clawjournal.skill.due import _SCAN_BUDGET
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    recent = (NOW - timedelta(days=1)).isoformat()
+    # The wall-clock representation sorts BEFORE NOW even though the instant is
+    # four hours in the future. All active rows must be removed before LIMIT.
+    future = (NOW + timedelta(hours=4)).astimezone(
+        timezone(timedelta(hours=-12))
+    ).isoformat()
+    for i in range(_SCAN_BUDGET):
+        ins(index_conn, f"emb{i}", start_time=recent, hold_state="embargoed")
+    index_conn.execute("UPDATE sessions SET embargo_until = ?", (future,))
+    older = (NOW - timedelta(days=5)).isoformat()
+    for i in range(6):
+        ins(index_conn, f"ok{i}", start_time=older)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and status.new_sessions == 6
+
+
+def test_short_final_page_over_threshold_still_reports_a_floor(index_conn, ins):
+    # stopping early because the count settled every threshold makes it a floor,
+    # even when the last page was short (the flag must not key off the loop exit)
+    from clawjournal.skill.due import _PAGE_SIZE, NUDGE_BURST_SESSIONS
+    assert NUDGE_BURST_SESSIONS < 30 < _PAGE_SIZE
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    _seed_sessions(index_conn, ins, 30)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and status.new_sessions == NUDGE_BURST_SESSIONS
+    assert f"{NUDGE_BURST_SESSIONS}+" in status.message
+
+
+def test_far_offset_timestamps_are_not_excluded_lexically(index_conn, ins):
+    # a -12:00 session is in-window by instant but reads as out of range under a
+    # raw string compare; SQL bounds are widened and the parse decides
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    stamp = (NOW - timedelta(days=1)).astimezone(
+        timezone(timedelta(hours=-12))).isoformat()
+    for i in range(6):
+        ins(index_conn, f"tz{i}", start_time=stamp)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and status.new_sessions == 6
+
+
+def test_saturated_count_is_reported_as_a_floor(index_conn, ins):
+    from clawjournal.skill.due import _PAGE_SIZE
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    start = (NOW - timedelta(days=1)).isoformat()
+    for i in range(_PAGE_SIZE * 3):
+        ins(index_conn, f"s{i}", start_time=start)
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and "+" in status.message  # a floor, not a total
+
+
+def test_nudge_hook_requested_flag_round_trip(index_conn):
+    from clawjournal.skill.due import nudge_hook_requested, set_nudge_hook_requested
+    assert nudge_hook_requested(index_conn) is False   # table may not even exist
+    set_nudge_hook_requested(index_conn, True, now=NOW)
+    assert nudge_hook_requested(index_conn) is True
+    set_nudge_hook_requested(index_conn, False)
+    assert nudge_hook_requested(index_conn) is False
+
+
+def test_rule_less_run_still_cools_the_nudge(index_conn, ins):
+    # a gate-blocked / empty-distill run writes no skill_rules row; the run
+    # marker must still count as conscious activity so the user is not re-nagged
+    # every cooldown about a pipeline they just tried
+    from clawjournal.skill.due import record_skill_run
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    _seed_sessions(index_conn, ins, 6)
+    assert distill_due_on_connection(index_conn, NOW).due
+    record_skill_run(index_conn, now=NOW - timedelta(days=1))
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "fresh"
+
+
+def test_first_rule_less_run_is_a_valid_anchor(index_conn, ins):
+    """The first completed run may create no skill_rules table or rows."""
+    from clawjournal.config import load_config, save_config
+    from clawjournal.skill.due import record_skill_run, set_nudge_hook_requested
+
+    cfg = load_config()
+    cfg["projects_confirmed"] = True
+    save_config(cfg)
+    set_nudge_hook_requested(index_conn, True, now=NOW - timedelta(days=30))
+    record_skill_run(index_conn, now=NOW - timedelta(days=15))
+    _seed_sessions(index_conn, ins, 6)
+
+    status = distill_due_on_connection(index_conn, NOW)
+    assert status.due and status.new_sessions == 6
+
+
+def test_unconfirmed_projects_fail_closed_to_no_nudge(index_conn, ins):
+    from clawjournal.config import load_config, save_config
+
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    _seed_sessions(index_conn, ins, 6)
+    cfg = load_config()
+    cfg["projects_confirmed"] = False
+    save_config(cfg)
+
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "scope-unconfirmed"
+    assert status.new_sessions == 0
+
+
+def test_broken_config_is_silent_and_never_widens_scope(
+    index_conn, ins, tmp_config, capsys
+):
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    _seed_sessions(index_conn, ins, 6)
+    tmp_config.write_text("{broken", encoding="utf-8")
+
+    status = distill_due_on_connection(index_conn, NOW)
+    captured = capsys.readouterr()
+    assert not status.due and status.reason == "scope-unavailable"
+    assert status.new_sessions == 0
+    assert captured.out == "" and captured.err == ""
+
+
+def test_malformed_excluded_projects_never_widens_scope(index_conn, ins):
+    from clawjournal.config import load_config, save_config
+
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    _seed_sessions(index_conn, ins, 6)
+    cfg = load_config()
+    cfg["excluded_projects"] = "secret"  # type: ignore[typeddict-item]
+    save_config(cfg)
+
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "scope-unavailable"
+    assert status.new_sessions == 0
+
+
+def test_effective_policy_read_failure_never_widens_scope(
+    index_conn, ins, monkeypatch
+):
+    _seed_skill_state(index_conn, installed_days_ago=15)
+    _seed_sessions(index_conn, ins, 6)
+    monkeypatch.setattr(
+        "clawjournal.workbench.index.get_effective_share_settings",
+        lambda conn, cfg: (_ for _ in ()).throw(sqlite3.OperationalError("busy")),
+    )
+
+    status = distill_due_on_connection(index_conn, NOW)
+    assert not status.due and status.reason == "scope-unavailable"
+    assert status.new_sessions == 0
+
+
+def test_uninstall_delete_failure_is_not_reported_as_success(
+    index_conn, monkeypatch, capsys
+):
+    from clawjournal.cli_skill import _run_nudge_hook_command
+    from clawjournal.skill.due import nudge_hook_requested, set_nudge_hook_requested
+
+    set_nudge_hook_requested(index_conn, True, now=NOW)
+    index_conn.execute(
+        "CREATE TRIGGER reject_nudge_delete BEFORE DELETE ON skill_nudge_state "
+        "BEGIN SELECT RAISE(ABORT, 'delete denied'); END"
+    )
+    index_conn.commit()
+    removed: list[str] = []
+    monkeypatch.setattr("clawjournal.auto_upload._snapshot_hook_files", lambda _targets: {})
+    monkeypatch.setattr("clawjournal.auto_upload._restore_hook_files", lambda _snapshot: None)
+    monkeypatch.setattr(
+        "clawjournal.auto_upload.uninstall_agent_hook", removed.append
+    )
+
+    with pytest.raises(sqlite3.IntegrityError, match="delete denied"):
+        _run_nudge_hook_command(install=False)
+    assert nudge_hook_requested(index_conn) is True
+    assert removed == []
+    assert "Nudge disabled" not in capsys.readouterr().out
+
+
+def test_uninstall_preserves_hooks_when_upload_ownership_is_unknown(
+    index_conn, monkeypatch, capsys
+):
+    from clawjournal.cli_skill import _run_nudge_hook_command
+    from clawjournal.skill.due import set_nudge_hook_requested
+
+    set_nudge_hook_requested(index_conn, True, now=NOW)
+    removed: list[str] = []
+    monkeypatch.setattr("clawjournal.auto_upload._snapshot_hook_files", lambda _targets: {})
+    monkeypatch.setattr(
+        "clawjournal.auto_upload.uninstall_agent_hook", removed.append
+    )
+    monkeypatch.setattr(
+        "clawjournal.auto_upload.get_auto_upload_enrollment",
+        lambda conn: (_ for _ in ()).throw(sqlite3.OperationalError("busy")),
+    )
+
+    _run_nudge_hook_command(install=False)
+    assert removed == []
+    assert "preserved conservatively" in capsys.readouterr().out

--- a/tests/test_agent_hooks.py
+++ b/tests/test_agent_hooks.py
@@ -383,6 +383,63 @@ def test_module_entrypoint_is_quiet_and_inert_by_default(capsys):
     assert captured.err == ""
 
 
+def test_module_entrypoint_runs_injected_nudge_emitter(capsys):
+    # the lessons nudge is the one deliberate output path (plan §16 CH-1)
+    calls: list[str] = []
+
+    def emit(client: str) -> bool:
+        calls.append(client)
+        print("nudge-line")
+        return True
+
+    assert hooks.main(
+        ["run", "--client", "claude"],
+        due_check=hooks._runner_not_configured,
+        nudge_emitter=emit,
+    ) == 0
+    assert calls == ["claude"]
+    assert "nudge-line" in capsys.readouterr().out
+
+
+def test_module_entrypoint_survives_nudge_emitter_error(capsys):
+    def boom(_client: str) -> bool:
+        raise RuntimeError("nudge failed")
+
+    assert hooks.main(
+        ["run", "--client", "claude"],
+        due_check=hooks._runner_not_configured,
+        nudge_emitter=boom,
+    ) == 0
+    assert capsys.readouterr().out == ""
+
+
+def test_module_entrypoint_default_binding_reaches_the_real_nudge(
+    tmp_path, monkeypatch, capsys
+):
+    # the all-adapters-None branch is what every installed hook runs in
+    # production: it must bind the auto-upload adapters AND the lessons nudge.
+    # With no index DB both fail open and print nothing.
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+    calls: list[str] = []
+    monkeypatch.setattr(
+        "clawjournal.skill.due.emit_session_start_nudge",
+        lambda client: calls.append(client) or True,
+    )
+    assert hooks.main(["run", "--client", "claude"]) == 0
+    assert calls == ["claude"]
+    assert capsys.readouterr().out == ""
+
+
+def test_module_entrypoint_default_binding_fails_open_without_db(
+    tmp_path, monkeypatch, capsys
+):
+    # same production branch, real (unpatched) nudge: a missing index DB must
+    # stay silent and inert end to end.
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
+    assert hooks.main(["run", "--client", "codex"]) == 0
+    assert capsys.readouterr().out == ""
+
+
 def test_detached_process_options_do_not_inherit_stdio():
     posix = hooks.detached_process_kwargs(platform="posix")
     assert posix["start_new_session"] is True

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -4124,11 +4124,15 @@ def test_reauthorization_discards_same_enrollment_sealed_artifact_after_patch(
 
 
 @pytest.mark.parametrize("rotating_credentials", [False, True])
-@pytest.mark.parametrize("restore_fails", [False, True])
+@pytest.mark.parametrize(
+    ("restore_fails", "hook_fails"),
+    [(False, False), (True, False), (False, True)],
+)
 def test_pause_racing_successful_reauthorization_reconciles_hosted_revision(
     isolated_auto_upload,
     monkeypatch,
     restore_fails,
+    hook_fails,
     rotating_credentials,
 ):
     config = _save_scope_config(upload_token="fresh-one-shot")
@@ -4148,6 +4152,20 @@ def test_pause_racing_successful_reauthorization_reconciles_hosted_revision(
         stored_credentials["active_token_expires_at"] = "2020-01-01T00:00:00+00:00"
     write_credentials(stored_credentials)
     _patch_enable_dependencies(monkeypatch)
+    if hook_fails:
+        real_reconcile_hooks = auto._reconcile_shared_hooks
+
+        def fail_paused_reconcile(conn, **kwargs):
+            enrollment = get_auto_upload_enrollment(conn)
+            if (
+                enrollment is not None
+                and enrollment.get("mode") == "paused"
+                and enrollment.get("authorization_revision") == 2
+            ):
+                raise OSError("hook write failed")
+            return real_reconcile_hooks(conn, **kwargs)
+
+        monkeypatch.setattr(auto, "_reconcile_shared_hooks", fail_paused_reconcile)
 
     patch_succeeded = threading.Event()
     recovery_only_written = threading.Event()
@@ -4223,6 +4241,8 @@ def test_pause_racing_successful_reauthorization_reconciles_hosted_revision(
     assert len(enable_results) == 1
     if restore_fails:
         assert enable_results[0]["code"] == "credential_store_failed"
+    elif hook_fails:
+        assert enable_results[0]["code"] == "hook_update_failed"
     else:
         assert enable_results[0]["mode"] == "paused"
         assert enable_results[0]["generation"] == 4
@@ -4232,10 +4252,12 @@ def test_pause_racing_successful_reauthorization_reconciles_hosted_revision(
         enrollment = get_auto_upload_enrollment(conn)
         assert enrollment["mode"] == "paused"
         assert enrollment["health"] == (
-            "action_required" if restore_fails else "ready"
+            "action_required" if restore_fails or hook_fails else "ready"
         )
         assert enrollment["last_result_code"] == (
-            "credential_store_failed" if restore_fails else "paused"
+            "credential_store_failed" if restore_fails
+            else "hook_update_failed" if hook_fails
+            else "paused"
         )
         assert enrollment["authorization_revision"] == 2
         assert enrollment["recurring_authorization_version"] == AUTH_VERSION
@@ -4381,6 +4403,168 @@ def test_enable_rolls_back_hook_failure_before_server_or_credentials(
         assert enrollment["server_enrollment_id"] is None
     finally:
         conn.close()
+
+
+def _patch_in_memory_hook_state(monkeypatch, initial=()):
+    state = set(initial)
+
+    def snapshot(_targets):
+        return {"state": set(state)}
+
+    def restore(saved):
+        state.clear()
+        state.update(saved["state"])
+
+    def install_hooks(*, agent):
+        targets = ("claude", "codex") if agent == "all" else (agent,)
+        results = []
+        for target in targets:
+            changed = target not in state
+            state.add(target)
+            results.append({
+                "agent": target,
+                "configured": True,
+                "changed": changed,
+                "path": target,
+            })
+        return results
+
+    monkeypatch.setattr(auto, "_snapshot_hook_files", snapshot)
+    monkeypatch.setattr(auto, "_restore_hook_files", restore)
+    monkeypatch.setattr(auto, "install_hooks", install_hooks)
+    monkeypatch.setattr(auto, "uninstall_agent_hook", state.discard)
+    return state
+
+
+def test_nudge_install_during_enable_failure_survives_snapshot_restore(
+    isolated_auto_upload, monkeypatch
+):
+    """Hosted I/O is unlocked; failure restore rebuilds current nudge ownership."""
+    from clawjournal.cli_skill import _run_nudge_hook_command
+    from clawjournal.skill.due import nudge_hook_requested
+
+    _save_scope_config(upload_token="fresh-one-shot")
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    conn.close()
+    _patch_enable_dependencies(monkeypatch)
+    hook_state = _patch_in_memory_hook_state(monkeypatch)
+    create_started = threading.Event()
+    release_create = threading.Event()
+
+    def blocked_create(*_args, **_kwargs):
+        create_started.set()
+        assert release_create.wait(timeout=5)
+        raise auto.AutoUploadError("forced_enable_failure", "forced")
+
+    monkeypatch.setattr(auto, "create_enrollment", blocked_create)
+    profile_hash = _current_authorization_profile_hash()
+    enable_results: list[dict[str, Any]] = []
+    enable_errors: list[BaseException] = []
+    nudge_errors: list[BaseException] = []
+
+    def run_enable():
+        try:
+            enable_results.append(auto.enable(
+                agent="claude",
+                accepted_authorization_version=AUTH_VERSION,
+                accepted_retention_version=RETENTION_VERSION,
+                accepted_ownership_certification_version=OWNERSHIP_VERSION,
+                accepted_authorization_profile_hash=profile_hash,
+            ))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            enable_errors.append(exc)
+
+    def install_nudge():
+        try:
+            _run_nudge_hook_command(install=True)
+        except BaseException as exc:  # pragma: no cover - asserted below
+            nudge_errors.append(exc)
+
+    enable_thread = threading.Thread(target=run_enable)
+    enable_thread.start()
+    assert create_started.wait(timeout=5)
+
+    nudge_thread = threading.Thread(target=install_nudge)
+    nudge_thread.start()
+    nudge_thread.join(timeout=5)
+    assert not nudge_thread.is_alive(), "hosted I/O must not hold the control lock"
+    assert nudge_errors == []
+    assert hook_state == {"claude", "codex"}
+
+    release_create.set()
+    enable_thread.join(timeout=5)
+    assert not enable_thread.is_alive()
+    assert enable_errors == []
+    assert enable_results[0]["code"] == "forced_enable_failure"
+    assert hook_state == {"claude", "codex"}
+    conn = open_index()
+    try:
+        assert nudge_hook_requested(conn) is True
+    finally:
+        conn.close()
+
+
+def test_nudge_uninstall_during_pending_enable_keeps_exact_upload_hook(
+    isolated_auto_upload, monkeypatch
+):
+    from clawjournal.cli_skill import _run_nudge_hook_command
+    from clawjournal.skill.due import nudge_hook_requested, set_nudge_hook_requested
+
+    _save_scope_config(upload_token="fresh-one-shot")
+    conn = open_index()
+    _seed_released_session(conn, isolated_auto_upload["root"])
+    set_nudge_hook_requested(conn, True)
+    conn.close()
+    _patch_enable_dependencies(monkeypatch)
+    hook_state = _patch_in_memory_hook_state(monkeypatch, ("claude", "codex"))
+    create_started = threading.Event()
+    release_create = threading.Event()
+
+    def blocked_create(*_args, **_kwargs):
+        create_started.set()
+        assert release_create.wait(timeout=5)
+        return _enrollment_response()
+
+    monkeypatch.setattr(auto, "create_enrollment", blocked_create)
+    profile_hash = _current_authorization_profile_hash()
+    enable_results: list[dict[str, Any]] = []
+    enable_errors: list[BaseException] = []
+
+    def run_enable():
+        try:
+            enable_results.append(auto.enable(
+                agent="claude",
+                accepted_authorization_version=AUTH_VERSION,
+                accepted_retention_version=RETENTION_VERSION,
+                accepted_ownership_certification_version=OWNERSHIP_VERSION,
+                accepted_authorization_profile_hash=profile_hash,
+            ))
+        except BaseException as exc:  # pragma: no cover - asserted below
+            enable_errors.append(exc)
+
+    enable_thread = threading.Thread(target=run_enable)
+    enable_thread.start()
+    assert create_started.wait(timeout=5)
+
+    _run_nudge_hook_command(install=False)
+    assert hook_state == {"claude"}
+    conn = open_index()
+    try:
+        enrollment = get_auto_upload_enrollment(conn)
+        assert enrollment["mode"] == "off"
+        assert enrollment["last_result_code"] == "enrollment_pending"
+        assert enrollment["hook_targets"] == ["claude"]
+        assert nudge_hook_requested(conn) is False
+    finally:
+        conn.close()
+
+    release_create.set()
+    enable_thread.join(timeout=5)
+    assert not enable_thread.is_alive()
+    assert enable_errors == []
+    assert enable_results[0]["ok"] is True
+    assert hook_state == {"claude"}
 
 
 def test_enable_revokes_server_enrollment_when_credential_commit_fails(
@@ -4863,6 +5047,10 @@ def test_stale_disable_cannot_erase_later_rollback_recovery_handoff(
     assert disable_in_hook_cleanup.wait(timeout=5)
 
     allow_create_response.set()
+    assert not rollback_revoke_failed.wait(timeout=0.2)
+    # Disable's marker read + hook cleanup is one local control phase. The
+    # enable failure cannot publish recovery state until that phase releases.
+    allow_disable_to_finish.set()
     assert rollback_revoke_failed.wait(timeout=5)
 
     deadline = time.monotonic() + 5
@@ -4881,16 +5069,13 @@ def test_stale_disable_cannot_erase_later_rollback_recovery_handoff(
     assert tombstone["active_token"] is None
     assert tombstone["recovery_token"] == "recovery-secret"
 
-    allow_disable_to_finish.set()
     enable_thread.join(timeout=5)
     disable_thread.join(timeout=5)
     assert not enable_thread.is_alive()
     assert not disable_thread.is_alive()
     assert thread_errors == []
     assert enable_results[0]["code"] == "control_changed"
-    assert disable_results[0]["generation"] == 3
-    assert disable_results[0]["overlay"] == "revocation_pending"
-    assert disable_results[0]["last_result"]["code"] == "revocation_pending"
+    assert disable_results[0]["mode"] == "off"
     assert load_credentials(required=True)["recovery_token"] == "recovery-secret"
 
     recovered = auto.disable()


### PR DESCRIPTION
## Summary

This extracts the opt-in SessionStart stale-lessons nudge from #181 so it can be reviewed and merged independently. PR #181 intentionally remains open.

- add explicit `skill --install-nudge` / `--uninstall-nudge` controls; the nudge remains off by default
- emit only bounded aggregate new-session and failure-evidence counts, with cooldowns and no automatic distillation or installation
- restrict counts to confirmed source/project scope and release-eligible sessions, failing closed when scope or ownership is unknown
- disclose in README and CLI help that emitted counts enter agent context and therefore reach the model provider
- reconcile the shared SessionStart hooks atomically with automatic-upload ownership, including pending enrollment, disable, rollback, and concurrent control changes

## Validation

- `python -m pytest tests/skill/test_due.py tests/test_agent_hooks.py -q` — 75 passed
- `python -m pytest tests/test_auto_upload.py -q` — 143 passed
- combined with the sibling objective branch — 857 passed, 2 skipped
- changed-file Ruff checks and `git diff --check`

No objective/MUST-COVER changes are included.