### PR TITLE
fix(workbench): show checkpoint families as one conversation

### DIFF
--- a/clawjournal/cli_security.py
+++ b/clawjournal/cli_security.py
@@ -33,7 +33,7 @@ from .workbench.index import (
     get_hold_history,
     open_index,
     read_blob,
-    set_hold_state,
+    set_logical_hold_state,
 )
 from .config import load_config
 
@@ -74,7 +74,7 @@ def run_hold(args) -> None:
     def body(conn: sqlite3.Connection) -> None:
         if _lookup_session(conn, args.session_id) is None:
             _fail("session not found", session_id=args.session_id)
-        set_hold_state(
+        set_logical_hold_state(
             conn, args.session_id, "pending_review",
             changed_by="user", reason=args.reason,
         )
@@ -86,7 +86,7 @@ def run_release(args) -> None:
     def body(conn: sqlite3.Connection) -> None:
         if _lookup_session(conn, args.session_id) is None:
             _fail("session not found", session_id=args.session_id)
-        set_hold_state(
+        set_logical_hold_state(
             conn, args.session_id, "released",
             changed_by="user", reason=args.reason,
         )
@@ -103,7 +103,7 @@ def run_embargo(args) -> None:
         if len(until) == 10 and until.count("-") == 2:
             until = f"{until}T00:00:00+00:00"
         try:
-            set_hold_state(
+            set_logical_hold_state(
                 conn, args.session_id, "embargoed",
                 changed_by="user", reason=args.reason, embargo_until=until,
             )

--- a/clawjournal/parsing/parser.py
+++ b/clawjournal/parsing/parser.py
@@ -1916,6 +1916,13 @@ def _finalize_append_only_segments(
 ) -> list[dict[str, Any]]:
     from .segmenter import segment_append_only_session
 
+    logical_session_id = str(session.get("session_id") or "")
+    existing_logical_id = session.get("logical_session_id")
+    if logical_session_id and (
+        not isinstance(existing_logical_id, str) or not existing_logical_id
+    ):
+        session["logical_session_id"] = logical_session_id
+
     full_fingerprint = session.get("_raw_source_fingerprint")
     offsets = session.pop("_raw_message_end_offsets", None)
     start_offsets = session.pop("_raw_message_start_offsets", None)

--- a/clawjournal/parsing/segmenter.py
+++ b/clawjournal/parsing/segmenter.py
@@ -23,6 +23,30 @@ APPEND_ONLY_MAX_TEXT_BYTES = 4 * 1024 * 1024
 APPEND_ONLY_MAX_RAW_BYTES = 8 * 1024 * 1024
 
 
+_INTERNAL_TITLE_WRAPPER_RE = re.compile(
+    r"\s*<(?P<tag>task-notification|command-message|command-name|command-args|"
+    r"local-command-caveat|local-command-stdout)\b[^>]*>"
+    r".*?</(?P=tag)>\s*",
+    re.DOTALL,
+)
+
+
+def strip_high_confidence_internal_wrappers(content: Any) -> str:
+    """Strip complete known harness wrappers from the start of *content*.
+
+    Keep this deliberately narrower than the heuristics used for scoring or
+    turn analysis. Wrappers embedded in ordinary prose are left untouched;
+    only a complete prefix block is display-only noise.
+    """
+
+    if not isinstance(content, str) or not content:
+        return ""
+    position = 0
+    while match := _INTERNAL_TITLE_WRAPPER_RE.match(content, position):
+        position = match.end()
+    return content[position:].strip() if position else content
+
+
 def _message_text_bytes(message: dict[str, Any]) -> int:
     total = 0
     stack: list[Any] = [message]
@@ -64,6 +88,15 @@ def segment_append_only_session(
     Snapshots that do not line up with the messages are ignored, leaving the
     children with the zeroed token counts they had before.
     """
+
+    root_session_id = str(session.get("session_id") or "")
+    existing_logical_id = session.get("logical_session_id")
+    if root_session_id and (
+        not isinstance(existing_logical_id, str) or not existing_logical_id
+    ):
+        # Checkpoints are transport/storage units of one logical conversation.
+        # Make that identity explicit even when the session stays unsegmented.
+        session["logical_session_id"] = root_session_id
 
     messages = session.get("messages", [])
     if not isinstance(messages, list) or not messages:
@@ -138,8 +171,7 @@ def segment_append_only_session(
     if len(starts) <= 1:
         return [session]
 
-    parent_id = str(session.get("session_id") or "")
-    if not parent_id:
+    if not root_session_id:
         return [session]
     closed_boundaries = set(boundaries)
     children: list[dict[str, Any]] = []
@@ -175,9 +207,9 @@ def segment_append_only_session(
             # hosted receiver sees a normal revision chain instead of a new,
             # overlapping trace. Later checkpoints are independent children.
             "session_id": (
-                parent_id
+                root_session_id
                 if segment_index == 0
-                else f"{parent_id}_seg-{segment_index:04d}"
+                else f"{root_session_id}_seg-{segment_index:04d}"
             ),
             "segment_index": segment_index,
             "segment_title": _extract_segment_title(segment_messages),
@@ -194,10 +226,6 @@ def segment_append_only_session(
             "messages": segment_messages,
             "stats": segment_stats,
         })
-        if segment_index == 0:
-            child.pop("parent_session_id", None)
-        else:
-            child["parent_session_id"] = parent_id
         children.append(child)
     return children
 
@@ -777,7 +805,11 @@ def _extract_segment_title(messages: list[dict]) -> str:
     """Generate a title from the first user message in the segment."""
     for msg in messages:
         if msg.get("role") == "user":
-            content = msg.get("content", "")
+            content = strip_high_confidence_internal_wrappers(
+                msg.get("content", "")
+            )
+            if not content:
+                continue
             # Strip common metadata prefixes (OpenClaw wraps user messages)
             text = _strip_openclaw_metadata(content)
             if text:

--- a/clawjournal/scoring/badges.py
+++ b/clawjournal/scoring/badges.py
@@ -3,6 +3,7 @@
 import re
 from collections.abc import Iterator
 
+from ..parsing.segmenter import strip_high_confidence_internal_wrappers
 from ..redaction.secrets import scan_text
 
 # ---------------------------------------------------------------------------
@@ -564,13 +565,7 @@ def compute_task_type(session: dict) -> str:
     return best_type
 
 
-_INTERNAL_TAG_RE = re.compile(
-    r"^\s*<(command-message|local-command-caveat|command-name|local-command-stdout)\b[^>]*>"
-    r".*?</\1>\s*$",
-    re.DOTALL,
-)
 _SKIP_PATTERNS = [
-    _INTERNAL_TAG_RE,
     re.compile(r"^\s*\[Request interrupted by user\]\s*$"),
     # Single-word terse commands (init, install, exit, help, etc.)
     re.compile(r"^\s*[a-z]{2,12}\s*$"),
@@ -580,7 +575,8 @@ _XML_TAG_RE = re.compile(r"<[^>]+>")
 
 def _is_skippable_message(text: str) -> bool:
     """Return True if *text* is an internal command or too terse to be a title."""
-    return any(p.match(text) for p in _SKIP_PATTERNS)
+    cleaned = strip_high_confidence_internal_wrappers(text)
+    return not cleaned or any(pattern.match(cleaned) for pattern in _SKIP_PATTERNS)
 
 
 def compute_display_title(session: dict) -> str:
@@ -590,9 +586,12 @@ def compute_display_title(session: dict) -> str:
     local-command wrappers, etc.) and strips XML/HTML tags from the result.
     Truncates to ~80 chars.
     """
-    # For segmented child traces, prefer the segment title (already cleaned)
-    seg_title = session.get("segment_title")
-    if seg_title:
+    # Prefer a real segment title, but tolerate blobs written by older parsers
+    # that selected an internal harness notification as the title.
+    seg_title = strip_high_confidence_internal_wrappers(
+        session.get("segment_title", "")
+    )
+    if seg_title and not _is_skippable_message(seg_title):
         if len(seg_title) > 80:
             return seg_title[:77] + "..."
         return seg_title
@@ -609,8 +608,9 @@ def compute_display_title(session: dict) -> str:
     # Find the first real user message (skip internal commands)
     text = ""
     for msg in user_msgs:
-        if not _is_skippable_message(msg):
-            text = msg.strip()
+        cleaned = strip_high_confidence_internal_wrappers(msg)
+        if not _is_skippable_message(cleaned):
+            text = cleaned.strip()
             break
 
     if not text:

--- a/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
+++ b/clawjournal/web/frontend/scripts/test-share-queue-state.mjs
@@ -123,9 +123,9 @@ assert.deepEqual(queueSelectionFromSearchParams(missingLockedParams, ids, storag
 
 const queueStep = await readFile(new URL('../src/views/Share/QueueStep.tsx', import.meta.url), 'utf8');
 assert.doesNotMatch(queueStep, /queueOrder\.includes\(/);
-assert.match(queueStep, /selectedIds\.has\(s\.session_id\)/);
-assert.match(queueStep, /p\.queuedSessions\.slice\(0, queueRenderLimit\)/);
-assert.match(queueStep, /filteredSessions\.slice\(0, pickerRenderLimit\)/);
+assert.match(queueStep, /selectedIds\.has\(session\.session_id\)/);
+assert.match(queueStep, /queuedGroups\.slice\(0, queueRenderLimit\)/);
+assert.match(queueStep, /filteredGroups\.slice\(0, pickerRenderLimit\)/);
 
 const redactStep = await readFile(new URL('../src/views/Share/RedactStep.tsx', import.meta.url), 'utf8');
 assert.match(redactStep, /p\.queuedSessions\.slice\(0, visibleCount\)/);

--- a/clawjournal/web/frontend/src/api.test.ts
+++ b/clawjournal/web/frontend/src/api.test.ts
@@ -252,3 +252,38 @@ describe('share scanner recovery API', () => {
     });
   });
 });
+
+describe('share creation API', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('sends both physical and logical revision preconditions', async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({ share_id: 'share-1' }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await api.shares.create(
+      ['trace', 'trace_seg-0001'],
+      'note',
+      undefined,
+      { trace: 'physical-0', 'trace_seg-0001': 'physical-1' },
+      { trace: 'logical-revision' },
+    );
+
+    expect(fetchMock).toHaveBeenCalledWith('/api/shares', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        session_ids: ['trace', 'trace_seg-0001'],
+        note: 'note',
+        attestation: undefined,
+        expected_revisions: { trace: 'physical-0', 'trace_seg-0001': 'physical-1' },
+        expected_logical_revisions: { trace: 'logical-revision' },
+      }),
+    });
+  });
+});

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -470,7 +470,7 @@ export const api = {
     return request('/projects');
   },
 
-  shareReady(opts?: { includeUnapproved?: boolean }): Promise<{ count: number; total_approved: number; projects: string[]; models: string[]; recommended_session_ids: string[]; sessions: Array<{ session_id: string; project: string; model: string | null; source: string; display_title: string; ai_quality_score: number | null; ai_failure_value_score: number | null; ai_recovery_labels: string[]; ai_failure_attribution: string | null; ai_failure_modes: string[]; ai_learning_summary: string | null; user_messages: number; assistant_messages: number; tool_uses: number; input_tokens: number; output_tokens: number; outcome_badge: string | null; client_origin: string | null; runtime_channel: string | null; start_time: string | null; review_status?: string; revision_hash?: string | null; last_shared_revision_hash?: string | null; updated_since_last_share?: boolean }> }> {
+  shareReady(opts?: { includeUnapproved?: boolean }): Promise<{ count: number; total_approved: number; logical_incomplete_excluded?: number; projects: string[]; models: string[]; recommended_session_ids: string[]; sessions: Array<{ session_id: string; logical_session_id?: string | null; logical_revision?: string | null; checkpoint_count?: number | null; checkpoint_session_ids?: string[]; checkpoint_revisions?: Record<string, string>; logical_incomplete?: boolean; segment_index?: number | null; segment_reason?: string | null; segment_sealed?: boolean; project: string; model: string | null; source: string; display_title: string; ai_quality_score: number | null; ai_failure_value_score: number | null; ai_recovery_labels: string[]; ai_failure_attribution: string | null; ai_failure_modes: string[]; ai_learning_summary: string | null; user_messages: number; assistant_messages: number; tool_uses: number; input_tokens: number; output_tokens: number; outcome_badge: string | null; client_origin: string | null; runtime_channel: string | null; start_time: string | null; review_status?: string; revision_hash?: string | null; last_shared_revision_hash?: string | null; updated_since_last_share?: boolean }> }> {
     const q = opts?.includeUnapproved ? '?include_unapproved=1' : '';
     return request(`/share-ready${q}`);
   },
@@ -595,6 +595,7 @@ export const api = {
       note?: string,
       attestation?: string,
       expectedRevisions?: Record<string, string>,
+      expectedLogicalRevisions?: Record<string, string>,
     ): Promise<{ share_id: string }> {
       return request('/shares', {
         method: 'POST',
@@ -604,6 +605,7 @@ export const api = {
           note,
           attestation,
           expected_revisions: expectedRevisions,
+          expected_logical_revisions: expectedLogicalRevisions,
         }),
       });
     },

--- a/clawjournal/web/frontend/src/components/SessionDrawer.tsx
+++ b/clawjournal/web/frontend/src/components/SessionDrawer.tsx
@@ -78,6 +78,7 @@ export function SessionDrawer({ sessionId, onClose }: SessionDrawerProps) {
               <div style={{ fontSize: 11, color: colors.gray500, marginTop: 2 }}>
                 {data.project} · {data.user_messages + data.assistant_messages} msgs
                 {data.tool_uses ? ` · ${data.tool_uses} tools` : ''}
+                {(data.checkpoint_count ?? 0) > 1 ? ` · ${data.checkpoint_count} upload checkpoints` : ''}
               </div>
             )}
           </div>
@@ -112,6 +113,18 @@ export function SessionDrawer({ sessionId, onClose }: SessionDrawerProps) {
               borderRadius: 6, fontSize: 13,
             }}>
               Failed to load: {error}
