### PR TITLE
fix(parsing): understand Codex Desktop retry and fork rollout mechanics

### DIFF
--- a/clawjournal/benchmark/select.py
+++ b/clawjournal/benchmark/select.py
@@ -15,6 +15,7 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
+from ..session_titles import resolve_session_title
 from ..workbench.index import FAILURE_VALUE_SOURCE_SCOPE
 
 DEFAULT_WINDOW_DAYS = 7
@@ -92,7 +93,8 @@ def select_week_failures(
     sql = (
         "SELECT session_id, project, source, ai_failure_value_score, ai_failure_modes, "
         "ai_failure_attribution, ai_recovery_labels, ai_learning_summary, ai_score_reason, "
-        "ai_summary, COALESCE(ai_display_title, display_title) AS title, blob_path, start_time "
+        "ai_summary, ai_display_title, display_title, fork_of, fork_nickname, "
+        "blob_path, start_time "
         "FROM sessions WHERE start_time >= ? AND review_status != 'segmented' "
         "AND (ai_failure_value_score >= 3 OR (ai_failure_modes IS NOT NULL "
         "AND json_valid(ai_failure_modes) AND json_array_length(ai_failure_modes) > 0))"
@@ -124,7 +126,7 @@ def select_week_failures(
                 learning_summary=learning,
                 score_reason=reason,
                 summary=row["ai_summary"],
-                title=row["title"],
+                title=resolve_session_title(dict(row), fallback=row["session_id"]),
                 blob_path=row["blob_path"],
                 start_time=row["start_time"],
                 has_trace_evidence=has_evidence,

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -7235,6 +7235,7 @@ def _run_export(args) -> None:
     export_format = getattr(args, "format", "jsonl")
     if export_format in ("md", "md-summary"):
         from .export.markdown import render_session_markdown, render_session_summary
+        from .session_titles import resolve_session_title
 
         output_dir = args.output or Path("clawjournal_markdown_export")
         if output_dir.is_file():
@@ -7269,7 +7270,9 @@ def _run_export(args) -> None:
                 safe_id = re.sub(r"[^\w\-]", "_", safe_id)
                 md_path = output_dir / f"{safe_id}.md"
                 md_path.write_text(md_content)
-                title = session.get("display_title", safe_id)
+                title = resolve_session_title(
+                    session, prefer_ai=False, fallback=safe_id,
+                )
                 index_lines.append(f"- [{title}]({safe_id}.md)")
                 count += 1
 

--- a/clawjournal/export/markdown.py
+++ b/clawjournal/export/markdown.py
@@ -7,6 +7,7 @@ from datetime import datetime
 from typing import Any
 
 from ..pricing import estimate_cost, format_cost
+from ..session_titles import resolve_session_title
 
 
 def render_session_markdown(session: dict[str, Any]) -> str:
@@ -18,10 +19,9 @@ def render_session_markdown(session: dict[str, Any]) -> str:
     parts: list[str] = []
 
     # Header
-    title = (
-        session.get("ai_display_title")
-        or session.get("display_title")
-        or session.get("session_id", "Untitled Session")
+    title = resolve_session_title(
+        session,
+        fallback=str(session.get("session_id") or "Untitled Session"),
     )
     parts.append(f"# {title}\n")
 
@@ -189,10 +189,9 @@ def render_session_summary(session: dict[str, Any]) -> str:
     """
     parts: list[str] = []
 
-    title = (
-        session.get("ai_display_title")
-        or session.get("display_title")
-        or session.get("session_id", "Untitled Session")
+    title = resolve_session_title(
+        session,
+        fallback=str(session.get("session_id") or "Untitled Session"),
     )
     parts.append(f"# {title}\n")
 

--- a/clawjournal/findings.py
+++ b/clawjournal/findings.py
@@ -40,16 +40,10 @@ from typing import Any, TypedDict
 from .config import mark_auto_upload_profile_changed
 from .paths import ensure_hash_salt
 
-ENGINE_VERSION = 2  # round-4 bump: A2 added stripe_key, stripe_webhook_secret,
-                    # and bearer_generic patterns + tightened the JWT bearer
-                    # regex (`\b` prefix, case-insensitive keyword). Old
-                    # findings rows for sessions scanned with ENGINE_VERSION=1
-                    # missed these, so revision drift from this constant
-                    # forces a re-scan via `compute_findings_revision` next
-                    # time the session settles. `apply_findings_to_blob`
-                    # already re-scans live at share time, so the bump is
-                    # about the user-facing review UI showing accurate
-                    # findings counts on pre-A2 sessions.
+ENGINE_VERSION = 3  # Include fork_nickname in every session-level findings
+                    # scanner/apply path. Version 2 caches could not contain
+                    # findings from that metadata field, so force one rebuild
+                    # even when the transcript content itself is unchanged.
 SESSION_SETTLE_SECONDS = 120
 REVISION_FORMAT = "v1"
 
@@ -211,8 +205,9 @@ def compute_findings_revision(
 
     Inputs pinned per spec: ENGINE_VERSION, ENABLED_ENGINES,
     config.allowlist_entries (canonical JSON), display_title, project,
-    git_branch, then per-message role/content/thinking, then per-tool
-    tool/input/output. Any change flips the revision and forces rebuild.
+    git_branch, fork_nickname, then per-message role/content/thinking,
+    then per-tool tool/input/output. Any change flips the revision and
+    forces rebuild.
     """
     enabled = get_enabled_engines(config)
     parts: list[str] = [
@@ -222,6 +217,7 @@ def compute_findings_revision(
         f"display_title={session.get('display_title') or ''}",
         f"project={session.get('project') or ''}",
         f"git_branch={session.get('git_branch') or ''}",
+        f"fork_nickname={session.get('fork_nickname') or ''}",
     ]
     # Fold the scanner binary fingerprints into the revision so
     # installing a binary (or upgrading it) automatically invalidates
@@ -986,7 +982,7 @@ def apply_findings_to_session(
         return session, 0
 
     for meta_field in (
-        "project", "git_branch", "display_title",
+        "project", "git_branch", "display_title", "fork_nickname",
         "ai_learning_summary", "ai_score_reason", "ai_display_title",
         "ai_summary",
     ):

--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -3029,6 +3029,10 @@ class _CodexParseState:
     max_output_tokens: int = 0
     max_cached_tokens: int = 0
     tool_result_map: dict[str, dict] = dataclasses.field(default_factory=dict)
+    retry_candidate_index: int | None = None
+    retry_candidate_replaced: bool = False
+    last_user_input_hash: str | None = None
+    retry_candidate_input_hash: str | None = None
 
 
 def _coalesce_codex_output(raw: Any) -> str:
@@ -3183,6 +3187,7 @@ def _parse_codex_session_file(
             snapshot_out=parse_snapshot,
         ):
             before_messages = len(state.messages)
+            replaced_retry_user = False
             timestamp = _normalize_timestamp(entry.get("timestamp"))
             entry_type = entry.get("type")
 
@@ -3191,6 +3196,12 @@ def _parse_codex_session_file(
             elif entry_type == "turn_context":
                 _handle_codex_turn_context(state, entry, anonymizer)
             elif entry_type == "response_item":
+                response_payload = entry.get("payload", {})
+                response_type = response_payload.get("type")
+                if response_type in ("function_call", "custom_tool_call") or (
+                    response_type == "reasoning" and include_thinking
+                ):
+                    _clear_codex_retry_candidate(state)
                 _handle_codex_response_item(state, entry, anonymizer, include_thinking)
             elif entry_type == "event_msg":
                 payload = entry.get("payload", {})
@@ -3198,6 +3209,7 @@ def _parse_codex_session_file(
                 if event_type == "token_count":
                     _handle_codex_token_count(state, payload)
                 elif event_type == "agent_reasoning" and include_thinking:
+                    _clear_codex_retry_candidate(state)
                     thinking = payload.get("text")
                     if isinstance(thinking, str) and thinking.strip():
                         cleaned = anonymizer.text(thinking.strip())
@@ -3205,34 +3217,39 @@ def _parse_codex_session_file(
                             state._pending_thinking_seen.add(cleaned)
                             state.pending_thinking.append(cleaned)
                 elif event_type == "user_message":
-                    _handle_codex_user_message(state, payload, timestamp, anonymizer)
+                    replaced_retry_user = _replace_codex_retry_user_message(
+                        state, payload, timestamp, anonymizer
+                    )
+                    if not replaced_retry_user:
+                        _handle_codex_user_message(
+                            state, payload, timestamp, anonymizer
+                        )
                 elif event_type == "agent_message":
+                    _clear_codex_retry_candidate(state)
                     _handle_codex_agent_message(
                         state, payload, timestamp, anonymizer, include_thinking
                     )
                 elif event_type in ("turn_aborted", "task_complete"):
-                    # A turn that ends with no visible output at all — no
-                    # assistant message and no pending reasoning/tool calls —
-                    # re-logs the same user message on the next attempt
-                    # (stop/retry, model switch, rollback edit-and-resend), so
-                    # keeping the unanswered copy surfaces duplicates. Drop it
-                    # together with its parallel-array entries; a turn that
-                    # produced anything is left untouched.
+                    # Do not delete the prompt at the terminal event: the log
+                    # may end here, or the next prompt may be an unrelated new
+                    # turn.  A confirmed retry replaces this slot later so its
+                    # original raw start remains an append-only boundary.
+                    _mark_codex_retry_candidate(state, event_type, payload)
+                elif event_type == "thread_rolled_back":
+                    # A rollback is an explicit edit-and-resend signal.  The
+                    # next user message replaces the output-free candidate even
+                    # when its text was edited.
                     if (
-                        state.messages
-                        and state.messages[-1].get("role") == "user"
-                        and not state.pending_tool_uses
-                        and not state.pending_thinking
+                        state.retry_candidate_index is not None
+                        and _safe_int(payload.get("num_turns")) == 1
                     ):
-                        state.messages.pop()
-                        state.stats["user_messages"] -= 1
-                        if capture_raw_offsets:
-                            if raw_message_start_offsets:
-                                raw_message_start_offsets.pop()
-                            if raw_message_end_offsets:
-                                raw_message_end_offsets.pop()
-                            if raw_message_token_snapshots:
-                                raw_message_token_snapshots.pop()
+                        state.retry_candidate_replaced = True
+            if (
+                capture_raw_offsets
+                and replaced_retry_user
+                and raw_message_end_offsets
+            ):
+                raw_message_end_offsets[-1] = int(parse_snapshot["record_end"])
             if capture_raw_offsets and len(state.messages) > before_messages:
                 added_messages = len(state.messages) - before_messages
                 raw_message_start_offsets.extend(
@@ -3350,7 +3367,9 @@ def _handle_codex_session_meta(
                 state.metadata["fork_source"] = thread_source.strip()
             nickname = payload.get("agent_nickname")
             if isinstance(nickname, str) and nickname.strip():
-                state.metadata["fork_nickname"] = nickname.strip()
+                cleaned_nickname = anonymizer.text(nickname.strip())
+                cleaned_nickname, _, _ = redact_text(cleaned_nickname)
+                state.metadata["fork_nickname"] = cleaned_nickname
 
 
 def _handle_codex_turn_context(
@@ -3426,20 +3445,124 @@ def _handle_codex_token_count(state: _CodexParseState, payload: dict[str, Any]) 
             state.max_cached_tokens = max(state.max_cached_tokens, cached_tokens)
 
 
+def _codex_user_message_parts(
+    payload: dict[str, Any], anonymizer: Anonymizer,
+) -> tuple[str, str] | None:
+    content = payload.get("message")
+    if not isinstance(content, str) or not content.strip():
+        return None
+    raw_content = content.strip()
+    raw_identity = json.dumps(
+        {
+            "message": raw_content,
+            "images": payload.get("images") or [],
+            "local_images": payload.get("local_images") or [],
+            "text_elements": payload.get("text_elements") or [],
+        },
+        ensure_ascii=False,
+        sort_keys=True,
+        separators=(",", ":"),
+    )
+    input_hash = hashlib.sha256(raw_identity.encode("utf-8")).hexdigest()
+    return anonymizer.text(raw_content), input_hash
+
+
+def _clear_codex_retry_candidate(state: _CodexParseState) -> None:
+    state.retry_candidate_index = None
+    state.retry_candidate_replaced = False
+    state.retry_candidate_input_hash = None
+
+
+def _mark_codex_retry_candidate(
+    state: _CodexParseState, terminal: str, payload: dict[str, Any],
+) -> None:
+    """Remember an output-free turn without deleting its prompt yet."""
+    if (
+        not state.messages
+        or state.messages[-1].get("role") != "user"
+        or state.pending_tool_uses
+        or state.pending_thinking
+    ):
+        _clear_codex_retry_candidate(state)
+        return
+    last_agent_message = payload.get("last_agent_message")
+    if isinstance(last_agent_message, str) and last_agent_message.strip():
+        _clear_codex_retry_candidate(state)
+        return
+
+    candidate_index = len(state.messages) - 1
+    if state.retry_candidate_index != candidate_index:
+        state.retry_candidate_index = candidate_index
+        state.retry_candidate_replaced = False
+        state.retry_candidate_input_hash = state.last_user_input_hash
+    if terminal == "turn_aborted" and payload.get("reason") == "replaced":
+        state.retry_candidate_replaced = True
+
+
+def _replace_codex_retry_user_message(
+    state: _CodexParseState,
+    payload: dict[str, Any],
+    timestamp: str | None,
+    anonymizer: Anonymizer,
+) -> bool:
+    """Replace a confirmed retry in place, preserving its raw start boundary."""
+    candidate_index = state.retry_candidate_index
+    if candidate_index is None:
+        return False
+    replacement_parts = _codex_user_message_parts(payload, anonymizer)
+    if replacement_parts is None:
+        return False
+    replacement, replacement_hash = replacement_parts
+    if (
+        candidate_index != len(state.messages) - 1
+        or state.messages[candidate_index].get("role") != "user"
+    ):
+        _clear_codex_retry_candidate(state)
+        return False
+
+    should_replace = (
+        state.retry_candidate_replaced
+        or state.retry_candidate_input_hash == replacement_hash
+    )
+    _clear_codex_retry_candidate(state)
+    if not should_replace:
+        return False
+
+    # Mutating the existing slot keeps its first-attempt raw start offset.  A
+    # sealed segment immediately before this turn therefore keeps the exact
+    # same byte boundary as the rollout grows from user -> abort -> retry.
+    previous_timestamp = state.messages[candidate_index].get("timestamp")
+    state.messages[candidate_index]["content"] = replacement
+    if timestamp is not None:
+        state.messages[candidate_index]["timestamp"] = timestamp
+        if state.metadata.get("start_time") == previous_timestamp:
+            timestamps = [
+                message.get("timestamp")
+                for message in state.messages
+                if isinstance(message.get("timestamp"), str)
+            ]
+            state.metadata["start_time"] = min(timestamps, default=timestamp)
+    state.last_user_input_hash = replacement_hash
+    _update_time_bounds(state.metadata, timestamp)
+    return True
+
+
 def _handle_codex_user_message(
     state: _CodexParseState, payload: dict[str, Any],
     timestamp: str | None, anonymizer: Anonymizer,
 ) -> None:
     _flush_codex_pending(state, timestamp)
-    content = payload.get("message")
-    if isinstance(content, str) and content.strip():
+    message_parts = _codex_user_message_parts(payload, anonymizer)
+    if message_parts is not None:
+        content, input_hash = message_parts
         state.messages.append(
             {
                 "role": "user",
-                "content": anonymizer.text(content.strip()),
+                "content": content,
                 "timestamp": timestamp,
             }
         )
+        state.last_user_input_hash = input_hash
         state.stats["user_messages"] += 1
         _update_time_bounds(state.metadata, timestamp)
 

--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -2374,7 +2374,10 @@ def _make_session_result(
         "stats": stats,
     }
     # Pass through optional provenance fields from metadata
-    for key in ("entrypoint", "originator", "codex_source", "model_effort", "segment_title"):
+    for key in (
+        "entrypoint", "originator", "codex_source", "model_effort",
+        "segment_title", "fork_of", "fork_source", "fork_nickname",
+    ):
         val = metadata.get(key)
         if val is not None:
             result[key] = val
@@ -3207,6 +3210,29 @@ def _parse_codex_session_file(
                     _handle_codex_agent_message(
                         state, payload, timestamp, anonymizer, include_thinking
                     )
+                elif event_type in ("turn_aborted", "task_complete"):
+                    # A turn that ends with no visible output at all — no
+                    # assistant message and no pending reasoning/tool calls —
+                    # re-logs the same user message on the next attempt
+                    # (stop/retry, model switch, rollback edit-and-resend), so
+                    # keeping the unanswered copy surfaces duplicates. Drop it
+                    # together with its parallel-array entries; a turn that
+                    # produced anything is left untouched.
+                    if (
+                        state.messages
+                        and state.messages[-1].get("role") == "user"
+                        and not state.pending_tool_uses
+                        and not state.pending_thinking
+                    ):
+                        state.messages.pop()
+                        state.stats["user_messages"] -= 1
+                        if capture_raw_offsets:
+                            if raw_message_start_offsets:
+                                raw_message_start_offsets.pop()
+                            if raw_message_end_offsets:
+                                raw_message_end_offsets.pop()
+                            if raw_message_token_snapshots:
+                                raw_message_token_snapshots.pop()
             if capture_raw_offsets and len(state.messages) > before_messages:
                 added_messages = len(state.messages) - before_messages
                 raw_message_start_offsets.extend(
@@ -3312,6 +3338,19 @@ def _handle_codex_session_meta(
         codex_src = payload.get("source")
         if isinstance(codex_src, str):
             state.metadata["codex_source"] = codex_src
+    # Codex Desktop fork rollouts (retry branches, subagent threads) carry
+    # their lineage in the first session_meta; later metas are replayed
+    # parent records, so first-wins.
+    if state.metadata.get("fork_of") is None:
+        forked_from = payload.get("forked_from_id")
+        if isinstance(forked_from, str) and forked_from.strip():
+            state.metadata["fork_of"] = forked_from.strip()
+            thread_source = payload.get("thread_source")
+            if isinstance(thread_source, str) and thread_source.strip():
+                state.metadata["fork_source"] = thread_source.strip()
+            nickname = payload.get("agent_nickname")
+            if isinstance(nickname, str) and nickname.strip():
+                state.metadata["fork_nickname"] = nickname.strip()
 
 
 def _handle_codex_turn_context(

--- a/clawjournal/redaction/pii.py
+++ b/clawjournal/redaction/pii.py
@@ -407,6 +407,7 @@ def _iter_session_level_text_locations(session: dict[str, Any]) -> Iterable[tupl
         "project",
         "git_branch",
         "display_title",
+        "fork_nickname",
         "ai_learning_summary",
         "ai_score_reason",
         "ai_display_title",

--- a/clawjournal/redaction/secrets.py
+++ b/clawjournal/redaction/secrets.py
@@ -683,7 +683,7 @@ def _collect_all_text(session: dict) -> list[tuple[str, str, int | None, str | N
     """
     texts: list[tuple[str, str, int | None, str | None]] = []
 
-    for field in ("display_title", "project", "git_branch"):
+    for field in ("display_title", "project", "git_branch", "fork_nickname"):
         val = session.get(field)
         if val and isinstance(val, str):
             texts.append((val, field, None, None))
@@ -918,7 +918,7 @@ def redact_session(
         # Step 3: Apply typed redaction map across all fields
         pass_count = 0
 
-        for field in ("display_title", "project", "git_branch"):
+        for field in ("display_title", "project", "git_branch", "fork_nickname"):
             if session.get(field) and isinstance(session[field], str):
                 session[field], n = _apply_redaction_set(session[field], secret_map)
                 pass_count += n
@@ -965,15 +965,15 @@ def _iter_text_locations(
 
     Field-name convention matches `derive_preview`'s parser in
     findings.py: top-level fields use their own name (`display_title`,
-    `project`, `git_branch`); per-message string fields use `content`
-    or `thinking`; tool_use strings use `tool_uses[<idx>].<branch>` or
+    `project`, `git_branch`, `fork_nickname`); per-message string fields
+    use `content` or `thinking`; tool_use strings use `tool_uses[<idx>].<branch>` or
     `tool_uses[<idx>].<branch>.<key>` when nested under a dict.
     """
     # (text, field, message_index, tool_field)
     # parent_path / parent_key indicate how to write back; emitted as
     # (text, field, message_index, tool_field, "write_kind", "write_key")
     # where write_kind ∈ {"top", "msg", "tool_str", "tool_dict"}.
-    for field in ("display_title", "project", "git_branch"):
+    for field in ("display_title", "project", "git_branch", "fork_nickname"):
         val = session.get(field)
         if isinstance(val, str) and val:
             yield val, field, None, None, "top", field
@@ -1193,7 +1193,7 @@ def apply_findings_to_blob(
             break
 
         pass_count = 0
-        for field in ("display_title", "project", "git_branch"):
+        for field in ("display_title", "project", "git_branch", "fork_nickname"):
             val = blob.get(field)
             if isinstance(val, str) and val:
                 blob[field], n = _apply_redaction_set(val, secret_map)

--- a/clawjournal/redaction/trufflehog.py
+++ b/clawjournal/redaction/trufflehog.py
@@ -693,7 +693,9 @@ def _iter_session_text_fields(session: dict, *, include_widened: bool = False):
     widened values would push big sessions past the engine's size cap."""
     from ..parsing.widened import iter_widened_text_locations  # noqa: PLC0415 — lazy
 
-    for field_name in ("display_title", "project", "git_branch"):
+    for field_name in (
+        "display_title", "project", "git_branch", "fork_nickname",
+    ):
         val = session.get(field_name)
         if isinstance(val, str) and val:
             yield val, field_name, None, None
@@ -856,7 +858,9 @@ def apply_trufflehog_pass(
                 log.append(dict(entry))
         return out, local
 
-    for field_name in ("display_title", "project", "git_branch"):
+    for field_name in (
+        "display_title", "project", "git_branch", "fork_nickname",
+    ):
         val = session.get(field_name)
         if isinstance(val, str) and val:
             new_val, n = _replace_in_text(val, field_name=field_name, message_index=None)

--- a/clawjournal/session_titles.py
+++ b/clawjournal/session_titles.py
@@ -1,0 +1,63 @@
+"""Shared session-title resolution helpers.
+
+The workbench stores its heuristic ``display_title`` with a fork label so
+plain-title consumers (including FTS and the web UI) can distinguish Codex
+Desktop fork rollouts.  AI titles are kept as the scorer produced them, so
+consumers that prefer ``ai_display_title`` must add the same label at display
+time.  Keeping that rule here prevents the two title paths from drifting.
+"""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping
+from typing import Any
+
+from .redaction.secrets import redact_text
+
+_FORK_TITLE_SUFFIX_RE = re.compile(r"(?: · fork: [^\r\n]*)+$")
+
+
+def fork_title_suffix(session: Mapping[str, Any]) -> str:
+    """Return the stable display suffix for a fork, or ``""`` otherwise."""
+    if not session.get("fork_of"):
+        return ""
+
+    nickname = session.get("fork_nickname")
+    if isinstance(nickname, str) and nickname.strip():
+        label = " ".join(nickname.split())
+    else:
+        session_id = str(session.get("session_id") or "")
+        fork_id = session_id.split("_seg-", 1)[0]
+        label = fork_id[-4:] or "fork"
+    label, _, _ = redact_text(label)
+    return f" · fork: {label}"
+
+
+def append_fork_title_suffix(title: str, session: Mapping[str, Any]) -> str:
+    """Append the current fork label, replacing an older generated label."""
+    clean_title = title.strip()
+    suffix = fork_title_suffix(session)
+    if not clean_title or not suffix or clean_title.endswith(suffix):
+        return clean_title
+    base_title = _FORK_TITLE_SUFFIX_RE.sub("", clean_title).rstrip()
+    return f"{base_title}{suffix}" if base_title else suffix.strip()
+
+
+def resolve_session_title(
+    session: Mapping[str, Any],
+    *,
+    prefer_ai: bool = True,
+    fallback: str = "Untitled",
+) -> str:
+    """Choose the effective title and consistently label fork rollouts.
+
+    ``prefer_ai=False`` deliberately ignores ``ai_display_title`` for callers
+    whose contract is to show the ingest-derived title.
+    """
+    title = session.get("ai_display_title") if prefer_ai else None
+    if not isinstance(title, str) or not title.strip():
+        title = session.get("display_title")
+    if not isinstance(title, str) or not title.strip():
+        title = fallback
+    return append_fork_title_suffix(str(title), session)

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -32,6 +32,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from .config import load_config
+from .session_titles import append_fork_title_suffix, resolve_session_title
 from .scoring.backends import (
     default_model_for_backend,
     installed_fallback_chain,
@@ -137,10 +138,9 @@ def user_prompt_title(conn, row: dict) -> str | None:
 
 
 def resolve_title(r: dict, summarized: bool) -> str:
-    raw = (r.get("display_title") or "").strip().replace("\n", " ") or "Untitled"
-    if summarized:
-        return (r.get("ai_display_title") or "").strip() or raw
-    return raw
+    return resolve_session_title(
+        r, prefer_ai=summarized, fallback="Untitled"
+    ).replace("\n", " ")
 
 
 def trace_title(r: dict, width: int = 52) -> str:
@@ -578,7 +578,9 @@ def step_queue(conn, settings, args) -> list[dict]:
     for r in rows:
         title = resolve_title(r, do_summary)
         if not do_summary and _looks_like_system_prompt(title):
-            title = user_prompt_title(conn, r) or title
+            replacement = user_prompt_title(conn, r)
+            if replacement:
+                title = append_fork_title_suffix(replacement, r)
         r["_clawshare_title"] = title
 
     print(f"\n  {'#':>3}  {'Fail':>4} {'Last turn':<11} {'Source':<8} {'Msgs':>5} "

--- a/clawjournal/skill/select.py
+++ b/clawjournal/skill/select.py
@@ -23,6 +23,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any, Callable
 
 from ..benchmark.select import _parse_json_list
+from ..session_titles import resolve_session_title
 from ..workbench.index import (
     FAILURE_VALUE_SOURCE_SCOPE,
     release_gate_blockers,
@@ -236,7 +237,7 @@ def select_skill_candidates(
         "session_id, project, source, ai_failure_value_score, ai_quality_score, "
         "ai_failure_modes, ai_recovery_labels, ai_outcome_badge, "
         "ai_learning_summary, ai_score_reason, "
-        "COALESCE(ai_display_title, display_title) AS title, start_time"
+        "ai_display_title, display_title, fork_of, fork_nickname, start_time"
     )
     base = f"FROM sessions WHERE start_time >= ? AND review_status != 'segmented'{src_clause}"
 
@@ -326,7 +327,8 @@ def select_skill_candidates(
             resolution=row["ai_outcome_badge"], failure_value=row["ai_failure_value_score"],
             quality=row["ai_quality_score"], learning_summary=row["ai_learning_summary"],
             score_reason=row["ai_score_reason"],
-            title=row["title"], start_time=row["start_time"],
+            title=resolve_session_title(dict(row), fallback=row["session_id"]),
+            start_time=row["start_time"],
             support_count=support, impact=impact, recency=recency,
             rank_score=_candidate_rank(support=support, impact=impact, recency=recency,
                                        corrections=len(excerpts)),
@@ -368,7 +370,8 @@ def select_skill_candidates(
             resolution=row["ai_outcome_badge"], failure_value=row["ai_failure_value_score"],
             quality=row["ai_quality_score"], learning_summary=row["ai_learning_summary"],
             score_reason=row["ai_score_reason"],
-            title=row["title"], start_time=row["start_time"],
+            title=resolve_session_title(dict(row), fallback=row["session_id"]),
+            start_time=row["start_time"],
             support_count=support, impact=impact, recency=recency,
             rank_score=_candidate_rank(support=support, impact=impact, recency=recency,
                                        corrections=len(excerpts)),

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -33,6 +33,7 @@ from ..config import (
 )
 from ..paths import ensure_install_files
 from ..pricing import estimate_cost
+from ..session_titles import append_fork_title_suffix
 
 INDEX_DB = CONFIG_DIR / "index.db"
 BLOBS_DIR = CONFIG_DIR / "blobs"
@@ -2711,16 +2712,10 @@ def upsert_sessions(
             continue
 
         # A fork rollout replays its parent's opening message, so its derived
-        # title collides with the main thread's. Label it apart, preferring
-        # the nickname Codex Desktop assigns the fork; fall back to the fork
-        # file's own id tail, which is stable across rescans (a positional
-        # "fork N" would renumber whenever an older fork file is discovered).
-        fork_of = session.get("fork_of")
-        if fork_of:
-            fork_label = session.get("fork_nickname")
-            if not isinstance(fork_label, str) or not fork_label.strip():
-                fork_label = str(session_id).split("_seg-")[0][-4:]
-            display_title = f"{display_title} · fork: {fork_label.strip()}"
+        # title collides with the main thread's.  Store the labeled heuristic
+        # title for plain-title consumers (including FTS and the web UI); AI
+        # title consumers use the same idempotent helper at display time.
+        display_title = append_fork_title_suffix(display_title, session)
 
         # The sessions row is a plaintext surface — list views, search,
         # API responses all return `display_title` directly. Strip any

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -885,6 +885,13 @@ def open_index() -> sqlite3.Connection:
         # them the Token Usage chart under-counts Claude input by ~50x.
         ("cache_read_tokens", "INTEGER DEFAULT 0"),
         ("cache_creation_tokens", "INTEGER DEFAULT 0"),
+        # Codex Desktop fork lineage (retry branches / subagent threads).
+        # A fork rollout replays its parent's history, so without these the
+        # index shows several identically titled traces with no hint of
+        # which one is the main thread.
+        ("fork_of", "TEXT"),
+        ("fork_source", "TEXT"),
+        ("fork_nickname", "TEXT"),
     ]:
         try:
             conn.execute(f"ALTER TABLE sessions ADD COLUMN {col} {col_type}")
@@ -2703,6 +2710,18 @@ def upsert_sessions(
         if display_title.startswith("/") and " " not in display_title.strip():
             continue
 
+        # A fork rollout replays its parent's opening message, so its derived
+        # title collides with the main thread's. Label it apart, preferring
+        # the nickname Codex Desktop assigns the fork; fall back to the fork
+        # file's own id tail, which is stable across rescans (a positional
+        # "fork N" would renumber whenever an older fork file is discovered).
+        fork_of = session.get("fork_of")
+        if fork_of:
+            fork_label = session.get("fork_nickname")
+            if not isinstance(fork_label, str) or not fork_label.strip():
+                fork_label = str(session_id).split("_seg-")[0][-4:]
+            display_title = f"{display_title} · fork: {fork_label.strip()}"
+
         # The sessions row is a plaintext surface — list views, search,
         # API responses all return `display_title` directly. Strip any
         # regex_secrets match before persisting so the body of a prompt
@@ -2833,6 +2852,7 @@ def upsert_sessions(
                 segment_start_message, segment_end_message,
                 segment_reason, segment_sealed,
                 client_origin, runtime_channel, outer_session_id,
+                fork_of, fork_source, fork_nickname,
                 estimated_cost_usd,
                 tool_counts, user_interrupts,
                 hold_state, content_revision, revision_stable_since
@@ -2860,6 +2880,7 @@ def upsert_sessions(
                 ?, ?, ?,
                 ?, ?,
                 ?,
+                ?, ?, ?,
                 ?, ?, ?,
                 ?,
                 ?, ?,
@@ -2986,6 +3007,9 @@ def upsert_sessions(
                 client_origin = excluded.client_origin,
                 runtime_channel = excluded.runtime_channel,
                 outer_session_id = excluded.outer_session_id,
+                fork_of = excluded.fork_of,
+                fork_source = excluded.fork_source,
+                fork_nickname = excluded.fork_nickname,
                 estimated_cost_usd = excluded.estimated_cost_usd,
                 tool_counts = excluded.tool_counts,
                 user_interrupts = excluded.user_interrupts,
@@ -3046,6 +3070,9 @@ def upsert_sessions(
                 session.get("client_origin"),
                 session.get("runtime_channel"),
                 session.get("outer_session_id"),
+                session.get("fork_of"),
+                session.get("fork_source"),
+                session.get("fork_nickname"),
                 cost,
                 json.dumps(badges.get("tool_counts", {})) or None,
                 session_stats.get("user_interrupts", 0),

--- a/clawjournal/workbench/timeline.py
+++ b/clawjournal/workbench/timeline.py
@@ -14,6 +14,7 @@ from clawjournal.events.cost.schema import ensure_cost_schema
 from clawjournal.events.incidents.schema import ensure_incidents_schema
 from clawjournal.events.schema import ensure_schema as ensure_events_schema
 from clawjournal.events.view import canonical_events, capability_join, ensure_view_schema
+from clawjournal.session_titles import resolve_session_title
 
 _WHITESPACE_RE = re.compile(r"\s+")
 _SUMMARY_KEYS = (
@@ -130,12 +131,13 @@ def load_timeline_page(
 def render_timeline_html(page: TimelinePage) -> str:
     """Render a full standalone HTML page for a timeline request."""
     workbench = page.workbench_row or {}
+    fallback_title = str(
+        page.canonical_session_key or page.requested_session_key
+    )
     title = (
-        (page.root.title if page.root is not None else None)
-        or workbench.get("ai_display_title")
-        or workbench.get("display_title")
-        or page.canonical_session_key
-        or page.requested_session_key
+        page.root.title
+        if page.root is not None
+        else resolve_session_title(workbench, fallback=fallback_title)
     )
     body = (
         _render_timeline_page(page)
@@ -514,7 +516,7 @@ def _load_workbench_session(
         """
         SELECT session_id, session_key, project, source, model,
                start_time, end_time, display_title, ai_display_title,
-               raw_source_path
+               raw_source_path, fork_of, fork_nickname
           FROM sessions
          WHERE session_key = ?
          ORDER BY COALESCE(updated_at, indexed_at, start_time, '') DESC
@@ -823,13 +825,12 @@ def _session_title(
     workbench: dict[str, Any] | None, session_row: sqlite3.Row
 ) -> str:
     if workbench:
-        return (
-            workbench.get("ai_display_title")
-            or workbench.get("display_title")
-            or workbench.get("project")
+        fallback = str(
+            workbench.get("project")
             or workbench.get("session_key")
-            or str(session_row["session_key"])
+            or session_row["session_key"]
         )
+        return resolve_session_title(workbench, fallback=fallback)
     return str(session_row["session_key"])
 
 

--- a/tests/benchmark/test_select.py
+++ b/tests/benchmark/test_select.py
@@ -78,3 +78,22 @@ class TestSelection:
         by_id = {c.session_id: c for c in result.candidates}
         assert by_id["evidenced"].has_trace_evidence is True
         assert by_id["bare-score"].has_trace_evidence is False
+
+    def test_ai_title_keeps_fork_identity(self, index_conn):
+        _ins(index_conn, "fork-child-9976", fvs=4, learning="concrete lesson")
+        index_conn.execute(
+            "UPDATE sessions SET display_title = ?, ai_display_title = ?, "
+            "fork_of = ?, fork_nickname = ? WHERE session_id = ?",
+            (
+                "Raw title · fork: Kierkegaard",
+                "AI title",
+                "parent-thread-id",
+                "Kierkegaard",
+                "fork-child-9976",
+            ),
+        )
+        index_conn.commit()
+
+        result = select_week_failures(index_conn, now=NOW)
+
+        assert result.candidates[0].title == "AI title · fork: Kierkegaard"

--- a/tests/parsing/test_parser.py
+++ b/tests/parsing/test_parser.py
@@ -1265,6 +1265,221 @@ class TestDiscoverProjects:
         assert result["stats"]["output_tokens"] == 40
         assert result["stats"]["cache_read_tokens"] == 50
 
+    def _write_codex_rollout(self, tmp_path, events):
+        session_file = tmp_path / "rollout-aborted.jsonl"
+        lines = [
+            {
+                "timestamp": "2026-08-01T10:00:00.000Z",
+                "type": "session_meta",
+                "payload": {"id": "session-aborted", "cwd": "/repo"},
+            },
+            *events,
+        ]
+        session_file.write_text(
+            "\n".join(json.dumps(line) for line in lines) + "\n",
+            encoding="utf-8",
+        )
+        return session_file
+
+    @staticmethod
+    def _codex_event(event_type, **payload):
+        return {
+            "timestamp": "2026-08-01T10:00:01.000Z",
+            "type": "event_msg",
+            "payload": {"type": event_type, **payload},
+        }
+
+    def test_codex_turn_aborted_drops_unanswered_user_message(
+        self, tmp_path, mock_anonymizer
+    ):
+        """Retried turns re-log the same user message; aborted attempts with no
+        assistant output must not surface as duplicate messages."""
+        session_file = self._write_codex_rollout(tmp_path, [
+            self._codex_event("user_message", message="review the paper"),
+            self._codex_event("turn_aborted"),
+            self._codex_event("user_message", message="review the paper"),
+            self._codex_event("turn_aborted"),
+            self._codex_event("user_message", message="review the paper."),
+            self._codex_event("agent_message", message="Reviewing now."),
+        ])
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+            capture_raw_offsets=True,
+        )
+
+        assert result is not None
+        assert [(m["role"], m.get("content")) for m in result["messages"]] == [
+            ("user", "review the paper."),
+            ("assistant", "Reviewing now."),
+        ]
+        assert result["stats"]["user_messages"] == 1
+        assert result["stats"]["assistant_messages"] == 1
+        # The parallel raw-offset/token arrays must shrink with the dropped
+        # messages, or segmentation silently rejects the session later.
+        assert len(result["_raw_message_start_offsets"]) == 2
+        assert len(result["_raw_message_end_offsets"]) == 2
+        assert len(result["_raw_message_token_snapshots"]) == 2
+
+    def test_codex_turn_aborted_keeps_answered_user_message(
+        self, tmp_path, mock_anonymizer
+    ):
+        session_file = self._write_codex_rollout(tmp_path, [
+            self._codex_event("user_message", message="review the paper"),
+            self._codex_event("agent_message", message="Halfway done..."),
+            self._codex_event("turn_aborted"),
+        ])
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+        )
+
+        assert result is not None
+        assert [m["role"] for m in result["messages"]] == ["user", "assistant"]
+        assert result["stats"]["user_messages"] == 1
+
+    def test_codex_session_of_only_aborted_attempts_returns_none(
+        self, tmp_path, mock_anonymizer
+    ):
+        session_file = self._write_codex_rollout(tmp_path, [
+            self._codex_event("user_message", message="never answered"),
+            self._codex_event("turn_aborted"),
+        ])
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+        )
+
+        assert result is None
+
+    def test_codex_parser_captures_fork_provenance(self, tmp_path, mock_anonymizer):
+        session_file = tmp_path / "rollout-fork.jsonl"
+        lines = [
+            {
+                "timestamp": "2026-08-01T10:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "fork-child-id",
+                    "session_id": "parent-thread-id",
+                    "forked_from_id": "parent-thread-id",
+                    "parent_thread_id": "parent-thread-id",
+                    "thread_source": "subagent",
+                    "agent_nickname": "Kierkegaard",
+                    "cwd": "/repo",
+                },
+            },
+            self._codex_event("user_message", message="hello"),
+            self._codex_event("agent_message", message="hi"),
+        ]
+        session_file.write_text(
+            "\n".join(json.dumps(line) for line in lines) + "\n",
+            encoding="utf-8",
+        )
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+        )
+
+        assert result is not None
+        assert result["session_id"] == "fork-child-id"
+        assert result["fork_of"] == "parent-thread-id"
+        assert result["fork_source"] == "subagent"
+        assert result["fork_nickname"] == "Kierkegaard"
+
+    def test_codex_parser_plain_session_has_no_fork_fields(
+        self, tmp_path, mock_anonymizer
+    ):
+        session_file = self._write_codex_rollout(tmp_path, [
+            self._codex_event("user_message", message="hello"),
+            self._codex_event("agent_message", message="hi"),
+        ])
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+        )
+
+        assert result is not None
+        assert "fork_of" not in result
+        assert "fork_source" not in result
+        assert "fork_nickname" not in result
+
+    def test_codex_empty_completed_turn_drops_resent_user_message(
+        self, tmp_path, mock_anonymizer
+    ):
+        """Rollback / edit-and-resend re-logs the message after a task_complete
+        with no output at all; only the finally answered copy should remain."""
+        session_file = self._write_codex_rollout(tmp_path, [
+            self._codex_event("user_message", message="rename the aliases"),
+            self._codex_event("task_complete"),
+            self._codex_event("user_message", message="rename the aliases"),
+            self._codex_event("task_complete"),
+            self._codex_event("user_message", message="rename the aliases, please"),
+            self._codex_event("agent_message", message="Renaming."),
+            self._codex_event("task_complete"),
+        ])
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+        )
+
+        assert result is not None
+        assert [(m["role"], m.get("content")) for m in result["messages"]] == [
+            ("user", "rename the aliases, please"),
+            ("assistant", "Renaming."),
+        ]
+
+    def test_codex_turn_aborted_keeps_user_message_when_tools_ran(
+        self, tmp_path, mock_anonymizer
+    ):
+        """An abort after the model already did work (pending tool call, no
+        final message yet) must not delete the prompt that produced it."""
+        session_file = self._write_codex_rollout(tmp_path, [
+            self._codex_event("user_message", message="apply the patch"),
+            {
+                "timestamp": "2026-08-01T10:00:02.000Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "function_call",
+                    "name": "shell",
+                    "arguments": "{\"command\": [\"ls\"]}",
+                    "call_id": "call-1",
+                },
+            },
+            self._codex_event("turn_aborted"),
+            self._codex_event("user_message", message="continue"),
+            self._codex_event("agent_message", message="Done."),
+        ])
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+        )
+
+        assert result is not None
+        roles = [m["role"] for m in result["messages"]]
+        assert roles == ["user", "assistant", "user", "assistant"]
+        assert result["messages"][0]["content"] == "apply the patch"
+
     def test_claude_parser_captures_per_message_token_snapshots(
         self, tmp_path, mock_anonymizer
     ):

--- a/tests/parsing/test_parser.py
+++ b/tests/parsing/test_parser.py
@@ -1059,6 +1059,174 @@ class TestDiscoverProjects:
         assert second[0]["_raw_source_fingerprint"] == first_fingerprint
         assert [item["segment_sealed"] for item in second] == [True, True, False]
 
+    def test_codex_retry_keeps_sealed_segment_stable_across_appends(
+        self, tmp_path, monkeypatch, mock_anonymizer
+    ):
+        monkeypatch.setattr(
+            "clawjournal.parsing.parser.PROJECTS_DIR",
+            tmp_path / "projects" / "nonexistent",
+        )
+        monkeypatch.setattr("clawjournal.parsing.parser._CODEX_PROJECT_INDEX", {})
+        codex_sessions = tmp_path / "codex-sessions" / "2026" / "08" / "01"
+        codex_sessions.mkdir(parents=True)
+        session_file = codex_sessions / "rollout-retry-boundary.jsonl"
+        cwd = "/home/user/retry-repo"
+        lines = [
+            {
+                "timestamp": "2026-08-01T00:00:00Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "retry-boundary",
+                    "cwd": cwd,
+                    "model_provider": "openai",
+                },
+            },
+            {
+                "timestamp": "2026-08-01T00:00:01Z",
+                "type": "turn_context",
+                "payload": {"cwd": cwd, "model": "gpt-test"},
+            },
+        ]
+        for turn in range(20):
+            lines.extend([
+                {
+                    "timestamp": f"2026-08-01T00:{turn:02d}:02Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "user_message",
+                        "message": f"question {turn}",
+                    },
+                },
+                {
+                    "timestamp": f"2026-08-01T00:{turn:02d}:03Z",
+                    "type": "event_msg",
+                    "payload": {
+                        "type": "agent_message",
+                        "message": f"answer {turn}",
+                    },
+                },
+            ])
+        encoded_prefix = "".join(
+            json.dumps(line) + "\n" for line in lines
+        ).encode("utf-8")
+        open_user = {
+            "timestamp": "2026-08-01T00:20:02Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "retry me"},
+        }
+        session_file.write_bytes(
+            encoded_prefix + (json.dumps(open_user) + "\n").encode("utf-8")
+        )
+        monkeypatch.setattr(
+            "clawjournal.parsing.parser.CODEX_SESSIONS_DIR",
+            tmp_path / "codex-sessions",
+        )
+        monkeypatch.setattr(
+            "clawjournal.parsing.parser.CODEX_ARCHIVED_DIR",
+            tmp_path / "codex-archived",
+        )
+
+        def parse():
+            return parse_project_sessions(
+                cwd, mock_anonymizer, source="codex", strict_jsonl=True
+            )
+
+        def sealed_projection(session):
+            return {
+                key: session.get(key)
+                for key in (
+                    "messages",
+                    "stats",
+                    "start_time",
+                    "end_time",
+                    "raw_source_start_offset",
+                    "raw_source_end_offset",
+                    "_raw_source_fingerprint",
+                )
+            }
+
+        def append_events(*events):
+            with session_file.open("ab") as handle:
+                for event in events:
+                    handle.write((json.dumps(event) + "\n").encode("utf-8"))
+
+        first = parse()
+        assert [item["segment_sealed"] for item in first] == [True, False]
+        assert first[0]["raw_source_end_offset"] == len(encoded_prefix)
+        assert [message["content"] for message in first[1]["messages"]] == [
+            "retry me"
+        ]
+        sealed_before_retry = sealed_projection(first[0])
+
+        append_events(
+            {
+                "timestamp": "2026-08-01T00:20:03Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 120,
+                            "cached_input_tokens": 20,
+                            "output_tokens": 10,
+                        }
+                    },
+                },
+            },
+            {
+                "timestamp": "2026-08-01T00:20:04Z",
+                "type": "event_msg",
+                "payload": {"type": "turn_aborted", "reason": "interrupted"},
+            },
+        )
+        after_abort = parse()
+        assert sealed_projection(after_abort[0]) == sealed_before_retry
+        assert [message["content"] for message in after_abort[1]["messages"]] == [
+            "retry me"
+        ]
+
+        append_events({
+            "timestamp": "2026-08-01T00:20:05Z",
+            "type": "event_msg",
+            "payload": {"type": "user_message", "message": "retry me"},
+        })
+        after_retry = parse()
+        assert sealed_projection(after_retry[0]) == sealed_before_retry
+        assert [message["content"] for message in after_retry[1]["messages"]] == [
+            "retry me"
+        ]
+
+        append_events(
+            {
+                "timestamp": "2026-08-01T00:20:06Z",
+                "type": "event_msg",
+                "payload": {"type": "agent_message", "message": "done"},
+            },
+            {
+                "timestamp": "2026-08-01T00:20:07Z",
+                "type": "event_msg",
+                "payload": {
+                    "type": "token_count",
+                    "info": {
+                        "total_token_usage": {
+                            "input_tokens": 250,
+                            "cached_input_tokens": 50,
+                            "output_tokens": 40,
+                        }
+                    },
+                },
+            },
+        )
+        completed = parse()
+        assert sealed_projection(completed[0]) == sealed_before_retry
+        assert [message["role"] for message in completed[1]["messages"]] == [
+            "user",
+            "assistant",
+        ]
+        assert sum(item["stats"]["input_tokens"] for item in completed) == 200
+        assert sum(item["stats"]["cache_read_tokens"] for item in completed) == 50
+        assert sum(item["stats"]["output_tokens"] for item in completed) == 40
+
     def test_codex_thinking_not_duplicated(self, tmp_path, monkeypatch, mock_anonymizer):
         """Reasoning from response_item and agent_reasoning event_msg should not duplicate."""
         monkeypatch.setattr("clawjournal.parsing.parser.PROJECTS_DIR", tmp_path / "projects" / "nonexistent")
@@ -1282,25 +1450,66 @@ class TestDiscoverProjects:
         return session_file
 
     @staticmethod
-    def _codex_event(event_type, **payload):
+    def _codex_event(
+        event_type, timestamp="2026-08-01T10:00:01.000Z", **payload
+    ):
         return {
-            "timestamp": "2026-08-01T10:00:01.000Z",
+            "timestamp": timestamp,
             "type": "event_msg",
             "payload": {"type": event_type, **payload},
         }
 
-    def test_codex_turn_aborted_drops_unanswered_user_message(
+    def test_codex_turn_aborted_deduplicates_confirmed_retries(
         self, tmp_path, mock_anonymizer
     ):
-        """Retried turns re-log the same user message; aborted attempts with no
-        assistant output must not surface as duplicate messages."""
+        """Explicit replacements reuse one logical message and raw boundary."""
         session_file = self._write_codex_rollout(tmp_path, [
-            self._codex_event("user_message", message="review the paper"),
-            self._codex_event("turn_aborted"),
-            self._codex_event("user_message", message="review the paper"),
-            self._codex_event("turn_aborted"),
-            self._codex_event("user_message", message="review the paper."),
-            self._codex_event("agent_message", message="Reviewing now."),
+            self._codex_event(
+                "user_message",
+                timestamp="2026-08-01T10:00:01.000Z",
+                message="review the paper",
+            ),
+            self._codex_event(
+                "turn_aborted",
+                timestamp="2026-08-01T10:00:02.000Z",
+                reason="interrupted",
+            ),
+            {
+                "timestamp": "2026-08-01T10:00:02.500Z",
+                "type": "response_item",
+                "payload": {
+                    "type": "message",
+                    "role": "user",
+                    "content": [
+                        {"type": "input_text", "text": "review the paper"}
+                    ],
+                },
+            },
+            self._codex_event(
+                "user_message",
+                timestamp="2026-08-01T10:00:03.000Z",
+                message="review the paper",
+            ),
+            self._codex_event(
+                "turn_aborted",
+                timestamp="2026-08-01T10:00:04.000Z",
+                reason="interrupted",
+            ),
+            self._codex_event(
+                "thread_rolled_back",
+                timestamp="2026-08-01T10:00:04.500Z",
+                num_turns=1,
+            ),
+            self._codex_event(
+                "user_message",
+                timestamp="2026-08-01T10:00:05.000Z",
+                message="review the paper.",
+            ),
+            self._codex_event(
+                "agent_message",
+                timestamp="2026-08-01T10:00:06.000Z",
+                message="Reviewing now.",
+            ),
         ])
 
         result = _parse_codex_session_file(
@@ -1318,11 +1527,15 @@ class TestDiscoverProjects:
         ]
         assert result["stats"]["user_messages"] == 1
         assert result["stats"]["assistant_messages"] == 1
-        # The parallel raw-offset/token arrays must shrink with the dropped
-        # messages, or segmentation silently rejects the session later.
+        assert result["messages"][0]["timestamp"] == "2026-08-01T10:00:05.000Z"
+        assert result["start_time"] == result["messages"][0]["timestamp"]
+        assert result["end_time"] == result["messages"][1]["timestamp"]
+        # The parallel raw-offset/token arrays stay aligned while the retained
+        # slot keeps the first attempt's start boundary.
         assert len(result["_raw_message_start_offsets"]) == 2
         assert len(result["_raw_message_end_offsets"]) == 2
         assert len(result["_raw_message_token_snapshots"]) == 2
+        assert result["_raw_message_start_offsets"][0] < result["_raw_message_end_offsets"][0]
 
     def test_codex_turn_aborted_keeps_answered_user_message(
         self, tmp_path, mock_anonymizer
@@ -1344,12 +1557,40 @@ class TestDiscoverProjects:
         assert [m["role"] for m in result["messages"]] == ["user", "assistant"]
         assert result["stats"]["user_messages"] == 1
 
-    def test_codex_session_of_only_aborted_attempts_returns_none(
-        self, tmp_path, mock_anonymizer
+    @pytest.mark.parametrize("terminal", ["turn_aborted", "task_complete"])
+    def test_codex_output_free_terminal_at_eof_keeps_user_message(
+        self, tmp_path, mock_anonymizer, terminal
     ):
         session_file = self._write_codex_rollout(tmp_path, [
             self._codex_event("user_message", message="never answered"),
-            self._codex_event("turn_aborted"),
+            self._codex_event(terminal),
+        ])
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+            capture_raw_offsets=True,
+        )
+
+        assert result is not None
+        assert [(m["role"], m.get("content")) for m in result["messages"]] == [
+            ("user", "never answered"),
+        ]
+        assert result["stats"]["user_messages"] == 1
+        assert len(result["_raw_message_start_offsets"]) == 1
+        assert len(result["_raw_message_end_offsets"]) == 1
+        assert len(result["_raw_message_token_snapshots"]) == 1
+
+    def test_codex_abort_before_different_prompt_keeps_both(
+        self, tmp_path, mock_anonymizer
+    ):
+        session_file = self._write_codex_rollout(tmp_path, [
+            self._codex_event("user_message", message="review the paper"),
+            self._codex_event("turn_aborted", reason="interrupted"),
+            self._codex_event("user_message", message="write a release note"),
+            self._codex_event("agent_message", message="Writing it now."),
         ])
 
         result = _parse_codex_session_file(
@@ -1359,7 +1600,93 @@ class TestDiscoverProjects:
             target_cwd="/repo",
         )
 
-        assert result is None
+        assert result is not None
+        assert [(m["role"], m.get("content")) for m in result["messages"]] == [
+            ("user", "review the paper"),
+            ("user", "write a release note"),
+            ("assistant", "Writing it now."),
+        ]
+        assert result["stats"]["user_messages"] == 2
+
+    def test_codex_same_text_with_different_attachment_is_not_a_retry(
+        self, tmp_path, mock_anonymizer
+    ):
+        session_file = self._write_codex_rollout(tmp_path, [
+            self._codex_event(
+                "user_message", message="review this", local_images=["first.png"]
+            ),
+            self._codex_event("turn_aborted", reason="interrupted"),
+            self._codex_event(
+                "user_message", message="review this", local_images=["second.png"]
+            ),
+            self._codex_event("agent_message", message="Done."),
+        ])
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+        )
+
+        assert result is not None
+        assert [message.get("content") for message in result["messages"]] == [
+            "review this",
+            "review this",
+            "Done.",
+        ]
+
+    def test_codex_multi_turn_rollback_does_not_replace_one_candidate(
+        self, tmp_path, mock_anonymizer
+    ):
+        session_file = self._write_codex_rollout(tmp_path, [
+            self._codex_event("user_message", message="original prompt"),
+            self._codex_event("task_complete"),
+            self._codex_event("thread_rolled_back", num_turns=2),
+            self._codex_event("user_message", message="edited prompt"),
+            self._codex_event("agent_message", message="Done."),
+        ])
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+        )
+
+        assert result is not None
+        assert [message.get("content") for message in result["messages"]] == [
+            "original prompt",
+            "edited prompt",
+            "Done.",
+        ]
+
+    def test_codex_terminal_with_last_agent_message_clears_retry_candidate(
+        self, tmp_path, mock_anonymizer
+    ):
+        session_file = self._write_codex_rollout(tmp_path, [
+            self._codex_event("user_message", message="same prompt"),
+            self._codex_event("turn_aborted", reason="interrupted"),
+            self._codex_event(
+                "task_complete", last_agent_message="Completed out of band."
+            ),
+            self._codex_event("user_message", message="same prompt"),
+            self._codex_event("agent_message", message="Done."),
+        ])
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+        )
+
+        assert result is not None
+        assert [message.get("content") for message in result["messages"]] == [
+            "same prompt",
+            "same prompt",
+            "Done.",
+        ]
 
     def test_codex_parser_captures_fork_provenance(self, tmp_path, mock_anonymizer):
         session_file = tmp_path / "rollout-fork.jsonl"
@@ -1398,6 +1725,41 @@ class TestDiscoverProjects:
         assert result["fork_source"] == "subagent"
         assert result["fork_nickname"] == "Kierkegaard"
 
+    def test_codex_parser_redacts_secret_in_fork_nickname(
+        self, tmp_path, mock_anonymizer
+    ):
+        token = "ghp_" + "a" * 36
+        session_file = tmp_path / "rollout-fork-secret.jsonl"
+        lines = [
+            {
+                "timestamp": "2026-08-01T10:00:00.000Z",
+                "type": "session_meta",
+                "payload": {
+                    "id": "fork-child-secret",
+                    "forked_from_id": "parent-thread-id",
+                    "agent_nickname": token,
+                    "cwd": "/repo",
+                },
+            },
+            self._codex_event("user_message", message="hello"),
+            self._codex_event("agent_message", message="hi"),
+        ]
+        session_file.write_text(
+            "\n".join(json.dumps(line) for line in lines) + "\n",
+            encoding="utf-8",
+        )
+
+        result = _parse_codex_session_file(
+            session_file,
+            mock_anonymizer,
+            include_thinking=True,
+            target_cwd="/repo",
+        )
+
+        assert result is not None
+        assert token not in result["fork_nickname"]
+        assert result["fork_nickname"] == "[REDACTED_GITHUB_TOKEN]"
+
     def test_codex_parser_plain_session_has_no_fork_fields(
         self, tmp_path, mock_anonymizer
     ):
@@ -1428,6 +1790,7 @@ class TestDiscoverProjects:
             self._codex_event("task_complete"),
             self._codex_event("user_message", message="rename the aliases"),
             self._codex_event("task_complete"),
+            self._codex_event("thread_rolled_back", num_turns=1),
             self._codex_event("user_message", message="rename the aliases, please"),
             self._codex_event("agent_message", message="Renaming."),
             self._codex_event("task_complete"),

--- a/tests/redaction/test_pii.py
+++ b/tests/redaction/test_pii.py
@@ -25,6 +25,7 @@ from clawjournal.redaction.pii import (
     review_session_pii_with_agent,
     write_findings,
 )
+from clawjournal.session_titles import resolve_session_title
 
 
 def test_replacement_for_type_defaults():
@@ -129,6 +130,30 @@ def test_apply_findings_to_session_redacts_scoring_text():
     assert "Jane D" not in redacted["ai_learning_summary"]
     assert "Jane D" not in detail["reasoning"]
     assert "Jane D" not in detail["ai_failure_evidence"][0]
+
+
+def test_fork_nickname_pii_cannot_reappear_in_resolved_title():
+    email = "alice.private@example.com"
+    session = {
+        "session_id": "fork-child-9976",
+        "display_title": "Raw title",
+        "ai_display_title": "AI title",
+        "fork_of": "parent-thread-id",
+        "fork_nickname": email,
+        "messages": [],
+    }
+
+    findings = review_session_pii(session)
+    assert any(
+        finding["field"] == "fork_nickname"
+        and finding["entity_text"] == email
+        for finding in findings
+    )
+
+    redacted, count = apply_findings_to_session(session, findings)
+    assert count >= 1
+    assert redacted["fork_nickname"] != email
+    assert email not in resolve_session_title(redacted)
 
 
 def test_collect_text_work_items_includes_scoring_text():

--- a/tests/redaction/test_secrets_findings.py
+++ b/tests/redaction/test_secrets_findings.py
@@ -19,6 +19,7 @@ from clawjournal.redaction.secrets import (
     redact_session,
     scan_session_for_findings,
 )
+from clawjournal.session_titles import resolve_session_title
 from clawjournal.workbench.index import open_index, upsert_sessions
 
 
@@ -198,6 +199,37 @@ def _field_text(blob, finding):
 
 
 class TestApplyFindingsToBlob:
+    def test_fork_nickname_secret_cannot_reappear_in_resolved_title(self, conn):
+        session = _session_with_secrets()
+        session.update({
+            "ai_display_title": "AI title",
+            "display_title": "Raw title",
+            "fork_of": "parent-thread-id",
+            "fork_nickname": _FAKE_GITHUB,
+        })
+
+        legacy_blob, legacy_count, _ = redact_session(copy.deepcopy(session))
+        assert legacy_count >= 1
+        assert legacy_blob["fork_nickname"] != _FAKE_GITHUB
+        assert _FAKE_GITHUB not in resolve_session_title(legacy_blob)
+
+        _seed_session_row(conn)
+        raw = scan_session_for_findings(session)
+        assert any(
+            finding.field == "fork_nickname"
+            and finding.entity_text == _FAKE_GITHUB
+            for finding in raw
+        )
+        write_findings_to_db(conn, "sess-1", raw, revision="v1:fork-title")
+        conn.commit()
+
+        db_blob, db_count = apply_findings_to_blob(
+            copy.deepcopy(session), conn, "sess-1",
+        )
+        assert db_count >= 1
+        assert db_blob["fork_nickname"] != _FAKE_GITHUB
+        assert _FAKE_GITHUB not in resolve_session_title(db_blob)
+
     def test_byte_equivalent_to_redact_session_all_accept(self, conn):
         """When every finding is open/accepted, DB-backed apply matches legacy."""
         _seed_session_row(conn)

--- a/tests/skill/test_select.py
+++ b/tests/skill/test_select.py
@@ -26,6 +26,32 @@ def test_drops_unevidenced_failures(index_conn, ins):
     assert {c.session_id for c in corpus.failures} == {"evidenced"}
 
 
+def test_ai_title_keeps_fork_identity(index_conn, ins):
+    ins(
+        index_conn,
+        "fork-child-9976",
+        fvs=4,
+        modes='["verification_skipped"]',
+        learning="concrete lesson",
+    )
+    index_conn.execute(
+        "UPDATE sessions SET display_title = ?, ai_display_title = ?, "
+        "fork_of = ?, fork_nickname = ? WHERE session_id = ?",
+        (
+            "Raw title · fork: Kierkegaard",
+            "AI title",
+            "parent-thread-id",
+            "Kierkegaard",
+            "fork-child-9976",
+        ),
+    )
+    index_conn.commit()
+
+    corpus = select_skill_candidates(index_conn, now=NOW)
+
+    assert corpus.failures[0].title == "AI title · fork: Kierkegaard"
+
+
 def test_drops_low_impact_mode_only_failures(index_conn, ins):
     ins(index_conn, "low", fvs=1, modes='["verification_skipped"]',
         outcome="resolved", learning="minor wobble")

--- a/tests/test_export_markdown.py
+++ b/tests/test_export_markdown.py
@@ -2,7 +2,7 @@
 
 import json
 
-from clawjournal.export.markdown import render_session_summary
+from clawjournal.export.markdown import render_session_markdown, render_session_summary
 
 
 def _summary_session(**overrides):
@@ -47,3 +47,18 @@ def test_summary_omits_failure_analysis_without_failure_data():
     text = render_session_summary(_summary_session())
 
     assert "## Failure Analysis" not in text
+
+
+def test_markdown_renderers_label_ai_title_for_fork_once():
+    session = _summary_session(
+        session_id="fork-child-9976",
+        display_title="Raw title · fork: Kierkegaard",
+        ai_display_title="AI title",
+        fork_of="parent-thread-id",
+        fork_nickname="Kierkegaard",
+        messages=[],
+    )
+
+    for rendered in (render_session_markdown(session), render_session_summary(session)):
+        assert rendered.startswith("# AI title · fork: Kierkegaard\n")
+        assert rendered.count(" · fork: Kierkegaard") == 1

--- a/tests/test_findings_substrate.py
+++ b/tests/test_findings_substrate.py
@@ -157,6 +157,15 @@ class TestComputeFindingsRevision:
         rev2 = compute_findings_revision(self._session(project="p2"))
         assert rev1 != rev2
 
+    def test_fork_nickname_change_flips_revision(self):
+        rev1 = compute_findings_revision(
+            self._session(fork_nickname="Kierkegaard")
+        )
+        rev2 = compute_findings_revision(
+            self._session(fork_nickname="Nietzsche")
+        )
+        assert rev1 != rev2
+
     def test_betterleaks_fingerprint_participates(self, monkeypatch):
         # Installing/upgrading the betterleaks binary must invalidate
         # cached findings, same as the trufflehog fingerprint fold.

--- a/tests/test_session_titles.py
+++ b/tests/test_session_titles.py
@@ -1,0 +1,64 @@
+from clawjournal.session_titles import (
+    append_fork_title_suffix,
+    fork_title_suffix,
+    resolve_session_title,
+)
+
+
+def _fork(**overrides):
+    session = {
+        "session_id": "fork-child-9976_seg-0002",
+        "display_title": "Raw title",
+        "ai_display_title": "AI title",
+        "fork_of": "parent-thread-id",
+        "fork_nickname": "Kierkegaard",
+    }
+    session.update(overrides)
+    return session
+
+
+def test_resolve_prefers_ai_and_labels_fork():
+    assert resolve_session_title(_fork()) == "AI title · fork: Kierkegaard"
+
+
+def test_resolve_can_deliberately_use_ingest_title():
+    assert resolve_session_title(_fork(), prefer_ai=False) == (
+        "Raw title · fork: Kierkegaard"
+    )
+
+
+def test_fork_label_is_idempotent_for_predecorated_titles():
+    session = _fork(ai_display_title="AI title · fork: Kierkegaard")
+    resolved = resolve_session_title(session)
+    assert resolved == "AI title · fork: Kierkegaard"
+    assert resolved.count(" · fork:") == 1
+    assert append_fork_title_suffix(resolved, session) == resolved
+
+
+def test_new_nickname_replaces_an_older_fallback_suffix():
+    session = _fork(ai_display_title="AI title · fork: 9976")
+    resolved = resolve_session_title(session)
+    assert resolved == "AI title · fork: Kierkegaard"
+    assert resolved.count(" · fork:") == 1
+
+
+def test_fork_nickname_cannot_reintroduce_a_secret_into_resolved_title():
+    token = "ghp_" + "a" * 36
+    resolved = resolve_session_title(_fork(fork_nickname=token))
+    assert token not in resolved
+    assert "[REDACTED_GITHUB_TOKEN]" in resolved
+
+
+def test_fork_without_nickname_uses_unsegmented_session_id_tail():
+    session = _fork(fork_nickname=None)
+    assert fork_title_suffix(session) == " · fork: 9976"
+    assert resolve_session_title(session) == "AI title · fork: 9976"
+
+
+def test_nonfork_and_empty_title_fallback_are_unchanged():
+    assert resolve_session_title(
+        {"session_id": "main", "display_title": "Main title"}
+    ) == "Main title"
+    assert resolve_session_title(
+        _fork(display_title="", ai_display_title=""), fallback="Fallback"
+    ) == "Fallback · fork: Kierkegaard"

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -330,6 +330,23 @@ def test_resolve_title_modes():
     assert share_cli.resolve_title({"display_title": "x"}, True) == "x"  # falls back when no AI title
 
 
+def test_resolve_title_labels_raw_cached_ai_title_for_fork_once():
+    row = {
+        "session_id": "fork-child-9976",
+        "display_title": "raw first msg · fork: Kierkegaard",
+        "ai_display_title": "Cached AI title",
+        "fork_of": "parent-thread-id",
+        "fork_nickname": "Kierkegaard",
+    }
+
+    assert share_cli.resolve_title(row, summarized=False) == (
+        "raw first msg · fork: Kierkegaard"
+    )
+    assert share_cli.resolve_title(row, summarized=True) == (
+        "Cached AI title · fork: Kierkegaard"
+    )
+
+
 def test_looks_like_system_prompt():
     assert share_cli._looks_like_system_prompt("You are a strict evaluation judge")
     assert share_cli._looks_like_system_prompt("Your task is to ...")

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -114,6 +114,44 @@ class TestUpsertSessions:
         assert get_session_detail(index_conn, session_id)["messages"]
         assert not (tmp_path / "outside-the-blob-directory.json").exists()
 
+    def test_fork_provenance_stored_and_title_labeled(self, index_conn):
+        session = _make_session("fork-child-9976", source="codex")
+        session["fork_of"] = "parent-thread-id"
+        session["fork_source"] = "subagent"
+        session["fork_nickname"] = "Kierkegaard"
+
+        upsert_sessions(index_conn, [session])
+
+        row = index_conn.execute(
+            "SELECT fork_of, fork_source, fork_nickname, display_title "
+            "FROM sessions WHERE session_id = 'fork-child-9976'"
+        ).fetchone()
+        assert row["fork_of"] == "parent-thread-id"
+        assert row["fork_source"] == "subagent"
+        assert row["fork_nickname"] == "Kierkegaard"
+        assert row["display_title"].endswith("· fork: Kierkegaard")
+
+    def test_fork_without_nickname_falls_back_to_short_id(self, index_conn):
+        session = _make_session("fork-child-9976_seg-0002", source="codex")
+        session["fork_of"] = "parent-thread-id"
+
+        upsert_sessions(index_conn, [session])
+
+        row = index_conn.execute(
+            "SELECT display_title FROM sessions "
+            "WHERE session_id = 'fork-child-9976_seg-0002'"
+        ).fetchone()
+        # Label derives from the fork file's own id (stable), not the
+        # segment suffix and not a scan-order-dependent counter.
+        assert row["display_title"].endswith("· fork: 9976")
+
+    def test_non_fork_title_is_not_decorated(self, index_conn):
+        upsert_sessions(index_conn, [_make_session()])
+        row = index_conn.execute(
+            "SELECT display_title FROM sessions WHERE session_id = 'sess-1'"
+        ).fetchone()
+        assert "fork" not in row["display_title"]
+
     @pytest.mark.parametrize("status", ["approved", "blocked"])
     def test_upsert_preserves_review_status(self, index_conn, status):
         upsert_sessions(index_conn, [_make_session()])

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from clawjournal.session_titles import resolve_session_title
 from clawjournal.workbench.index import (
     _migrate_bundles_to_shares,
     add_policy,
@@ -151,6 +152,30 @@ class TestUpsertSessions:
             "SELECT display_title FROM sessions WHERE session_id = 'sess-1'"
         ).fetchone()
         assert "fork" not in row["display_title"]
+
+    def test_metadata_only_fork_reindex_keeps_effective_ai_title(self, index_conn):
+        session = _make_session("fork-child-9976", source="codex")
+        upsert_sessions(index_conn, [session])
+        update_session(
+            index_conn,
+            "fork-child-9976",
+            ai_display_title="AI title",
+        )
+
+        enriched = _make_session("fork-child-9976", source="codex")
+        enriched["fork_of"] = "parent-thread-id"
+        enriched["fork_nickname"] = "Kierkegaard"
+        upsert_sessions(index_conn, [enriched])
+
+        row = index_conn.execute(
+            "SELECT session_id, display_title, ai_display_title, "
+            "fork_of, fork_nickname FROM sessions "
+            "WHERE session_id = 'fork-child-9976'"
+        ).fetchone()
+        assert row["ai_display_title"] == "AI title"
+        assert resolve_session_title(dict(row)) == (
+            "AI title · fork: Kierkegaard"
+        )
 
     @pytest.mark.parametrize("status", ["approved", "blocked"])
     def test_upsert_preserves_review_status(self, index_conn, status):

--- a/tests/workbench/test_timeline_titles.py
+++ b/tests/workbench/test_timeline_titles.py
@@ -1,0 +1,40 @@
+from clawjournal.workbench.timeline import (
+    TimelinePage,
+    _session_title,
+    render_timeline_html,
+)
+
+
+def _fork_workbench_row():
+    return {
+        "session_id": "fork-child-9976",
+        "session_key": "codex:proj:fork-child-9976",
+        "project": "proj",
+        "display_title": "Raw title · fork: Kierkegaard",
+        "ai_display_title": "AI title",
+        "fork_of": "parent-thread-id",
+        "fork_nickname": "Kierkegaard",
+    }
+
+
+def test_session_title_labels_preferred_ai_title_for_fork():
+    title = _session_title(
+        _fork_workbench_row(),
+        {"session_key": "codex:proj:fork-child-9976"},
+    )
+
+    assert title == "AI title · fork: Kierkegaard"
+
+
+def test_pending_timeline_page_labels_preferred_ai_title_for_fork():
+    page = TimelinePage(
+        requested_session_key="codex:proj:fork-child-9976",
+        canonical_session_key="codex:proj:fork-child-9976",
+        redirect_session_key=None,
+        root=None,
+        workbench_row=_fork_workbench_row(),
+    )
+
+    rendered = render_timeline_html(page)
+
+    assert "<title>AI title · fork: Kierkegaard · Session Timeline</title>" in rendered


### PR DESCRIPTION
Two indexing defects from the same log format, both making one conversation surface as several confusingly identical entries:

- Aborted turn retries: stopping/retrying/switching model before any output re-logs the same user message, and rollback edit-and-resend does the same via an empty task_complete. Messages from turns that ended (turn_aborted / task_complete) with no assistant output and no pending reasoning or tool calls are now dropped, together with their raw-offset and token-snapshot entries so segmentation stays aligned. Turns that produced anything are untouched.

- Fork lineage: a fork rollout (retry branch or subagent thread) replays its parent's history, so its derived title collides with the main thread's. The parser now captures forked_from_id, thread_source and agent_nickname from the first session_meta; the index stores them (fork_of / fork_source / fork_nickname) and labels the display title "<title> - fork: <nickname>", falling back to the fork file's stable id tail rather than a scan-order-dependent number.