+            </div>
+          )}
+          {data?.logical_incomplete && (
+            <div
+              role="alert"
+              style={{
+                color: colors.red700, background: colors.red100,
+                border: `1px solid ${colors.red200}`, padding: 12,
+                borderRadius: 6, fontSize: 13, marginBottom: 12,
+              }}
+            >
+              This conversation has a missing or overlapping upload checkpoint. Run a successful scan before sharing it.
             </div>
           )}
           {data?.messages?.map((msg, i) => (

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -47,6 +47,19 @@ export interface Session {
   estimated_cost_usd: number | null;
   parent_session_id: string | null;
   subagent_session_ids: string | null;
+  /** Stable identity shared by append-only upload checkpoints. */
+  logical_session_id?: string | null;
+  /** Revision of the active checkpoint membership and ordering. */
+  logical_revision?: string | null;
+  /** Number of active upload checkpoints represented by this logical row. */
+  checkpoint_count?: number | null;
+  /** Physical checkpoint ids represented by this logical row, when supplied. */
+  checkpoint_session_ids?: string[];
+  /** Physical components merged into a logical detail response. */
+  component_session_ids?: string[];
+  checkpoint_revisions?: Record<string, string>;
+  /** True when the checkpoint family could not be projected losslessly. */
+  logical_incomplete?: boolean;
   user_interrupts: number | null;
   hold_state: HoldState | null;
   embargo_until: string | null;

--- a/clawjournal/web/frontend/src/views/Inbox.test.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.test.tsx
@@ -136,6 +136,18 @@ describe('Inbox selection defaults', () => {
     expect(second).not.toBeChecked();
     expect(screen.queryByText(/selected$/)).not.toBeInTheDocument();
   });
+
+  it('labels logical conversations and warns about an incomplete projection', async () => {
+    renderInbox([{
+      ...session('logical'),
+      logical_session_id: 'logical',
+      checkpoint_count: 3,
+      logical_incomplete: true,
+    }]);
+
+    expect(await screen.findByText('3 upload checkpoints')).toBeInTheDocument();
+    expect(screen.getByText('Incomplete conversation')).toBeInTheDocument();
+  });
 });
 
 describe('Inbox bulk status updates', () => {

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -894,6 +894,30 @@ export function Inbox() {
                         {LABELS[s.task_type] ?? s.task_type.replace(/_/g, ' ')}
                       </span>
                     )}
+                    {(s.checkpoint_count ?? 0) > 1 && (
+                      <span
+                        style={{
+                          fontSize: 11, padding: '1px 8px', borderRadius: 9999,
+                          background: colors.gray100, color: colors.gray600,
+                          fontWeight: 600, flexShrink: 0,
+                        }}
+                        title="This conversation is stored as bounded upload checkpoints."
+                      >
+                        {s.checkpoint_count} upload checkpoints
+                      </span>
+                    )}
+                    {s.logical_incomplete && (
+                      <span
+                        style={{
+                          fontSize: 11, padding: '1px 8px', borderRadius: 9999,
+                          background: colors.red100, color: colors.red700,
+                          fontWeight: 600, flexShrink: 0,
+                        }}
+                        title="One or more checkpoints are missing or overlap; sharing is disabled until the next successful scan."
+                      >
+                        Incomplete conversation
+                      </span>
+                    )}
                   </div>
                   <div style={{ fontSize: '12px', color: colors.gray400, lineHeight: '1.3', display: 'flex', alignItems: 'center', gap: 4 }}>
                     <span style={{

--- a/clawjournal/web/frontend/src/views/SessionDetail.test.tsx
+++ b/clawjournal/web/frontend/src/views/SessionDetail.test.tsx
@@ -1,0 +1,103 @@
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../api.ts';
+import { ToastProvider } from '../components/Toast.tsx';
+import type { SessionDetail as SessionDetailType } from '../types.ts';
+import SessionDetail from './SessionDetail.tsx';
+
+function logicalDetail(): SessionDetailType {
+  return {
+    session_id: 'logical-session',
+    logical_session_id: 'logical-session',
+    logical_revision: 'logical-r1',
+    checkpoint_count: 2,
+    project: 'project-a',
+    source: 'claude',
+    model: 'claude-test',
+    model_effort: null,
+    start_time: '2026-08-15T10:00:00Z',
+    end_time: '2026-08-15T10:01:00Z',
+    duration_seconds: 60,
+    git_branch: 'main',
+    user_messages: 1,
+    assistant_messages: 1,
+    tool_uses: 0,
+    input_tokens: 100,
+    output_tokens: 50,
+    display_title: 'Logical conversation',
+    outcome_label: 'resolved',
+    value_labels: [],
+    risk_level: [],
+    sensitivity_score: 0,
+    task_type: 'testing',
+    files_touched: [],
+    commands_run: [],
+    review_status: 'new',
+    selection_reason: null,
+    reviewer_notes: null,
+    reviewed_at: null,
+    ai_quality_score: 4,
+    ai_failure_value_score: 3,
+    ai_recovery_labels: [],
+    ai_failure_attribution: null,
+    ai_failure_modes: [],
+    ai_learning_summary: 'Checkpoint-only learning summary',
+    ai_score_reason: 'Checkpoint-only score reason',
+    ai_summary: null,
+    ai_effort_estimate: null,
+    ai_scoring_detail: null,
+    blob_path: null,
+    raw_source_path: null,
+    client_origin: null,
+    runtime_channel: null,
+    outer_session_id: null,
+    indexed_at: '2026-08-15T10:01:00Z',
+    updated_at: null,
+    share_id: null,
+    estimated_cost_usd: null,
+    parent_session_id: null,
+    subagent_session_ids: null,
+    user_interrupts: null,
+    hold_state: 'auto_redacted',
+    embargo_until: null,
+    findings_revision: null,
+    messages: [
+      { role: 'user', content: 'Question' },
+      { role: 'assistant', content: 'Answer' },
+    ],
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('logical conversation scoring', () => {
+  it('does not present or mutate a representative checkpoint score', async () => {
+    vi.spyOn(api.sessions, 'get').mockResolvedValue(logicalDetail());
+    const scoreSpy = vi.spyOn(api.sessions, 'score');
+    const updateSpy = vi.spyOn(api.sessions, 'update');
+
+    render(
+      <MemoryRouter initialEntries={['/session/logical-session']}>
+        <ToastProvider>
+          <Routes>
+            <Route path="/session/:id" element={<SessionDetail />} />
+          </Routes>
+        </ToastProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/no checkpoint score is presented/)).toBeInTheDocument();
+    expect(screen.queryByText('Failure value 3/5')).not.toBeInTheDocument();
+    expect(screen.queryByText('Productivity 4/5')).not.toBeInTheDocument();
+
+    const scoreButton = screen.getByRole('button', { name: 'Conversation scoring unavailable' });
+    expect(scoreButton).toBeDisabled();
+    expect(screen.getByPlaceholderText('Evidence for 4-5 overrides')).toBeDisabled();
+    expect(screen.getByRole('button', { name: '1' })).toBeDisabled();
+    expect(scoreSpy).not.toHaveBeenCalled();
+    expect(updateSpy).not.toHaveBeenCalled();
+  });
+});

--- a/clawjournal/web/frontend/src/views/SessionDetail.tsx
+++ b/clawjournal/web/frontend/src/views/SessionDetail.tsx
@@ -289,6 +289,7 @@ export default function SessionDetail() {
     0,
   );
   const userMsgCount = session.messages.filter((m) => m.role === 'user').length;
+  const logicalScoringUnavailable = (session.checkpoint_count ?? 1) > 1;
   const firstUserMsg = session.messages.find((m) => m.role === 'user');
   const firstUserPreview = firstUserMsg
     ? truncate((firstUserMsg.content ?? '').trim(), 200)
@@ -318,11 +319,27 @@ export default function SessionDetail() {
           </button>
         </div>
 
+        {session.logical_incomplete && (
+          <div
+            role="alert"
+            style={{
+              margin: '10px 10px 2px', padding: '8px 10px', borderRadius: 6,
+              border: `1px solid ${colors.red200}`, background: colors.red100,
+              color: colors.red700, fontSize: 12, lineHeight: 1.4,
+            }}
+          >
+            This conversation has a missing or overlapping upload checkpoint. Run a successful scan before sharing it.
+          </div>
+        )}
+
         <div style={{ padding: '8px 10px 4px', fontWeight: 700, fontSize: 12, color: colors.gray400 }}>
           SUMMARY
         </div>
         <div style={{ padding: '4px 10px' }}>
           <SummaryRow label="Messages" value={String(session.messages.length)} />
+          {(session.checkpoint_count ?? 0) > 1 && (
+            <SummaryRow label="Upload checkpoints" value={String(session.checkpoint_count)} />
+          )}
           <SummaryRow label="User msgs" value={String(userMsgCount)} />
           <SummaryRow label="Tool uses" value={String(totalToolUses)} />
           <SummaryRow label="Tokens" value={formatTokens(session.input_tokens + session.output_tokens)} />
@@ -342,6 +359,9 @@ export default function SessionDetail() {
             SESSION INFO
           </div>
           <MetaRow label="ID" value={session.session_id} mono />
+          {session.logical_session_id && session.logical_session_id !== session.session_id && (
+            <MetaRow label="Conversation" value={session.logical_session_id} mono />
+          )}
           <MetaRow label="Source" value={
             <span style={{
               fontSize: 11, fontWeight: 600, padding: '1px 6px', borderRadius: 4,
@@ -396,12 +416,13 @@ export default function SessionDetail() {
             const modes = Array.isArray(session.ai_failure_modes) ? session.ai_failure_modes : [];
             const recovery = Array.isArray(session.ai_recovery_labels) ? session.ai_recovery_labels : [];
             const hasFailureBlock =
-              session.ai_failure_value_score != null
+              !logicalScoringUnavailable
+              && (session.ai_failure_value_score != null
               || modes.length > 0
               || metaLabels.length > 0
               || evidence.length > 0
               || (session.ai_failure_attribution && session.ai_failure_attribution.length > 0)
-              || (session.ai_learning_summary && session.ai_learning_summary.length > 0);
+              || (session.ai_learning_summary && session.ai_learning_summary.length > 0));
             if (!hasFailureBlock) return null;
             return (
               <>
@@ -574,7 +595,20 @@ export default function SessionDetail() {
         }}
       >
         <Section title="Failure Value">
-          {(failureValueOverride ?? session.ai_failure_value_score) != null ? (() => {
+          {logicalScoringUnavailable && (
+            <div
+              role="note"
+              style={{
+                fontSize: 12, color: colors.gray500, lineHeight: 1.45,
+                marginBottom: 10, padding: '7px 8px', borderRadius: 5,
+                background: colors.gray100,
+              }}
+            >
+              AI scoring is currently recorded per upload checkpoint, so no
+              checkpoint score is presented as a score for this full conversation.
+            </div>
+          )}
+          {!logicalScoringUnavailable && ((failureValueOverride ?? session.ai_failure_value_score) != null ? (() => {
             const displayScore = failureValueOverride ?? session.ai_failure_value_score!;
             return (
             <div>
@@ -615,10 +649,11 @@ export default function SessionDetail() {
             );
           })() : (
             <div style={{ fontSize: 12, color: colors.gray400, marginBottom: 8 }}>Failure value not scored yet</div>
-          )}
+          ))}
 
           <button
-            disabled={scoring}
+            disabled={scoring || logicalScoringUnavailable}
+            title={logicalScoringUnavailable ? 'Conversation-level scoring is not available yet.' : undefined}
             onClick={async () => {
               if (!id) return;
               setScoring(true);
@@ -642,13 +677,17 @@ export default function SessionDetail() {
               fontSize: 12,
               fontWeight: 600,
               color: colors.gray50,
-              background: scoring ? colors.gray400 : colors.gray700,
+              background: scoring || logicalScoringUnavailable ? colors.gray400 : colors.gray700,
               border: 'none',
               borderRadius: 4,
-              cursor: scoring ? 'wait' : 'pointer',
+              cursor: scoring || logicalScoringUnavailable ? 'not-allowed' : 'pointer',
             }}
           >
-            {scoring ? 'Scoring…' : (session.ai_failure_value_score ? 'Re-score with AI' : 'Score with AI')}
+            {logicalScoringUnavailable
+              ? 'Conversation scoring unavailable'
+              : scoring
+                ? 'Scoring…'
+                : (session.ai_failure_value_score ? 'Re-score with AI' : 'Score with AI')}
           </button>
 
           <div style={{ fontSize: 11, color: colors.gray400, lineHeight: 1.45, marginBottom: 10 }}>
@@ -659,6 +698,7 @@ export default function SessionDetail() {
 
           <div style={{ fontSize: 12, fontWeight: 600, color: colors.gray700, marginBottom: 4 }}>Override failure value</div>
           <textarea
+            disabled={logicalScoringUnavailable}
             value={failureValueEvidence}
             onChange={e => setFailureValueEvidence(e.target.value)}
             placeholder="Evidence for 4-5 overrides"
@@ -683,6 +723,7 @@ export default function SessionDetail() {
               return (
                 <button
                   key={n}
+                  disabled={logicalScoringUnavailable}
                   onClick={async () => {
                     const evidence = splitEvidence(failureValueEvidence);
                     if (n >= 4 && evidence.length === 0) {
@@ -713,7 +754,8 @@ export default function SessionDetail() {
                     borderRadius: 4,
                     fontSize: 12,
                     fontWeight: 700,
-                    cursor: 'pointer',
+                    cursor: logicalScoringUnavailable ? 'not-allowed' : 'pointer',
+                    opacity: logicalScoringUnavailable ? 0.5 : 1,
                     lineHeight: 1,
                   }}
                 >

--- a/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
@@ -8,7 +8,7 @@ import { SessionDrawer } from '../../components/SessionDrawer.tsx';
 import { TraceCard } from '../../components/TraceCard.tsx';
 import { LARGE_BUNDLE_CONFIRM_THRESHOLD, MAX_SHARE_QUEUE_SIZE } from './types.ts';
 import type { ReadySession, ShareReadyStats } from './types.ts';
-import { autoDescription, formatDate, formatTokens, outcomeBadge, outcomeTooltip, sessionTotalTokens, sourceFullLabel } from './helpers.ts';
+import { autoDescription, formatDate, formatTokens, groupReadySessions, outcomeBadge, outcomeTooltip, sessionTotalTokens, sourceFullLabel } from './helpers.ts';
 import { SHARE_SHELL_WIDTH, btnGhost, btnPrimary, btnSecondary } from './styles.tsx';
 import { CheckboxRow, HelpModal, Icon, SourceBadge, UsageDisclosure } from './shared.tsx';
 
@@ -76,6 +76,10 @@ export function QueueStep(p: QueueStepProps) {
   const [confirmLargeBundle, setConfirmLargeBundle] = useState(false);
 
   const allSessions = p.readyStats?.sessions || [];
+  const allGroups = groupReadySessions(allSessions);
+  const queuedGroups = groupReadySessions(p.queuedSessions);
+  const logicalGroupingActive = allSessions.some((session) => Boolean(session.logical_session_id))
+    || allGroups.some((group) => group.members.length > 1);
   const selectedIds = new Set(p.queueOrder);
   const selectionLimitReached = p.queueOrder.length >= MAX_SHARE_QUEUE_SIZE;
   // `total_approved` counts every approved session; `allSessions` only holds the
@@ -85,6 +89,9 @@ export function QueueStep(p: QueueStepProps) {
   const totalApproved = p.readyStats?.total_approved ?? 0;
   const totalTokens = p.queuedSessions.reduce((sum, s) => sum + sessionTotalTokens(s), 0);
   const uniqueProjects = [...new Set(p.queuedSessions.map(s => s.project).filter(Boolean))];
+  const selectionSummary = logicalGroupingActive
+    ? `${queuedGroups.length} conversation${queuedGroups.length === 1 ? '' : 's'} / ${p.queuedSessions.length} upload checkpoint${p.queuedSessions.length === 1 ? '' : 's'}`
+    : `${p.queuedSessions.length} trace${p.queuedSessions.length === 1 ? '' : 's'}`;
 
   const onDragStart = (e: React.DragEvent, id: string) => {
     setDragId(id);
@@ -105,7 +112,7 @@ export function QueueStep(p: QueueStepProps) {
   // eslint-disable-next-line react-hooks/purity
   const dateCutoffMs = p.dateFilter ? (Date.now() - ((p.dateFilter === '7d' ? 7 : p.dateFilter === '30d' ? 30 : 90) * 86_400_000)) : null;
 
-  const filteredSessions = allSessions.filter(s => {
+  const filteredGroups = allGroups.filter((group) => group.members.some((s) => {
     if (p.searchQuery && !(s.display_title || '').toLowerCase().includes(p.searchQuery.toLowerCase())
       && !(s.project || '').toLowerCase().includes(p.searchQuery.toLowerCase())) return false;
     if (p.sourceFilter && s.source !== p.sourceFilter) return false;
@@ -113,10 +120,12 @@ export function QueueStep(p: QueueStepProps) {
     if (p.scoreFilter > 0 && (s.ai_failure_value_score == null || s.ai_failure_value_score < p.scoreFilter)) return false;
     if (dateCutoffMs && (!s.start_time || new Date(s.start_time).getTime() < dateCutoffMs)) return false;
     return true;
-  });
-  const available = filteredSessions.filter((s) => !selectedIds.has(s.session_id));
-  const visiblePickerSessions = filteredSessions.slice(0, pickerRenderLimit);
-  const visibleQueuedSessions = p.queuedSessions.slice(0, queueRenderLimit);
+  }));
+  const available = filteredGroups.filter((group) => (
+    !group.members.every((session) => selectedIds.has(session.session_id))
+  ));
+  const visiblePickerGroups = filteredGroups.slice(0, pickerRenderLimit);
+  const visibleQueuedGroups = queuedGroups.slice(0, queueRenderLimit);
 
   const historyShares = p.shares.filter(b => b.status === 'shared' || b.status === 'exported');
 
@@ -167,24 +176,41 @@ export function QueueStep(p: QueueStepProps) {
           <option value="90d">Last 90 days</option>
         </select>
       </div>
-      {filteredSessions.length > 0 && (() => {
-        const filteredIds = filteredSessions.map(s => s.session_id);
-        const selectedInFilter = filteredIds.filter(id => selectedIds.has(id)).length;
+      {filteredGroups.length > 0 && (() => {
+        const filteredIds = filteredGroups.flatMap((group) => group.members.map((s) => s.session_id));
+        const selectedInFilter = filteredGroups.filter((group) => (
+          group.members.every((session) => selectedIds.has(session.session_id))
+        )).length;
         const filterActive = !!(p.searchQuery || p.sourceFilter || p.projectFilter || p.scoreFilter > 0 || p.dateFilter);
-        const allSelected = selectedInFilter === filteredIds.length;
-        const batchDisabled = allSelected || selectionLimitReached;
+        const allSelected = selectedInFilter === filteredGroups.length;
         const remainingSlots = Math.max(0, MAX_SHARE_QUEUE_SIZE - p.queueOrder.length);
-        const unselectedInFilter = filteredIds.length - selectedInFilter;
-        const batchSelectionWouldBeCapped = unselectedInFilter > remainingSlots;
+        let batchSlots = remainingSlots;
+        const addableGroups = filteredGroups.filter((group) => {
+          if (group.logical_incomplete) return false;
+          const missing = group.members.filter((session) => !selectedIds.has(session.session_id));
+          if (missing.length === 0 || missing.length > batchSlots) return false;
+          batchSlots -= missing.length;
+          return true;
+        });
+        const batchAddIds = addableGroups.flatMap((group) => (
+          group.members
+            .map((session) => session.session_id)
+            .filter((id) => !selectedIds.has(id))
+        ));
+        const unselectedInFilter = filteredGroups.length - selectedInFilter;
+        const batchSelectionWouldBeCapped = addableGroups.length < unselectedInFilter;
+        const batchDisabled = allSelected || batchAddIds.length === 0;
         let batchLabel = filterActive
-          ? `Select ${filteredIds.length} filtered`
-          : `Select all ${filteredIds.length}`;
+          ? `Select ${filteredGroups.length} filtered`
+          : `Select all ${filteredGroups.length}`;
         if (selectionLimitReached && !allSelected) {
-          batchLabel = `${MAX_SHARE_QUEUE_SIZE} trace limit reached`;
+          batchLabel = `${MAX_SHARE_QUEUE_SIZE} ${logicalGroupingActive ? 'checkpoint' : 'trace'} limit reached`;
         } else if (batchSelectionWouldBeCapped) {
           batchLabel = filterActive
-            ? `Select ${remainingSlots} more filtered (${MAX_SHARE_QUEUE_SIZE} max)`
-            : `Select first ${remainingSlots} (${MAX_SHARE_QUEUE_SIZE} max)`;
+            ? `Select ${addableGroups.length} more filtered (${MAX_SHARE_QUEUE_SIZE} ${logicalGroupingActive ? 'checkpoints max' : 'max'})`
+            : logicalGroupingActive
+              ? `Select first ${addableGroups.length} (${MAX_SHARE_QUEUE_SIZE} checkpoints max)`
+              : `Select first ${batchAddIds.length} (${MAX_SHARE_QUEUE_SIZE} max)`;
         }
         const batchBtn = {
           ...btnGhost, fontSize: 12, padding: '5px 10px',
@@ -194,7 +220,7 @@ export function QueueStep(p: QueueStepProps) {
           <div style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 8, flexWrap: 'wrap' }}>
             <button
               type="button"
-              onClick={() => p.onAddMany(filteredIds)}
+              onClick={() => p.onAddMany(batchAddIds)}
               disabled={batchDisabled}
               style={{ ...batchBtn, opacity: batchDisabled ? 0.45 : 1, cursor: batchDisabled ? 'not-allowed' : 'pointer' }}
             >
@@ -209,37 +235,46 @@ export function QueueStep(p: QueueStepProps) {
               {filterActive ? `Deselect ${selectedInFilter} filtered` : 'Deselect all'}
             </button>
             <span style={{ fontSize: 11.5, color: colors.gray500 }}>
-              {selectedInFilter} of {filteredIds.length}{filterActive ? ' filtered' : ''} selected
-              {' · '}{MAX_SHARE_QUEUE_SIZE} trace maximum
+              {selectedInFilter} of {filteredGroups.length}{filterActive ? ' filtered' : ''}{' '}
+              {logicalGroupingActive ? 'conversations' : 'traces'} selected
+              {' · '}{MAX_SHARE_QUEUE_SIZE} {logicalGroupingActive ? 'upload checkpoint' : 'trace'} maximum
             </span>
           </div>
         );
       })()}
       <div style={{ maxHeight: '36vh', overflowY: 'auto', border: `1px solid ${colors.gray200}`, borderRadius: 6, background: colors.white }}>
-        {filteredSessions.length === 0 ? (
+        {filteredGroups.length === 0 ? (
           <div style={{ padding: 14, textAlign: 'center', color: colors.gray400, fontSize: 13 }}>
             No sessions match your filters.
           </div>
-        ) : visiblePickerSessions.map((s, i) => {
-          const selected = selectedIds.has(s.session_id);
-          const blockedByLimit = selectionLimitReached && !selected;
+        ) : visiblePickerGroups.map((group, i) => {
+          const s = group.display;
+          const checkpointIds = group.members.map((session) => session.session_id);
+          const selected = checkpointIds.every((id) => selectedIds.has(id));
+          const missingCount = checkpointIds.filter((id) => !selectedIds.has(id)).length;
+          const blockedByLimit = !selected && missingCount > (MAX_SHARE_QUEUE_SIZE - p.queueOrder.length);
+          const selectionBlocked = group.logical_incomplete || blockedByLimit;
           return (
             <label
-              key={s.session_id}
-              title={blockedByLimit ? 'Remove a selected trace before adding another.' : undefined}
+              key={group.logical_session_id}
+              title={group.logical_incomplete
+                ? 'This conversation has a missing or overlapping checkpoint. Run a successful scan before sharing it.'
+                : blockedByLimit
+                  ? 'Remove selected upload checkpoints before adding this conversation.'
+                  : undefined}
               style={{
                 display: 'grid', gridTemplateColumns: 'auto 1fr', gap: 10,
                 alignItems: 'center', padding: '8px 12px',
-                borderBottom: i < visiblePickerSessions.length - 1 ? `1px solid ${colors.gray100}` : 'none',
-                cursor: blockedByLimit ? 'not-allowed' : 'pointer',
-                opacity: blockedByLimit ? 0.55 : 1,
+                borderBottom: i < visiblePickerGroups.length - 1 ? `1px solid ${colors.gray100}` : 'none',
+                cursor: selectionBlocked ? 'not-allowed' : 'pointer',
+                opacity: selectionBlocked ? 0.55 : 1,
               }}>
               <input
                 type="checkbox"
                 checked={selected}
-                disabled={blockedByLimit}
-                aria-label={`Include trace: ${s.display_title || 'Untitled'}`}
-                onChange={(e) => e.target.checked ? p.onAdd(s.session_id) : p.onRemove(s.session_id)}
+                disabled={selectionBlocked}
+                aria-label={`Include ${logicalGroupingActive ? 'conversation' : 'trace'}: ${s.display_title || 'Untitled'}`}
+                onChange={(e) => e.target.checked ? p.onAddMany(checkpointIds) : p.onRemoveMany(checkpointIds)}
                 style={{ width: 15, height: 15, accentColor: colors.gray900 }}
               />
               <div style={{ minWidth: 0 }}>
@@ -257,6 +292,18 @@ export function QueueStep(p: QueueStepProps) {
                   <span>{s.project}</span>
                   <span style={{ opacity: 0.5 }}>&middot;</span>
                   <span>{formatTokens(sessionTotalTokens(s))} tokens</span>
+                  {(s.checkpoint_count ?? group.members.length) > 1 && (<>
+                    <span style={{ opacity: 0.5 }}>&middot;</span>
+                    <span>
+                      {group.members.length < (s.checkpoint_count ?? group.members.length)
+                        ? `${group.members.length} eligible of ${s.checkpoint_count} upload checkpoints`
+                        : `${s.checkpoint_count ?? group.members.length} upload checkpoints`}
+                    </span>
+                  </>)}
+                  {group.members.some((session) => session.logical_incomplete) && (<>
+                    <span style={{ opacity: 0.5 }}>&middot;</span>
+                    <span style={{ color: colors.red700, fontWeight: 600 }}>Checkpoint sequence incomplete</span>
+                  </>)}
                   {s.review_status && s.review_status !== 'approved' && (<>
                     <span style={{ opacity: 0.5 }}>&middot;</span>
                     <span style={{ color: colors.gray400, fontStyle: 'italic' }}>{s.review_status}</span>
@@ -266,7 +313,7 @@ export function QueueStep(p: QueueStepProps) {
             </label>
           );
         })}
-        {filteredSessions.length > visiblePickerSessions.length && (
+        {filteredGroups.length > visiblePickerGroups.length && (
           <button
             onClick={() => setPickerRenderLimit((current) => current + TRACE_RENDER_BATCH)}
             style={{
@@ -274,16 +321,16 @@ export function QueueStep(p: QueueStepProps) {
               borderTop: `1px solid ${colors.gray200}`, borderRadius: 0,
             }}
           >
-            Show {Math.min(TRACE_RENDER_BATCH, filteredSessions.length - visiblePickerSessions.length)} more
+            Show {Math.min(TRACE_RENDER_BATCH, filteredGroups.length - visiblePickerGroups.length)} more
             <span style={{ color: colors.gray400, fontWeight: 400 }}>
-              ({filteredSessions.length - visiblePickerSessions.length} remaining)
+              ({filteredGroups.length - visiblePickerGroups.length} remaining)
             </span>
           </button>
         )}
       </div>
-      {filteredSessions.length > TRACE_RENDER_BATCH && (
+      {filteredGroups.length > TRACE_RENDER_BATCH && (
         <div style={{ marginTop: 7, fontSize: 11.5, color: colors.gray500 }}>
-          Showing {visiblePickerSessions.length} of {filteredSessions.length} matching traces. Only selected traces are in this bundle ({MAX_SHARE_QUEUE_SIZE} maximum); unselected matches remain available to swap in.
+          Showing {visiblePickerGroups.length} of {filteredGroups.length} matching {logicalGroupingActive ? 'conversations' : 'traces'}. Only selected {logicalGroupingActive ? 'upload checkpoints' : 'traces'} are in this bundle ({MAX_SHARE_QUEUE_SIZE} maximum); unselected matches remain available to swap in.
         </div>
       )}
     </div>
@@ -293,6 +340,18 @@ export function QueueStep(p: QueueStepProps) {
     <div style={{ padding: '32px 24px 48px', maxWidth: SHARE_SHELL_WIDTH, margin: '0 auto' }}>
       {p.globalStyles}
       {p.stepperHeader}
+      {(p.readyStats?.logical_incomplete_excluded ?? 0) > 0 && (
+        <div
+          role="alert"
+          style={{
+            marginBottom: 14, padding: '9px 12px', borderRadius: 7,
+            border: `1px solid ${colors.red200}`, background: colors.red100,
+            color: colors.red700, fontSize: 12.5,
+          }}
+        >
+          {p.readyStats?.logical_incomplete_excluded} incomplete conversation{p.readyStats?.logical_incomplete_excluded === 1 ? '' : 's'} hidden from sharing. Run a successful scan to repair the checkpoint sequence.
+        </div>
+      )}
 
       {allSessions.length === 0 && p.candidates.length === 0 ? (
         <>
@@ -398,7 +457,7 @@ export function QueueStep(p: QueueStepProps) {
             <div style={{ display: 'flex', alignItems: 'center', gap: 12 }}>
               <div style={{ fontSize: 13, color: colors.gray900, fontWeight: 500 }}>draft-bundle</div>
               <div style={{ fontSize: 12, color: colors.gray500, fontVariantNumeric: 'tabular-nums' }}>
-                {p.queuedSessions.length} trace{p.queuedSessions.length === 1 ? '' : 's'} &middot; ~{formatTokens(totalTokens)} tokens
+                {selectionSummary} &middot; ~{formatTokens(totalTokens)} tokens
                 {uniqueProjects.length > 0 && ` · ${uniqueProjects.length} project${uniqueProjects.length !== 1 ? 's' : ''}`}
               </div>
             </div>
@@ -449,14 +508,18 @@ export function QueueStep(p: QueueStepProps) {
           {/* Trace list */}
           {!p.showAddTraces && (
           <div style={{ display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 18 }} onDragEnd={onDragEnd}>
-            {visibleQueuedSessions.map((s) => {
-              const isDragging = dragId === s.session_id;
+            {visibleQueuedGroups.map((group) => {
+              const s = group.display;
+              const checkpointIds = group.members.map((session) => session.session_id);
+              const canDrag = checkpointIds.length === 1;
+              const dragSessionId = checkpointIds[0];
+              const isDragging = canDrag && dragId === dragSessionId;
               return (
                 <div
-                  key={s.session_id}
-                  draggable
-                  onDragStart={(e) => onDragStart(e, s.session_id)}
-                  onDragOver={(e) => onDragOver(e, s.session_id)}
+                  key={group.logical_session_id}
+                  draggable={canDrag}
+                  onDragStart={(e) => { if (canDrag) onDragStart(e, dragSessionId); }}
+                  onDragOver={(e) => { if (canDrag) onDragOver(e, dragSessionId); }}
                   onDrop={(e) => { e.preventDefault(); setDragId(null); }}
                   style={{
                     display: 'grid', gridTemplateColumns: '20px 1fr auto', gap: 12,
@@ -469,7 +532,10 @@ export function QueueStep(p: QueueStepProps) {
                     transition: 'border-color 140ms, background 140ms, box-shadow 200ms',
                   }}
                 >
-                  <div style={{ color: colors.gray400, cursor: 'grab', display: 'grid', placeItems: 'center' }} title="Drag to reorder">
+                  <div
+                    style={{ color: colors.gray400, cursor: canDrag ? 'grab' : 'default', opacity: canDrag ? 1 : 0.35, display: 'grid', placeItems: 'center' }}
+                    title={canDrag ? 'Drag to reorder' : 'Grouped upload checkpoints stay together'}
+                  >
                     <Icon name="grip" size={14} />
                   </div>
                   <div style={{ minWidth: 0 }}>
@@ -488,6 +554,14 @@ export function QueueStep(p: QueueStepProps) {
                       <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', minWidth: 0, flexShrink: 1 }}>{s.project}</span>
                       <span style={{ opacity: 0.5, flexShrink: 0 }}>&middot;</span>
                       <span style={{ flexShrink: 0, whiteSpace: 'nowrap' }}>{formatTokens(sessionTotalTokens(s))} tokens</span>
+                      {(s.checkpoint_count ?? group.members.length) > 1 && (<>
+                        <span style={{ opacity: 0.5, flexShrink: 0 }}>&middot;</span>
+                        <span style={{ flexShrink: 0, whiteSpace: 'nowrap' }}>
+                          {group.members.length < (s.checkpoint_count ?? group.members.length)
+                            ? `${group.members.length} eligible of ${s.checkpoint_count} upload checkpoints`
+                            : `${s.checkpoint_count ?? group.members.length} upload checkpoints`}
+                        </span>
+                      </>)}
                       {s.tool_uses > 0 && (<>
                         <span style={{ opacity: 0.5, flexShrink: 0 }}>&middot;</span>
                         <span style={{ flexShrink: 0, whiteSpace: 'nowrap' }}>{s.tool_uses} tools</span>
@@ -533,14 +607,14 @@ export function QueueStep(p: QueueStepProps) {
                   </div>
                   <div style={{ display: 'flex', alignItems: 'center', gap: 4 }}>
                     <button
-                      onClick={() => p.setDrawerSessionId(s.session_id)}
+                      onClick={() => p.setDrawerSessionId(group.logical_session_id)}
                       style={btnGhost}
                       title="Preview"
                     >
                       Preview
                     </button>
                     <button
-                      onClick={() => p.onRemove(s.session_id)}
+                      onClick={() => p.onRemoveMany(checkpointIds)}
                       style={{ ...btnGhost, color: colors.red700 }}
                       title="Remove from bundle"
                     >
@@ -550,12 +624,12 @@ export function QueueStep(p: QueueStepProps) {
                 </div>
               );
             })}
-            {p.queuedSessions.length > visibleQueuedSessions.length && (
+            {queuedGroups.length > visibleQueuedGroups.length && (
               <button
                 onClick={() => setQueueRenderLimit((current) => current + TRACE_RENDER_BATCH)}
                 style={{ ...btnSecondary, alignSelf: 'center', marginTop: 4 }}
               >
-                Show {Math.min(TRACE_RENDER_BATCH, p.queuedSessions.length - visibleQueuedSessions.length)} more selected traces
+                Show {Math.min(TRACE_RENDER_BATCH, queuedGroups.length - visibleQueuedGroups.length)} more selected conversations
               </button>
             )}
           </div>
@@ -623,7 +697,7 @@ export function QueueStep(p: QueueStepProps) {
             }}>
               <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
                 <div style={{ fontSize: 13, color: colors.gray900 }}>
-                  {p.queuedSessions.length} trace{p.queuedSessions.length === 1 ? '' : 's'} selected
+                  {selectionSummary} selected
                 </div>
                 <div style={{ fontSize: 11.5, color: colors.gray500, fontVariantNumeric: 'tabular-nums' }}>
                   Next: we&rsquo;ll redact secrets and identifiers on your device
@@ -652,8 +726,8 @@ export function QueueStep(p: QueueStepProps) {
           <ConfirmDialog
             open={confirmLargeBundle}
             title="Review large bundle?"
-            message={`You selected ${p.queuedSessions.length} traces. Redaction and optional AI-assisted PII review will run for every selected trace. Continue only if you intend to review this full bundle.`}
-            confirmLabel={`Redact ${p.queuedSessions.length} traces`}
+            message={`You selected ${selectionSummary}. Redaction and optional AI-assisted PII review will run for every selected upload checkpoint. Continue only if you intend to review this full bundle.`}
+            confirmLabel={`Redact ${p.queuedSessions.length} upload checkpoints`}
             onConfirm={() => {
               setConfirmLargeBundle(false);
               p.onContinue();

--- a/clawjournal/web/frontend/src/views/Share/helpers.test.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.test.ts
@@ -2,6 +2,9 @@ import { describe, expect, it } from 'vitest';
 import type { ReadySession, ShareReadyStats } from './types.ts';
 import {
   classify,
+  collectExpectedLogicalRevisions,
+  expandLogicalQueueSelection,
+  groupReadySessions,
   hasLockedQueueSelection,
   queueFromSelectionParams,
   queueFromStats,
@@ -122,5 +125,81 @@ describe('Share queue selection encoding', () => {
 
     params.delete('ids');
     expect(hasLockedQueueSelection(params)).toBe(false);
+  });
+});
+
+describe('logical conversation queue projection', () => {
+  function checkpoint(id: string, segmentIndex: number, checkpointCount = 2): ReadySession {
+    return {
+      ...readySession(id),
+      logical_session_id: 'conversation-1',
+      logical_revision: 'logical-r1',
+      checkpoint_count: checkpointCount,
+      segment_index: segmentIndex,
+      input_tokens: 10 * (segmentIndex + 1),
+      output_tokens: 5 * (segmentIndex + 1),
+    };
+  }
+
+  it('groups checkpoint rows once while retaining physical members for upload', () => {
+    const groups = groupReadySessions([
+      checkpoint('conversation-1_seg-0001', 1, 3),
+      checkpoint('conversation-1', 0, 3),
+    ]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].members.map((session) => session.session_id)).toEqual([
+      'conversation-1',
+      'conversation-1_seg-0001',
+    ]);
+    expect(groups[0].display.checkpoint_count).toBe(3);
+    expect(groups[0].display.input_tokens).toBe(30);
+    expect(groups[0].display.ai_failure_value_score).toBeNull();
+    expect(groups[0].display.ai_quality_score).toBeNull();
+    expect(groups[0].logical_incomplete).toBe(false);
+  });
+
+  it('expands a selected checkpoint to all currently eligible group members', () => {
+    const sessions = [
+      checkpoint('conversation-1', 0),
+      checkpoint('conversation-1_seg-0001', 1),
+      readySession('standalone'),
+    ];
+    const stats: ShareReadyStats = { ...readyStats(0), count: 3, sessions };
+
+    expect(expandLogicalQueueSelection(stats, ['conversation-1_seg-0001'])).toEqual([
+      'conversation-1',
+      'conversation-1_seg-0001',
+    ]);
+  });
+
+  it('does not split a checkpoint family at the 50-checkpoint default cap', () => {
+    const standalone = Array.from({ length: 49 }, (_, index) => readySession(`s${index + 1}`));
+    const sessions = [
+      ...standalone,
+      checkpoint('conversation-1', 0),
+      checkpoint('conversation-1_seg-0001', 1),
+      readySession('fits-after-group'),
+    ];
+    const stats: ShareReadyStats = { ...readyStats(0), count: sessions.length, sessions };
+
+    expect(queueFromStats(stats)).toHaveLength(50);
+    expect(queueFromStats(stats)).not.toContain('conversation-1');
+    expect(queueFromStats(stats)).not.toContain('conversation-1_seg-0001');
+    expect(queueFromStats(stats)).toContain('fits-after-group');
+  });
+
+  it('rejects conflicting logical revisions before packaging', () => {
+    const first = checkpoint('conversation-1', 0);
+    const second = { ...checkpoint('conversation-1_seg-0001', 1), logical_revision: 'logical-r2' };
+
+    expect(() => collectExpectedLogicalRevisions([first, second])).toThrow(/changed while preparing/);
+  });
+
+  it('collects one logical precondition for multiple physical checkpoints', () => {
+    expect(collectExpectedLogicalRevisions([
+      checkpoint('conversation-1', 0),
+      checkpoint('conversation-1_seg-0001', 1),
+    ])).toEqual({ 'conversation-1': 'logical-r1' });
   });
 });

--- a/clawjournal/web/frontend/src/views/Share/helpers.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.ts
@@ -7,6 +7,8 @@ import {
 import type {
   BlockedShareSession,
   BucketCounts,
+  LogicalReadySessionGroup,
+  ReadySession,
   RedactedSessionData,
   RedactionBucket,
   ShareReadyStats,
@@ -137,19 +139,191 @@ export function formatShareDestination(url: string): string {
   }
 }
 
+export function readySessionLogicalId(session: ReadySession): string {
+  return session.logical_session_id || session.session_id;
+}
+
+/**
+ * Project physical upload checkpoints as one conversation for Queue display.
+ * The original rows remain intact in `members`; redaction and packaging must
+ * continue to consume those physical ids and revisions.
+ */
+export function groupReadySessions(sessions: ReadySession[]): LogicalReadySessionGroup[] {
+  const groups = new Map<string, Array<{ session: ReadySession; inputIndex: number }>>();
+  sessions.forEach((session, inputIndex) => {
+    const logicalId = readySessionLogicalId(session);
+    const members = groups.get(logicalId) || [];
+    members.push({ session, inputIndex });
+    groups.set(logicalId, members);
+  });
+
+  return [...groups.entries()].map(([logicalId, indexedMembers]) => {
+    const members = [...indexedMembers]
+      .sort((a, b) => {
+        const aIndex = a.session.segment_index;
+        const bIndex = b.session.segment_index;
+        if (typeof aIndex === 'number' && typeof bIndex === 'number' && aIndex !== bIndex) {
+          return aIndex - bIndex;
+        }
+        if (typeof aIndex === 'number' && typeof bIndex !== 'number') return -1;
+        if (typeof aIndex !== 'number' && typeof bIndex === 'number') return 1;
+        return a.inputIndex - b.inputIndex;
+      })
+      .map(({ session }) => session);
+    const representative = members.find((session) => session.session_id === logicalId)
+      || members.find((session) => session.segment_index === 0)
+      || members[0];
+    const revisions = new Set(
+      members.map((session) => session.logical_revision).filter((value): value is string => Boolean(value)),
+    );
+    const logicalRevision = revisions.size === 1 ? [...revisions][0] : null;
+    const checkpointCount = Math.max(
+      members.length,
+      ...members.map((session) => (
+        typeof session.checkpoint_count === 'number' ? session.checkpoint_count : 0
+      )),
+    );
+    // A smaller eligible subset is normal after earlier checkpoints were
+    // shared. Only the backend's structural gap/overlap flag is fail-closed.
+    const logicalIncomplete = members.some((session) => Boolean(session.logical_incomplete));
+    const checkpointScoringOnly = checkpointCount > 1;
+    const display: ReadySession = {
+      ...representative,
+      session_id: logicalId,
+      logical_session_id: logicalId,
+      logical_revision: logicalRevision,
+      checkpoint_count: checkpointCount,
+      user_messages: members.reduce((sum, session) => sum + session.user_messages, 0),
+      assistant_messages: members.reduce((sum, session) => sum + session.assistant_messages, 0),
+      tool_uses: members.reduce((sum, session) => sum + session.tool_uses, 0),
+      input_tokens: members.reduce((sum, session) => sum + session.input_tokens, 0),
+      output_tokens: members.reduce((sum, session) => sum + session.output_tokens, 0),
+      updated_since_last_share: members.some((session) => session.updated_since_last_share),
+      // These scores were produced for individual transport checkpoints. Do
+      // not present a representative checkpoint's score as though the judge
+      // evaluated the complete logical conversation.
+      ai_quality_score: checkpointScoringOnly ? null : representative.ai_quality_score,
+      ai_failure_value_score: checkpointScoringOnly ? null : representative.ai_failure_value_score,
+      ai_recovery_labels: checkpointScoringOnly ? [] : representative.ai_recovery_labels,
+      ai_failure_attribution: checkpointScoringOnly ? null : representative.ai_failure_attribution,
+      ai_failure_modes: checkpointScoringOnly ? [] : representative.ai_failure_modes,
+      ai_learning_summary: checkpointScoringOnly ? null : representative.ai_learning_summary,
+    };
+    return {
+      logical_session_id: logicalId,
+      logical_revision: logicalRevision,
+      members,
+      display,
+      logical_incomplete: logicalIncomplete,
+    };
+  });
+}
+
+export function checkpointIdsForReadySession(
+  stats: ShareReadyStats,
+  sessionId: string,
+): string[] {
+  const group = groupReadySessions(stats.sessions).find((candidate) => (
+    candidate.logical_session_id === sessionId
+    || candidate.members.some((session) => session.session_id === sessionId)
+  ));
+  return group?.members.map((session) => session.session_id) || [];
+}
+
+/** Expand any selected member to its complete eligible checkpoint family. */
+export function expandLogicalQueueSelection(
+  stats: ShareReadyStats,
+  selection: string[],
+): string[] {
+  const groups = groupReadySessions(stats.sessions);
+  const byId = new Map<string, LogicalReadySessionGroup>();
+  groups.forEach((group) => {
+    byId.set(group.logical_session_id, group);
+    group.members.forEach((session) => byId.set(session.session_id, group));
+  });
+  const seenGroups = new Set<string>();
+  const expanded: string[] = [];
+  for (const id of selection) {
+    const group = byId.get(id);
+    if (!group || group.logical_incomplete || seenGroups.has(group.logical_session_id)) continue;
+    seenGroups.add(group.logical_session_id);
+    const ids = group.members.map((session) => session.session_id);
+    if (expanded.length + ids.length > MAX_SHARE_QUEUE_SIZE) continue;
+    expanded.push(...ids);
+  }
+  return expanded;
+}
+
+/**
+ * Preserve explicit exclusions: a partial group is treated as deselected, not
+ * silently broadened by restoring its omitted checkpoint.
+ */
+export function retainCompleteLogicalQueueGroups(
+  stats: ShareReadyStats,
+  selection: string[],
+): string[] {
+  const selected = new Set(selection);
+  return groupReadySessions(stats.sessions)
+    .filter((group) => (
+      !group.logical_incomplete
+      && group.members.every((session) => selected.has(session.session_id))
+    ))
+    .flatMap((group) => group.members.map((session) => session.session_id))
+    .slice(0, MAX_SHARE_QUEUE_SIZE);
+}
+
+export function collectExpectedLogicalRevisions(
+  sessions: ReadySession[],
+): Record<string, string> {
+  const expected: Record<string, string> = {};
+  for (const group of groupReadySessions(sessions)) {
+    if (group.logical_incomplete) {
+      throw new Error(
+        `Conversation ${group.logical_session_id} has an incomplete checkpoint sequence. Run a successful scan before sharing it.`,
+      );
+    }
+    const revisions = new Set(
+      group.members
+        .map((session) => session.logical_revision)
+        .filter((revision): revision is string => Boolean(revision)),
+    );
+    if (revisions.size > 1) {
+      throw new Error(
+        `Conversation ${group.logical_session_id} changed while preparing this share. Return to Queue and try again.`,
+      );
+    }
+    if (revisions.size === 1) expected[group.logical_session_id] = [...revisions][0];
+  }
+  return expected;
+}
+
 export function queueFromStats(stats: ShareReadyStats): string[] {
-  const validIds = new Set(stats.sessions.map((s) => s.session_id));
-  const recommended = (stats.recommended_session_ids || [])
-    .filter((id) => validIds.has(id));
+  const groups = groupReadySessions(stats.sessions);
+  const groupById = new Map<string, LogicalReadySessionGroup>();
+  groups.forEach((group) => {
+    groupById.set(group.logical_session_id, group);
+    group.members.forEach((session) => groupById.set(session.session_id, group));
+  });
+  const recommendedGroups = (stats.recommended_session_ids || [])
+    .map((id) => groupById.get(id))
+    .filter((group): group is LogicalReadySessionGroup => Boolean(group));
+  const orderedGroups = [...new Map([
+    ...recommendedGroups,
+    ...groups,
+  ].map((group) => [group.logical_session_id, group])).values()];
 
   // Start with the server's highest-value recommendations, then fill the
-  // bounded queue from the remaining eligible traces. The complete eligible
-  // pool stays available in the picker, but a share never starts with the
-  // user's entire local history selected.
-  return [...new Set([
-    ...recommended,
-    ...stats.sessions.map((s) => s.session_id).filter(Boolean),
-  ])].slice(0, MAX_SHARE_QUEUE_SIZE);
+  // bounded queue from the remaining eligible conversations. Never split a
+  // logical conversation at the physical-checkpoint cap.
+  const selected: string[] = [];
+  orderedGroups.forEach((group) => {
+    if (group.logical_incomplete) return;
+    const checkpointIds = group.members.map((session) => session.session_id);
+    if (selected.length + checkpointIds.length <= MAX_SHARE_QUEUE_SIZE) {
+      selected.push(...checkpointIds);
+    }
+  });
+  return selected;
 }
 
 function csvParam(params: URLSearchParams, name: string): string[] | null {
@@ -165,14 +339,18 @@ export function queueFromSelectionParams(
   // queue and must not fall back to the select-all default on reload.
   const explicitIds = csvParam(params, 'ids');
   if (explicitIds !== null) {
-    return sanitizeQueueSelection(stats, explicitIds);
+    const sanitized = sanitizeQueueSelection(stats, explicitIds);
+    return params.get('selection') === 'locked'
+      ? sanitized
+      : expandLogicalQueueSelection(stats, sanitized);
   }
 
   const excludedIds = new Set([
     ...(csvParam(params, 'exclude') || []),
     ...(csvParam(params, 'exclude_ids') || []),
   ]);
-  return queueFromStats(stats).filter((id) => !excludedIds.has(id));
+  const selected = queueFromStats(stats).filter((id) => !excludedIds.has(id));
+  return retainCompleteLogicalQueueGroups(stats, selected);
 }
 
 export function sanitizeQueueSelection(

--- a/clawjournal/web/frontend/src/views/Share/index.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.test.tsx
@@ -109,6 +109,93 @@ describe('Share selection defaults', () => {
     });
   });
 
+  it('shows one conversation while selecting and redacting every eligible checkpoint', async () => {
+    const root: ReadySession = {
+      ...readySession('long-trace'),
+      display_title: 'Long conversation',
+      logical_session_id: 'long-trace',
+      logical_revision: 'logical-r1',
+      checkpoint_count: 3,
+      segment_index: 0,
+      revision_hash: 'physical-r0',
+    };
+    const tail: ReadySession = {
+      ...readySession('long-trace_seg-0001'),
+      display_title: 'Long conversation',
+      logical_session_id: 'long-trace',
+      logical_revision: 'logical-r1',
+      checkpoint_count: 3,
+      segment_index: 1,
+      revision_hash: 'physical-r1',
+    };
+    mockInitialLoad({
+      ...readyStats(0),
+      count: 2,
+      total_approved: 2,
+      recommended_session_ids: ['long-trace'],
+      sessions: [root, tail],
+    });
+    const redactionSpy = vi.spyOn(api.sessions, 'redactionReport').mockImplementation(async (id) => ({
+      session_id: id,
+      redaction_count: 0,
+      redaction_log: [],
+      ai_pii_findings: [],
+      ai_coverage: 'disabled',
+      redacted_session: { messages: [] },
+    }) as unknown as Awaited<ReturnType<typeof api.sessions.redactionReport>>);
+
+    render(
+      <MemoryRouter initialEntries={['/share']}>
+        <ToastProvider><Share /></ToastProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('1 conversation / 2 upload checkpoints selected')).toBeInTheDocument();
+    expect(screen.getByText('2 eligible of 3 upload checkpoints')).toBeInTheDocument();
+    expect(screen.getAllByText('Long conversation')).toHaveLength(1);
+    expect(screen.getAllByRole('checkbox', { name: 'Include conversation: Long conversation' })).toHaveLength(1);
+
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Include conversation: Long conversation' }));
+    expect(await screen.findByText(/Nothing is preselected/)).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('checkbox', { name: 'Include conversation: Long conversation' }));
+    expect(await screen.findByText('1 conversation / 2 upload checkpoints selected')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Redact & review' }));
+    await waitFor(() => expect(redactionSpy).toHaveBeenCalledTimes(2));
+    expect(redactionSpy.mock.calls.map(([id]) => id)).toEqual([
+      'long-trace',
+      'long-trace_seg-0001',
+    ]);
+  });
+
+  it('fails closed when a conversation checkpoint sequence is incomplete', async () => {
+    const incomplete: ReadySession = {
+      ...readySession('incomplete-trace'),
+      logical_session_id: 'incomplete-trace',
+      logical_revision: 'logical-r1',
+      checkpoint_count: 2,
+      segment_index: 0,
+      logical_incomplete: true,
+    };
+    mockInitialLoad({
+      ...readyStats(0),
+      count: 1,
+      total_approved: 1,
+      recommended_session_ids: ['incomplete-trace'],
+      sessions: [incomplete],
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/share']}>
+        <ToastProvider><Share /></ToastProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText(/Nothing is preselected/)).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Include conversation: Trace incomplete-trace' })).toBeDisabled();
+    expect(screen.getByText('Checkpoint sequence incomplete')).toBeInTheDocument();
+  });
+
   it('keeps a custom queue order when bulk-selecting filtered traces', async () => {
     mockInitialLoad(readyStats(3));
 

--- a/clawjournal/web/frontend/src/views/Share/index.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.tsx
@@ -23,13 +23,17 @@ import {
   blockedSessionsFromError,
   bucketOf,
   classify,
+  checkpointIdsForReadySession,
+  collectExpectedLogicalRevisions,
   completedKeysForStep,
   emptyBuckets,
+  expandLogicalQueueSelection,
   formatBytes,
   formatDate,
   hasLockedQueueSelection,
   parseStep,
   queueFromStats,
+  retainCompleteLogicalQueueGroups,
   sanitizeQueueSelection,
   sessionTotalTokens,
 } from './helpers.ts';
@@ -92,7 +96,12 @@ function restoredQueueFromParams(
 ): string[] {
   const defaultQueue = queueFromStats(stats);
   const restored = queueSelectionFromSearchParams(params, defaultQueue, storage);
-  return sanitizeQueueSelection(stats, restored ?? defaultQueue);
+  const sanitized = sanitizeQueueSelection(stats, restored ?? defaultQueue);
+  if (params.get('selection') === 'locked') return sanitized;
+  if (params.has('exclude') || params.has('exclude_ids')) {
+    return retainCompleteLogicalQueueGroups(stats, sanitized);
+  }
+  return expandLogicalQueueSelection(stats, sanitized);
 }
 
 
@@ -146,10 +155,14 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
       : null
   ));
   const eligibleQueueOrder = useMemo(
-    () => readyStats
-      ? sanitizeQueueSelection(readyStats, queueOrder)
-      : [...new Set(queueOrder)].slice(0, MAX_SHARE_QUEUE_SIZE),
-    [readyStats, queueOrder],
+    () => {
+      if (!readyStats) return [...new Set(queueOrder)].slice(0, MAX_SHARE_QUEUE_SIZE);
+      const sanitized = sanitizeQueueSelection(readyStats, queueOrder);
+      return selectionLocked
+        ? sanitized
+        : expandLogicalQueueSelection(readyStats, sanitized);
+    },
+    [readyStats, queueOrder, selectionLocked],
   );
   const queueSet = useMemo(() => new Set(eligibleQueueOrder), [eligibleQueueOrder]);
 
@@ -552,7 +565,11 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
   };
 
   const addToQueue = (id: string) => {
-    if (!eligibleQueueOrder.includes(id) && eligibleQueueOrder.length >= MAX_SHARE_QUEUE_SIZE) {
+    const checkpointIds = readyStats
+      ? checkpointIdsForReadySession(readyStats, id)
+      : [id];
+    const missingIds = checkpointIds.filter((checkpointId) => !eligibleQueueOrder.includes(checkpointId));
+    if (eligibleQueueOrder.length + missingIds.length > MAX_SHARE_QUEUE_SIZE) {
       toast(`A share can include at most ${MAX_SHARE_QUEUE_SIZE} traces. Remove one before adding another.`, 'error');
       return;
     }
@@ -561,18 +578,18 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
       const current = readyStats
         ? sanitizeQueueSelection(readyStats, prev)
         : [...new Set(prev)].slice(0, MAX_SHARE_QUEUE_SIZE);
-      if (current.includes(id)) return current;
-      if (current.length >= MAX_SHARE_QUEUE_SIZE) return current;
+      if (missingIds.length === 0) return current;
+      if (current.length + missingIds.length > MAX_SHARE_QUEUE_SIZE) return current;
       const defaults = readyStats ? queueFromStats(readyStats) : [];
       const previousIds = new Set(current);
       const defaultOrderedSubset = defaults.filter((sessionId) => previousIds.has(sessionId));
       const followsDefaultOrder = defaultOrderedSubset.length === current.length
         && defaultOrderedSubset.every((sessionId, index) => sessionId === current[index]);
-      if (followsDefaultOrder && defaults.includes(id)) {
-        previousIds.add(id);
+      if (followsDefaultOrder && missingIds.every((checkpointId) => defaults.includes(checkpointId))) {
+        missingIds.forEach((checkpointId) => previousIds.add(checkpointId));
         return defaults.filter((sessionId) => previousIds.has(sessionId));
       }
-      return [...current, id];
+      return [...current, ...missingIds];
     });
   };
 
@@ -1078,11 +1095,13 @@ export function Share({ onSubmittedShareChange }: ShareProps = {}) {
           .filter((s): s is ReadySession & { revision_hash: string } => Boolean(s.revision_hash))
           .map((s) => [s.session_id, s.revision_hash]),
       );
+      const expectedLogicalRevisions = collectExpectedLogicalRevisions(approvedList);
       const { share_id } = await api.shares.create(
         ids,
         note || undefined,
         undefined,
         expectedRevisions,
+        expectedLogicalRevisions,
       );
       setPackageProgress(2);
       setPackageLog('Starting local packaging...');

--- a/clawjournal/web/frontend/src/views/Share/types.ts
+++ b/clawjournal/web/frontend/src/views/Share/types.ts
@@ -34,6 +34,17 @@ export interface BlockedShareSession {
 
 export interface ReadySession {
   session_id: string;
+  /** Stable conversation identity; falls back to session_id on older daemons. */
+  logical_session_id?: string | null;
+  /** Revision of this conversation's active checkpoint membership. */
+  logical_revision?: string | null;
+  checkpoint_count?: number | null;
+  checkpoint_session_ids?: string[];
+  checkpoint_revisions?: Record<string, string>;
+  logical_incomplete?: boolean;
+  segment_index?: number | null;
+  segment_reason?: string | null;
+  segment_sealed?: boolean;
   project: string;
   model: string | null;
   source: string;
@@ -62,9 +73,19 @@ export interface ReadySession {
   updated_since_last_share?: boolean;
 }
 
+export interface LogicalReadySessionGroup {
+  logical_session_id: string;
+  logical_revision: string | null;
+  members: ReadySession[];
+  /** Aggregate used only for the Queue conversation card. */
+  display: ReadySession;
+  logical_incomplete: boolean;
+}
+
 export interface ShareReadyStats {
   count: number;
   total_approved: number;
+  logical_incomplete_excluded?: number;
   projects: string[];
   models: string[];
   recommended_session_ids: string[];

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -64,7 +64,7 @@ from .index import (
     add_policy,
     already_shared_revision_blockers,
     apply_share_redactions,
-    bulk_update_review_status,
+    bulk_update_logical_review_status,
     create_share,
     export_share_to_disk,
     FAILURE_VALUE_SOURCE_SCOPE,
@@ -73,25 +73,30 @@ from .index import (
     get_shares,
     get_dashboard_analytics,
     get_highlights,
+    get_logical_stats,
+    get_logical_session_detail,
+    get_logical_session_members,
     get_policies,
     get_session_detail,
     get_share_ready_stats,
-    get_stats,
     link_subagent_hierarchy,
+    LogicalProjectionError,
     open_index,
-    query_sessions,
+    query_logical_sessions,
     query_unscored_sessions,
     release_gate_blockers,
     RevisionConflictError,
     revision_review_blockers,
     remove_policy,
-    search_fts,
+    search_logical_sessions,
     SCORE_SETTLE_SECONDS,
     session_matches_excluded_projects,
+    set_logical_hold_state,
     share_predecessor_blockers,
     share_revision_blockers,
     source_scope_blockers,
     synchronize_share_predecessors,
+    _validate_hold_target,
     update_session,
     upsert_sessions,
 )
@@ -4241,7 +4246,7 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             status_filter = None
         conn = open_index()
         try:
-            result = query_sessions(
+            result = query_logical_sessions(
                 conn,
                 status=status_filter,
                 source=params.get("source", [None])[0],
@@ -4264,7 +4269,14 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
     def _handle_get_session(self, session_id: str) -> None:
         conn = open_index()
         try:
-            detail = get_session_detail(conn, session_id)
+            try:
+                detail = get_logical_session_detail(conn, session_id)
+            except LogicalProjectionError as exc:
+                _json_response(self, {
+                    "error": str(exc),
+                    "block_reason": "logical_projection_incomplete",
+                }, 409)
+                return
             if detail is None:
                 _json_response(self, {"error": "Session not found"}, 404)
                 return
@@ -4277,10 +4289,77 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         body = _read_body(self)
         conn = open_index()
         try:
+            members = get_logical_session_members(conn, session_id)
+            if not members:
+                _json_response(self, {"error": "Session not found"}, 404)
+                return
+            representative_id = str(members[0]["session_id"])
+
+            scoring_fields = {
+                "ai_quality_score", "ai_score_reason", "ai_scoring_detail",
+                "ai_effort_estimate", "ai_summary", "ai_task_type",
+                "ai_outcome_badge", "ai_value_badges",
+                "ai_risk_badges", "ai_failure_value_score",
+                "ai_failure_evidence", "ai_recovery_labels",
+                "ai_failure_attribution", "ai_failure_modes",
+                "ai_learning_summary", "ai_scorer_backend",
+                "ai_scorer_model", "ai_rubric_git_sha", "ai_scored_at",
+            }
+            if len(members) > 1 and scoring_fields.intersection(body):
+                _json_response(self, {
+                    "error": (
+                        "Conversation-level scoring is not available for a "
+                        "multi-checkpoint conversation yet."
+                    ),
+                    "block_reason": "logical_scoring_not_supported",
+                }, 409)
+                return
+
+            # Validate every field that can reject the request before changing
+            # any member of the logical family.  Review status and hold state
+            # are committed by separate audited helpers below, so a late
+            # validation failure must not leave a partially updated family.
+            status = body.get("status")
+            if status is not None and status not in {
+                "new", "shortlisted", "approved", "blocked",
+            }:
+                _json_response(self, {"error": "Invalid review status"}, 400)
+                return
+            for score_field in ("ai_quality_score", "ai_failure_value_score"):
+                raw_score = body.get(score_field)
+                if raw_score is None:
+                    continue
+                try:
+                    score = int(raw_score)
+                except (TypeError, ValueError):
+                    _json_response(self, {"error": f"Invalid {score_field}"}, 400)
+                    return
+                if not 1 <= score <= 5:
+                    _json_response(self, {"error": f"Invalid {score_field}"}, 400)
+                    return
+                body[score_field] = score
+            hold_state = body.get("hold_state")
+            if hold_state is not None:
+                if not isinstance(hold_state, str):
+                    _json_response(self, {"error": "Invalid hold_state"}, 400)
+                    return
+                try:
+                    _validate_hold_target(
+                        hold_state,
+                        body.get("embargo_until"),
+                    )
+                except (TypeError, ValueError) as exc:
+                    _json_response(self, {"error": str(exc)}, 400)
+                    return
+
             if "ai_failure_value_score" in body or "ai_failure_evidence" in body:
-                detail = get_session_detail(conn, session_id)
-                if detail is None:
-                    _json_response(self, {"error": "Session not found"}, 404)
+                try:
+                    detail = get_logical_session_detail(conn, session_id)
+                except LogicalProjectionError as exc:
+                    _json_response(self, {
+                        "error": str(exc),
+                        "block_reason": "logical_projection_incomplete",
+                    }, 409)
                     return
 
                 failure_value = body.get("ai_failure_value_score")
@@ -4314,9 +4393,21 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                         provided_evidence,
                     )
 
+            status_ok = True
+            if status is not None:
+                try:
+                    updated_ids, _ = bulk_update_logical_review_status(
+                        conn,
+                        [session_id],
+                        status,
+                    )
+                except ValueError as exc:
+                    _json_response(self, {"error": str(exc)}, 400)
+                    return
+                status_ok = bool(updated_ids)
+
             ok = update_session(
-                conn, session_id,
-                status=body.get("status"),
+                conn, representative_id,
                 notes=body.get("notes"),
                 reason=body.get("reason"),
                 ai_quality_score=body.get("ai_quality_score"),
@@ -4337,15 +4428,14 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                 ai_scorer_model=body.get("ai_scorer_model"),
                 ai_rubric_git_sha=body.get("ai_rubric_git_sha"),
                 ai_scored_at=body.get("ai_scored_at"),
-            )
+            ) and status_ok
             # Hold-state transitions are separate from review-status updates
             # — they pass through `set_hold_state` so the audit log and
             # validation stay in one place.
             hold_state = body.get("hold_state")
             if hold_state is not None:
-                from .index import set_hold_state
                 try:
-                    ok = set_hold_state(
+                    ok = set_logical_hold_state(
                         conn, session_id, hold_state,
                         changed_by="user",
                         reason=body.get("reason"),
@@ -4399,7 +4489,7 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         conn = open_index()
         try:
             try:
-                updated_ids, missing_ids = bulk_update_review_status(
+                updated_ids, missing_ids = bulk_update_logical_review_status(
                     conn,
                     session_ids,
                     status,
@@ -4609,6 +4699,20 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
 
         conn = open_index()
         try:
+            members = get_logical_session_members(conn, session_id)
+            if not members:
+                _json_response(self, {"error": "Session not found"}, 404)
+                return
+            if len(members) > 1:
+                _json_response(self, {
+                    "error": (
+                        "Conversation-level scoring is not available for a "
+                        "multi-checkpoint conversation yet."
+                    ),
+                    "block_reason": "logical_scoring_not_supported",
+                }, 409)
+                return
+            representative_id = str(members[0]["session_id"])
             # Manual scoring is AI egress too: scrub configured redaction
             # strings/usernames/blocked-domains before the prompt leaves the
             # machine, matching the background warmup path. Unlike warmup we do
@@ -4621,17 +4725,17 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             if redaction_settings is not None:
                 score_kwargs["redaction_settings"] = redaction_settings
             try:
-                result = score_session(conn, session_id, **score_kwargs)
+                result = score_session(conn, representative_id, **score_kwargs)
             except RuntimeError as e:
                 _json_response(self, {"error": str(e)}, 503)
                 return
 
-            ok = _persist_scoring_result(conn, session_id, result)
+            ok = _persist_scoring_result(conn, representative_id, result)
             if not ok:
                 _json_response(self, {"error": "Session not found"}, 404)
                 return
 
-            _maybe_create_trace_note(conn, session_id)
+            _maybe_create_trace_note(conn, representative_id)
 
             _json_response(self, {
                 "ok": True,
@@ -4803,7 +4907,7 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             return
         conn = open_index()
         try:
-            results = search_fts(
+            results = search_logical_sessions(
                 conn, q,
                 limit=int(params.get("limit", ["50"])[0]),
                 offset=int(params.get("offset", ["0"])[0]),
@@ -4818,7 +4922,7 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         end = params.get("end", [None])[0]
         conn = open_index()
         try:
-            stats = get_stats(conn, start=start, end=end)
+            stats = get_logical_stats(conn, start=start, end=end)
             _json_response(self, stats)
         finally:
             conn.close()
@@ -4923,7 +5027,14 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         """Return session with secrets redacted — for pre-share review."""
         conn = open_index()
         try:
-            detail = get_session_detail(conn, session_id)
+            try:
+                detail = get_logical_session_detail(conn, session_id)
+            except LogicalProjectionError as exc:
+                _json_response(self, {
+                    "error": str(exc),
+                    "block_reason": "logical_projection_incomplete",
+                }, 409)
+                return
             if detail is None:
                 _json_response(self, {"error": "Session not found"}, 404)
                 return
@@ -5888,6 +5999,17 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         if expected_revisions is not None and not isinstance(expected_revisions, dict):
             _json_response(self, {"error": "expected_revisions must be an object"}, 400)
             return
+        expected_logical_revisions = body.get("expected_logical_revisions")
+        if (
+            expected_logical_revisions is not None
+            and not isinstance(expected_logical_revisions, dict)
+        ):
+            _json_response(
+                self,
+                {"error": "expected_logical_revisions must be an object"},
+                400,
+            )
+            return
         conn = open_index()
         try:
             settings = get_effective_share_settings(conn, load_config())
@@ -5919,6 +6041,7 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                     note=body.get("note"),
                     source_filter=settings.get("source_filter"),
                     expected_revisions=expected_revisions,
+                    expected_logical_revisions=expected_logical_revisions,
                 )
             except RevisionConflictError as exc:
                 _json_response(self, {

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -260,8 +260,10 @@ def open_existing_index(
 # fingerprint snapshot needed to recover a sealed artifact safely, version 9
 # pins hosted recurring-protocol-v2 authorization metadata, version 10
 # stores the exact source/project pair snapshot used by recurring selection,
-# and version 11 records which share predecessors the hosted receiver dictated
-# so a retried submission can tell them apart from a locally stale claim.
+# version 11 records which share predecessors the hosted receiver dictated
+# so a retried submission can tell them apart from a locally stale claim, and
+# version 12 separates append-only upload checkpoints from the logical
+# conversation projected by the local workbench.
 SECURITY_SCHEMA_VERSION = 2
 SESSION_IDENTITY_SCHEMA_VERSION = 3
 WIDENED_MESSAGE_SCHEMA_VERSION = 4
@@ -272,7 +274,8 @@ AUTO_UPLOAD_SCHEMA_VERSION = 8
 RECURRING_PROTOCOL_V2_SCHEMA_VERSION = 9
 EXACT_SCOPE_PAIRS_SCHEMA_VERSION = 10
 RECEIVER_PREDECESSOR_SCHEMA_VERSION = 11
-WORKBENCH_SCHEMA_VERSION = RECEIVER_PREDECESSOR_SCHEMA_VERSION
+LOGICAL_CHECKPOINT_SCHEMA_VERSION = 12
+WORKBENCH_SCHEMA_VERSION = LOGICAL_CHECKPOINT_SCHEMA_VERSION
 
 # `share_sessions.predecessor_source` values. NULL means the predecessor is the
 # create-time local baseline; RECEIVER means the hosted lineage preflight
@@ -295,6 +298,10 @@ class RevisionConflictError(ValueError):
             str(blocker.get("session_id", "unknown")) for blocker in blockers
         )
         super().__init__(f"Trace revisions changed before share creation: {session_ids}")
+
+
+class LogicalProjectionError(ValueError):
+    """A checkpoint family cannot be losslessly projected as one transcript."""
 
 
 # Display-only normalization from the mixed AI/heuristic outcome vocabulary
@@ -376,7 +383,10 @@ CREATE TABLE IF NOT EXISTS sessions (
     ai_scored_at           TEXT,
     segment_sealed         INTEGER DEFAULT 0,
     content_revision       TEXT,
-    revision_stable_since  TEXT
+    revision_stable_since  TEXT,
+    logical_session_id     TEXT,
+    checkpoint_active      INTEGER NOT NULL DEFAULT 1,
+    logical_revision       TEXT
 );
 
 CREATE TABLE IF NOT EXISTS shares (
@@ -662,6 +672,223 @@ def compute_content_revision(session: dict[str, Any]) -> str:
     return f"sha256:{digest.hexdigest()}"
 
 
+_APPEND_ONLY_CHECKPOINT_REASONS = frozenset({"bounded_checkpoint", "active_tail"})
+
+
+def _checkpoint_logical_id(item: Mapping[str, Any]) -> str | None:
+    """Return a verified-by-shape append-only checkpoint root id.
+
+    The append-only segmenter has shipped two layouts: older builds emitted
+    ``<root>_seg-0000`` as the first child, while current builds keep ``root``
+    for segment zero and use ``<root>_seg-0001`` onward.  Do not group generic
+    segmented/subagent rows merely because they have a parent or a suffix.
+    """
+
+    if item.get("segment_reason") not in _APPEND_ONLY_CHECKPOINT_REASONS:
+        return None
+    index = item.get("segment_index")
+    if not isinstance(index, int) or isinstance(index, bool) or index < 0:
+        return None
+    session_id = item.get("session_id")
+    if not isinstance(session_id, str) or not session_id:
+        return None
+    parent_id = item.get("parent_session_id")
+    if index == 0:
+        if (
+            isinstance(parent_id, str)
+            and parent_id
+            and session_id == f"{parent_id}_seg-0000"
+        ):
+            return parent_id
+        return session_id
+    if (
+        isinstance(parent_id, str)
+        and parent_id
+        and session_id == f"{parent_id}_seg-{index:04d}"
+    ):
+        return parent_id
+    explicit = item.get("logical_session_id")
+    if (
+        isinstance(explicit, str)
+        and explicit
+        and session_id == f"{explicit}_seg-{index:04d}"
+    ):
+        return explicit
+    # A v11 row could not persist the parser's explicit logical id.  The exact
+    # checkpoint suffix is still recoverable when the segment keeps a genuine
+    # subagent parent; migration additionally requires a real root row with
+    # matching source provenance before accepting this inferred identity.
+    suffix = f"_seg-{index:04d}"
+    if session_id.endswith(suffix) and len(session_id) > len(suffix):
+        return session_id[:-len(suffix)]
+    return None
+
+
+def _declared_logical_session_id(item: Mapping[str, Any]) -> str | None:
+    """Return parser-declared logical identity, preferring verified checkpoints."""
+
+    checkpoint_id = _checkpoint_logical_id(item)
+    if checkpoint_id is not None:
+        return checkpoint_id
+    explicit = item.get("logical_session_id")
+    if isinstance(explicit, str) and explicit.strip():
+        return explicit
+    return None
+
+
+def _same_checkpoint_provenance(
+    root: Mapping[str, Any], member: Mapping[str, Any]
+) -> bool:
+    """Require a checkpoint and its root to name the same physical source."""
+
+    if root.get("session_id") == member.get("session_id"):
+        return True
+    if root.get("source") != member.get("source"):
+        return False
+    if root.get("project") != member.get("project"):
+        return False
+    root_key = root.get("session_key")
+    member_key = member.get("session_key")
+    if root_key and member_key:
+        return root_key == member_key
+    root_path = root.get("raw_source_path")
+    member_path = member.get("raw_source_path")
+    return bool(root_path and member_path and root_path == member_path)
+
+
+def _logical_revision_for_members(members: Sequence[Mapping[str, Any]]) -> str:
+    """Hash the exact ordered physical membership of one logical trace."""
+
+    ordered = sorted(
+        members,
+        key=lambda item: (
+            item.get("segment_index") is None,
+            item.get("segment_index") if item.get("segment_index") is not None else 0,
+            str(item.get("session_id") or ""),
+        ),
+    )
+    payload = [
+        {
+            "session_id": item.get("session_id"),
+            "content_revision": item.get("content_revision"),
+            "segment_index": item.get("segment_index"),
+            "segment_start_message": item.get("segment_start_message"),
+            "segment_end_message": item.get("segment_end_message"),
+        }
+        for item in ordered
+    ]
+    encoded = json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        default=str,
+    ).encode("utf-8")
+    return f"logical-sha256:{hashlib.sha256(encoded).hexdigest()}"
+
+
+def _logical_review_status(rows: Sequence[Mapping[str, Any]]) -> str:
+    """Project physical review states using the list-query precedence."""
+
+    statuses = [str(row.get("review_status") or "new") for row in rows]
+    if "blocked" in statuses:
+        return "blocked"
+    if "new" in statuses:
+        return "new"
+    if "shortlisted" in statuses:
+        return "shortlisted"
+    if statuses and all(status == "approved" for status in statuses):
+        return "approved"
+    return min(statuses, default="new")
+
+
+_LOGICAL_MULTI_CHECKPOINT_AI_FIELDS = (
+    "ai_quality_score",
+    "ai_score_reason",
+    "ai_scoring_detail",
+    "ai_episode_quality",
+    "ai_quality_tier",
+    "ai_display_title",
+    "ai_task_type",
+    "ai_outcome_badge",
+    "ai_value_badges",
+    "ai_risk_badges",
+    "ai_effort_estimate",
+    "ai_summary",
+    "ai_failure_value_score",
+    "ai_recovery_labels",
+    "ai_failure_attribution",
+    "ai_failure_modes",
+    "ai_learning_summary",
+    "ai_scorer_backend",
+    "ai_scorer_model",
+    "ai_rubric_git_sha",
+    "ai_scored_at",
+)
+
+
+def _clear_multi_checkpoint_ai_projection(
+    item: dict[str, Any], checkpoint_count: int
+) -> None:
+    """Do not present one component's judge result as a family-wide score."""
+
+    if checkpoint_count <= 1:
+        return
+    for field in _LOGICAL_MULTI_CHECKPOINT_AI_FIELDS:
+        item[field] = None
+
+
+def _project_family_controls(
+    rows: Sequence[Mapping[str, Any]],
+    *,
+    changed_at: str,
+    include_shareable_state: bool,
+) -> tuple[str | None, str | None, str | None]:
+    """Fold physical review/hold controls into a conservative family state."""
+
+    review_status = _logical_review_status(rows) if rows else None
+    if not rows:
+        return review_status, None, None
+    try:
+        controls_now = datetime.fromisoformat(changed_at)
+        if controls_now.tzinfo is None:
+            controls_now = controls_now.replace(tzinfo=timezone.utc)
+    except (TypeError, ValueError):
+        controls_now = datetime.now(timezone.utc)
+    effective_states = [
+        effective_hold_state(
+            row.get("hold_state"), row.get("embargo_until"), now=controls_now
+        )
+        for row in rows
+    ]
+    if "pending_review" in effective_states:
+        return review_status, "pending_review", None
+    if "embargoed" in effective_states:
+        embargoes: list[tuple[datetime, str]] = []
+        for row, effective in zip(rows, effective_states):
+            if effective != "embargoed":
+                continue
+            raw_until = row.get("embargo_until")
+            if not isinstance(raw_until, str) or not raw_until:
+                return review_status, "pending_review", None
+            try:
+                parsed_until = datetime.fromisoformat(raw_until)
+            except ValueError:
+                return review_status, "pending_review", None
+            if parsed_until.tzinfo is None:
+                parsed_until = parsed_until.replace(tzinfo=timezone.utc)
+            embargoes.append((parsed_until, raw_until))
+        if embargoes:
+            _, embargo_until = max(embargoes, key=lambda item: item[0])
+            return review_status, "embargoed", embargo_until
+        return review_status, "pending_review", None
+    if include_shareable_state:
+        if all(state == "released" for state in effective_states):
+            return review_status, "released", None
+        return review_status, "auto_redacted", None
+    return review_status, None, None
+
+
 def _legacy_content_revision(session_id: str) -> str:
     """Return a stable opaque baseline when a migrated blob is unreadable."""
     digest = hashlib.sha256(f"legacy-session:{session_id}".encode("utf-8")).hexdigest()
@@ -923,6 +1150,7 @@ def open_index() -> sqlite3.Connection:
     _migrate_recurring_protocol_v2(conn)
     _migrate_exact_scope_pairs(conn)
     _migrate_receiver_predecessor(conn)
+    _migrate_logical_checkpoint_projection(conn)
 
     # Clean up ai_outcome_badge values that the judge wrote before the
     # resolution validator rejected invalid labels. Idempotent: after
@@ -1421,6 +1649,260 @@ def _migrate_receiver_predecessor(conn: sqlite3.Connection) -> None:
         conn.execute(
             f"PRAGMA user_version = {RECEIVER_PREDECESSOR_SCHEMA_VERSION}"
         )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def _migrate_logical_checkpoint_projection(conn: sqlite3.Connection) -> None:
+    """Advance v11 -> v12 without moving or deleting checkpoint artifacts.
+
+    The projection columns are rebuildable metadata.  Historical session rows,
+    blobs, share links, findings, hold history, and receipt lineage stay on the
+    original physical ids.  Legacy parent cleanup is deliberately limited to
+    append-only rows whose id shape and source provenance both verify.
+    """
+
+    version_row = conn.execute("PRAGMA user_version").fetchone()
+    version = version_row[0] if version_row else 0
+    if version >= LOGICAL_CHECKPOINT_SCHEMA_VERSION:
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sessions_logical_checkpoint "
+            "ON sessions(logical_session_id, checkpoint_active, segment_index) "
+            "WHERE logical_session_id IS NOT NULL"
+        )
+        conn.commit()
+        return
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        for column, definition in (
+            ("logical_session_id", "TEXT"),
+            ("checkpoint_active", "INTEGER NOT NULL DEFAULT 1"),
+            ("logical_revision", "TEXT"),
+        ):
+            try:
+                conn.execute(
+                    f"ALTER TABLE sessions ADD COLUMN {column} {definition}"
+                )
+            except sqlite3.OperationalError as exc:
+                if "duplicate column" not in str(exc):
+                    raise
+
+        session_columns = {
+            str(row[1]) for row in conn.execute("PRAGMA table_info(sessions)")
+        }
+        optional_columns = (
+            "raw_source_path",
+            "session_key",
+            "parent_session_id",
+            "subagent_session_ids",
+            "segment_index",
+            "segment_start_message",
+            "segment_end_message",
+            "segment_reason",
+            "content_revision",
+            "reviewed_at",
+            "hold_state",
+            "embargo_until",
+        )
+        optional_select = ", ".join(
+            column if column in session_columns else f"NULL AS {column}"
+            for column in optional_columns
+        )
+        rows = [
+            dict(row)
+            for row in conn.execute(
+                "SELECT session_id, project, source, review_status, "
+                f"{optional_select} FROM sessions"
+            ).fetchall()
+        ]
+        by_id = {str(row["session_id"]): row for row in rows}
+        families: dict[str, list[dict[str, Any]]] = {}
+        for row in rows:
+            logical_id = _checkpoint_logical_id(row)
+            if logical_id is None:
+                continue
+            root = by_id.get(logical_id)
+            if root is None or not _same_checkpoint_provenance(root, row):
+                continue
+            families.setdefault(logical_id, []).append(row)
+
+        checkpoint_representatives: dict[str, str] = {}
+        migration_time = _now_iso()
+        for logical_id, members in families.items():
+            root = by_id[logical_id]
+            root_is_checkpoint = _checkpoint_logical_id(root) == logical_id
+            # A transition between the legacy `_seg-0000` layout and the
+            # current root-as-zero layout can leave two physical rows for the
+            # same ordinal. Prefer the current root row; retain the other as an
+            # inactive historical artifact.
+            ordered = sorted(
+                members,
+                key=lambda item: (
+                    int(item.get("segment_index") or 0),
+                    item.get("session_id") != logical_id,
+                    str(item.get("session_id")),
+                ),
+            )
+            active_by_index: dict[int, dict[str, Any]] = {}
+            for member in ordered:
+                index = int(member["segment_index"])
+                if index == 0 and root_is_checkpoint:
+                    if member["session_id"] == logical_id:
+                        active_by_index[0] = member
+                    continue
+                active_by_index.setdefault(index, member)
+            active_ids = {
+                str(member["session_id"]) for member in active_by_index.values()
+            }
+            representative = active_by_index.get(0)
+            if representative is not None:
+                representative_id = str(representative["session_id"])
+                for member in members:
+                    checkpoint_representatives[str(member["session_id"])] = (
+                        representative_id
+                    )
+            active_members = list(active_by_index.values())
+            logical_revision = _logical_revision_for_members(active_members)
+            classified_ids = {str(member["session_id"]) for member in members}
+
+            # Old physical UI actions could hold/block only one checkpoint.
+            # Project the strict negative control across every active member
+            # immediately, before any background scan or candidate poll can
+            # observe the newly grouped family.
+            control_rows = {
+                str(member["session_id"]): member for member in [root, *members]
+            }
+            projected_review, projected_hold, projected_embargo = (
+                _project_family_controls(
+                    list(control_rows.values()),
+                    changed_at=migration_time,
+                    include_shareable_state=False,
+                )
+            )
+            for member_id in active_ids:
+                current = by_id[member_id]
+                if projected_hold is not None and (
+                    current.get("hold_state") != projected_hold
+                    or current.get("embargo_until") != projected_embargo
+                ):
+                    conn.execute(
+                        "UPDATE sessions SET hold_state = ?, embargo_until = ?, "
+                        "updated_at = ? WHERE session_id = ?",
+                        (projected_hold, projected_embargo, migration_time, member_id),
+                    )
+                    conn.execute(
+                        "INSERT INTO session_hold_history "
+                        "(history_id, session_id, from_state, to_state, embargo_until, "
+                        " changed_by, changed_at, reason) "
+                        "VALUES (?, ?, ?, ?, ?, 'migration', ?, ?)",
+                        (
+                            str(uuid.uuid4()),
+                            member_id,
+                            current.get("hold_state"),
+                            projected_hold,
+                            projected_embargo,
+                            migration_time,
+                            "Migrated logical checkpoint family hold",
+                        ),
+                    )
+                if (
+                    projected_review == "blocked"
+                    and current.get("review_status") != "blocked"
+                ):
+                    conn.execute(
+                        "UPDATE sessions SET review_status = 'blocked', "
+                        "reviewed_at = COALESCE(reviewed_at, ?), updated_at = ? "
+                        "WHERE session_id = ?",
+                        (migration_time, migration_time, member_id),
+                    )
+
+            for member in members:
+                member_id = str(member["session_id"])
+                conn.execute(
+                    "UPDATE sessions SET logical_session_id = ?, "
+                    "checkpoint_active = ?, logical_revision = ? "
+                    "WHERE session_id = ?",
+                    (
+                        logical_id,
+                        1 if member_id in active_ids else 0,
+                        logical_revision,
+                        member_id,
+                    ),
+                )
+                if member_id != logical_id:
+                    conn.execute(
+                        "UPDATE sessions SET parent_session_id = NULL "
+                        "WHERE session_id = ? AND parent_session_id = ?",
+                        (member_id, logical_id),
+                    )
+
+            if logical_id not in classified_ids:
+                # Old layouts retained the complete source row only as a
+                # hidden `segmented` parent; it is the logical address, not an
+                # upload member.
+                conn.execute(
+                    "UPDATE sessions SET logical_session_id = ?, "
+                    "checkpoint_active = 0, logical_revision = ? "
+                    "WHERE session_id = ?",
+                    (logical_id, logical_revision, logical_id),
+                )
+
+            encoded_children = root.get("subagent_session_ids")
+            if encoded_children:
+                try:
+                    child_ids = json.loads(encoded_children)
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    child_ids = None
+                if isinstance(child_ids, list):
+                    cleaned = [
+                        child_id
+                        for child_id in child_ids
+                        if child_id not in classified_ids - {logical_id}
+                    ]
+                    if cleaned != child_ids:
+                        conn.execute(
+                            "UPDATE sessions SET subagent_session_ids = ? "
+                            "WHERE session_id = ?",
+                            (
+                                json.dumps(cleaned) if cleaned else None,
+                                logical_id,
+                            ),
+                        )
+
+        # A real subagent parent may already list every physical checkpoint.
+        # Keep its relationship to the segment-zero representative only. The
+        # logical root's own polluted list was cleared above and is excluded
+        # here so it never becomes its own child.
+        for row in rows:
+            parent_id = str(row["session_id"])
+            if parent_id in families or not row.get("subagent_session_ids"):
+                continue
+            try:
+                child_ids = json.loads(row["subagent_session_ids"])
+            except (TypeError, ValueError, json.JSONDecodeError):
+                continue
+            if not isinstance(child_ids, list):
+                continue
+            cleaned: list[Any] = []
+            for child_id in child_ids:
+                replacement = checkpoint_representatives.get(child_id, child_id)
+                if replacement not in cleaned:
+                    cleaned.append(replacement)
+            if cleaned != child_ids:
+                conn.execute(
+                    "UPDATE sessions SET subagent_session_ids = ? WHERE session_id = ?",
+                    (json.dumps(cleaned) if cleaned else None, parent_id),
+                )
+
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_sessions_logical_checkpoint "
+            "ON sessions(logical_session_id, checkpoint_active, segment_index) "
+            "WHERE logical_session_id IS NOT NULL"
+        )
+        conn.execute(f"PRAGMA user_version = {LOGICAL_CHECKPOINT_SCHEMA_VERSION}")
         conn.commit()
     except Exception:
         conn.rollback()
@@ -2670,6 +3152,224 @@ def recompute_estimated_costs(conn: sqlite3.Connection) -> int:
     return changed
 
 
+def _reconcile_emitted_checkpoint_families(
+    conn: sqlite3.Connection,
+    declared: Mapping[str, Mapping[str, int | None]],
+    indexed: Mapping[str, Mapping[str, int | None]],
+    *,
+    collapsed: set[str],
+    fresh_members: Mapping[str, set[str]],
+    prior_family_controls: Mapping[str, Sequence[Mapping[str, Any]]],
+    changed_at: str,
+) -> None:
+    """Refresh logical membership for complete families in one scan batch."""
+
+    def refresh_current_revision(logical_id: str) -> None:
+        """Hash only the membership that was already active before reconcile.
+
+        SQL upserts deliberately leave existing activity unchanged and insert
+        new logical members inactive.  If a parser row is filtered after the
+        family was declared, the complete-family checks below abort membership
+        reconciliation; this refresh still prevents updated active content
+        from retaining an obsolete logical revision.
+        """
+
+        active_rows = [
+            dict(row)
+            for row in conn.execute(
+                "SELECT session_id, content_revision, segment_index, "
+                "segment_start_message, segment_end_message FROM sessions "
+                "WHERE logical_session_id = ? AND checkpoint_active = 1 "
+                "ORDER BY segment_index, session_id",
+                (logical_id,),
+            ).fetchall()
+        ]
+        logical_revision = (
+            _logical_revision_for_members(active_rows) if active_rows else None
+        )
+        conn.execute(
+            "UPDATE sessions SET logical_revision = ? "
+            "WHERE logical_session_id = ?",
+            (logical_revision, logical_id),
+        )
+
+    for logical_id in sorted(indexed):
+        declared_members = dict(declared.get(logical_id, {}))
+        indexed_members = dict(indexed[logical_id])
+        if not declared_members or declared_members != indexed_members:
+            # A slash-command/invalid row was skipped. Retaining the previous
+            # projection is safer than retiring a checkpoint from a partial
+            # parse result.
+            refresh_current_revision(logical_id)
+            continue
+        if logical_id in collapsed:
+            if indexed_members != {logical_id: None}:
+                refresh_current_revision(logical_id)
+                continue
+        else:
+            indices = list(indexed_members.values())
+            if (
+                any(index is None for index in indices)
+                or len(set(indices)) != len(indices)
+                or sorted(int(index) for index in indices if index is not None)
+                != list(range(len(indices)))
+            ):
+                refresh_current_revision(logical_id)
+                continue
+
+        requested_ids = set(indexed_members)
+        lookup_ids = sorted(requested_ids | {logical_id})
+        placeholders = ",".join("?" for _ in lookup_ids)
+        current_rows = [
+            dict(row)
+            for row in conn.execute(
+                "SELECT session_id, project, source, raw_source_path, session_key, "
+                "parent_session_id, segment_index, segment_start_message, "
+                "segment_end_message, segment_reason, content_revision, "
+                "logical_session_id FROM sessions "
+                f"WHERE session_id IN ({placeholders})",
+                lookup_ids,
+            ).fetchall()
+        ]
+        by_id = {str(row["session_id"]): row for row in current_rows}
+        root = by_id.get(logical_id)
+        if root is None or requested_ids - set(by_id):
+            refresh_current_revision(logical_id)
+            continue
+        if any(
+            not _same_checkpoint_provenance(root, by_id[session_id])
+            for session_id in requested_ids
+        ):
+            refresh_current_revision(logical_id)
+            continue
+
+        # Snapshot the established family's negative controls before changing
+        # membership. Newly inserted/reactivated checkpoints start with schema
+        # defaults and must not dilute a logical hold, embargo, or block.
+        fresh_ids = set(fresh_members.get(logical_id, set()))
+        prior_controls = [
+            dict(row) for row in prior_family_controls.get(logical_id, ())
+        ]
+        projected_review_status, inherited_hold_state, inherited_embargo_until = (
+            _project_family_controls(
+                prior_controls,
+                changed_at=changed_at,
+                include_shareable_state=True,
+            )
+        )
+        inherited_review_status = (
+            "blocked" if projected_review_status == "blocked" else None
+        )
+
+        emitted_ids = sorted(requested_ids)
+        conn.executemany(
+            "UPDATE sessions SET logical_session_id = ?, checkpoint_active = 1 "
+            "WHERE session_id = ?",
+            [(logical_id, session_id) for session_id in emitted_ids],
+        )
+        if logical_id not in requested_ids:
+            conn.execute(
+                "UPDATE sessions SET logical_session_id = ?, checkpoint_active = 0 "
+                "WHERE session_id = ?",
+                (logical_id, logical_id),
+            )
+
+        emitted_placeholders = ",".join("?" for _ in emitted_ids)
+        conn.execute(
+            "UPDATE sessions SET checkpoint_active = 0 "
+            "WHERE logical_session_id = ? "
+            f"AND session_id NOT IN ({emitted_placeholders})",
+            (logical_id, *emitted_ids),
+        )
+        emitted_controls = {
+            str(row["session_id"]): dict(row)
+            for row in conn.execute(
+                "SELECT session_id, review_status, reviewed_at, hold_state, "
+                "embargo_until FROM sessions "
+                f"WHERE session_id IN ({emitted_placeholders})",
+                emitted_ids,
+            ).fetchall()
+        }
+        for session_id in emitted_ids:
+            current = emitted_controls[session_id]
+            inherit_hold_for_member = (
+                inherited_hold_state in {"pending_review", "embargoed"}
+                or session_id in fresh_ids
+            )
+            if inherited_hold_state is not None and inherit_hold_for_member and (
+                current.get("hold_state") != inherited_hold_state
+                or current.get("embargo_until") != inherited_embargo_until
+            ):
+                conn.execute(
+                    "UPDATE sessions SET hold_state = ?, embargo_until = ?, updated_at = ? "
+                    "WHERE session_id = ?",
+                    (
+                        inherited_hold_state,
+                        inherited_embargo_until,
+                        changed_at,
+                        session_id,
+                    ),
+                )
+                conn.execute(
+                    "INSERT INTO session_hold_history "
+                    "(history_id, session_id, from_state, to_state, embargo_until, "
+                    " changed_by, changed_at, reason) "
+                    "VALUES (?, ?, ?, ?, ?, 'auto', ?, ?)",
+                    (
+                        str(uuid.uuid4()),
+                        session_id,
+                        current.get("hold_state"),
+                        inherited_hold_state,
+                        inherited_embargo_until,
+                        changed_at,
+                        "Inherited logical checkpoint family hold",
+                    ),
+                )
+            if (
+                inherited_review_status == "blocked"
+                and current.get("review_status") != "blocked"
+            ):
+                conn.execute(
+                    "UPDATE sessions SET review_status = 'blocked', reviewed_at = ?, "
+                    "updated_at = ? WHERE session_id = ?",
+                    (changed_at, changed_at, session_id),
+                )
+        if logical_id in collapsed:
+            conn.execute(
+                "UPDATE sessions SET review_status = CASE "
+                "WHEN review_status = 'segmented' THEN 'new' ELSE review_status END "
+                "WHERE session_id = ?",
+                (logical_id,),
+            )
+
+        polluted_children = requested_ids - {logical_id}
+        if polluted_children:
+            conn.executemany(
+                "UPDATE sessions SET parent_session_id = NULL "
+                "WHERE session_id = ? AND parent_session_id = ?",
+                [(session_id, logical_id) for session_id in sorted(polluted_children)],
+            )
+            root_children = conn.execute(
+                "SELECT subagent_session_ids FROM sessions WHERE session_id = ?",
+                (logical_id,),
+            ).fetchone()
+            if root_children is not None and root_children["subagent_session_ids"]:
+                try:
+                    decoded = json.loads(root_children["subagent_session_ids"])
+                except (TypeError, ValueError, json.JSONDecodeError):
+                    decoded = None
+                if isinstance(decoded, list):
+                    cleaned = [item for item in decoded if item not in polluted_children]
+                    if cleaned != decoded:
+                        conn.execute(
+                            "UPDATE sessions SET subagent_session_ids = ? "
+                            "WHERE session_id = ?",
+                            (json.dumps(cleaned) if cleaned else None, logical_id),
+                        )
+
+        refresh_current_revision(logical_id)
+
+
 def upsert_sessions(
     conn: sqlite3.Connection,
     sessions: list[dict[str, Any]],
@@ -2694,6 +3394,44 @@ def upsert_sessions(
     if not sessions:
         return 0
 
+    declared_families: dict[str, dict[str, int | None]] = {}
+    indexed_families: dict[str, dict[str, int | None]] = {}
+    fresh_family_members: dict[str, set[str]] = {}
+    collapsed_families: set[str] = set()
+    for session in sessions:
+        logical_id = _declared_logical_session_id(session)
+        session_id = session.get("session_id")
+        if logical_id is not None and isinstance(session_id, str) and session_id:
+            index = session.get("segment_index")
+            declared_families.setdefault(logical_id, {})[session_id] = (
+                int(index)
+                if isinstance(index, int) and not isinstance(index, bool) and index >= 0
+                else None
+            )
+    collapsed_families.update(
+        logical_id
+        for logical_id, members in declared_families.items()
+        if members == {logical_id: None}
+    )
+
+    def snapshot_family_controls(logical_id: str) -> list[dict[str, Any]]:
+        return [
+            dict(row)
+            for row in conn.execute(
+                "SELECT session_id, review_status, hold_state, embargo_until "
+                "FROM sessions WHERE "
+                "(logical_session_id = ? OR "
+                " (logical_session_id IS NULL AND session_id = ?)) "
+                "AND COALESCE(checkpoint_active, 1) = 1",
+                (logical_id, logical_id),
+            ).fetchall()
+        ]
+
+    prior_family_controls = {
+        logical_id: snapshot_family_controls(logical_id)
+        for logical_id in declared_families
+    }
+
     now = _now_iso()
     new_count = 0
     emitted_session_ids = {
@@ -2701,11 +3439,14 @@ def upsert_sessions(
         for session in sessions
         if session.get("session_id")
     }
+    # Older checkpoint layouts emitted a hidden logical root and pointed every
+    # segment at it as though it were a subagent parent.  Newer parsers can keep
+    # a *real* subagent parent on every checkpoint, so only the independently
+    # verified logical id may be treated as the hidden segmented parent.
     segmented_parent_ids = {
-        str(session.get("parent_session_id"))
+        logical_id
         for session in sessions
-        if session.get("parent_session_id")
-        and session.get("segment_reason") in {"bounded_checkpoint", "active_tail"}
+        if (logical_id := _checkpoint_logical_id(session)) is not None
     } - emitted_session_ids
 
     # Check FTS availability
@@ -2759,6 +3500,7 @@ def upsert_sessions(
             "ai_value_badges, ai_risk_badges, "
             "ai_effort_estimate, ai_summary, "
             "share_id, session_key, parent_session_id, subagent_session_ids, "
+            "logical_session_id, checkpoint_active, "
             "estimated_cost_usd, input_tokens, output_tokens, "
             "cache_read_tokens, cache_creation_tokens, end_time, content_revision "
             "FROM sessions WHERE session_id = ?",
@@ -2769,6 +3511,27 @@ def upsert_sessions(
             existing is not None
             and existing["content_revision"] != content_revision
         )
+        logical_id = _declared_logical_session_id(session)
+        if (
+            logical_id is None
+            and existing is not None
+            and existing["logical_session_id"] == session_id
+            and session.get("segment_reason") not in _APPEND_ONLY_CHECKPOINT_REASONS
+            and session_id not in declared_families
+        ):
+            # A current parser result collapsed a formerly segmented family
+            # back to one physical root. The old children remain historical
+            # artifacts but must leave the active projection/candidate pool.
+            logical_id = str(session_id)
+            declared_families[logical_id] = {str(session_id): None}
+            collapsed_families.add(logical_id)
+            prior_family_controls.setdefault(
+                logical_id, snapshot_family_controls(logical_id)
+            )
+        if logical_id is not None and (
+            is_new or not bool(existing["checkpoint_active"])
+        ):
+            fresh_family_members.setdefault(logical_id, set()).add(str(session_id))
 
         # Avoid rewriting the blob/FTS record for a byte-equivalent transcript.
         # Metadata fields still flow through the SQL upsert below so parser
@@ -2878,7 +3641,8 @@ def upsert_sessions(
                 fork_of, fork_source, fork_nickname,
                 estimated_cost_usd,
                 tool_counts, user_interrupts,
-                hold_state, content_revision, revision_stable_since
+                hold_state, content_revision, revision_stable_since,
+                logical_session_id, checkpoint_active, logical_revision
             ) VALUES (
                 ?, ?, ?, ?, ?,
                 ?, ?, ?,
@@ -2907,7 +3671,8 @@ def upsert_sessions(
                 ?, ?, ?,
                 ?,
                 ?, ?,
-                'auto_redacted', ?, ?
+                'auto_redacted', ?, ?,
+                ?, ?, NULL
             )
             ON CONFLICT(session_id) DO UPDATE SET
                 project = excluded.project,
@@ -3040,6 +3805,8 @@ def upsert_sessions(
                     WHEN sessions.content_revision IS NOT excluded.content_revision
                     THEN excluded.revision_stable_since
                     ELSE sessions.revision_stable_since END,
+                logical_session_id = sessions.logical_session_id,
+                checkpoint_active = sessions.checkpoint_active,
                 content_revision = excluded.content_revision
             """,
             (
@@ -3101,6 +3868,8 @@ def upsert_sessions(
                 session_stats.get("user_interrupts", 0),
                 content_revision,
                 now,
+                logical_id,
+                0 if logical_id is not None else 1,
             ),
         )
 
@@ -3141,6 +3910,29 @@ def upsert_sessions(
         else:
             counts["unchanged"] += 1
 
+        if logical_id is not None:
+            segment_index = session.get("segment_index")
+            indexed_families.setdefault(logical_id, {})[str(session_id)] = (
+                None
+                if logical_id in collapsed_families
+                else (
+                    int(segment_index)
+                    if isinstance(segment_index, int)
+                    and not isinstance(segment_index, bool)
+                    and segment_index >= 0
+                    else None
+                )
+            )
+
+    _reconcile_emitted_checkpoint_families(
+        conn,
+        declared_families,
+        indexed_families,
+        collapsed=collapsed_families,
+        fresh_members=fresh_family_members,
+        prior_family_controls=prior_family_controls,
+        changed_at=now,
+    )
     if segmented_parent_ids:
         conn.executemany(
             "UPDATE sessions SET review_status = 'segmented' WHERE session_id = ?",
@@ -3178,6 +3970,270 @@ def _build_start_time_where(
     if not clauses:
         return "", []
     return f" WHERE {' AND '.join(clauses)}", params
+
+
+def query_logical_sessions(
+    conn: sqlite3.Connection,
+    *,
+    status: str | list[str] | tuple[str, ...] | None = None,
+    source: str | list[str] | tuple[str, ...] | None = None,
+    project: str | None = None,
+    task_type: str | None = None,
+    recovery_label: str | None = None,
+    failure_attribution: str | None = None,
+    failure_mode: str | None = None,
+    search_text: str | None = None,
+    sort: str = "ai_failure_value_score",
+    order: str = "desc",
+    limit: int = 50,
+    offset: int = 0,
+    exclude_segmented_parents: bool = False,
+    logical_session_ids: Sequence[str] | None = None,
+) -> list[dict[str, Any]]:
+    """Return one metadata row per active logical conversation.
+
+    Filtering identifies matching families first; aggregation and pagination
+    then operate on those families. A child-only match therefore cannot leak a
+    duplicate card or consume another pagination slot.
+    """
+
+    allowed_sort_columns = {
+        "start_time", "end_time", "indexed_at", "updated_at",
+        "project", "source", "model", "model_effort", "review_status", "task_type",
+        "user_messages", "assistant_messages", "tool_uses",
+        "input_tokens", "output_tokens", "duration_seconds",
+        "sensitivity_score", "ai_quality_score", "ai_failure_value_score",
+    }
+    if sort not in allowed_sort_columns:
+        sort = "start_time"
+    if order.lower() not in {"asc", "desc"}:
+        order = "desc"
+    direction = order.upper()
+
+    params: list[Any] = []
+    clauses: list[str] = []
+    eligible_from = "active a"
+    if search_text:
+        if _has_fts(conn):
+            eligible_from += " JOIN sessions_fts f ON f.session_id = a.session_id"
+            clauses.append("sessions_fts MATCH ?")
+            params.append(search_text)
+        else:
+            clauses.append("a.display_title LIKE ?")
+            params.append(f"%{search_text}%")
+
+    def add_multi(column: str, value: str | Sequence[str] | None) -> None:
+        if value is None:
+            return
+        if isinstance(value, str):
+            clauses.append(f"a.{column} = ?")
+            params.append(value)
+            return
+        values = [item for item in value if item]
+        if values:
+            clauses.append(f"a.{column} IN ({','.join('?' for _ in values)})")
+            params.extend(values)
+
+    add_multi("source", source)
+    family_size_sql = (
+        "(SELECT COUNT(*) FROM active family_member "
+        "WHERE family_member._logical_id = a._logical_id)"
+    )
+    if project is not None:
+        clauses.append("a.project = ?")
+        params.append(project)
+    if task_type is not None:
+        clauses.append(
+            "CASE WHEN " + family_size_sql + " = 1 "
+            "THEN COALESCE(a.ai_task_type, a.task_type) "
+            "ELSE a.task_type END = ?"
+        )
+        params.append(task_type)
+    if recovery_label is not None:
+        clauses.append(
+            family_size_sql + " = 1 AND "
+            "EXISTS (SELECT 1 FROM json_each(COALESCE(a.ai_recovery_labels, '[]')) "
+            "WHERE value = ?)"
+        )
+        params.append(recovery_label)
+    if failure_attribution is not None:
+        clauses.append(
+            family_size_sql + " = 1 AND a.ai_failure_attribution = ?"
+        )
+        params.append(failure_attribution)
+    if failure_mode is not None:
+        clauses.append(
+            family_size_sql + " = 1 AND "
+            "EXISTS (SELECT 1 FROM json_each(COALESCE(a.ai_failure_modes, '[]')) "
+            "WHERE value = ?)"
+        )
+        params.append(failure_mode)
+    if exclude_segmented_parents:
+        clauses.append("a.review_status != 'segmented'")
+    if logical_session_ids is not None:
+        ids = list(dict.fromkeys(item for item in logical_session_ids if item))
+        if not ids:
+            return []
+        clauses.append(f"a._logical_id IN ({','.join('?' for _ in ids)})")
+        params.extend(ids)
+    where_sql = " AND ".join(clauses) if clauses else "1=1"
+    projected_status_params: list[Any] = []
+    projected_status_sql = ""
+    if status is not None:
+        if isinstance(status, str):
+            projected_status_sql = " AND g._logical_review_status = ?"
+            projected_status_params.append(status)
+        else:
+            statuses = [item for item in status if item]
+            if statuses:
+                projected_status_sql = (
+                    " AND g._logical_review_status IN "
+                    f"({','.join('?' for _ in statuses)})"
+                )
+                projected_status_params.extend(statuses)
+
+    aggregate_sort = {
+        "start_time": "g._logical_start_time",
+        "end_time": "g._logical_end_time",
+        "user_messages": "g._logical_user_messages",
+        "assistant_messages": "g._logical_assistant_messages",
+        "tool_uses": "g._logical_tool_uses",
+        "input_tokens": "g._logical_input_tokens",
+        "output_tokens": "g._logical_output_tokens",
+        "duration_seconds": "g._logical_duration_seconds",
+        "review_status": "g._logical_review_status",
+    }
+    sort_expression = aggregate_sort.get(sort, f"r.{sort}")
+    if sort == "ai_failure_value_score":
+        order_sql = (
+            "ORDER BY (CASE WHEN g._checkpoint_count > 1 THEN NULL "
+            "ELSE r.ai_failure_value_score END IS NULL), "
+            "CASE WHEN g._checkpoint_count > 1 THEN NULL "
+            f"ELSE r.ai_failure_value_score END {direction}, "
+            "g._logical_start_time DESC"
+        )
+    elif sort == "ai_quality_score":
+        order_sql = (
+            "ORDER BY (CASE WHEN g._checkpoint_count > 1 THEN NULL "
+            "ELSE r.ai_quality_score END IS NULL), "
+            "CASE WHEN g._checkpoint_count > 1 THEN NULL "
+            f"ELSE r.ai_quality_score END {direction}, "
+            "g._logical_start_time DESC"
+        )
+    else:
+        order_sql = f"ORDER BY {sort_expression} {direction}, r.session_id"
+
+    sql = f"""
+        WITH active AS (
+            SELECT s.*, COALESCE(s.logical_session_id, s.session_id) AS _logical_id
+            FROM sessions s
+            WHERE COALESCE(s.checkpoint_active, 1) = 1
+        ), eligible AS (
+            SELECT DISTINCT a._logical_id
+            FROM {eligible_from}
+            WHERE {where_sql}
+        ), ranked AS (
+            SELECT a.*,
+                   ROW_NUMBER() OVER (
+                       PARTITION BY a._logical_id
+                       ORDER BY
+                           CASE WHEN a.session_id = a._logical_id THEN 0 ELSE 1 END,
+                           CASE WHEN a.segment_index IS NULL THEN 1 ELSE 0 END,
+                           a.segment_index,
+                           a.session_id
+                   ) AS _logical_row
+            FROM active a JOIN eligible e ON e._logical_id = a._logical_id
+        ), grouped AS (
+            SELECT a._logical_id,
+                   COUNT(*) AS _checkpoint_count,
+                   MIN(a.start_time) AS _logical_start_time,
+                   MAX(a.end_time) AS _logical_end_time,
+                   CAST(ROUND((julianday(MAX(a.end_time)) -
+                               julianday(MIN(a.start_time))) * 86400.0)
+                        AS INTEGER) AS _logical_duration_seconds,
+                   SUM(COALESCE(a.user_messages, 0)) AS _logical_user_messages,
+                   SUM(COALESCE(a.assistant_messages, 0)) AS _logical_assistant_messages,
+                   SUM(COALESCE(a.tool_uses, 0)) AS _logical_tool_uses,
+                   SUM(COALESCE(a.input_tokens, 0)) AS _logical_input_tokens,
+                   SUM(COALESCE(a.output_tokens, 0)) AS _logical_output_tokens,
+                   SUM(COALESCE(a.cache_read_tokens, 0)) AS _logical_cache_read_tokens,
+                   SUM(COALESCE(a.cache_creation_tokens, 0)) AS _logical_cache_creation_tokens,
+                   SUM(COALESCE(a.estimated_cost_usd, 0)) AS _logical_estimated_cost,
+                   MIN(COALESCE(a.segment_sealed, 0)) AS _logical_segment_sealed,
+                   MAX(a.logical_revision) AS _stored_logical_revision,
+                   CASE
+                     WHEN SUM(CASE WHEN a.review_status = 'blocked' THEN 1 ELSE 0 END) > 0
+                       THEN 'blocked'
+                     WHEN SUM(CASE WHEN a.review_status = 'new' THEN 1 ELSE 0 END) > 0
+                       THEN 'new'
+                     WHEN SUM(CASE WHEN a.review_status = 'shortlisted' THEN 1 ELSE 0 END) > 0
+                       THEN 'shortlisted'
+                     WHEN SUM(CASE WHEN a.review_status = 'approved' THEN 1 ELSE 0 END) = COUNT(*)
+                       THEN 'approved'
+                     ELSE MIN(a.review_status)
+                   END AS _logical_review_status
+            FROM active a JOIN eligible e ON e._logical_id = a._logical_id
+            GROUP BY a._logical_id
+        )
+        SELECT r.*, g._checkpoint_count, g._logical_start_time,
+               g._logical_end_time, g._logical_duration_seconds,
+               g._logical_user_messages,
+               g._logical_assistant_messages, g._logical_tool_uses,
+               g._logical_input_tokens, g._logical_output_tokens,
+               g._logical_cache_read_tokens, g._logical_cache_creation_tokens,
+               g._logical_estimated_cost, g._logical_segment_sealed,
+               g._stored_logical_revision, g._logical_review_status
+        FROM ranked r JOIN grouped g ON g._logical_id = r._logical_id
+        WHERE r._logical_row = 1 {projected_status_sql}
+        {order_sql}
+        LIMIT ? OFFSET ?
+    """
+    rows = conn.execute(
+        sql, (*params, *projected_status_params, limit, offset)
+    ).fetchall()
+    result: list[dict[str, Any]] = []
+    projection_time = _now_iso()
+    for row in rows:
+        item = dict(row)
+        logical_id = str(item.pop("_logical_id"))
+        item.pop("_logical_row", None)
+        item["session_id"] = logical_id
+        item["logical_session_id"] = logical_id
+        item["checkpoint_count"] = int(item.pop("_checkpoint_count"))
+        item["start_time"] = item.pop("_logical_start_time")
+        item["end_time"] = item.pop("_logical_end_time")
+        item["duration_seconds"] = item.pop("_logical_duration_seconds")
+        item["user_messages"] = int(item.pop("_logical_user_messages") or 0)
+        item["assistant_messages"] = int(item.pop("_logical_assistant_messages") or 0)
+        item["tool_uses"] = int(item.pop("_logical_tool_uses") or 0)
+        item["input_tokens"] = int(item.pop("_logical_input_tokens") or 0)
+        item["output_tokens"] = int(item.pop("_logical_output_tokens") or 0)
+        item["cache_read_tokens"] = int(item.pop("_logical_cache_read_tokens") or 0)
+        item["cache_creation_tokens"] = int(
+            item.pop("_logical_cache_creation_tokens") or 0
+        )
+        item["estimated_cost_usd"] = item.pop("_logical_estimated_cost")
+        item["segment_sealed"] = int(item.pop("_logical_segment_sealed") or 0)
+        item["review_status"] = item.pop("_logical_review_status")
+        item["logical_revision"] = (
+            item.pop("_stored_logical_revision") or item.get("content_revision")
+        )
+        members = get_logical_session_members(conn, logical_id)
+        item["checkpoint_session_ids"] = [
+            str(member["session_id"]) for member in members
+        ]
+        item["logical_incomplete"] = not _logical_member_metadata_complete(members)
+        projected_review, projected_hold, projected_embargo = _project_family_controls(
+            members,
+            changed_at=projection_time,
+            include_shareable_state=True,
+        )
+        item["review_status"] = projected_review or "new"
+        item["hold_state"] = projected_hold or "pending_review"
+        item["embargo_until"] = projected_embargo
+        _clear_multi_checkpoint_ai_projection(item, item["checkpoint_count"])
+        result.append(item)
+    return result
 
 
 def query_sessions(
@@ -3329,6 +4385,300 @@ def get_session_detail(conn: sqlite3.Connection, session_id: str) -> dict[str, A
             except (json.JSONDecodeError, ValueError):
                 pass
 
+    return result
+
+
+def get_logical_session_members(
+    conn: sqlite3.Connection,
+    session_id: str,
+    *,
+    active_only: bool = True,
+) -> list[dict[str, Any]]:
+    """Resolve a logical/root/child id to its ordered physical members."""
+
+    requested = conn.execute(
+        "SELECT session_id, logical_session_id FROM sessions WHERE session_id = ?",
+        (session_id,),
+    ).fetchone()
+    if requested is None:
+        return []
+    logical_id = requested["logical_session_id"] or requested["session_id"]
+    active_clause = "AND COALESCE(checkpoint_active, 1) = 1 " if active_only else ""
+    rows = conn.execute(
+        "SELECT * FROM sessions WHERE "
+        "(logical_session_id = ? OR (logical_session_id IS NULL AND session_id = ?)) "
+        + active_clause
+        + "ORDER BY CASE WHEN segment_index IS NULL THEN 1 ELSE 0 END, "
+        "segment_index, session_id",
+        (logical_id, logical_id),
+    ).fetchall()
+    return [dict(row) for row in rows]
+
+
+def _logical_member_ranges_complete(members: Sequence[Mapping[str, Any]]) -> bool:
+    if not members:
+        return False
+    indexes = [member.get("segment_index") for member in members]
+    if all(index is None for index in indexes):
+        return len(members) == 1
+    if (
+        any(not isinstance(index, int) or isinstance(index, bool) for index in indexes)
+        or indexes != list(range(len(indexes)))
+    ):
+        return False
+    expected_start = 0
+    for member in members:
+        start = member.get("segment_start_message")
+        end = member.get("segment_end_message")
+        if (
+            not isinstance(start, int)
+            or isinstance(start, bool)
+            or not isinstance(end, int)
+            or isinstance(end, bool)
+            or start != expected_start
+            or end < start
+        ):
+            return False
+        expected_start = end + 1
+    return True
+
+
+def _logical_member_payload_complete(
+    members: Sequence[Mapping[str, Any]],
+) -> bool:
+    """Verify active membership plus the blobs needed for a lossless package."""
+
+    if not _logical_member_ranges_complete(members):
+        return False
+    checkpointed = any(member.get("segment_index") is not None for member in members)
+    for member in members:
+        session_id = str(member.get("session_id") or "")
+        blob = _read_blob_for_revision(session_id, member.get("blob_path"))
+        if blob is None or not isinstance(blob.get("messages"), list):
+            return False
+        if checkpointed:
+            start = member.get("segment_start_message")
+            end = member.get("segment_end_message")
+            if len(blob["messages"]) != int(end) - int(start) + 1:
+                return False
+    return True
+
+
+def _logical_member_metadata_complete(
+    members: Sequence[Mapping[str, Any]],
+) -> bool:
+    """Cheap list-view completeness: structural ranges plus blob presence."""
+
+    return _logical_member_ranges_complete(members) and all(
+        _blob_present_for_revision(
+            str(member.get("session_id") or ""), member.get("blob_path")
+        )
+        for member in members
+    )
+
+
+def _current_logical_revision(members: Sequence[Mapping[str, Any]]) -> str | None:
+    if not members:
+        return None
+    if len(members) == 1 and members[0].get("logical_session_id") is None:
+        revision = members[0].get("content_revision")
+        return str(revision) if revision is not None else None
+    return _logical_revision_for_members(members)
+
+
+def expand_logical_session_ids(
+    conn: sqlite3.Connection,
+    session_ids: Sequence[str],
+    *,
+    expected_logical_revisions: Mapping[str, str] | None = None,
+    expected_component_revisions: Mapping[str, str] | None = None,
+) -> list[str]:
+    """Expand logical ids to current active physical ids in deterministic order.
+
+    Callers that need a race-free write should begin ``IMMEDIATE`` before this
+    helper and retain that transaction through their update. Optional expected
+    maps bind both family membership and component revisions to a prior UI read.
+    """
+
+    ordered_logical_ids: list[str] = []
+    by_logical: dict[str, list[dict[str, Any]]] = {}
+    blockers: list[dict[str, Any]] = []
+    for requested_id in dict.fromkeys(session_ids):
+        members = get_logical_session_members(conn, requested_id)
+        if not members:
+            blockers.append({
+                "session_id": requested_id,
+                "logical_session_id": requested_id,
+                "expected_revision_hash": None,
+                "current_revision_hash": None,
+                "member_session_ids": [],
+            })
+            continue
+        logical_id = str(
+            members[0].get("logical_session_id") or members[0]["session_id"]
+        )
+        if logical_id not in by_logical:
+            ordered_logical_ids.append(logical_id)
+            by_logical[logical_id] = members
+
+    if expected_logical_revisions is not None:
+        expected_ids = set(expected_logical_revisions)
+        actual_ids = set(by_logical)
+        for logical_id in sorted(expected_ids | actual_ids):
+            members = by_logical.get(logical_id, [])
+            current = _current_logical_revision(members)
+            expected = expected_logical_revisions.get(logical_id)
+            if logical_id not in expected_ids or logical_id not in actual_ids or expected != current:
+                blockers.append({
+                    "session_id": logical_id,
+                    "logical_session_id": logical_id,
+                    "expected_revision_hash": expected,
+                    "current_revision_hash": current,
+                    "member_session_ids": [row["session_id"] for row in members],
+                })
+
+    expanded = [
+        str(member["session_id"])
+        for logical_id in ordered_logical_ids
+        for member in by_logical[logical_id]
+    ]
+    if expected_component_revisions is not None:
+        current_components = {
+            str(member["session_id"]): member.get("content_revision")
+            for members in by_logical.values()
+            for member in members
+        }
+        expected_ids = set(expected_component_revisions)
+        current_ids = set(current_components)
+        for component_id in sorted(expected_ids | current_ids):
+            expected = expected_component_revisions.get(component_id)
+            current = current_components.get(component_id)
+            if component_id not in expected_ids or component_id not in current_ids or expected != current:
+                blockers.append({
+                    "session_id": component_id,
+                    "logical_session_id": next(
+                        (
+                            logical_id
+                            for logical_id, members in by_logical.items()
+                            if any(row["session_id"] == component_id for row in members)
+                        ),
+                        None,
+                    ),
+                    "expected_revision_hash": expected,
+                    "current_revision_hash": current,
+                })
+    if blockers:
+        raise RevisionConflictError(blockers)
+    return expanded
+
+
+def get_logical_session_detail(
+    conn: sqlite3.Connection, session_id: str
+) -> dict[str, Any] | None:
+    """Return a lossless merged detail for one active checkpoint family."""
+
+    members = get_logical_session_members(conn, session_id)
+    if not members:
+        return None
+    logical_id = str(members[0].get("logical_session_id") or members[0]["session_id"])
+    checkpointed = any(member.get("segment_index") is not None for member in members)
+    if checkpointed:
+        indexes = [member.get("segment_index") for member in members]
+        if (
+            any(not isinstance(index, int) or isinstance(index, bool) for index in indexes)
+            or indexes != list(range(len(indexes)))
+        ):
+            raise LogicalProjectionError(
+                f"Checkpoint indexes for {logical_id} are not contiguous from zero."
+            )
+
+    details: list[dict[str, Any]] = []
+    expected_start = 0
+    for member in members:
+        detail = get_session_detail(conn, str(member["session_id"]))
+        if detail is None:
+            raise LogicalProjectionError(
+                f"Checkpoint blob metadata vanished for {member['session_id']}."
+            )
+        if checkpointed:
+            start = member.get("segment_start_message")
+            end = member.get("segment_end_message")
+            if (
+                not isinstance(start, int)
+                or isinstance(start, bool)
+                or not isinstance(end, int)
+                or isinstance(end, bool)
+                or start != expected_start
+                or end < start
+            ):
+                raise LogicalProjectionError(
+                    f"Checkpoint message ranges for {logical_id} are not contiguous."
+                )
+            if len(detail.get("messages", [])) != end - start + 1:
+                raise LogicalProjectionError(
+                    f"Checkpoint {member['session_id']} does not match its message range."
+                )
+            expected_start = end + 1
+        details.append(detail)
+
+    result = dict(details[0])
+    result["session_id"] = logical_id
+    result["logical_session_id"] = logical_id
+    result["checkpoint_count"] = len(details)
+    result["logical_incomplete"] = False
+    result["component_session_ids"] = [
+        str(member["session_id"]) for member in members
+    ]
+    result["checkpoint_session_ids"] = list(result["component_session_ids"])
+    result["messages"] = [
+        message for detail in details for message in detail.get("messages", [])
+    ]
+    for field in (
+        "user_messages", "assistant_messages", "tool_uses", "input_tokens",
+        "output_tokens", "cache_read_tokens", "cache_creation_tokens",
+    ):
+        result[field] = sum(int(member.get(field) or 0) for member in members)
+    result["estimated_cost_usd"] = sum(
+        float(member.get("estimated_cost_usd") or 0) for member in members
+    )
+    result["start_time"] = min(
+        (member.get("start_time") for member in members if member.get("start_time")),
+        default=None,
+    )
+    result["end_time"] = max(
+        (member.get("end_time") for member in members if member.get("end_time")),
+        default=None,
+    )
+    result["duration_seconds"] = _compute_duration(result)
+    result["logical_revision"] = _current_logical_revision(members)
+    result["content_revision"] = compute_content_revision(result)
+    result["segment_index"] = None
+    result["segment_start_message"] = None
+    result["segment_end_message"] = None
+    result["segment_reason"] = None
+    result["segment_sealed"] = int(
+        all(bool(member.get("segment_sealed")) for member in members)
+    )
+    result["raw_source_start_offset"] = None
+    result["raw_source_end_offset"] = None
+    projected_review, projected_hold, projected_embargo = _project_family_controls(
+        members,
+        changed_at=_now_iso(),
+        include_shareable_state=True,
+    )
+    result["review_status"] = projected_review or "new"
+    result["hold_state"] = projected_hold or "pending_review"
+    result["embargo_until"] = projected_embargo
+    _clear_multi_checkpoint_ai_projection(result, len(members))
+    for field in ("value_badges", "risk_badges", "files_touched", "commands_run"):
+        combined: list[Any] = []
+        for detail in details:
+            value = detail.get(field)
+            if isinstance(value, list):
+                for item in value:
+                    if item not in combined:
+                        combined.append(item)
+        result[field] = combined
     return result
 
 
@@ -3567,11 +4917,91 @@ def bulk_update_review_status(
     return updated_ids, missing_ids
 
 
+def bulk_update_logical_review_status(
+    conn: sqlite3.Connection,
+    session_ids: Sequence[str],
+    status: str,
+) -> tuple[list[str], list[str]]:
+    """Atomically apply one review status to every active family member."""
+
+    logical_statuses = frozenset({"new", "shortlisted", "approved", "blocked"})
+    if not isinstance(status, str) or status not in logical_statuses:
+        raise ValueError(
+            "status must be 'new', 'shortlisted', 'approved', or 'blocked'"
+        )
+    if (
+        isinstance(session_ids, (str, bytes))
+        or not isinstance(session_ids, Sequence)
+        or not (1 <= len(session_ids) <= REVIEW_BULK_LIMIT)
+    ):
+        raise ValueError(
+            f"session_ids must contain 1-{REVIEW_BULK_LIMIT} entries"
+        )
+    if any(not isinstance(session_id, str) or not session_id for session_id in session_ids):
+        raise ValueError("session_ids must contain non-empty strings")
+    if conn.in_transaction:
+        raise RuntimeError(
+            "bulk logical review updates require a connection without "
+            "an active transaction"
+        )
+
+    requested_ids = list(dict.fromkeys(session_ids))
+    updated_requested: list[str] = []
+    missing_requested: list[str] = []
+    member_ids: list[str] = []
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        for requested_id in requested_ids:
+            members = get_logical_session_members(conn, requested_id)
+            if not members:
+                missing_requested.append(requested_id)
+                continue
+            updated_requested.append(requested_id)
+            for member in members:
+                physical_id = str(member["session_id"])
+                if physical_id not in member_ids:
+                    member_ids.append(physical_id)
+        now = _now_iso()
+        conn.executemany(
+            "UPDATE sessions SET review_status = ?, "
+            "reviewed_at = CASE WHEN review_status = ? THEN reviewed_at ELSE ? END, "
+            "updated_at = ? WHERE session_id = ? AND checkpoint_active = 1",
+            [(status, status, now, now, session_id) for session_id in member_ids],
+        )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    return updated_requested, missing_requested
+
+
 # ---------------------------------------------------------------------------
 # Hold-state lifecycle
 # ---------------------------------------------------------------------------
 
 HOLD_STATES = frozenset({"auto_redacted", "pending_review", "released", "embargoed"})
+
+
+def _validate_hold_target(
+    to_state: str, embargo_until: str | None
+) -> str | None:
+    """Validate a hold transition and normalize its embargo timestamp."""
+
+    if to_state not in HOLD_STATES:
+        raise ValueError(f"invalid hold_state: {to_state!r}")
+    if to_state != "embargoed":
+        return None
+    if not embargo_until:
+        raise ValueError("embargoed requires embargo_until (ISO 8601)")
+    try:
+        parsed = datetime.fromisoformat(embargo_until)
+    except ValueError as exc:
+        raise ValueError(f"embargo_until is not ISO 8601: {embargo_until!r}") from exc
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    if parsed <= datetime.now(timezone.utc):
+        raise ValueError("embargo_until must be in the future; use release instead")
+    return embargo_until
 
 
 def set_hold_state(
@@ -3593,21 +5023,7 @@ def set_hold_state(
     Returns True on success, False if the session is missing. Invalid
     state transitions raise `ValueError`.
     """
-    if to_state not in HOLD_STATES:
-        raise ValueError(f"invalid hold_state: {to_state!r}")
-    if to_state == "embargoed":
-        if not embargo_until:
-            raise ValueError("embargoed requires embargo_until (ISO 8601)")
-        try:
-            parsed = datetime.fromisoformat(embargo_until)
-        except ValueError as exc:
-            raise ValueError(f"embargo_until is not ISO 8601: {embargo_until!r}") from exc
-        if parsed.tzinfo is None:
-            parsed = parsed.replace(tzinfo=timezone.utc)
-        if parsed <= datetime.now(timezone.utc):
-            raise ValueError("embargo_until must be in the future; use release instead")
-    else:
-        embargo_until = None
+    embargo_until = _validate_hold_target(to_state, embargo_until)
 
     row = conn.execute(
         "SELECT hold_state, embargo_until FROM sessions WHERE session_id = ?",
@@ -3639,6 +5055,64 @@ def set_hold_state(
     return True
 
 
+def set_logical_hold_state(
+    conn: sqlite3.Connection,
+    session_id: str,
+    to_state: str,
+    *,
+    changed_by: str,
+    reason: str | None = None,
+    embargo_until: str | None = None,
+) -> bool:
+    """Atomically transition every active member of one logical conversation.
+
+    Each physical checkpoint keeps its own audit entry because share and
+    recovery records continue to address physical session ids.  ``False`` is
+    returned only when ``session_id`` cannot resolve to a current family.
+    """
+
+    embargo_until = _validate_hold_target(to_state, embargo_until)
+    if conn.in_transaction:
+        raise RuntimeError(
+            "logical hold updates require a connection without an active transaction"
+        )
+    now = _now_iso()
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        members = get_logical_session_members(conn, session_id)
+        if not members:
+            conn.rollback()
+            return False
+        for member in members:
+            physical_id = str(member["session_id"])
+            conn.execute(
+                "UPDATE sessions SET hold_state = ?, embargo_until = ?, updated_at = ? "
+                "WHERE session_id = ? AND COALESCE(checkpoint_active, 1) = 1",
+                (to_state, embargo_until, now, physical_id),
+            )
+            conn.execute(
+                "INSERT INTO session_hold_history "
+                "(history_id, session_id, from_state, to_state, embargo_until, "
+                " changed_by, changed_at, reason) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    str(uuid.uuid4()),
+                    physical_id,
+                    member.get("hold_state"),
+                    to_state,
+                    embargo_until,
+                    changed_by,
+                    now,
+                    reason,
+                ),
+            )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    return True
+
+
 def get_hold_history(
     conn: sqlite3.Connection, session_id: str,
 ) -> list[dict[str, Any]]:
@@ -3656,6 +5130,64 @@ def get_hold_history(
 SHAREABLE_HOLD_STATES = frozenset({"auto_redacted", "released"})
 
 
+def _active_family_controls_for_session_ids(
+    conn: sqlite3.Connection,
+    session_ids: Sequence[str],
+    *,
+    now: datetime | None = None,
+) -> tuple[dict[str, dict[str, Any]], dict[str, tuple[str | None, str | None, str | None]]]:
+    """Resolve selected rows and conservatively fold their active families.
+
+    Egress continues to address physical checkpoint ids, but a negative user
+    control belongs to the logical conversation.  Reading every active member
+    here makes the gates safe even when an older writer (or a findings worker)
+    changed only one checkpoint.
+    """
+
+    ordered_ids = list(dict.fromkeys(str(session_id) for session_id in session_ids))
+    if not ordered_ids:
+        return {}, {}
+    placeholders = ", ".join("?" for _ in ordered_ids)
+    selected_rows = conn.execute(
+        "SELECT session_id, COALESCE(logical_session_id, session_id) "
+        "AS logical_session_id, review_status, hold_state, embargo_until, "
+        "COALESCE(checkpoint_active, 1) AS checkpoint_active FROM sessions "
+        f"WHERE session_id IN ({placeholders})",
+        ordered_ids,
+    ).fetchall()
+    selected = {str(row["session_id"]): dict(row) for row in selected_rows}
+    logical_ids = list(dict.fromkeys(
+        str(row["logical_session_id"]) for row in selected.values()
+    ))
+    if not logical_ids:
+        return selected, {}
+    family_placeholders = ", ".join("?" for _ in logical_ids)
+    family_rows = conn.execute(
+        "SELECT session_id, COALESCE(logical_session_id, session_id) "
+        "AS logical_session_id, review_status, hold_state, embargo_until "
+        "FROM sessions WHERE COALESCE(checkpoint_active, 1) = 1 "
+        "AND COALESCE(logical_session_id, session_id) "
+        f"IN ({family_placeholders}) ORDER BY session_id",
+        logical_ids,
+    ).fetchall()
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for row in family_rows:
+        item = dict(row)
+        grouped.setdefault(str(item["logical_session_id"]), []).append(item)
+    controls_at = now or datetime.now(timezone.utc)
+    if controls_at.tzinfo is None:
+        controls_at = controls_at.replace(tzinfo=timezone.utc)
+    controls = {
+        logical_id: _project_family_controls(
+            members,
+            changed_at=controls_at.isoformat(),
+            include_shareable_state=True,
+        )
+        for logical_id, members in grouped.items()
+    }
+    return selected, controls
+
+
 def release_gate_blockers(
     conn: sqlite3.Connection, session_ids: list[str],
     *, now: datetime | None = None,
@@ -3669,25 +5201,37 @@ def release_gate_blockers(
     """
     if not session_ids:
         return []
-    placeholders = ",".join("?" * len(session_ids))
-    rows = conn.execute(
-        f"SELECT session_id, hold_state, embargo_until FROM sessions "
-        f"WHERE session_id IN ({placeholders})",
-        session_ids,
-    ).fetchall()
-    seen = {r["session_id"]: r for r in rows}
+    seen, family_controls = _active_family_controls_for_session_ids(
+        conn, session_ids, now=now
+    )
     blockers: list[dict[str, Any]] = []
     for sid in session_ids:
         row = seen.get(sid)
         if row is None:
             blockers.append({"session_id": sid, "hold_state": "missing"})
             continue
-        effective = effective_hold_state(row["hold_state"], row["embargo_until"], now=now)
+        if not bool(row.get("checkpoint_active")):
+            blockers.append({
+                "session_id": sid,
+                "hold_state": "inactive_checkpoint",
+                "reason": "inactive_checkpoint",
+            })
+            continue
+        _, effective, embargo_until = family_controls.get(
+            str(row["logical_session_id"]),
+            (
+                row.get("review_status"),
+                effective_hold_state(
+                    row.get("hold_state"), row.get("embargo_until"), now=now
+                ),
+                row.get("embargo_until"),
+            ),
+        )
         if effective not in SHAREABLE_HOLD_STATES:
             blockers.append({
                 "session_id": sid,
                 "hold_state": effective,
-                "embargo_until": row["embargo_until"],
+                "embargo_until": embargo_until,
             })
     return blockers
 
@@ -3849,7 +5393,8 @@ def query_unscored_sessions(
     sql = (
         "SELECT session_id, display_title, task_type, outcome_badge, project, source, "
         "end_time, ai_scored_at, ai_quality_score, ai_failure_value_score "
-        f"FROM sessions WHERE {where} AND review_status != 'segmented'"
+        f"FROM sessions WHERE {where} AND review_status != 'segmented' "
+        "AND COALESCE(checkpoint_active, 1) = 1"
     )
     if since is not None:
         sql += " AND start_time >= ?"
@@ -3919,7 +5464,8 @@ def query_sessions_for_rescore(
     params: list[Any] = [cutoff]
     sql = (
         "SELECT session_id, display_title, task_type, outcome_badge, project, source "
-        "FROM sessions WHERE start_time >= ? AND review_status != 'segmented'"
+        "FROM sessions WHERE start_time >= ? AND review_status != 'segmented' "
+        "AND COALESCE(checkpoint_active, 1) = 1"
     )
     if source is not None:
         if isinstance(source, (list, tuple)):
@@ -3966,6 +5512,58 @@ def search_fts(
         (normalized_query, limit, offset),
     ).fetchall()
     return [dict(row) for row in rows]
+
+
+def search_logical_sessions(
+    conn: sqlite3.Connection,
+    query: str,
+    *,
+    limit: int = 50,
+    offset: int = 0,
+) -> list[dict[str, Any]]:
+    """FTS search grouped by logical family before offset/limit are applied."""
+
+    if not _has_fts(conn):
+        return []
+    terms = re.findall(r"\w+", query, flags=re.UNICODE)
+    if not terms:
+        return []
+    normalized_query = " AND ".join(f'"{term}"' for term in terms)
+    matches = conn.execute(
+        "SELECT COALESCE(s.logical_session_id, s.session_id) AS logical_id, "
+        "bm25(sessions_fts) AS search_rank "
+        "FROM sessions_fts JOIN sessions s "
+        "ON s.session_id = sessions_fts.session_id "
+        "WHERE sessions_fts MATCH ? AND COALESCE(s.checkpoint_active, 1) = 1 "
+        "ORDER BY search_rank, s.session_id",
+        (normalized_query,),
+    ).fetchall()
+    best_rank: dict[str, float] = {}
+    ranked_ids: list[str] = []
+    for match in matches:
+        logical_id = str(match["logical_id"])
+        if logical_id in best_rank:
+            continue
+        best_rank[logical_id] = float(match["search_rank"])
+        ranked_ids.append(logical_id)
+    page_ids = ranked_ids[offset:offset + limit]
+    if not page_ids:
+        return []
+    summaries = query_logical_sessions(
+        conn,
+        logical_session_ids=page_ids,
+        sort="start_time",
+        limit=len(page_ids),
+    )
+    by_id = {str(summary["session_id"]): summary for summary in summaries}
+    result: list[dict[str, Any]] = []
+    for logical_id in page_ids:
+        summary = by_id.get(logical_id)
+        if summary is None:
+            continue
+        summary["search_rank"] = best_rank[logical_id]
+        result.append(summary)
+    return result
 
 
 def get_stats(
@@ -4015,6 +5613,108 @@ def get_stats(
         tt_params,
     ).fetchall():
         result["by_task_type"][row["tt"]] = row["cnt"]
+
+    return result
+
+
+def get_logical_stats(
+    conn: sqlite3.Connection,
+    *,
+    start: str | None = None,
+    end: str | None = None,
+) -> dict[str, Any]:
+    """Return Inbox counts using the same active-family semantics as its list.
+
+    Dashboard analytics intentionally remain physical/history based.  This
+    projection is only for surfaces backed by :func:`query_logical_sessions`,
+    where one checkpoint family is one conversation and status/task-type
+    filters must lead to the same set of cards as their displayed counts.
+    """
+
+    date_clauses: list[str] = []
+    params: list[Any] = []
+    if start:
+        date_clauses.append("DATE(_logical_start_time) >= ?")
+        params.append(start)
+    if end:
+        date_clauses.append("DATE(_logical_start_time) <= ?")
+        params.append(end)
+    included_where = (
+        f"WHERE {' AND '.join(date_clauses)}" if date_clauses else ""
+    )
+    cte = f"""
+        WITH active AS (
+            SELECT s.*,
+                   COALESCE(s.logical_session_id, s.session_id) AS _logical_id
+            FROM sessions s
+            WHERE COALESCE(s.checkpoint_active, 1) = 1
+        ), grouped AS (
+            SELECT _logical_id,
+                   COUNT(*) AS _checkpoint_count,
+                   MIN(start_time) AS _logical_start_time,
+                   CASE
+                     WHEN SUM(CASE WHEN review_status = 'blocked' THEN 1 ELSE 0 END) > 0
+                       THEN 'blocked'
+                     WHEN SUM(CASE WHEN review_status = 'new' THEN 1 ELSE 0 END) > 0
+                       THEN 'new'
+                     WHEN SUM(CASE WHEN review_status = 'shortlisted' THEN 1 ELSE 0 END) > 0
+                       THEN 'shortlisted'
+                     WHEN SUM(CASE WHEN review_status = 'approved' THEN 1 ELSE 0 END) = COUNT(*)
+                       THEN 'approved'
+                     ELSE MIN(review_status)
+                   END AS _logical_review_status
+            FROM active
+            GROUP BY _logical_id
+        ), included AS (
+            SELECT * FROM grouped {included_where}
+        )
+    """
+    result: dict[str, Any] = {
+        "total": 0,
+        "by_status": {},
+        "by_source": {},
+        "by_project": {},
+        "by_task_type": {},
+    }
+
+    row = conn.execute(cte + "SELECT COUNT(*) AS cnt FROM included", params).fetchone()
+    result["total"] = int(row["cnt"] if row else 0)
+
+    for row in conn.execute(
+        cte
+        + "SELECT _logical_review_status AS value, COUNT(*) AS cnt "
+          "FROM included GROUP BY _logical_review_status",
+        params,
+    ).fetchall():
+        result["by_status"][row["value"]] = row["cnt"]
+
+    for field, result_key in (("source", "by_source"), ("project", "by_project")):
+        for row in conn.execute(
+            cte
+            + f"SELECT a.{field} AS value, COUNT(DISTINCT a._logical_id) AS cnt "
+              "FROM active a JOIN included i ON i._logical_id = a._logical_id "
+            + f"GROUP BY a.{field}",
+            params,
+        ).fetchall():
+            result[result_key][row["value"]] = row["cnt"]
+
+    # This expression deliberately mirrors query_logical_sessions: a single
+    # physical trace may use its AI classification, while a multi-checkpoint
+    # conversation exposes only per-checkpoint heuristic task types.  DISTINCT
+    # keeps one family from inflating a chip when several members share a type.
+    for row in conn.execute(
+        cte
+        + "SELECT task_type, COUNT(*) AS cnt FROM ("
+          "  SELECT DISTINCT a._logical_id, "
+          "    CASE WHEN i._checkpoint_count = 1 "
+          "         THEN COALESCE(a.ai_task_type, a.task_type) "
+          "         ELSE a.task_type END AS task_type "
+          "  FROM active a JOIN included i ON i._logical_id = a._logical_id"
+          ") WHERE task_type IS NOT NULL "
+          "GROUP BY task_type ORDER BY cnt DESC",
+        params,
+    ).fetchall():
+        result["by_task_type"][row["task_type"]] = row["cnt"]
 
     return result
 
@@ -4468,29 +6168,103 @@ def link_subagent_hierarchy(conn: sqlite3.Connection) -> int:
     """
     links_created = 0
 
-    # Step 1: Link sessions that already have parent_session_id from parsing
+    # A real subagent can itself be checkpointed.  Its physical checkpoints
+    # retain the true parent_session_id as provenance, but the parent's child
+    # list must contain one logical representative rather than every upload
+    # component.  Include inactive historical members in the replacement map
+    # so old polluted child lists are cleaned as well.
+    logical_rows = conn.execute(
+        "SELECT session_id, logical_session_id, segment_index, checkpoint_active "
+        "FROM sessions WHERE logical_session_id IS NOT NULL "
+        "ORDER BY logical_session_id, "
+        "CASE WHEN segment_index IS NULL THEN 1 ELSE 0 END, segment_index, "
+        "CASE WHEN session_id = logical_session_id THEN 0 ELSE 1 END, session_id"
+    ).fetchall()
+    representatives: dict[str, str] = {}
+    for row in logical_rows:
+        logical_id = str(row["logical_session_id"])
+        if bool(row["checkpoint_active"]) and logical_id not in representatives:
+            representatives[logical_id] = str(row["session_id"])
+    checkpoint_representatives = {
+        str(row["session_id"]): representatives[str(row["logical_session_id"])]
+        for row in logical_rows
+        if str(row["logical_session_id"]) in representatives
+    }
+
+    def representative_id(session_id: str) -> str:
+        return checkpoint_representatives.get(session_id, session_id)
+
+    parent_children: dict[str, list[str]] = {}
+    assigned_parent_by_child: dict[str, str] = {}
+
+    # Seed and sanitize already-materialized parent child lists.  Mapping both
+    # sides handles the unusual but valid case where a checkpointed trace is
+    # itself a parent.
+    existing_parent_rows = conn.execute(
+        "SELECT session_id, subagent_session_ids FROM sessions "
+        "WHERE subagent_session_ids IS NOT NULL"
+    ).fetchall()
+    for row in existing_parent_rows:
+        parent_id = representative_id(str(row["session_id"]))
+        try:
+            raw_children = json.loads(row["subagent_session_ids"])
+        except (TypeError, ValueError, json.JSONDecodeError):
+            continue
+        if not isinstance(raw_children, list):
+            continue
+        children = parent_children.setdefault(parent_id, [])
+        for raw_child in raw_children:
+            if not isinstance(raw_child, str) or not raw_child:
+                continue
+            child_id = representative_id(raw_child)
+            if child_id != parent_id and child_id not in children:
+                children.append(child_id)
+                assigned_parent_by_child.setdefault(child_id, parent_id)
+
+    # Step 1: Link parser-provided parents, collapsing checkpoint members to
+    # their active segment-zero representative.
     rows = conn.execute(
         "SELECT session_id, parent_session_id FROM sessions "
         "WHERE parent_session_id IS NOT NULL"
     ).fetchall()
-    parent_children: dict[str, list[str]] = {}
-    assigned_parent_by_child: dict[str, str] = {}
-    for r in rows:
-        parent_id = r["parent_session_id"]
-        child_id = r["session_id"]
-        parent_children.setdefault(parent_id, []).append(child_id)
-        assigned_parent_by_child[child_id] = parent_id
+    for row in rows:
+        parent_id = representative_id(str(row["parent_session_id"]))
+        child_id = representative_id(str(row["session_id"]))
+        if child_id == parent_id:
+            continue
+        children = parent_children.setdefault(parent_id, [])
+        if child_id not in children:
+            children.append(child_id)
+        assigned_parent_by_child.setdefault(child_id, parent_id)
 
     # Step 2: Detect Agent/Task tool calls in session blobs.
     # Query all sessions for candidate matching, but only read blobs for
     # sessions that haven't been linked yet (subagent_session_ids IS NULL)
     # to avoid re-reading all blobs on every scan cycle.
-    all_sessions = conn.execute(
+    all_session_rows = conn.execute(
         "SELECT session_id, project, source, start_time, end_time, "
-        "blob_path, subagent_session_ids "
+        "blob_path, subagent_session_ids, logical_session_id, checkpoint_active "
         "FROM sessions WHERE start_time IS NOT NULL "
         "ORDER BY start_time"
     ).fetchall()
+    all_sessions: list[dict[str, Any]] = []
+    seen_representatives: set[str] = set()
+    for row in all_session_rows:
+        item = dict(row)
+        session_id = str(item["session_id"])
+        logical_id = item.get("logical_session_id")
+        if logical_id is not None:
+            representative = representatives.get(str(logical_id))
+            if (
+                not bool(item.get("checkpoint_active"))
+                or representative is None
+                or session_id != representative
+            ):
+                continue
+            if representative in seen_representatives:
+                continue
+            seen_representatives.add(representative)
+        all_sessions.append(item)
 
     # Build a lookup for quick matching
     by_project: dict[str, list[dict]] = {}
@@ -4574,7 +6348,7 @@ def link_subagent_hierarchy(conn: sqlite3.Connection) -> int:
         conn.execute(
             "UPDATE sessions SET subagent_session_ids = ?, updated_at = ? "
             "WHERE session_id = ?",
-            (json.dumps(child_ids), now, parent_id),
+            (json.dumps(child_ids) if child_ids else None, now, parent_id),
         )
         for child_id in child_ids:
             cursor = conn.execute(
@@ -4788,12 +6562,16 @@ def create_share(
     note: str | None = None,
     source_filter: str | list[str] | tuple[str, ...] | None = None,
     expected_revisions: dict[str, str] | None = None,
+    expected_logical_revisions: dict[str, str] | None = None,
 ) -> str:
     """Create a share linking the given sessions.
 
     Returns the new share_id. ``expected_revisions`` lets callers bind a UI
     selection to the exact revisions the user reviewed; a concurrent append
     raises ``ValueError`` before any share row is created.
+    ``expected_logical_revisions`` additionally binds the selected physical
+    subset to the family membership visible in the UI without requiring that
+    already-shared or otherwise unselected active checkpoints be resubmitted.
     """
     share_id = str(uuid.uuid4())
     now = _now_iso()
@@ -4804,7 +6582,21 @@ def create_share(
         # Verify all sessions exist while holding the same write transaction
         # that records their immutable share snapshots.
         found_sessions: dict[str, str | None] = {}
+        selected_rows: list[sqlite3.Row] = []
         if session_ids:
+            session_columns = {
+                str(row[1]) for row in conn.execute("PRAGMA table_info(sessions)")
+            }
+            logical_id_sql = (
+                "logical_session_id"
+                if "logical_session_id" in session_columns
+                else "NULL AS logical_session_id"
+            )
+            checkpoint_active_sql = (
+                "checkpoint_active"
+                if "checkpoint_active" in session_columns
+                else "1 AS checkpoint_active"
+            )
             placeholders = ", ".join("?" for _ in session_ids)
             source_clause = ""
             params: list[Any] = list(session_ids)
@@ -4819,15 +6611,79 @@ def create_share(
                 else:
                     source_clause = " AND source = ?"
                     params.append(source_filter)
-            rows = conn.execute(
-                "SELECT session_id, content_revision FROM sessions "
+            selected_rows = conn.execute(
+                "SELECT session_id, content_revision, "
+                f"{logical_id_sql}, {checkpoint_active_sql} FROM sessions "
                 f"WHERE session_id IN ({placeholders}){source_clause}",
                 params,
             ).fetchall()
             found_sessions = {
                 row["session_id"]: row["content_revision"]
-                for row in rows
+                for row in selected_rows
             }
+
+        inactive_blockers = [
+            {
+                "session_id": str(row["session_id"]),
+                "logical_session_id": str(
+                    row["logical_session_id"] or row["session_id"]
+                ),
+                "reason": "inactive_checkpoint",
+            }
+            for row in selected_rows
+            if not bool(row["checkpoint_active"])
+        ]
+        if inactive_blockers:
+            raise RevisionConflictError(inactive_blockers)
+
+        if expected_logical_revisions is not None:
+            selected_logical_ids = {
+                str(row["logical_session_id"] or row["session_id"])
+                for row in selected_rows
+            }
+            expected_logical_ids = set(expected_logical_revisions)
+            logical_blockers: list[dict[str, Any]] = []
+            for logical_id in sorted(selected_logical_ids | expected_logical_ids):
+                members = get_logical_session_members(conn, logical_id)
+                current_revision = _current_logical_revision(members)
+                payload_complete = _logical_member_payload_complete(members)
+                expected_revision = expected_logical_revisions.get(logical_id)
+                selected_for_family = sorted(
+                    str(row["session_id"])
+                    for row in selected_rows
+                    if str(row["logical_session_id"] or row["session_id"])
+                    == logical_id
+                )
+                selected_inactive = any(
+                    not bool(row["checkpoint_active"])
+                    for row in selected_rows
+                    if str(row["logical_session_id"] or row["session_id"])
+                    == logical_id
+                )
+                if (
+                    logical_id not in selected_logical_ids
+                    or logical_id not in expected_logical_ids
+                    or expected_revision != current_revision
+                    or selected_inactive
+                    or not payload_complete
+                ):
+                    logical_blockers.append({
+                        "session_id": logical_id,
+                        "logical_session_id": logical_id,
+                        "expected_revision_hash": expected_revision,
+                        "current_revision_hash": current_revision,
+                        "member_session_ids": [
+                            str(member["session_id"]) for member in members
+                        ],
+                        "selected_session_ids": selected_for_family,
+                        "reason": (
+                            "logical_incomplete"
+                            if members and not payload_complete
+                            else "revision_conflict"
+                        ),
+                    })
+            if logical_blockers:
+                raise RevisionConflictError(logical_blockers)
 
         if expected_revisions is not None:
             expected_ids = set(expected_revisions)
@@ -5752,6 +7608,7 @@ def get_auto_upload_candidate_report(
         _LATEST_SUCCESSFUL_REVISIONS_CTE
         + "SELECT s.session_id, s.project, s.source, s.display_title, "
         "s.end_time, s.review_status, s.hold_state, s.embargo_until, "
+        "COALESCE(s.logical_session_id, s.session_id) AS logical_session_id, "
         "s.blob_path, s.raw_source_path, s.raw_source_start_offset, "
         "s.raw_source_end_offset, s.segment_sealed, "
         "s.content_revision AS revision_hash, "
@@ -5761,8 +7618,21 @@ def get_auto_upload_candidate_report(
         "AS already_shared_exact_revision "
         "FROM sessions s "
         "LEFT JOIN latest_shared_revisions latest ON latest.session_id = s.session_id "
+        "WHERE COALESCE(s.checkpoint_active, 1) = 1 "
         "ORDER BY s.session_id"
     ).fetchall()
+
+    grouped_controls: dict[str, list[dict[str, Any]]] = {}
+    for row in rows:
+        grouped_controls.setdefault(str(row["logical_session_id"]), []).append(dict(row))
+    family_controls = {
+        logical_id: _project_family_controls(
+            members,
+            changed_at=current_time.isoformat(),
+            include_shareable_state=True,
+        )
+        for logical_id, members in grouped_controls.items()
+    }
 
     eligible: list[dict[str, Any]] = []
     exclusions: list[dict[str, str]] = []
@@ -5772,6 +7642,9 @@ def get_auto_upload_candidate_report(
         exclusions.append({"session_id": row["session_id"], "reason": reason})
 
     for row in rows:
+        family_review, family_hold, _family_embargo = family_controls[
+            str(row["logical_session_id"])
+        ]
         if row["source"] not in enrolled_sources:
             exclude(row, "source_excluded")
             continue
@@ -5825,14 +7698,14 @@ def get_auto_upload_candidate_report(
         ):
             exclude(row, "changed_revision_needing_approval")
             continue
-        if row["review_status"] not in AUTO_UPLOAD_ALLOWED_REVIEW_STATUSES:
+        if (
+            family_review == "blocked"
+            or row["review_status"] not in AUTO_UPLOAD_ALLOWED_REVIEW_STATUSES
+        ):
             exclude(row, "blocked_review_status")
             continue
 
-        hold_state = effective_hold_state(
-            row["hold_state"], row["embargo_until"], now=current_time
-        )
-        if hold_state not in SHAREABLE_HOLD_STATES:
+        if family_hold not in SHAREABLE_HOLD_STATES:
             exclude(row, "held_or_embargoed")
             continue
         if not _blob_present_for_revision(row["session_id"], row["blob_path"]):
@@ -5905,18 +7778,16 @@ def auto_upload_review_blockers(
 
     First-time traces may remain ``new``, ``shortlisted``, or ``approved``.
     A changed revision of a previously shared trace must remain ``approved``
-    through the final submission transition.
+    through the final submission transition. Checkpoints retired after
+    candidate selection fail closed. Receipt reconciliation for an artifact
+    already in ``submitting`` happens before this new-submission gate.
     """
     ordered_ids = list(dict.fromkeys(session_ids))
     if not ordered_ids:
         return []
-    placeholders = ", ".join("?" for _ in ordered_ids)
-    rows = conn.execute(
-        "SELECT session_id, review_status FROM sessions "
-        f"WHERE session_id IN ({placeholders})",
-        ordered_ids,
-    ).fetchall()
-    by_id = {str(row["session_id"]): row for row in rows}
+    by_id, family_controls = _active_family_controls_for_session_ids(
+        conn, ordered_ids
+    )
     blockers: list[dict[str, Any]] = []
     blocked_ids: set[str] = set()
     for session_id in ordered_ids:
@@ -5928,10 +7799,29 @@ def auto_upload_review_blockers(
                 "reason": "missing",
             })
             blocked_ids.add(session_id)
-        elif row["review_status"] not in AUTO_UPLOAD_ALLOWED_REVIEW_STATUSES:
+        elif not bool(row["checkpoint_active"]):
             blockers.append({
                 "session_id": session_id,
-                "review_status": row["review_status"],
+                "review_status": row.get("review_status"),
+                "checkpoint_active": False,
+                "reason": "inactive_checkpoint",
+            })
+            blocked_ids.add(session_id)
+        elif (
+            family_controls.get(str(row["logical_session_id"]), (None, None, None))[0]
+            == "blocked"
+            or row.get("review_status") not in AUTO_UPLOAD_ALLOWED_REVIEW_STATUSES
+        ):
+            blockers.append({
+                "session_id": session_id,
+                "review_status": (
+                    "blocked"
+                    if family_controls.get(
+                        str(row["logical_session_id"]), (None, None, None)
+                    )[0]
+                    == "blocked"
+                    else row.get("review_status")
+                ),
                 "reason": "blocked_review_status",
             })
             blocked_ids.add(session_id)
@@ -6051,6 +7941,7 @@ def get_share_ready_stats(
     """
     where_clauses: list[str] = []
     params: list[Any] = []
+    where_clauses.append("COALESCE(s.checkpoint_active, 1) = 1")
     if include_unapproved:
         where_clauses.append(
             "s.review_status IN ('new', 'shortlisted', 'approved')"
@@ -6086,6 +7977,14 @@ def get_share_ready_stats(
         f" s.input_tokens, s.output_tokens, ({_OUTCOME_NORMALIZE_SQL}) as outcome_badge, s.client_origin,"
         " s.runtime_channel, s.start_time, s.review_status, s.hold_state, s.embargo_until,"
         " s.content_revision AS revision_hash,"
+        " COALESCE(s.logical_session_id, s.session_id) AS logical_session_id,"
+        " COALESCE(s.logical_revision, s.content_revision) AS logical_revision,"
+        " s.segment_index, s.segment_reason, s.segment_sealed,"
+        " CASE WHEN s.logical_session_id IS NULL THEN 1 ELSE ("
+        "   SELECT COUNT(*) FROM sessions checkpoint_member"
+        "   WHERE checkpoint_member.logical_session_id = s.logical_session_id"
+        "   AND COALESCE(checkpoint_member.checkpoint_active, 1) = 1"
+        " ) END AS checkpoint_count,"
         " latest.content_revision AS last_shared_revision_hash,"
         " CASE WHEN latest.content_revision IS NOT NULL "
         "      AND s.content_revision IS NOT latest.content_revision "
@@ -6103,8 +8002,10 @@ def get_share_ready_stats(
             "ai_failure_attribution", "ai_failure_modes", "ai_learning_summary",
             "user_messages", "assistant_messages", "tool_uses", "input_tokens",
             "output_tokens", "outcome_badge", "client_origin", "runtime_channel",
-            "start_time", "review_status", "hold_state", "embargo_until",
-            "revision_hash", "last_shared_revision_hash",
+             "start_time", "review_status", "hold_state", "embargo_until",
+             "revision_hash", "logical_session_id", "logical_revision",
+             "segment_index", "segment_reason", "segment_sealed", "checkpoint_count",
+             "last_shared_revision_hash",
             "updated_since_last_share"]
     sessions = [dict(zip(cols, r)) for r in rows]
     for session in sessions:
@@ -6117,6 +8018,45 @@ def get_share_ready_stats(
                     session[field] = json.loads(session[field])
                 except (json.JSONDecodeError, ValueError):
                     session[field] = []
+    # Manual sharing may still package physical checkpoints, but it must never
+    # silently package a family whose active ordinal/message ranges have a gap
+    # or overlap.  Resolve completeness against *all* active members before
+    # hold/share-history filtering so every candidate from that family fails
+    # closed together.
+    logical_members: dict[
+        str,
+        tuple[list[str], bool, str | None, str | None, str | None],
+    ] = {}
+    incomplete_logical_ids: set[str] = set()
+    complete_sessions: list[dict[str, Any]] = []
+    for session in sessions:
+        logical_id = str(session["logical_session_id"])
+        cached = logical_members.get(logical_id)
+        if cached is None:
+            members = get_logical_session_members(conn, str(session["session_id"]))
+            member_ids = [str(member["session_id"]) for member in members]
+            complete = _logical_member_metadata_complete(members)
+            projected_controls = _project_family_controls(
+                members,
+                changed_at=_now_iso(),
+                include_shareable_state=True,
+            )
+            cached = (member_ids, complete, *projected_controls)
+            logical_members[logical_id] = cached
+        member_ids, complete, family_review, family_hold, _family_embargo = cached
+        session["checkpoint_session_ids"] = member_ids
+        session["checkpoint_count"] = len(member_ids)
+        session["logical_incomplete"] = not complete
+        if not complete:
+            incomplete_logical_ids.add(logical_id)
+            continue
+        if (
+            family_review == "blocked"
+            or family_hold not in SHAREABLE_HOLD_STATES
+        ):
+            continue
+        complete_sessions.append(session)
+    sessions = complete_sessions
     # Only offer sessions that are actually shareable: drop explicit holds
     # (`pending_review`, active `embargoed`) so the student cannot pick a
     # session that the submit-time release gate would later reject. Auto-expired
@@ -6173,6 +8113,7 @@ def get_share_ready_stats(
         ).fetchone()[0],
         "projects": sorted(projects),
         "models": sorted(models),
+        "logical_incomplete_excluded": len(incomplete_logical_ids),
         "recommended_session_ids": recommended_ids,
         "sessions": sessions,
     }

--- a/clawjournal/workbench/index_recovery.py
+++ b/clawjournal/workbench/index_recovery.py
@@ -43,9 +43,22 @@ _SESSION_STATE_COLUMNS = (
     "reviewed_at",
     "blob_path",
     "raw_source_path",
+    "raw_source_start_offset",
+    "raw_source_end_offset",
+    "session_key",
     "indexed_at",
     "updated_at",
     "share_id",
+    "parent_session_id",
+    "subagent_session_ids",
+    "segment_index",
+    "segment_start_message",
+    "segment_end_message",
+    "segment_reason",
+    "segment_sealed",
+    "logical_session_id",
+    "checkpoint_active",
+    "logical_revision",
     "hold_state",
     "embargo_until",
     "content_revision",
@@ -1308,27 +1321,60 @@ def _restore_session_state(
             and current["content_revision"] == row.get("content_revision")
         )
         if current is None:
+            checkpoint_active = row.get("checkpoint_active")
+            if checkpoint_active not in (0, 1):
+                checkpoint_active = 1
+            segment_sealed = row.get("segment_sealed")
+            if segment_sealed not in (0, 1):
+                segment_sealed = 0
             conn.execute(
                 """INSERT INTO sessions (
                     session_id, project, source, display_title, review_status,
                     selection_reason, reviewer_notes, reviewed_at, blob_path,
-                    raw_source_path, indexed_at, updated_at, share_id,
-                    hold_state, embargo_until, content_revision
-                ) VALUES (?, ?, ?, ?, 'new', NULL, NULL, NULL, ?, ?, ?, ?, ?,
-                          'pending_review', NULL, ?)""",
-                (
-                    session_id,
-                    row.get("project") or "recovered",
-                    row.get("source") or "recovered",
-                    row.get("display_title") or "Recovered trace",
-                    row.get("blob_path"),
-                    row.get("raw_source_path"),
-                    row.get("indexed_at")
+                    raw_source_path, raw_source_start_offset,
+                    raw_source_end_offset, session_key, indexed_at, updated_at,
+                    share_id, parent_session_id, subagent_session_ids,
+                    segment_index, segment_start_message, segment_end_message,
+                    segment_reason, segment_sealed, logical_session_id,
+                    checkpoint_active, logical_revision, hold_state,
+                    embargo_until, content_revision
+                ) VALUES (
+                    :session_id, :project, :source, :display_title, 'new',
+                    NULL, NULL, NULL, :blob_path, :raw_source_path,
+                    :raw_source_start_offset, :raw_source_end_offset,
+                    :session_key, :indexed_at, :updated_at, :share_id,
+                    :parent_session_id, :subagent_session_ids, :segment_index,
+                    :segment_start_message, :segment_end_message,
+                    :segment_reason, :segment_sealed, :logical_session_id,
+                    :checkpoint_active, :logical_revision, 'pending_review',
+                    NULL, :content_revision
+                )""",
+                {
+                    "session_id": session_id,
+                    "project": row.get("project") or "recovered",
+                    "source": row.get("source") or "recovered",
+                    "display_title": row.get("display_title") or "Recovered trace",
+                    "blob_path": row.get("blob_path"),
+                    "raw_source_path": row.get("raw_source_path"),
+                    "raw_source_start_offset": row.get("raw_source_start_offset"),
+                    "raw_source_end_offset": row.get("raw_source_end_offset"),
+                    "session_key": row.get("session_key"),
+                    "indexed_at": row.get("indexed_at")
                     or datetime.now(timezone.utc).isoformat(),
-                    row.get("updated_at"),
-                    share_id,
-                    row.get("content_revision"),
-                ),
+                    "updated_at": row.get("updated_at"),
+                    "share_id": share_id,
+                    "parent_session_id": row.get("parent_session_id"),
+                    "subagent_session_ids": row.get("subagent_session_ids"),
+                    "segment_index": row.get("segment_index"),
+                    "segment_start_message": row.get("segment_start_message"),
+                    "segment_end_message": row.get("segment_end_message"),
+                    "segment_reason": row.get("segment_reason"),
+                    "segment_sealed": segment_sealed,
+                    "logical_session_id": row.get("logical_session_id"),
+                    "checkpoint_active": checkpoint_active,
+                    "logical_revision": row.get("logical_revision"),
+                    "content_revision": row.get("content_revision"),
+                },
             )
             needs_review += 1
             continue

--- a/tests/parsing/test_parser.py
+++ b/tests/parsing/test_parser.py
@@ -766,6 +766,7 @@ class TestDiscoverProjects:
         assert len(sessions) == 1
         # Project is the cwd basename (consistent with codex/opencode/openclaw).
         assert sessions[0]["project"] == "claude:test-project"
+        assert sessions[0]["logical_session_id"] == "session1"
 
     def test_parse_project_sessions_uses_cwd_basename_for_hyphenated_project(
         self, tmp_path, monkeypatch, mock_anonymizer
@@ -958,6 +959,7 @@ class TestDiscoverProjects:
         assert sessions[0]["messages"][1]["role"] == "assistant"
         assert sessions[0]["messages"][1]["tool_uses"][0]["tool"] == "exec_command"
         assert sessions[0]["raw_source_path"] == str(session_file)
+        assert sessions[0]["logical_session_id"] == "session-1"
 
     def test_long_codex_session_seals_stable_append_only_segments(
         self, tmp_path, monkeypatch, mock_anonymizer
@@ -1029,8 +1031,45 @@ class TestDiscoverProjects:
         ]
         assert first[0]["segment_sealed"] is True
         assert first[1]["segment_sealed"] is False
-        assert first[0].get("parent_session_id") is None
-        assert first[1]["parent_session_id"] == "long-codex"
+        assert all(item.get("parent_session_id") is None for item in first)
+        assert [item["logical_session_id"] for item in first] == [
+            "long-codex",
+            "long-codex",
+        ]
+        assert [item["segment_message_range"] for item in first] == [
+            [0, 39],
+            [40, 41],
+        ]
+        assert [item["messages"] for item in first] == [
+            [
+                message
+                for turn in range(20)
+                for message in (
+                    {
+                        "role": "user",
+                        "content": f"question {turn}",
+                        "timestamp": f"2026-07-29T00:{turn:02d}:02Z",
+                    },
+                    {
+                        "role": "assistant",
+                        "content": f"answer {turn}",
+                        "timestamp": f"2026-07-29T00:{turn:02d}:03Z",
+                    },
+                )
+            ],
+            [
+                {
+                    "role": "user",
+                    "content": "question 20",
+                    "timestamp": "2026-07-29T00:20:02Z",
+                },
+                {
+                    "role": "assistant",
+                    "content": "answer 20",
+                    "timestamp": "2026-07-29T00:20:03Z",
+                },
+            ],
+        ]
         assert first[0]["raw_source_start_offset"] == 0
         assert first[1]["raw_source_start_offset"] is None
         assert first[1]["raw_source_end_offset"] is None
@@ -1057,6 +1096,16 @@ class TestDiscoverProjects:
         assert len(second) == 3
         assert second[0]["messages"] == first_messages
         assert second[0]["_raw_source_fingerprint"] == first_fingerprint
+        assert [item["session_id"] for item in second] == [
+            "long-codex",
+            "long-codex_seg-0001",
+            "long-codex_seg-0002",
+        ]
+        assert [item["segment_message_range"] for item in second] == [
+            [0, 39],
+            [40, 79],
+            [80, 81],
+        ]
         assert [item["segment_sealed"] for item in second] == [True, True, False]
 
     def test_codex_retry_keeps_sealed_segment_stable_across_appends(
@@ -3667,6 +3716,26 @@ def test_long_claude_session_checkpoint_includes_interstitial_tool_result(
     assert [session["session_id"] for session in sessions] == [
         "claude-long",
         "claude-long_seg-0001",
+    ]
+    assert [session["logical_session_id"] for session in sessions] == [
+        "claude-long",
+        "claude-long",
+    ]
+    assert all(session.get("parent_session_id") is None for session in sessions)
+    assert [session["segment_message_range"] for session in sessions] == [
+        [0, 39],
+        [40, 41],
+    ]
+    assert [
+        [(message["role"], message.get("content")) for message in session["messages"]]
+        for session in sessions
+    ] == [
+        [
+            item
+            for turn in range(20)
+            for item in (("user", f"question {turn}"), ("assistant", f"answer {turn}"))
+        ],
+        [("user", "question 20"), ("assistant", "answer 20")],
     ]
     assert [session["segment_sealed"] for session in sessions] == [True, False]
     first_raw = session_file.read_bytes()[

--- a/tests/parsing/test_segmenter.py
+++ b/tests/parsing/test_segmenter.py
@@ -95,6 +95,7 @@ class TestAppendOnlySegmentation:
         )
 
         assert result == [session]
+        assert result[0]["logical_session_id"] == "growing"
 
     def test_next_user_seals_prior_turn_and_leaves_tail_unranged(self):
         messages = [
@@ -121,11 +122,57 @@ class TestAppendOnlySegmentation:
             "growing",
             "growing_seg-0001",
         ]
+        assert [item["logical_session_id"] for item in result] == [
+            "growing",
+            "growing",
+        ]
+        assert [item["segment_message_range"] for item in result] == [
+            [0, 3],
+            [4, 4],
+        ]
+        assert [item["messages"] for item in result] == [
+            messages[:4],
+            messages[4:],
+        ]
+        assert [
+            (
+                item.get("raw_source_start_offset"),
+                item.get("raw_source_end_offset"),
+            )
+            for item in result
+        ] == [(0, 50), (None, None)]
+        assert all("parent_session_id" not in item for item in result)
         assert result[0]["segment_sealed"] is True
-        assert result[0]["raw_source_end_offset"] == 50
         assert result[1]["segment_sealed"] is False
-        assert result[1]["raw_source_start_offset"] is None
-        assert result[1]["raw_source_end_offset"] is None
+
+    def test_checkpointing_preserves_a_real_subagent_parent(self):
+        messages = [
+            _user("question one"),
+            _assistant("answer one"),
+            _user("question two"),
+        ]
+        session = _session(messages, session_id="child", source="claude")
+        session["parent_session_id"] = "real-subagent-parent"
+
+        result = segment_append_only_session(
+            session,
+            [10, 20, 30],
+            message_start_offsets=[0, 10, 20],
+            raw_source_size=30,
+            max_messages=2,
+            max_user_messages=99,
+            max_text_bytes=999_999,
+            max_raw_bytes=999_999,
+        )
+
+        assert [item["session_id"] for item in result] == [
+            "child",
+            "child_seg-0001",
+        ]
+        assert all(
+            item["parent_session_id"] == "real-subagent-parent" for item in result
+        )
+        assert all(item["logical_session_id"] == "child" for item in result)
 
     def test_token_snapshots_split_into_per_segment_deltas(self):
         messages = [
@@ -689,6 +736,30 @@ class TestHelpers:
     def test_extract_segment_title(self):
         msgs = [_user("Fix the authentication bug"), _assistant("On it")]
         assert _extract_segment_title(msgs) == "Fix the authentication bug"
+
+    def test_extract_segment_title_skips_complete_internal_wrappers(self):
+        msgs = [
+            _user(
+                "<task-notification>background task completed</task-notification>"
+            ),
+            _assistant("Noted"),
+            _user("Fix the authentication bug"),
+        ]
+
+        assert _extract_segment_title(msgs) == "Fix the authentication bug"
+        assert msgs[0]["content"] == (
+            "<task-notification>background task completed</task-notification>"
+        )
+
+    def test_extract_segment_title_keeps_user_text_after_wrapper(self):
+        content = (
+            "<command-name>/review</command-name>\n"
+            "Review the authentication changes"
+        )
+
+        assert _extract_segment_title([_user(content)]) == (
+            "Review the authentication changes"
+        )
 
     def test_extract_segment_title_truncates(self):
         long_msg = "A" * 200

--- a/tests/scoring/test_badges.py
+++ b/tests/scoring/test_badges.py
@@ -243,6 +243,54 @@ class TestDisplayTitle:
         title = compute_display_title(session)
         assert title == "Refactor the auth middleware"
 
+    def test_skips_task_notification(self):
+        session = _make_session("")
+        session["messages"] = [
+            {
+                "role": "user",
+                "content": "<task-notification>background task completed</task-notification>",
+                "tool_uses": [],
+            },
+            {"role": "assistant", "content": "Noted", "tool_uses": []},
+            {
+                "role": "user",
+                "content": "Refactor the auth middleware",
+                "tool_uses": [],
+            },
+        ]
+
+        assert compute_display_title(session) == "Refactor the auth middleware"
+
+    def test_legacy_internal_segment_title_falls_back_to_real_user(self):
+        session = _make_session("")
+        session["segment_title"] = (
+            "<task-notification>background task completed</task-notification>"
+        )
+        session["messages"] = [
+            {
+                "role": "user",
+                "content": session["segment_title"],
+                "tool_uses": [],
+            },
+            {
+                "role": "user",
+                "content": "Refactor the auth middleware",
+                "tool_uses": [],
+            },
+        ]
+
+        assert compute_display_title(session) == "Refactor the auth middleware"
+
+    def test_wrapper_plus_user_text_is_not_skipped(self):
+        content = (
+            "<command-name>/review</command-name>\n"
+            "Review the authentication changes"
+        )
+
+        assert compute_display_title(_make_session(content)) == (
+            "Review the authentication changes"
+        )
+
     def test_skips_terse_single_word(self):
         session = _make_session("")
         session["messages"] = [

--- a/tests/test_auto_upload.py
+++ b/tests/test_auto_upload.py
@@ -1914,9 +1914,11 @@ def test_revoked_fresh_approval_stops_before_ai_and_submit(
 
 
 @pytest.mark.parametrize("boundary", ["seal", "submit"])
-def test_revoked_fresh_approval_stops_atomic_artifact_boundaries(
+@pytest.mark.parametrize("mutation", ["review", "inactive"])
+def test_revoked_control_stops_atomic_artifact_boundaries(
     isolated_auto_upload,
     boundary,
+    mutation,
 ):
     config = _save_scope_config()
     conn = open_index()
@@ -1944,9 +1946,14 @@ def test_revoked_fresh_approval_stops_atomic_artifact_boundaries(
             state="sealed",
         )
 
-    conn.execute(
-        "UPDATE sessions SET review_status = 'new' WHERE session_id = 'session-one'"
-    )
+    if mutation == "review":
+        conn.execute(
+            "UPDATE sessions SET review_status = 'new' WHERE session_id = 'session-one'"
+        )
+    else:
+        conn.execute(
+            "UPDATE sessions SET checkpoint_active = 0 WHERE session_id = 'session-one'"
+        )
     conn.commit()
 
     if boundary == "seal":
@@ -1974,6 +1981,89 @@ def test_revoked_fresh_approval_stops_atomic_artifact_boundaries(
         "SELECT submission_state FROM shares WHERE share_id = ?", (share_id,)
     ).fetchone()[0]
     assert state == expected_state
+    conn.close()
+
+
+def test_retired_submitting_checkpoint_allows_receipt_lookup_but_not_repost(
+    isolated_auto_upload,
+    monkeypatch,
+):
+    config = _save_scope_config()
+    conn = open_index()
+    _seed_changed_approved_revision(conn, isolated_auto_upload["root"])
+    enrollment = _save_enabled_enrollment(conn, config)
+    share_id, _ = _create_pending_share(
+        conn,
+        isolated_auto_upload["install"],
+        session_id="session-one",
+        enrollment_id="server-enrollment-1",
+        state="submitting",
+    )
+    conn.execute(
+        "UPDATE sessions SET checkpoint_active = 0 WHERE session_id = 'session-one'"
+    )
+    conn.commit()
+
+    pending = conn.execute(
+        "SELECT * FROM shares WHERE share_id = ?", (share_id,)
+    ).fetchone()
+    with pytest.raises(auto.ControlChanged):
+        auto._validate_pending_for_submission(
+            conn,
+            share=dict(pending),
+            enrollment=enrollment,
+            expected_profile_hash=str(enrollment["egress_profile_hash"]),
+            api_origin=ORIGIN,
+            ai_backend=None,
+            check_raw_fingerprints=False,
+        )
+    assert auto._transition_submission(
+        conn,
+        share_id=share_id,
+        from_state="submitting",
+        to_state="submitting",
+        generation=int(enrollment["generation"]),
+    ) is False
+    assert conn.execute(
+        "SELECT submission_state FROM shares WHERE share_id = ?", (share_id,)
+    ).fetchone()[0] == "submitting"
+
+    submitted: list[str] = []
+    monkeypatch.setattr(auto, "fetch_capabilities", lambda **_kwargs: _capabilities())
+    monkeypatch.setattr(auto, "_server_enrollment_gate", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(auto, "submit_artifact", lambda *_args, **_kwargs: submitted.append("POST"))
+    share = dict(conn.execute(
+        "SELECT * FROM shares WHERE share_id = ?", (share_id,)
+    ).fetchone())
+    with pytest.raises(auto.ControlChanged):
+        auto._submit_pending_artifact(
+            conn,
+            share=share,
+            enrollment=enrollment,
+            credentials=_credentials(),
+            capabilities=_capabilities(),
+        )
+    assert submitted == []
+
+    monkeypatch.setattr(
+        auto,
+        "lookup_receipt",
+        lambda *_args, **_kwargs: {
+            "receipt_id": "receipt-retired-recovery",
+            "accepted_at": "2026-07-15T14:00:00+00:00",
+            "status": "accepted",
+        },
+    )
+    result = auto._reconcile_pending(
+        conn,
+        enrollment=enrollment,
+        credentials=_credentials(),
+        capabilities=_capabilities(),
+        allow_submit=False,
+    )
+    assert result is not None
+    assert result["code"] == "uploaded"
+    assert submitted == []
     conn.close()
 
 

--- a/tests/test_cli_security.py
+++ b/tests/test_cli_security.py
@@ -90,6 +90,28 @@ class TestHoldVerbs:
         assert history[-1]["changed_by"] == "user"
         assert history[-1]["reason"] == "reviewing"
 
+    def test_hold_updates_every_active_checkpoint_in_logical_conversation(self, conn):
+        _seed(conn, "root")
+        _seed(conn, "tail")
+        conn.execute(
+            "UPDATE sessions SET logical_session_id = 'conversation', "
+            "segment_index = CASE session_id WHEN 'root' THEN 0 ELSE 1 END "
+            "WHERE session_id IN ('root', 'tail')"
+        )
+        conn.commit()
+
+        _run(cli_security.run_hold, session_id="root", reason="review family")
+
+        states = conn.execute(
+            "SELECT session_id, hold_state FROM sessions "
+            "WHERE logical_session_id = 'conversation' ORDER BY session_id"
+        ).fetchall()
+        assert [(row["session_id"], row["hold_state"]) for row in states] == [
+            ("root", "pending_review"),
+            ("tail", "pending_review"),
+        ]
+        assert get_hold_history(conn, "tail")[-1]["reason"] == "review family"
+
     def test_release(self, conn):
         _seed(conn)
         result = _run(cli_security.run_release, session_id="sess-1", reason=None)

--- a/tests/workbench/test_auto_upload_index.py
+++ b/tests/workbench/test_auto_upload_index.py
@@ -10,15 +10,19 @@ import pytest
 
 from clawjournal.workbench.index import (
     EXACT_SCOPE_PAIRS_SCHEMA_VERSION,
+    LOGICAL_CHECKPOINT_SCHEMA_VERSION,
     PREDECESSOR_SOURCE_RECEIVER,
     RECEIVER_PREDECESSOR_SCHEMA_VERSION,
     RECURRING_PROTOCOL_V2_SCHEMA_VERSION,
+    RevisionConflictError,
     WORKBENCH_SCHEMA_VERSION,
     already_shared_revision_blockers,
+    auto_upload_review_blockers,
     create_share,
     get_auto_upload_candidate_report,
     get_auto_upload_enrollment,
     open_index,
+    release_gate_blockers,
     revision_review_blockers,
     save_auto_upload_enrollment,
     set_hold_state,
@@ -110,9 +114,10 @@ def _mark_shared(conn, session_id: str) -> str:
 
 def test_fresh_schema_has_auto_upload_foundation(index_conn):
     assert index_conn.execute("PRAGMA user_version").fetchone()[0] == WORKBENCH_SCHEMA_VERSION
-    assert WORKBENCH_SCHEMA_VERSION == RECEIVER_PREDECESSOR_SCHEMA_VERSION
+    assert WORKBENCH_SCHEMA_VERSION == LOGICAL_CHECKPOINT_SCHEMA_VERSION
     assert EXACT_SCOPE_PAIRS_SCHEMA_VERSION == 10
     assert RECEIVER_PREDECESSOR_SCHEMA_VERSION == 11
+    assert LOGICAL_CHECKPOINT_SCHEMA_VERSION == 12
     assert RECURRING_PROTOCOL_V2_SCHEMA_VERSION == 9
 
     session_columns = {
@@ -123,7 +128,14 @@ def test_fresh_schema_has_auto_upload_foundation(index_conn):
         "raw_source_start_offset",
         "raw_source_end_offset",
         "segment_sealed",
+        "logical_session_id",
+        "checkpoint_active",
+        "logical_revision",
     } <= session_columns
+    assert index_conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type = 'index' "
+        "AND name = 'idx_sessions_logical_checkpoint'"
+    ).fetchone()
 
     share_columns = {
         row[1] for row in index_conn.execute("PRAGMA table_info(shares)")
@@ -157,6 +169,151 @@ def test_fresh_schema_has_auto_upload_foundation(index_conn):
         row[1] for row in index_conn.execute("PRAGMA index_list(shares)")
     }
     assert "idx_shares_client_submission_id" in indexes
+
+
+@pytest.mark.parametrize(
+    ("hold_state", "embargo_until"),
+    [
+        ("pending_review", None),
+        ("embargoed", "2099-01-01T00:00:00+00:00"),
+    ],
+)
+def test_v11_migration_projects_checkpoint_family_without_losing_history(
+    tmp_path, monkeypatch, hold_state, embargo_until
+):
+    db_path = tmp_path / "index.db"
+    monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", db_path)
+    monkeypatch.setattr("clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs")
+    monkeypatch.setattr("clawjournal.workbench.index.CONFIG_DIR", tmp_path)
+    parent = _session("real-parent")
+    root = _session("child")
+    root.update({
+        "logical_session_id": "child",
+        "parent_session_id": "real-parent",
+        "segment_index": 0,
+        "segment_message_range": [0, 1],
+        "segment_reason": "bounded_checkpoint",
+        "segment_sealed": True,
+    })
+    tail = _session("child_seg-0001")
+    tail.update({
+        "logical_session_id": "child",
+        "parent_session_id": "real-parent",
+        "segment_index": 1,
+        "segment_message_range": [2, 3],
+        "segment_reason": "active_tail",
+        "segment_sealed": False,
+    })
+    conn = open_index()
+    upsert_sessions(conn, [parent, root, tail])
+    share_id = create_share(conn, ["child_seg-0001"])
+    conn.execute(
+        "UPDATE shares SET status = 'shared', shared_at = ?, "
+        "hosted_receipt_id = ?, hosted_status = ? WHERE share_id = ?",
+        (
+            "2026-07-13T00:00:00+00:00",
+            "receipt-v11",
+            "accepted",
+            share_id,
+        ),
+    )
+    tail_revision = conn.execute(
+        "SELECT content_revision FROM sessions WHERE session_id = 'child_seg-0001'"
+    ).fetchone()[0]
+    conn.execute(
+        "INSERT INTO findings (finding_id, session_id, engine, rule, "
+        "entity_hash, field, offset, length, status, decided_by, decided_at, "
+        "revision, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        (
+            "finding-v11",
+            "child_seg-0001",
+            "test",
+            "rule",
+            "hash:v11",
+            "content",
+            0,
+            1,
+            "ignored",
+            "user",
+            "2026-07-12T12:00:00+00:00",
+            tail_revision,
+            "2026-07-12T11:00:00+00:00",
+        ),
+    )
+    conn.commit()
+    set_hold_state(
+        conn,
+        "child_seg-0001",
+        hold_state,
+        changed_by="user",
+        reason="migration hold",
+        embargo_until=embargo_until,
+    )
+    conn.execute(
+        "UPDATE sessions SET review_status = 'blocked' "
+        "WHERE session_id = 'child_seg-0001'"
+    )
+    conn.execute(
+        "UPDATE sessions SET subagent_session_ids = ? WHERE session_id = ?",
+        ('["child", "child_seg-0001"]', "real-parent"),
+    )
+    conn.commit()
+    conn.close()
+
+    raw = sqlite3.connect(db_path)
+    raw.execute("DROP INDEX idx_sessions_logical_checkpoint")
+    raw.execute("ALTER TABLE sessions DROP COLUMN logical_session_id")
+    raw.execute("ALTER TABLE sessions DROP COLUMN checkpoint_active")
+    raw.execute("ALTER TABLE sessions DROP COLUMN logical_revision")
+    raw.execute(f"PRAGMA user_version = {RECEIVER_PREDECESSOR_SCHEMA_VERSION}")
+    raw.commit()
+    raw.close()
+
+    conn = open_index()
+    try:
+        members = conn.execute(
+            "SELECT session_id, logical_session_id, checkpoint_active, "
+            "parent_session_id, logical_revision FROM sessions "
+            "WHERE logical_session_id = 'child' ORDER BY segment_index"
+        ).fetchall()
+        assert [row["session_id"] for row in members] == [
+            "child", "child_seg-0001"
+        ]
+        assert all(row["checkpoint_active"] == 1 for row in members)
+        assert all(row["parent_session_id"] == "real-parent" for row in members)
+        assert len({row["logical_revision"] for row in members}) == 1
+        controls = conn.execute(
+            "SELECT review_status, hold_state, embargo_until FROM sessions "
+            "WHERE logical_session_id = 'child' ORDER BY segment_index"
+        ).fetchall()
+        assert [row["review_status"] for row in controls] == ["blocked", "blocked"]
+        assert [row["hold_state"] for row in controls] == [hold_state, hold_state]
+        assert [row["embargo_until"] for row in controls] == [
+            embargo_until, embargo_until
+        ]
+        parent_children = conn.execute(
+            "SELECT subagent_session_ids FROM sessions "
+            "WHERE session_id = 'real-parent'"
+        ).fetchone()[0]
+        assert parent_children == '["child"]'
+        assert conn.execute(
+            "SELECT COUNT(*) FROM share_sessions WHERE share_id = ?",
+            (share_id,),
+        ).fetchone()[0] == 1
+        receipt = conn.execute(
+            "SELECT hosted_receipt_id, hosted_status FROM shares WHERE share_id = ?",
+            (share_id,),
+        ).fetchone()
+        assert tuple(receipt) == ("receipt-v11", "accepted")
+        assert conn.execute(
+            "SELECT status FROM findings WHERE finding_id = 'finding-v11'"
+        ).fetchone()[0] == "ignored"
+        assert conn.execute(
+            "SELECT COUNT(*) FROM session_hold_history "
+            "WHERE session_id IN ('child', 'child_seg-0001')"
+        ).fetchone()[0] == 4
+    finally:
+        conn.close()
 
 
 def test_v6_migration_backfills_stability_and_adds_share_ledger_fields(
@@ -609,6 +766,113 @@ def test_first_checkpoint_keeps_parent_identity_without_being_hidden(index_conn)
         "long-parent",
         "long-parent_seg-0001",
     ]
+
+
+def test_inactive_checkpoint_leaves_auto_candidate_pool_but_keeps_history(index_conn):
+    _enroll(index_conn)
+
+    def checkpoint(index: int) -> dict:
+        item = _session(
+            "long-parent" if index == 0 else f"long-parent_seg-{index:04d}"
+        )
+        item.update({
+            "logical_session_id": "long-parent",
+            "segment_index": index,
+            "segment_reason": "bounded_checkpoint" if index < 2 else "active_tail",
+            "segment_message_range": [index * 2, index * 2 + 1],
+            "segment_sealed": index < 2,
+        })
+        return item
+
+    first, second, stale = (checkpoint(index) for index in range(3))
+    upsert_sessions(index_conn, [first, second, stale])
+    upsert_sessions(index_conn, [first, second])
+    index_conn.execute(
+        "UPDATE sessions SET revision_stable_since = ?",
+        ("2026-07-11T00:00:00+00:00",),
+    )
+    index_conn.commit()
+
+    report = get_auto_upload_candidate_report(
+        index_conn,
+        current_sources=("claude",),
+        current_projects=("project-one",),
+        source_confirmed=True,
+        projects_confirmed=True,
+        completion_modes={"claude": "stable_revision"},
+        now=NOW,
+    )
+
+    assert [item["session_id"] for item in report["selected"]] == [
+        "long-parent", "long-parent_seg-0001"
+    ]
+    assert index_conn.execute(
+        "SELECT checkpoint_active FROM sessions WHERE session_id = ?",
+        ("long-parent_seg-0002",),
+    ).fetchone()[0] == 0
+    assert auto_upload_review_blockers(
+        index_conn, ["long-parent_seg-0002"]
+    ) == [{
+        "session_id": "long-parent_seg-0002",
+        "review_status": "new",
+        "checkpoint_active": False,
+        "reason": "inactive_checkpoint",
+    }]
+    assert release_gate_blockers(index_conn, ["long-parent_seg-0002"]) == [{
+        "session_id": "long-parent_seg-0002",
+        "hold_state": "inactive_checkpoint",
+        "reason": "inactive_checkpoint",
+    }]
+    with pytest.raises(RevisionConflictError) as exc_info:
+        create_share(index_conn, ["long-parent_seg-0002"])
+    assert exc_info.value.blockers[0]["reason"] == "inactive_checkpoint"
+
+
+def test_one_negative_checkpoint_blocks_the_auto_upload_family(index_conn):
+    _enroll(index_conn)
+    upsert_sessions(index_conn, [_session("root"), _session("tail")])
+    index_conn.execute(
+        "UPDATE sessions SET logical_session_id = 'conversation', "
+        "segment_index = CASE session_id WHEN 'root' THEN 0 ELSE 1 END, "
+        "revision_stable_since = '2026-07-11T00:00:00+00:00' "
+        "WHERE session_id IN ('root', 'tail')"
+    )
+    index_conn.commit()
+
+    set_hold_state(index_conn, "tail", "pending_review", changed_by="findings")
+    held_report = get_auto_upload_candidate_report(
+        index_conn,
+        current_sources=("claude",),
+        current_projects=("project-one",),
+        source_confirmed=True,
+        projects_confirmed=True,
+        completion_modes={"claude": "stable_revision"},
+        now=NOW,
+    )
+    assert held_report["selected"] == []
+    assert held_report["exclusion_counts"]["held_or_embargoed"] == 2
+
+    set_hold_state(index_conn, "tail", "released", changed_by="user")
+    index_conn.execute(
+        "UPDATE sessions SET review_status = 'blocked' WHERE session_id = 'tail'"
+    )
+    index_conn.commit()
+    blocked_report = get_auto_upload_candidate_report(
+        index_conn,
+        current_sources=("claude",),
+        current_projects=("project-one",),
+        source_confirmed=True,
+        projects_confirmed=True,
+        completion_modes={"claude": "stable_revision"},
+        now=NOW,
+    )
+    assert blocked_report["selected"] == []
+    assert blocked_report["exclusion_counts"]["blocked_review_status"] == 2
+    assert auto_upload_review_blockers(index_conn, ["root"]) == [{
+        "session_id": "root",
+        "review_status": "blocked",
+        "reason": "blocked_review_status",
+    }]
 
 
 def test_candidate_report_uses_cheap_blob_presence_not_full_parse(

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -1712,6 +1712,168 @@ class TestSessionsAPI:
         assert data["session_id"] == "sess-0"
         assert "messages" in data
 
+    def test_checkpoint_family_projects_as_one_complete_session(self, server):
+        def checkpoint(index: int, content: str) -> dict:
+            session_id = "logical-long" if index == 0 else f"logical-long_seg-{index:04d}"
+            return {
+                "session_id": session_id,
+                "logical_session_id": "logical-long",
+                "project": "logical-project",
+                "source": "claude",
+                "model": "claude-sonnet-4",
+                "raw_source_path": "C:/tmp/logical-long.jsonl",
+                "start_time": f"2025-02-01T00:0{index}:00+00:00",
+                "end_time": f"2025-02-01T00:0{index + 1}:00+00:00",
+                "segment_index": index,
+                "segment_message_range": [index * 2, index * 2 + 1],
+                "segment_reason": "bounded_checkpoint" if index == 0 else "active_tail",
+                "segment_sealed": index == 0,
+                "messages": [
+                    {"role": "user", "content": content, "tool_uses": []},
+                    {"role": "assistant", "content": f"answer {index}", "tool_uses": []},
+                ],
+                "stats": {
+                    "user_messages": 1,
+                    "assistant_messages": 1,
+                    "tool_uses": 0,
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                },
+            }
+
+        conn = open_index()
+        try:
+            upsert_sessions(conn, [
+                checkpoint(0, "opening request"),
+                checkpoint(1, "unique-tail-search-needle"),
+            ])
+        finally:
+            conn.close()
+
+        status, rows = _get(server, "/api/sessions?project=logical-project")
+        assert status == 200
+        assert [(row["session_id"], row["checkpoint_count"]) for row in rows] == [
+            ("logical-long", 2)
+        ]
+
+        status, detail = _get(server, "/api/sessions/logical-long_seg-0001")
+        assert status == 200
+        assert detail["session_id"] == "logical-long"
+        assert [message["content"] for message in detail["messages"]] == [
+            "opening request",
+            "answer 0",
+            "unique-tail-search-needle",
+            "answer 1",
+        ]
+
+        status, search = _get(server, "/api/search?q=unique-tail-search-needle")
+        assert status == 200
+        assert [row["session_id"] for row in search] == ["logical-long"]
+
+        status, scoring_error = _post(
+            server, "/api/sessions/logical-long/score", {"backend": "auto"}
+        )
+        assert status == 409
+        assert scoring_error["block_reason"] == "logical_scoring_not_supported"
+
+        status, override_error = _post(
+            server,
+            "/api/sessions/logical-long",
+            {"ai_failure_value_score": 1},
+        )
+        assert status == 409
+        assert override_error["block_reason"] == "logical_scoring_not_supported"
+        for field, value in (
+            ("ai_summary", "not a conversation-level score"),
+            ("ai_effort_estimate", 0.9),
+        ):
+            status, override_error = _post(
+                server,
+                "/api/sessions/logical-long",
+                {field: value},
+            )
+            assert status == 409
+            assert (
+                override_error["block_reason"]
+                == "logical_scoring_not_supported"
+            )
+
+        status, result = _post(
+            server,
+            "/api/sessions/logical-long",
+            {"status": "shortlisted", "hold_state": "pending_review"},
+        )
+        assert status == 200
+        assert result["ok"] is True
+        conn = open_index()
+        try:
+            states = conn.execute(
+                "SELECT review_status, hold_state FROM sessions "
+                "WHERE logical_session_id = 'logical-long' ORDER BY segment_index"
+            ).fetchall()
+            assert [(row["review_status"], row["hold_state"]) for row in states] == [
+                ("shortlisted", "pending_review"),
+                ("shortlisted", "pending_review"),
+            ]
+        finally:
+            conn.close()
+
+    def test_logical_update_validates_before_changing_family(self, server):
+        def checkpoint(index: int) -> dict:
+            session_id = "validated-family" if index == 0 else "validated-family_seg-0001"
+            return {
+                "session_id": session_id,
+                "logical_session_id": "validated-family",
+                "project": "logical-project",
+                "source": "claude",
+                "raw_source_path": "C:/tmp/validated-family.jsonl",
+                "segment_index": index,
+                "segment_message_range": [index, index],
+                "segment_reason": "bounded_checkpoint" if index == 0 else "active_tail",
+                "segment_sealed": index == 0,
+                "messages": [{
+                    "role": "user" if index == 0 else "assistant",
+                    "content": f"message {index}",
+                    "tool_uses": [],
+                }],
+                "stats": {},
+            }
+
+        conn = open_index()
+        try:
+            upsert_sessions(conn, [checkpoint(0), checkpoint(1)])
+        finally:
+            conn.close()
+
+        status, data = _post(
+            server,
+            "/api/sessions/validated-family",
+            {"status": "approved", "ai_quality_score": 99},
+        )
+        assert status == 409
+        assert data["block_reason"] == "logical_scoring_not_supported"
+
+        status, data = _post(
+            server,
+            "/api/sessions/validated-family",
+            {"status": "approved", "hold_state": "not-a-hold-state"},
+        )
+        assert status == 400
+        assert "invalid hold_state" in data["error"]
+
+        conn = open_index()
+        try:
+            states = conn.execute(
+                "SELECT review_status, hold_state FROM sessions "
+                "WHERE logical_session_id = 'validated-family' ORDER BY segment_index"
+            ).fetchall()
+            assert [(row["review_status"], row["hold_state"]) for row in states] == [
+                ("new", "auto_redacted"),
+                ("new", "auto_redacted"),
+            ]
+        finally:
+            conn.close()
+
     def test_encoded_session_id_routes(self, server, monkeypatch):
         from urllib.parse import quote
 
@@ -1748,7 +1910,7 @@ class TestSessionsAPI:
 
         monkeypatch.setattr(
             "clawjournal.scoring.scoring.score_session",
-            lambda conn, sid, model=None, backend="auto": SimpleNamespace(
+            lambda conn, sid, model=None, backend="auto", **kwargs: SimpleNamespace(
                 quality=4,
                 reason=f"scored {sid}",
                 detail_json='{"substance": 4}',
@@ -1980,7 +2142,7 @@ class TestSessionsAPI:
     def test_score_session_endpoint_updates_session(self, server, monkeypatch):
         monkeypatch.setattr(
             "clawjournal.scoring.scoring.score_session",
-            lambda conn, session_id, model=None, backend="auto": SimpleNamespace(
+            lambda conn, session_id, model=None, backend="auto", **kwargs: SimpleNamespace(
                 quality=4,
                 reason="Solid debugging session",
                 detail_json='{"substance": 4}',
@@ -2046,6 +2208,67 @@ class TestStatsAPI:
         assert data["total"] == 3
         assert "by_status" in data
         assert "by_source" in data
+
+    def test_stats_count_logical_family_once_and_match_filters(self, server):
+        def checkpoint(index: int) -> dict:
+            session_id = (
+                "stats-family"
+                if index == 0
+                else f"stats-family_seg-{index:04d}"
+            )
+            return {
+                "session_id": session_id,
+                "logical_session_id": "stats-family",
+                "project": "stats-project",
+                "source": "claude",
+                "model": "claude-sonnet-4",
+                "start_time": f"2025-02-01T00:0{index}:00+00:00",
+                "end_time": f"2025-02-01T00:0{index + 1}:00+00:00",
+                "segment_index": index,
+                "segment_message_range": [index, index],
+                "segment_reason": (
+                    "bounded_checkpoint" if index == 0 else "active_tail"
+                ),
+                "segment_sealed": index == 0,
+                "raw_source_path": __file__,
+                "messages": [
+                    {"role": "user", "content": f"checkpoint {index}", "tool_uses": []}
+                ],
+                "stats": {
+                    "user_messages": 1,
+                    "assistant_messages": 0,
+                    "tool_uses": 0,
+                    "input_tokens": 1,
+                    "output_tokens": 0,
+                },
+            }
+
+        conn = open_index()
+        try:
+            upsert_sessions(conn, [checkpoint(0), checkpoint(1)])
+            conn.execute(
+                "UPDATE sessions SET review_status = 'approved', "
+                "ai_task_type = 'root-only-ai-type' "
+                "WHERE session_id = 'stats-family'"
+            )
+            conn.execute(
+                "UPDATE sessions SET task_type = 'family-debugging' "
+                "WHERE logical_session_id = 'stats-family'"
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        status, data = _get(server, "/api/stats")
+        assert status == 200
+        assert data["total"] == 4
+        assert data["by_status"] == {"new": 4}
+        assert data["by_task_type"]["family-debugging"] == 1
+        assert "root-only-ai-type" not in data["by_task_type"]
+
+        status, rows = _get(server, "/api/sessions?task_type=family-debugging")
+        assert status == 200
+        assert [row["session_id"] for row in rows] == ["stats-family"]
 
 
 class TestScanner:
@@ -3459,6 +3682,69 @@ class TestSharesAPI:
         assert status == 409
         assert data["block_reason"] == "revision_conflict"
         assert data["blockers"][0]["session_id"] == "sess-0"
+
+    def test_create_rejects_checkpoint_added_after_queue_review(self, server):
+        def checkpoint(index: int) -> dict:
+            session_id = "share-long" if index == 0 else f"share-long_seg-{index:04d}"
+            return {
+                "session_id": session_id,
+                "logical_session_id": "share-long",
+                "project": "test-project",
+                "source": "claude",
+                "model": "claude-sonnet-4",
+                "raw_source_path": "C:/tmp/share-long.jsonl",
+                "start_time": f"2025-03-01T00:0{index}:00+00:00",
+                "end_time": f"2025-03-01T00:0{index + 1}:00+00:00",
+                "segment_index": index,
+                "segment_message_range": [index * 2, index * 2 + 1],
+                "segment_reason": "bounded_checkpoint" if index < 2 else "active_tail",
+                "segment_sealed": index < 2,
+                "messages": [
+                    {"role": "user", "content": f"question {index}", "tool_uses": []},
+                    {"role": "assistant", "content": f"answer {index}", "tool_uses": []},
+                ],
+                "stats": {
+                    "user_messages": 1,
+                    "assistant_messages": 1,
+                    "tool_uses": 0,
+                    "input_tokens": 10,
+                    "output_tokens": 5,
+                },
+            }
+
+        root = checkpoint(0)
+        tail = checkpoint(1)
+        conn = open_index()
+        try:
+            upsert_sessions(conn, [root, tail])
+            rows = conn.execute(
+                "SELECT session_id, content_revision, logical_revision FROM sessions "
+                "WHERE logical_session_id = 'share-long' ORDER BY segment_index"
+            ).fetchall()
+            expected_revisions = {
+                row["session_id"]: row["content_revision"] for row in rows
+            }
+            reviewed_logical_revision = rows[0]["logical_revision"]
+            upsert_sessions(conn, [root, tail, checkpoint(2)])
+        finally:
+            conn.close()
+
+        status, data = _post(server, "/api/shares", {
+            "session_ids": ["share-long", "share-long_seg-0001"],
+            "expected_revisions": expected_revisions,
+            "expected_logical_revisions": {
+                "share-long": reviewed_logical_revision,
+            },
+        })
+
+        assert status == 409
+        assert data["block_reason"] == "revision_conflict"
+        assert data["blockers"][0]["logical_session_id"] == "share-long"
+        assert data["blockers"][0]["member_session_ids"] == [
+            "share-long",
+            "share-long_seg-0001",
+            "share-long_seg-0002",
+        ]
 
     def test_create_rejects_exact_revision_already_shared(self, server):
         from clawjournal.workbench.index import create_share

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -8,9 +8,12 @@ import pytest
 
 from clawjournal.session_titles import resolve_session_title
 from clawjournal.workbench.index import (
+    LogicalProjectionError,
+    RevisionConflictError,
     _migrate_bundles_to_shares,
     add_policy,
     backfill_session_keys,
+    bulk_update_logical_review_status,
     bulk_update_review_status,
     create_share,
     effective_hold_state,
@@ -20,19 +23,25 @@ from clawjournal.workbench.index import (
     get_shares,
     get_policies,
     get_share_ready_stats,
+    get_logical_session_detail,
+    get_logical_session_members,
+    get_logical_stats,
     get_session_detail,
     get_stats,
     link_subagent_hierarchy,
     open_index,
+    query_logical_sessions,
     query_sessions,
     query_sessions_for_rescore,
     query_unscored_sessions,
     recompute_estimated_costs,
     remove_policy,
     search_fts,
+    search_logical_sessions,
     session_matches_excluded_projects,
     source_scope_blockers,
     set_hold_state,
+    set_logical_hold_state,
     update_session,
     upsert_sessions,
 )
@@ -79,6 +88,39 @@ def _make_session(session_id="sess-1", project="test-project", source="claude",
             "output_tokens": 100,
         },
     }
+
+
+def _make_checkpoint(
+    logical_id: str,
+    index: int,
+    *,
+    content: str | None = None,
+    parent_session_id: str | None = None,
+    start_message: int | None = None,
+    sealed: bool | None = None,
+):
+    session_id = logical_id if index == 0 else f"{logical_id}_seg-{index:04d}"
+    start = index * 2 if start_message is None else start_message
+    checkpoint = _make_session(
+        session_id,
+        content=content or f"checkpoint {index}",
+        start_time=f"2025-01-01T00:0{index}:00+00:00",
+        end_time=f"2025-01-01T00:0{index + 1}:00+00:00",
+    )
+    checkpoint.update({
+        "logical_session_id": logical_id,
+        "parent_session_id": parent_session_id,
+        "segment_index": index,
+        "segment_message_range": [start, start + 1],
+        "segment_reason": (
+            "bounded_checkpoint"
+            if sealed is not False and index == 0
+            else "active_tail"
+        ),
+        "segment_sealed": index == 0 if sealed is None else sealed,
+        "raw_source_path": f"/tmp/{logical_id}.jsonl",
+    })
+    return checkpoint
 
 
 class TestUpsertSessions:
@@ -546,6 +588,507 @@ class TestCostAccounting:
         assert child_row["parent_session_id"] == "parent-1"
 
 
+class TestLogicalCheckpointProjection:
+    def test_unsegmented_identity_grows_into_one_logical_trace(self, index_conn):
+        initial = _make_session("long", content="checkpoint 0")
+        initial["logical_session_id"] = "long"
+        initial["raw_source_path"] = "/tmp/long.jsonl"
+        upsert_sessions(index_conn, [initial])
+
+        before = query_logical_sessions(index_conn)
+        assert [(row["session_id"], row["checkpoint_count"]) for row in before] == [
+            ("long", 1)
+        ]
+        before_revision = before[0]["logical_revision"]
+        assert before_revision.startswith("logical-sha256:")
+
+        root = _make_checkpoint("long", 0, content="checkpoint 0")
+        tail = _make_checkpoint("long", 1, content="unique tail needle")
+        upsert_sessions(index_conn, [root, tail])
+
+        rows = query_logical_sessions(index_conn)
+        assert len(rows) == 1
+        assert rows[0]["session_id"] == "long"
+        assert rows[0]["checkpoint_count"] == 2
+        assert rows[0]["checkpoint_session_ids"] == [
+            "long", "long_seg-0001"
+        ]
+        assert rows[0]["logical_incomplete"] is False
+        assert rows[0]["logical_revision"] != before_revision
+        detail = get_logical_session_detail(index_conn, "long_seg-0001")
+        assert detail["session_id"] == "long"
+        assert detail["component_session_ids"] == ["long", "long_seg-0001"]
+        assert len(detail["messages"]) == 4
+        assert get_session_detail(index_conn, "long_seg-0001")["session_id"] == (
+            "long_seg-0001"
+        )
+
+    def test_family_growth_and_retirement_keep_physical_history(self, index_conn):
+        root = _make_checkpoint("long", 0)
+        tail = _make_checkpoint("long", 1)
+        upsert_sessions(index_conn, [root, tail])
+        first_revision = query_logical_sessions(index_conn)[0]["logical_revision"]
+
+        third = _make_checkpoint("long", 2)
+        upsert_sessions(index_conn, [root, tail, third])
+        grown_revision = query_logical_sessions(index_conn)[0]["logical_revision"]
+        assert grown_revision != first_revision
+        assert [row["session_id"] for row in get_logical_session_members(index_conn, "long")] == [
+            "long", "long_seg-0001", "long_seg-0002"
+        ]
+
+        upsert_sessions(index_conn, [root, tail])
+        active = get_logical_session_members(index_conn, "long")
+        assert [row["session_id"] for row in active] == ["long", "long_seg-0001"]
+        stale = index_conn.execute(
+            "SELECT checkpoint_active FROM sessions WHERE session_id = ?",
+            ("long_seg-0002",),
+        ).fetchone()
+        assert stale["checkpoint_active"] == 0
+        assert get_session_detail(index_conn, "long_seg-0002") is not None
+
+    def test_partial_filtered_family_preserves_prior_active_membership(self, index_conn):
+        root = _make_checkpoint("long", 0)
+        tail = _make_checkpoint("long", 1)
+        upsert_sessions(index_conn, [root, tail])
+        prior_revision = query_logical_sessions(index_conn)[0]["logical_revision"]
+
+        updated_root = _make_checkpoint("long", 0, content="updated root")
+        filtered_tail = _make_checkpoint("long", 1, content="/clear")
+        new_third = _make_checkpoint("long", 2)
+        upsert_sessions(index_conn, [updated_root, filtered_tail, new_third])
+
+        members = index_conn.execute(
+            "SELECT session_id, checkpoint_active, logical_revision "
+            "FROM sessions WHERE logical_session_id = 'long' "
+            "ORDER BY segment_index"
+        ).fetchall()
+        assert [
+            (row["session_id"], row["checkpoint_active"])
+            for row in members
+        ] == [
+            ("long", 1),
+            ("long_seg-0001", 1),
+            ("long_seg-0002", 0),
+        ]
+        projected = query_logical_sessions(index_conn)
+        assert len(projected) == 1
+        assert projected[0]["checkpoint_session_ids"] == [
+            "long", "long_seg-0001"
+        ]
+        assert projected[0]["checkpoint_count"] == 2
+        assert projected[0]["logical_revision"] != prior_revision
+        assert {row["logical_revision"] for row in members} == {
+            projected[0]["logical_revision"]
+        }
+
+    def test_logical_status_filter_and_bulk_shortlist_use_whole_family(self, index_conn):
+        upsert_sessions(
+            index_conn,
+            [_make_checkpoint("long", 0), _make_checkpoint("long", 1)],
+        )
+        update_session(index_conn, "long", status="approved")
+
+        assert query_logical_sessions(index_conn, status="approved") == []
+        assert [row["session_id"] for row in query_logical_sessions(
+            index_conn, status="new"
+        )] == ["long"]
+
+        updated, missing = bulk_update_logical_review_status(
+            index_conn, ["long_seg-0001", "missing"], "shortlisted"
+        )
+        assert updated == ["long_seg-0001"]
+        assert missing == ["missing"]
+        statuses = index_conn.execute(
+            "SELECT review_status FROM sessions WHERE logical_session_id = 'long'"
+        ).fetchall()
+        assert {row["review_status"] for row in statuses} == {"shortlisted"}
+
+    def test_list_and_detail_project_same_mixed_review_and_hold(self, index_conn):
+        upsert_sessions(
+            index_conn,
+            [_make_checkpoint("long", 0), _make_checkpoint("long", 1)],
+        )
+        update_session(index_conn, "long", status="approved")
+        set_hold_state(
+            index_conn,
+            "long_seg-0001",
+            "pending_review",
+            changed_by="user",
+        )
+
+        summary = query_logical_sessions(index_conn)[0]
+        detail = get_logical_session_detail(index_conn, "long")
+        assert summary["review_status"] == detail["review_status"] == "new"
+        assert summary["hold_state"] == detail["hold_state"] == "pending_review"
+        assert summary["embargo_until"] is detail["embargo_until"] is None
+
+    def test_multi_checkpoint_projection_does_not_reuse_root_ai_score(self, index_conn):
+        upsert_sessions(
+            index_conn,
+            [_make_checkpoint("long", 0), _make_checkpoint("long", 1)],
+        )
+        update_session(
+            index_conn,
+            "long",
+            ai_quality_score=5,
+            ai_score_reason="root-only score",
+            ai_effort_estimate=0.8,
+            ai_summary="root-only summary",
+            ai_scoring_detail='{"reason":"root"}',
+            ai_task_type="ai-only-type",
+            ai_outcome_badge="resolved",
+            ai_value_badges='["high_value"]',
+            ai_risk_badges='["low_risk"]',
+            ai_display_title="AI root title",
+            ai_failure_value_score=4,
+            ai_recovery_labels='["recovered"]',
+            ai_failure_attribution="assistant",
+            ai_failure_modes='["reasoning"]',
+            ai_learning_summary="root learning",
+            ai_scorer_backend="judge",
+            ai_scorer_model="model",
+            ai_rubric_git_sha="abc",
+            ai_scored_at="2025-01-01T01:00:00+00:00",
+        )
+        index_conn.execute(
+            "UPDATE sessions SET ai_episode_quality = 0.5, ai_quality_tier = 'high' "
+            "WHERE session_id = 'long'"
+        )
+        index_conn.commit()
+        physical = get_session_detail(index_conn, "long")
+
+        summary = query_logical_sessions(index_conn)[0]
+        detail = get_logical_session_detail(index_conn, "long")
+        ai_fields = (
+            "ai_quality_score", "ai_score_reason", "ai_scoring_detail",
+            "ai_episode_quality", "ai_quality_tier", "ai_display_title",
+            "ai_task_type", "ai_outcome_badge", "ai_value_badges",
+            "ai_risk_badges", "ai_effort_estimate", "ai_summary",
+            "ai_failure_value_score", "ai_recovery_labels",
+            "ai_failure_attribution", "ai_failure_modes",
+            "ai_learning_summary", "ai_scorer_backend", "ai_scorer_model",
+            "ai_rubric_git_sha", "ai_scored_at",
+        )
+        assert all(summary[field] is None for field in ai_fields)
+        assert all(detail[field] is None for field in ai_fields)
+        assert query_logical_sessions(index_conn, task_type="ai-only-type") == []
+        assert query_logical_sessions(index_conn, recovery_label="recovered") == []
+        assert detail["display_title"] == physical["display_title"]
+        assert detail["outcome_badge"] == physical["outcome_badge"]
+
+    def test_duration_sort_uses_whole_logical_time_range(self, index_conn):
+        short = [_make_checkpoint("short", 0), _make_checkpoint("short", 1)]
+        short[0]["start_time"] = "2025-01-02T00:00:00+00:00"
+        short[0]["end_time"] = "2025-01-02T00:02:00+00:00"
+        short[1]["start_time"] = "2025-01-02T00:02:00+00:00"
+        short[1]["end_time"] = "2025-01-02T00:10:00+00:00"
+        long = _make_session(
+            "longer",
+            start_time="2025-01-01T00:00:00+00:00",
+            end_time="2025-01-01T02:00:00+00:00",
+        )
+        long["logical_session_id"] = "longer"
+        long["raw_source_path"] = "/tmp/longer.jsonl"
+        upsert_sessions(index_conn, [*short, long])
+
+        descending = query_logical_sessions(
+            index_conn, sort="duration_seconds", order="desc"
+        )
+        ascending = query_logical_sessions(
+            index_conn, sort="duration_seconds", order="asc"
+        )
+        assert [row["session_id"] for row in descending] == ["longer", "short"]
+        assert [row["session_id"] for row in ascending] == ["short", "longer"]
+        assert {row["session_id"]: row["duration_seconds"] for row in descending} == {
+            "longer": 7200,
+            "short": 600,
+        }
+
+    def test_child_fts_hit_returns_root_once(self, index_conn):
+        upsert_sessions(
+            index_conn,
+            [
+                _make_checkpoint("long", 0, content="ordinary opening"),
+                _make_checkpoint("long", 1, content="rarechildneedle"),
+            ],
+        )
+
+        results = search_logical_sessions(index_conn, "rarechildneedle")
+        assert [row["session_id"] for row in results] == ["long"]
+        assert results[0]["checkpoint_count"] == 2
+
+    def test_grouping_happens_before_list_and_fts_pagination(self, index_conn):
+        family_a = [
+            _make_checkpoint("family-a", 0, content="sharedsearchterm root"),
+            _make_checkpoint("family-a", 1, content="sharedsearchterm tail"),
+        ]
+        family_b = _make_session(
+            "family-b",
+            content="sharedsearchterm standalone",
+            start_time="2025-01-02T00:00:00+00:00",
+            end_time="2025-01-02T00:01:00+00:00",
+        )
+        family_b["logical_session_id"] = "family-b"
+        family_b["raw_source_path"] = "/tmp/family-b.jsonl"
+        upsert_sessions(index_conn, [*family_a, family_b])
+
+        first_page = query_logical_sessions(
+            index_conn, sort="start_time", limit=1, offset=0
+        )
+        second_page = query_logical_sessions(
+            index_conn, sort="start_time", limit=1, offset=1
+        )
+        assert [row["session_id"] for row in first_page] == ["family-b"]
+        assert [row["session_id"] for row in second_page] == ["family-a"]
+
+        first_hit = search_logical_sessions(
+            index_conn, "sharedsearchterm", limit=1, offset=0
+        )
+        second_hit = search_logical_sessions(
+            index_conn, "sharedsearchterm", limit=1, offset=1
+        )
+        assert len(first_hit) == len(second_hit) == 1
+        assert {first_hit[0]["session_id"], second_hit[0]["session_id"]} == {
+            "family-a", "family-b"
+        }
+
+    def test_incomplete_family_is_visible_but_fails_closed_for_share(self, index_conn):
+        root = _make_checkpoint("long", 0)
+        gap = _make_checkpoint("long", 1, start_message=3)
+        upsert_sessions(index_conn, [root, gap])
+        bulk_update_logical_review_status(index_conn, ["long"], "approved")
+
+        projected = query_logical_sessions(index_conn)
+        assert projected[0]["logical_incomplete"] is True
+        with pytest.raises(LogicalProjectionError):
+            get_logical_session_detail(index_conn, "long")
+        stats = get_share_ready_stats(index_conn)
+        assert stats["sessions"] == []
+        assert stats["logical_incomplete_excluded"] == 1
+
+    def test_share_ready_keeps_physical_candidates_with_family_metadata(self, index_conn):
+        upsert_sessions(
+            index_conn,
+            [_make_checkpoint("long", 0), _make_checkpoint("long", 1)],
+        )
+        bulk_update_logical_review_status(index_conn, ["long"], "approved")
+
+        stats = get_share_ready_stats(index_conn)
+        assert [row["session_id"] for row in stats["sessions"]] == [
+            "long_seg-0001", "long"
+        ]
+        for row in stats["sessions"]:
+            assert row["logical_session_id"] == "long"
+            assert row["logical_revision"].startswith("logical-sha256:")
+            assert row["checkpoint_count"] == 2
+            assert row["checkpoint_session_ids"] == ["long", "long_seg-0001"]
+            assert row["logical_incomplete"] is False
+            assert row["segment_index"] in (0, 1)
+            assert row["segment_reason"] in ("bounded_checkpoint", "active_tail")
+
+    def test_share_ready_fails_closed_for_one_negative_family_member(self, index_conn):
+        upsert_sessions(
+            index_conn,
+            [_make_checkpoint("long", 0), _make_checkpoint("long", 1)],
+        )
+        bulk_update_logical_review_status(index_conn, ["long"], "approved")
+        set_hold_state(
+            index_conn,
+            "long_seg-0001",
+            "pending_review",
+            changed_by="findings",
+        )
+
+        assert get_share_ready_stats(index_conn)["sessions"] == []
+
+        set_hold_state(
+            index_conn,
+            "long_seg-0001",
+            "released",
+            changed_by="user",
+        )
+        index_conn.execute(
+            "UPDATE sessions SET review_status = 'blocked' "
+            "WHERE session_id = 'long_seg-0001'"
+        )
+        index_conn.commit()
+        assert get_share_ready_stats(index_conn)["sessions"] == []
+
+    def test_missing_checkpoint_blob_fails_share_ready_and_create(self, index_conn):
+        upsert_sessions(
+            index_conn,
+            [_make_checkpoint("long", 0), _make_checkpoint("long", 1)],
+        )
+        bulk_update_logical_review_status(index_conn, ["long"], "approved")
+        preview = query_logical_sessions(index_conn)[0]
+        root_revision = index_conn.execute(
+            "SELECT content_revision FROM sessions WHERE session_id = 'long'"
+        ).fetchone()[0]
+        tail_blob = index_conn.execute(
+            "SELECT blob_path FROM sessions WHERE session_id = 'long_seg-0001'"
+        ).fetchone()[0]
+        Path(tail_blob).unlink()
+
+        assert query_logical_sessions(index_conn)[0]["logical_incomplete"] is True
+        stats = get_share_ready_stats(index_conn)
+        assert stats["sessions"] == []
+        assert stats["logical_incomplete_excluded"] == 1
+        with pytest.raises(RevisionConflictError) as exc_info:
+            create_share(
+                index_conn,
+                ["long"],
+                expected_revisions={"long": root_revision},
+                expected_logical_revisions={
+                    "long": preview["logical_revision"]
+                },
+            )
+        assert exc_info.value.blockers[0]["reason"] == "logical_incomplete"
+
+    def test_logical_hold_updates_every_checkpoint_and_audits_each(self, index_conn):
+        upsert_sessions(
+            index_conn,
+            [_make_checkpoint("long", 0), _make_checkpoint("long", 1)],
+        )
+
+        assert set_logical_hold_state(
+            index_conn,
+            "long_seg-0001",
+            "pending_review",
+            changed_by="user",
+            reason="logical hold",
+        )
+        rows = index_conn.execute(
+            "SELECT session_id, hold_state FROM sessions "
+            "WHERE logical_session_id = 'long' ORDER BY session_id"
+        ).fetchall()
+        assert [(row["session_id"], row["hold_state"]) for row in rows] == [
+            ("long", "pending_review"),
+            ("long_seg-0001", "pending_review"),
+        ]
+        history = index_conn.execute(
+            "SELECT session_id FROM session_hold_history "
+            "WHERE reason = 'logical hold' ORDER BY session_id"
+        ).fetchall()
+        assert [row["session_id"] for row in history] == [
+            "long", "long_seg-0001"
+        ]
+
+    @pytest.mark.parametrize(
+        ("hold_state", "embargo_until"),
+        [
+            ("pending_review", None),
+            ("embargoed", "2099-01-01T00:00:00+00:00"),
+            ("released", None),
+        ],
+    )
+    def test_new_checkpoint_inherits_logical_family_hold(
+        self, index_conn, hold_state, embargo_until
+    ):
+        root = _make_checkpoint("long", 0)
+        tail = _make_checkpoint("long", 1)
+        upsert_sessions(index_conn, [root, tail])
+        assert set_logical_hold_state(
+            index_conn,
+            "long",
+            hold_state,
+            changed_by="user",
+            embargo_until=embargo_until,
+        )
+
+        third = _make_checkpoint("long", 2)
+        upsert_sessions(index_conn, [root, tail, third])
+
+        row = index_conn.execute(
+            "SELECT hold_state, embargo_until FROM sessions WHERE session_id = ?",
+            ("long_seg-0002",),
+        ).fetchone()
+        assert row["hold_state"] == hold_state
+        assert row["embargo_until"] == embargo_until
+        history = index_conn.execute(
+            "SELECT from_state, to_state FROM session_hold_history "
+            "WHERE session_id = ? AND reason = ?",
+            (
+                "long_seg-0002",
+                "Inherited logical checkpoint family hold",
+            ),
+        ).fetchone()
+        assert tuple(history) == ("auto_redacted", hold_state)
+
+    def test_new_checkpoint_inherits_block_but_not_approval(self, index_conn):
+        blocked = [_make_checkpoint("blocked-family", 0), _make_checkpoint("blocked-family", 1)]
+        approved = [
+            _make_checkpoint("approved-family", 0),
+            _make_checkpoint("approved-family", 1),
+        ]
+        upsert_sessions(index_conn, [*blocked, *approved])
+        bulk_update_logical_review_status(
+            index_conn, ["blocked-family"], "blocked"
+        )
+        bulk_update_logical_review_status(
+            index_conn, ["approved-family"], "approved"
+        )
+
+        blocked_third = _make_checkpoint("blocked-family", 2)
+        approved_third = _make_checkpoint("approved-family", 2)
+        upsert_sessions(index_conn, [*blocked, blocked_third])
+        upsert_sessions(index_conn, [*approved, approved_third])
+
+        statuses = {
+            row["session_id"]: row["review_status"]
+            for row in index_conn.execute(
+                "SELECT session_id, review_status FROM sessions "
+                "WHERE session_id IN (?, ?)",
+                ("blocked-family_seg-0002", "approved-family_seg-0002"),
+            ).fetchall()
+        }
+        assert statuses == {
+            "blocked-family_seg-0002": "blocked",
+            "approved-family_seg-0002": "new",
+        }
+
+    def test_unsegmented_block_survives_threshold_split(self, index_conn):
+        initial = _make_session("threshold", content="full conversation before split")
+        initial["logical_session_id"] = "threshold"
+        initial["raw_source_path"] = "/tmp/threshold.jsonl"
+        upsert_sessions(index_conn, [initial])
+        bulk_update_logical_review_status(index_conn, ["threshold"], "blocked")
+
+        root = _make_checkpoint("threshold", 0, content="shorter sealed prefix")
+        tail = _make_checkpoint("threshold", 1, content="new active tail")
+        upsert_sessions(index_conn, [root, tail])
+
+        statuses = index_conn.execute(
+            "SELECT review_status FROM sessions WHERE logical_session_id = ? "
+            "ORDER BY segment_index",
+            ("threshold",),
+        ).fetchall()
+        assert [row["review_status"] for row in statuses] == ["blocked", "blocked"]
+
+    def test_hierarchy_links_only_checkpoint_representative(self, index_conn):
+        parent = _make_session("real-parent", project="test-project")
+        root = _make_checkpoint("child", 0, parent_session_id="real-parent")
+        tail = _make_checkpoint("child", 1, parent_session_id="real-parent")
+        upsert_sessions(index_conn, [parent, root, tail])
+
+        link_subagent_hierarchy(index_conn)
+
+        parent_row = index_conn.execute(
+            "SELECT review_status, subagent_session_ids FROM sessions "
+            "WHERE session_id = 'real-parent'"
+        ).fetchone()
+        assert parent_row["review_status"] != "segmented"
+        assert json.loads(parent_row["subagent_session_ids"]) == ["child"]
+        child_parents = index_conn.execute(
+            "SELECT session_id, parent_session_id FROM sessions "
+            "WHERE logical_session_id = 'child' ORDER BY segment_index"
+        ).fetchall()
+        assert [(row["session_id"], row["parent_session_id"]) for row in child_parents] == [
+            ("child", "real-parent"),
+            ("child_seg-0001", "real-parent"),
+        ]
+
+
 class TestQuerySessions:
     def test_query_all(self, index_conn):
         upsert_sessions(index_conn, [_make_session("s1"), _make_session("s2")])
@@ -622,6 +1165,17 @@ class TestGetSessionDetail:
 
 
 class TestQueryUnscoredSessions:
+    def test_skips_retired_checkpoint(self, index_conn):
+        checkpoints = [_make_checkpoint("long", index) for index in range(3)]
+        upsert_sessions(index_conn, checkpoints)
+        upsert_sessions(index_conn, checkpoints[:2])
+
+        ids = {
+            row["session_id"]
+            for row in query_unscored_sessions(index_conn, source=["claude"])
+        }
+        assert ids == {"long", "long_seg-0001"}
+
     def test_since_filters_old_unscored_sessions(self, index_conn):
         upsert_sessions(index_conn, [
             _make_session("old", start_time="2025-01-01T00:00:00+00:00"),
@@ -727,6 +1281,25 @@ class TestQueryUnscoredSessions:
 
 
 class TestQuerySessionsForRescore:
+    def test_skips_retired_checkpoint(self, index_conn):
+        from datetime import datetime, timezone
+
+        checkpoints = [_make_checkpoint("long", index) for index in range(3)]
+        now_iso = datetime.now(timezone.utc).isoformat()
+        for checkpoint in checkpoints:
+            checkpoint["start_time"] = now_iso
+            checkpoint["end_time"] = now_iso
+        upsert_sessions(index_conn, checkpoints)
+        upsert_sessions(index_conn, checkpoints[:2])
+
+        ids = {
+            row["session_id"]
+            for row in query_sessions_for_rescore(
+                index_conn, window_days=7, source=["claude"]
+            )
+        }
+        assert ids == {"long", "long_seg-0001"}
+
     def test_returns_sessions_regardless_of_existing_score(self, index_conn):
         """`clawjournal rescore --window` must overwrite, so the query
         returns scored sessions too — the difference from
@@ -987,6 +1560,39 @@ class TestStats:
         assert stats["by_source"] == {"codex": 1}
         assert stats["by_status"] == {"new": 1}
 
+    def test_logical_stats_match_family_status_and_task_type_filters(self, index_conn):
+        upsert_sessions(
+            index_conn,
+            [_make_checkpoint("long", 0), _make_checkpoint("long", 1)],
+        )
+        update_session(index_conn, "long", status="approved")
+        index_conn.execute(
+            "UPDATE sessions SET task_type = 'debugging' "
+            "WHERE logical_session_id = 'long'"
+        )
+        index_conn.execute(
+            "UPDATE sessions SET ai_task_type = 'root-only-ai-type' "
+            "WHERE session_id = 'long'"
+        )
+        index_conn.commit()
+
+        stats = get_logical_stats(index_conn)
+
+        assert stats["total"] == 1
+        assert stats["by_status"] == {"new": 1}
+        assert stats["by_source"] == {"claude": 1}
+        assert stats["by_project"] == {"test-project": 1}
+        assert stats["by_task_type"] == {"debugging": 1}
+        assert [row["session_id"] for row in query_logical_sessions(
+            index_conn, status="new"
+        )] == ["long"]
+        assert [row["session_id"] for row in query_logical_sessions(
+            index_conn, task_type="debugging"
+        )] == ["long"]
+        assert query_logical_sessions(
+            index_conn, task_type="root-only-ai-type"
+        ) == []
+
 
 class TestDashboardAnalytics:
     def test_filters_by_date_range(self, index_conn):
@@ -1106,6 +1712,61 @@ class TestDashboardAnalytics:
 
 
 class TestShares:
+    def test_create_share_binds_selected_subset_to_logical_revision(self, index_conn):
+        root = _make_checkpoint("long", 0)
+        tail = _make_checkpoint("long", 1)
+        upsert_sessions(index_conn, [root, tail])
+        preview = query_logical_sessions(index_conn)[0]
+        tail_revision = index_conn.execute(
+            "SELECT content_revision FROM sessions WHERE session_id = ?",
+            ("long_seg-0001",),
+        ).fetchone()[0]
+
+        with pytest.raises(RevisionConflictError):
+            create_share(
+                index_conn,
+                ["long_seg-0001"],
+                expected_revisions={"long_seg-0001": tail_revision},
+                expected_logical_revisions={},
+            )
+        with pytest.raises(RevisionConflictError):
+            create_share(
+                index_conn,
+                ["long_seg-0001"],
+                expected_revisions={"long_seg-0001": tail_revision},
+                expected_logical_revisions={
+                    "long": preview["logical_revision"],
+                    "unselected-family": "logical-sha256:stale",
+                },
+            )
+
+        # A physical subset is valid: a prior successful share or hold can
+        # legitimately make another active member absent from this package.
+        share_id = create_share(
+            index_conn,
+            ["long_seg-0001"],
+            expected_revisions={"long_seg-0001": tail_revision},
+            expected_logical_revisions={"long": preview["logical_revision"]},
+        )
+        assert get_share(index_conn, share_id)["session_count"] == 1
+
+        third = _make_checkpoint("long", 2)
+        upsert_sessions(index_conn, [root, tail, third])
+        with pytest.raises(RevisionConflictError) as exc_info:
+            create_share(
+                index_conn,
+                ["long_seg-0001"],
+                expected_revisions={"long_seg-0001": tail_revision},
+                expected_logical_revisions={"long": preview["logical_revision"]},
+            )
+        assert exc_info.value.blockers[0]["logical_session_id"] == "long"
+        assert exc_info.value.blockers[0]["selected_session_ids"] == [
+            "long_seg-0001"
+        ]
+        assert exc_info.value.blockers[0]["member_session_ids"] == [
+            "long", "long_seg-0001", "long_seg-0002"
+        ]
+
     def test_create_and_get(self, index_conn):
         upsert_sessions(index_conn, [_make_session("s1"), _make_session("s2")])
         share_id = create_share(index_conn, ["s1", "s2"], note="Test share")

--- a/tests/workbench/test_index_recovery.py
+++ b/tests/workbench/test_index_recovery.py
@@ -464,6 +464,68 @@ def test_snapshot_treats_missing_critical_session_columns_as_unreadable():
     assert errors == ["session decisions and hold state"]
 
 
+def test_recovery_preserves_missing_checkpoint_projection_metadata(
+    recovery_install,
+):
+    conn = index_module.open_index()
+    try:
+        session = _session()
+        session.update({
+            "logical_session_id": "session-recovery",
+            "parent_session_id": "real-parent",
+            "segment_index": 0,
+            "segment_message_range": [0, 1],
+            "segment_reason": "bounded_checkpoint",
+            "segment_sealed": True,
+            "raw_source_start_offset": 0,
+            "raw_source_end_offset": 42,
+        })
+        index_module.upsert_sessions(conn, [session])
+        conn.execute(
+            "UPDATE sessions SET checkpoint_active = 0 WHERE session_id = ?",
+            ("session-recovery",),
+        )
+        conn.commit()
+        snapshot, errors = index_recovery._recovery_snapshot(conn)
+        assert errors == []
+        saved = snapshot["sessions"][0]
+        assert saved["logical_session_id"] == "session-recovery"
+        assert saved["checkpoint_active"] == 0
+
+        conn.execute(
+            "DELETE FROM sessions WHERE session_id = ?", ("session-recovery",)
+        )
+        conn.commit()
+        restored, needs_review, skipped = index_recovery._restore_session_state(
+            conn, snapshot["sessions"]
+        )
+        conn.commit()
+
+        assert (restored, needs_review, skipped) == (0, 1, 0)
+        row = conn.execute(
+            "SELECT parent_session_id, segment_index, segment_start_message, "
+            "segment_end_message, segment_reason, segment_sealed, "
+            "raw_source_start_offset, raw_source_end_offset, logical_session_id, "
+            "checkpoint_active, logical_revision FROM sessions "
+            "WHERE session_id = 'session-recovery'"
+        ).fetchone()
+        assert dict(row) == {
+            "parent_session_id": "real-parent",
+            "segment_index": 0,
+            "segment_start_message": 0,
+            "segment_end_message": 1,
+            "segment_reason": "bounded_checkpoint",
+            "segment_sealed": 1,
+            "raw_source_start_offset": 0,
+            "raw_source_end_offset": 42,
+            "logical_session_id": "session-recovery",
+            "checkpoint_active": 0,
+            "logical_revision": saved["logical_revision"],
+        }
+    finally:
+        conn.close()
+
+
 def test_snapshot_treats_missing_critical_finding_columns_as_unreadable():
     conn = sqlite3.connect(":memory:")
     conn.row_factory = sqlite3.Row

--- a/tests/workbench/test_share_gates.py
+++ b/tests/workbench/test_share_gates.py
@@ -80,6 +80,22 @@ class TestReleaseGate:
         assert len(blockers) == 1
         assert blockers[0]["hold_state"] == "pending_review"
 
+    def test_one_held_checkpoint_blocks_its_logical_family(self, conn):
+        upsert_sessions(conn, [_settled_session("root"), _settled_session("tail")])
+        conn.execute(
+            "UPDATE sessions SET logical_session_id = 'conversation', "
+            "segment_index = CASE session_id WHEN 'root' THEN 0 ELSE 1 END "
+            "WHERE session_id IN ('root', 'tail')"
+        )
+        conn.commit()
+        set_hold_state(conn, "tail", "pending_review", changed_by="findings")
+
+        blockers = release_gate_blockers(conn, ["root"])
+
+        assert len(blockers) == 1
+        assert blockers[0]["session_id"] == "root"
+        assert blockers[0]["hold_state"] == "pending_review"
+
     def test_released_passes(self, conn):
         upsert_sessions(conn, [_settled_session("a")])
         conn.commit()


### PR DESCRIPTION
Fixes #192.

## What changed

- Add an explicit schema-v12 logical conversation projection (`logical_session_id`, active checkpoint membership, and a family revision) while retaining every physical upload checkpoint and its history.
- Reconcile checkpoint families atomically after scans. New members stay inactive until the complete contiguous family validates; stale members are retired rather than deleted, and partial/filtered scans preserve the prior projection.
- Make Workbench list, detail, search, Inbox stats, status updates, and hold controls operate on one logical conversation. Detail concatenation fails closed on missing/overlapping ranges or blobs.
- Group the Share Queue by conversation while keeping redaction, review, packaging, receipts, and automatic upload addressed by physical checkpoint IDs. Share creation now binds both component revisions and the logical family revision.
- Propagate negative review/hold controls across active family members and re-check the whole family at manual and automatic egress gates. Inactive checkpoints cannot enter quick-share or a new upload.
- Stop presenting one checkpoint's AI score as a score for a multi-checkpoint conversation; conversation-level scoring returns an explicit 409 until it has its own revision-aware model.
- Clean high-confidence Claude/Codex harness wrappers from display titles only, and stop using checkpoint membership as a fake subagent parent relationship.

## Compatibility and scope

- The append-only segmentation thresholds, checkpoint IDs, message slices, raw byte ranges, fingerprints, and recurring-upload protocol are unchanged.
- Physical checkpoint rows remain the immutable transport/audit units for hosted upload, findings, holds, receipts, and recovery.
- The `clawjournal-share` service and wire format are unchanged; this is a client-side projection and safety fix.
- Dashboard historical analytics remain physical by design in this PR; Inbox counts use the new logical projection.

## Verification

- `512 passed, 1 deselected` — Workbench index, daemon, v1/v2→v12 migrations, recovery, share gates, and CLI security (the deselected assertion is POSIX chmod-only on Windows).
- `197 passed` — automatic upload state machine, candidate/index, and recovery tests.
- `294 passed` — parser, append-only segmenter, and badge/title tests.
- `206 passed` — events export and benchmark suites under UTF-8 mode.
- `28 passed` — trace-note suites with the repository test namespace isolated from an installed third-party `tests` package.
- Frontend: TypeScript, ESLint, 122 Vitest tests, Share Queue state script, and production build all pass.
- `git diff --check` and Python compilation pass.

A full Windows sweep also exercised 3,856 passing tests. The compatibility failures it exposed in this change (old DB columns and minimal event-export schemas) were fixed and rerun above; the remaining failures are existing platform assumptions around `HOME`, LF byte offsets, symlinks, POSIX file modes, and the Windows default GBK encoding.