### PR TITLE
Guard workbench state on network filesystems

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,8 @@ clawjournal skill --install-nudge        # opt in to a stale-lessons SessionStar
 clawjournal skill --uninstall-nudge      # disable that reminder and its context output
 clawjournal share --interactive --weekly --no-score # guided sharing without AI scoring
 clawjournal status                       # check your setup
+clawjournal --version                    # show the package version and checkout revision
+clawjournal doctor index --json          # collect bounded, path-free index diagnostics
 clawjournal selfupdate --check           # see whether a newer version is available
 clawjournal selfupdate --reinstall       # update and rerun the installer in one step
 clawjournal selfupdate --reinstall --with-frontend --with-sharing # also add UI + managed scanners
@@ -188,11 +190,24 @@ background process and follow the SSH tunnel instructions it prints.
 
 On a cluster or another machine whose home directory is on a shared/network
 filesystem, set `CLAWJOURNAL_HOME` to a private, persistent local-filesystem
-directory before first use. For an existing install, stop ClawJournal and move
+directory before first use. For an existing install, stop ClawJournal and copy
 the whole state directory together (index, review state, tokens, and local trace
-copies) before setting the variable; setting it alone selects a separate state
+copies), keeping the original unchanged until recovery succeeds, before setting
+the variable; setting it alone selects a separate state
 root. For example, use `export CLAWJOURNAL_HOME=/local/path/clawjournal` on
 macOS/Linux or `$env:CLAWJOURNAL_HOME='D:\local\clawjournal'` in PowerShell.
+ClawJournal refuses to create, open, or rebuild its mutable SQLite index when it
+can positively identify the state directory as a network filesystem. Unknown
+filesystem types keep the existing behavior, so cluster users should still
+confirm the target with their administrator. Do not use an ephemeral node-local
+temporary directory for state that must survive a reboot or job migration.
+
+`clawjournal doctor index --json` is read-only and does not require the external
+`sqlite3` command. Its output is deliberately bounded and omits state paths,
+mount sources, hostnames, usernames, and session content, so it can be reviewed
+before attaching it to a support report. On known network storage or while live
+SQLite sidecars are present, it reports that condition without opening the
+database. Do not attach `index.db` itself.
 
 `clawjournal skill` uses one optional AI distill call to propose up to five
 coding-agent lessons. Its preview names one human-facing weekly focus only when a

--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -55,6 +55,27 @@ def _argparse_path(path: Path) -> str:
     return str(path).replace("%", "%%")
 
 
+class _VersionAction(argparse.Action):
+    """Resolve checkout HEAD only when ``--version`` is actually requested."""
+
+    def __init__(self, option_strings, dest=argparse.SUPPRESS,
+                 default=argparse.SUPPRESS, **kwargs):
+        kwargs.pop("nargs", None)
+        super().__init__(
+            option_strings=option_strings,
+            dest=dest,
+            nargs=0,
+            default=default,
+            **kwargs,
+        )
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        from .support_diagnostics import version_string
+
+        parser._print_message(version_string() + "\n", sys.stdout)
+        parser.exit()
+
+
 REQUIRED_REVIEW_ATTESTATIONS: dict[str, str] = {
     "asked_full_name": "I asked the user for their full name and scanned for it.",
     "asked_sensitive_entities": "I asked about company/client/internal names and private URLs.",
@@ -3997,21 +4018,22 @@ def _should_auto_update(argv: list[str] | None = None) -> bool:
       - A one-shot workbench controller is about to start a `serve` child.
         The child must pin its imported backend/frontend pair before it starts
         the updater, so the parent must not race an update ahead of that pin.
-      - The user invoked help/version (`-h`, `--help`, `--version`)
-        with no real subcommand — argparse prints and exits, so a
-        background fetch is wasted work that surprises the user.
+      - The user invoked help/version (`-h`, `--help`, `--version`) —
+        argparse prints and exits, so a background fetch is wasted work that
+        surprises the user even when help belongs to a subcommand.
 
     Matching `"selfupdate"` anywhere in argv produced false positives
     like `clawjournal export --output ./selfupdate`.
     """
     tokens = (sys.argv if argv is None else argv)[1:]
+    if any(token in _AUTO_UPDATE_SKIP_FLAGS for token in tokens):
+        return False
     command = _requested_subcommand(argv)
     if command is None:
         if not tokens:
             return True
-        # All tokens were flags — no subcommand. Skip when any are help/version.
-        return not any(t in _AUTO_UPDATE_SKIP_FLAGS for t in tokens)
-    if command in {"selfupdate", "open"}:
+        return True
+    if command in {"selfupdate", "open", "doctor"}:
         return False
     # `desktop launch` has no options of its own, so its subcommand is the
     # final token. Avoid mistaking an unrelated global option value named
@@ -4046,7 +4068,7 @@ def _should_pin_frontend(
     return True
 
 
-def main() -> None:
+def _main() -> None:
     # A workbench process must remember the revision its already-imported
     # Python belongs to and pin its matching frontend before the detached
     # updater can fast-forward the checkout or rebuild dist/.
@@ -4089,11 +4111,28 @@ def main() -> None:
             pass
 
     parser = argparse.ArgumentParser(description="ClawJournal — coding agent conversation exporter")
+    parser.add_argument(
+        "--version",
+        action=_VersionAction,
+        help="Show package version and checkout revision, then exit",
+    )
     sub = parser.add_subparsers(dest="command")
 
     prep_parser = sub.add_parser("prep", help="Data prep — discover projects, output JSON")
     prep_parser.add_argument("--source", choices=SOURCE_CHOICES, default="auto")
     sub.add_parser("status", help="Show current stage and next steps (JSON)")
+    doctor = sub.add_parser(
+        "doctor",
+        help="Collect privacy-bounded, read-only support diagnostics",
+    )
+    doctor_sub = doctor.add_subparsers(dest="doctor_command", required=True)
+    doctor_index = doctor_sub.add_parser(
+        "index",
+        help="Inspect index health without creating or migrating the database",
+    )
+    doctor_index.add_argument(
+        "--json", action="store_true", help="Output structured JSON report"
+    )
     cf = sub.add_parser("confirm", help="Scan for PII, summarize export, and record review state (JSON)")
     cf.add_argument("--file", "-f", type=Path, default=None, help="Path to export JSONL file")
     cf.add_argument("--full-name", type=str, default=None,
@@ -5022,6 +5061,23 @@ def main() -> None:
     if command == "desktop":
         from .desktop import run_desktop_command
         exit_code = run_desktop_command(args)
+        if exit_code:
+            raise SystemExit(exit_code)
+        return
+
+    if command == "doctor":
+        from .support_diagnostics import (
+            collect_index_diagnostics,
+            diagnostics_exit_code,
+            render_index_diagnostics,
+        )
+
+        report = collect_index_diagnostics()
+        if args.json:
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(render_index_diagnostics(report))
+        exit_code = diagnostics_exit_code(report)
         if exit_code:
             raise SystemExit(exit_code)
         return
@@ -7405,6 +7461,22 @@ def _print_pii_guidance(output_path: Path) -> None:
     print(f"  clawjournal export -o {abs_output}")
     print()
     print(f"Found an issue? Help improve ClawJournal: {REPO_URL}/issues")
+
+
+def main() -> None:
+    """CLI boundary with a path-free error for refused shared-state writes."""
+
+    from .filesystem import UnsafeStateStorageError
+
+    try:
+        _main()
+    except UnsafeStateStorageError as exc:
+        # The dedicated exception is constructed from a path-free filesystem
+        # classification.  Still collapse control characters so stderr stays
+        # one line if a future subclass adds dynamic context.
+        message = re.sub(r"[\x00-\x1f\x7f]+", " ", str(exc)).strip()
+        print(f"error: {message[:500] or 'unsafe state storage'}", file=sys.stderr)
+        raise SystemExit(1) from None
 
 
 if __name__ == "__main__":

--- a/clawjournal/filesystem.py
+++ b/clawjournal/filesystem.py
@@ -1,0 +1,273 @@
+"""Conservative filesystem classification for SQLite state storage.
+
+Only filesystem kinds that can be identified without exposing mount sources or
+mount paths are returned.  Unknown platforms and unrecognised filesystem kinds
+remain usable: callers fail closed only for an explicit, known network or
+cluster filesystem.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Literal
+
+StorageRisk = Literal["network", "local", "unknown"]
+
+
+class UnsafeStateStorageError(RuntimeError):
+    """A write was refused because application state is on unsafe storage."""
+
+
+@dataclass(frozen=True)
+class FilesystemInfo:
+    """Sanitised storage classification safe to include in diagnostics."""
+
+    filesystem_type: str
+    storage_risk: StorageRisk
+
+    @property
+    def storage_migration_required(self) -> bool:
+        return self.storage_risk == "network"
+
+    def health_fields(self) -> dict[str, str | bool]:
+        return {
+            "filesystem_type": self.filesystem_type,
+            "storage_risk": self.storage_risk,
+            "storage_migration_required": self.storage_migration_required,
+        }
+
+
+_NETWORK_FILESYSTEM_ALIASES = {
+    "9p": "9p",
+    "afs": "afs",
+    "beegfs": "beegfs",
+    "blobfuse": "blobfuse",
+    "blobfuse2": "blobfuse",
+    "ceph": "ceph",
+    "cifs": "cifs",
+    "cvmfs": "cvmfs",
+    "davfs": "davfs",
+    "davfs2": "davfs",
+    "fuse.afs": "afs",
+    "fuse.beegfs": "beegfs",
+    "fuse.ceph": "ceph",
+    "fuse.cvmfs": "cvmfs",
+    "fuse.glusterfs": "glusterfs",
+    "fuse.gcsfuse": "gcsfuse",
+    "fuse.juicefs": "juicefs",
+    "fuse.rclone": "rclone",
+    "fuse.s3fs": "s3fs",
+    "fuse.sshfs": "sshfs",
+    "fuse.weka": "weka",
+    "gfs2": "gfs2",
+    "gcsfuse": "gcsfuse",
+    "glusterfs": "glusterfs",
+    "gpfs": "gpfs",
+    "juicefs": "juicefs",
+    "lustre": "lustre",
+    "nfs": "nfs",
+    "nfs4": "nfs4",
+    "ocfs2": "ocfs2",
+    "orangefs": "orangefs",
+    "panfs": "panfs",
+    "pvfs2": "orangefs",
+    "rclone": "rclone",
+    "s3fs": "s3fs",
+    "smb2": "smbfs",
+    "smb3": "smbfs",
+    "smbfs": "smbfs",
+    "sshfs": "sshfs",
+    "virtiofs": "virtiofs",
+    "weka": "weka",
+}
+
+_LOCAL_FILESYSTEM_ALIASES = {
+    "apfs": "apfs",
+    "btrfs": "btrfs",
+    "exfat": "exfat",
+    "ext2": "ext2",
+    "ext3": "ext3",
+    "ext4": "ext4",
+    "f2fs": "f2fs",
+    "hfs": "hfs",
+    "hfsplus": "hfsplus",
+    "jfs": "jfs",
+    "ntfs": "ntfs",
+    "ntfs3": "ntfs3",
+    "ramfs": "ramfs",
+    "reiserfs": "reiserfs",
+    "tmpfs": "tmpfs",
+    "ufs": "ufs",
+    "vfat": "vfat",
+    "xfs": "xfs",
+    "zfs": "zfs",
+}
+
+_KNOWN_UNKNOWN_FILESYSTEM_ALIASES = {
+    "autofs": "autofs",
+    "cgroup": "cgroup",
+    "cgroup2": "cgroup2",
+    "devtmpfs": "devtmpfs",
+    "ecryptfs": "ecryptfs",
+    "fuse": "fuse",
+    "fuseblk": "fuseblk",
+    "iso9660": "iso9660",
+    "nsfs": "nsfs",
+    "overlay": "overlay",
+    "overlayfs": "overlay",
+    "proc": "proc",
+    "squashfs": "squashfs",
+    "sysfs": "sysfs",
+    "udf": "udf",
+}
+
+_MOUNTINFO_ESCAPE = re.compile(r"\\([0-7]{3})")
+_SAFE_FILESYSTEM_TYPE = re.compile(r"[a-z0-9._+-]{1,32}\Z")
+
+
+def _unescape_mountinfo_field(value: str) -> str:
+    """Decode the octal escapes used for paths in proc mountinfo."""
+
+    return _MOUNTINFO_ESCAPE.sub(lambda match: chr(int(match.group(1), 8)), value)
+
+
+def _filesystem_info(filesystem_type: str) -> FilesystemInfo:
+    normalized = filesystem_type.strip().lower()
+    if _SAFE_FILESYSTEM_TYPE.fullmatch(normalized) is None:
+        return FilesystemInfo("unknown", "unknown")
+    if normalized in _NETWORK_FILESYSTEM_ALIASES:
+        return FilesystemInfo(
+            _NETWORK_FILESYSTEM_ALIASES[normalized],
+            "network",
+        )
+    if normalized in _LOCAL_FILESYSTEM_ALIASES:
+        return FilesystemInfo(
+            _LOCAL_FILESYSTEM_ALIASES[normalized],
+            "local",
+        )
+    if normalized in _KNOWN_UNKNOWN_FILESYSTEM_ALIASES:
+        return FilesystemInfo(
+            _KNOWN_UNKNOWN_FILESYSTEM_ALIASES[normalized],
+            "unknown",
+        )
+    # FUSE subtypes can be user-chosen strings. Unknown kernel kinds therefore
+    # cannot be returned verbatim in support-safe health payloads.
+    return FilesystemInfo("unknown", "unknown")
+
+
+def sanitized_filesystem_type(value: object) -> str:
+    """Return only a fixed, support-safe filesystem identifier."""
+
+    return _filesystem_info(str(value or "")).filesystem_type
+
+
+def _classify_linux_mountinfo(path: Path, mountinfo: str) -> FilesystemInfo:
+    """Classify *path* using the longest matching mountinfo mount point."""
+
+    # mountinfo paths always use Linux/POSIX syntax.  Keeping the parser on
+    # PurePosixPath also lets its behaviour be tested from non-Linux clients.
+    target = PurePosixPath(path.as_posix())
+
+    best_specificity = -1
+    best_filesystem_types: list[str] = []
+    for line in mountinfo.splitlines():
+        before, separator, after = line.partition(" - ")
+        if not separator:
+            continue
+        mount_fields = before.split()
+        filesystem_fields = after.split()
+        if len(mount_fields) < 5 or not filesystem_fields:
+            continue
+        mount_point = PurePosixPath(_unescape_mountinfo_field(mount_fields[4]))
+        try:
+            target.relative_to(mount_point)
+        except (OSError, ValueError):
+            continue
+        specificity = len(mount_point.parts)
+        if specificity > best_specificity:
+            best_specificity = specificity
+            best_filesystem_types = [filesystem_fields[0]]
+        elif specificity == best_specificity:
+            best_filesystem_types.append(filesystem_fields[0])
+
+    if not best_filesystem_types:
+        return FilesystemInfo("unknown", "unknown")
+    candidates = [_filesystem_info(value) for value in best_filesystem_types]
+    # Stacked mounts can expose multiple entries at the same mountpoint, and
+    # mount IDs do not define which layer is visible. Avoid a false-local
+    # admission: any network candidate makes the ambiguous stack unsafe. If
+    # the sanitised candidates agree, their shared classification is safe;
+    # otherwise degrade to unknown rather than guessing.
+    for candidate in candidates:
+        if candidate.storage_risk == "network":
+            return candidate
+    if all(candidate == candidates[0] for candidate in candidates[1:]):
+        return candidates[0]
+    return FilesystemInfo("unknown", "unknown")
+
+
+def _read_linux_mountinfo() -> str | None:
+    """Read the kernel mount table without exposing it outside this module."""
+
+    try:
+        return Path("/proc/self/mountinfo").read_text(
+            encoding="utf-8",
+            errors="replace",
+        )
+    except OSError:
+        return None
+
+
+def classify_filesystem(path: Path) -> FilesystemInfo:
+    """Return a sanitised, conservative classification for *path*.
+
+    Linux exposes the mounted filesystem kind in ``/proc/self/mountinfo``.
+    Other platforms deliberately degrade to ``unknown`` until an equally
+    reliable, source-free implementation is available.
+    """
+
+    if not sys.platform.startswith("linux"):
+        return FilesystemInfo("unknown", "unknown")
+
+    mountinfo = _read_linux_mountinfo()
+    if mountinfo is None:
+        return FilesystemInfo("unknown", "unknown")
+
+    # A direct path on a hard, disconnected NFS mount can block in resolve()
+    # before the daemon has a chance to show migration guidance. Match the
+    # lexical absolute path first and stop immediately when mountinfo already
+    # proves it is network-backed. Local/unknown paths still resolve so a
+    # symlink into shared storage cannot bypass the guard.
+    lexical_target = Path(os.path.abspath(Path(path)))
+    lexical_info = _classify_linux_mountinfo(lexical_target, mountinfo)
+    if lexical_info.storage_migration_required:
+        return lexical_info
+
+    try:
+        target = Path(path).resolve(strict=False)
+    except (OSError, RuntimeError):
+        return lexical_info
+
+    # Resolving can trigger autofs or race a remount, so classify against a
+    # fresh kernel snapshot instead of the one read before resolve().
+    refreshed_mountinfo = _read_linux_mountinfo()
+    if refreshed_mountinfo is None:
+        return FilesystemInfo("unknown", "unknown")
+    return _classify_linux_mountinfo(target, refreshed_mountinfo)
+
+
+def storage_migration_message(info: FilesystemInfo) -> str:
+    """Return the actionable, path-free message for unsafe SQLite storage."""
+
+    filesystem_type = sanitized_filesystem_type(info.filesystem_type)
+    return (
+        "ClawJournal's state directory is on a network or shared filesystem "
+        f"({filesystem_type}). Stop all ClawJournal processes, copy the "
+        "entire state directory to private persistent local storage, set "
+        "CLAWJOURNAL_HOME to that local directory, and restart before scanning "
+        "or rebuilding the index."
+    )

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -32,6 +32,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from .config import load_config
+from .filesystem import UnsafeStateStorageError
 from .session_titles import append_fork_title_suffix, resolve_session_title
 from .scoring.backends import (
     SUPPORTED_BACKENDS,
@@ -1210,6 +1211,8 @@ def run(args) -> None:
                 )
             else:
                 print(f"{DIM}Index already up to date.{RST}")
+        except UnsafeStateStorageError:
+            raise
         except Exception as exc:  # noqa: BLE001
             print(f"{YEL}Index refresh skipped: {exc}{RST}")
     config = load_config()
@@ -1229,7 +1232,7 @@ def run(args) -> None:
         conn.close()
 
 
-def main(argv: list[str] | None = None) -> None:
+def _main(argv: list[str] | None = None) -> None:
     """Console-script entry point for the thin `clawshare` alias."""
     parser = argparse.ArgumentParser(
         prog="clawshare",
@@ -1238,6 +1241,20 @@ def main(argv: list[str] | None = None) -> None:
     )
     add_share_cli_args(parser)
     run(parser.parse_args(argv))
+
+
+def main(argv: list[str] | None = None) -> None:
+    """CLI boundary with a path-free error for refused shared-state writes."""
+
+    try:
+        _main(argv)
+    except UnsafeStateStorageError as exc:
+        message = re.sub(r"[\x00-\x1f\x7f]+", " ", str(exc)).strip()
+        print(
+            f"error: {message[:500] or 'unsafe state storage'}",
+            file=sys.stderr,
+        )
+        raise SystemExit(1) from None
 
 
 if __name__ == "__main__":

--- a/clawjournal/support_diagnostics.py
+++ b/clawjournal/support_diagnostics.py
@@ -1,0 +1,493 @@
+"""Privacy-bounded diagnostics for support reports.
+
+This module deliberately does not call :func:`workbench.index.open_index`:
+doing so would create or migrate the database, acquire ClawJournal's normal
+state files, and turn a diagnostic command into a write path.  The index probe
+opens only an already-existing SQLite file in read-only mode and reports a
+small, schema-versioned allowlist of values.
+"""
+
+from __future__ import annotations
+
+import platform
+import re
+import sqlite3
+import subprocess
+from pathlib import Path
+from typing import Mapping
+
+from . import __version__
+
+
+SUPPORT_DIAGNOSTICS_SCHEMA_VERSION = 1
+MAX_QUICK_CHECK_ISSUES = 20
+MAX_FOREIGN_KEY_VIOLATIONS = 20
+_REVISION_RE = re.compile(r"[0-9a-fA-F]{7,64}")
+_KNOWN_SCHEMA_IDENTIFIERS = frozenset({
+    "auto_upload_enrollment",
+    "auto_upload_enrollment_job",
+    "benchmark_exports",
+    "benchmark_tasks",
+    "benchmarks",
+    "capture_cursors",
+    "cost_anomalies",
+    "cost_ingest_state",
+    "event_overrides",
+    "event_sessions",
+    "event_source_snippets",
+    "events",
+    "findings",
+    "findings_allowlist",
+    "incidents",
+    "loop_ingest_state",
+    "policies",
+    "session_hold_history",
+    "sessions",
+    "share_sessions",
+    "shares",
+    "token_usage",
+})
+_OS_FAMILY_ALIASES = {
+    "darwin": "macOS",
+    "freebsd": "FreeBSD",
+    "linux": "Linux",
+    "windows": "Windows",
+}
+_ARCHITECTURE_ALIASES = {
+    "aarch64": "arm64",
+    "amd64": "x86_64",
+    "arm64": "arm64",
+    "i386": "x86",
+    "i686": "x86",
+    "ppc64le": "ppc64le",
+    "riscv64": "riscv64",
+    "s390x": "s390x",
+    "x86": "x86",
+    "x86_64": "x86_64",
+}
+_OS_RELEASE_PREFIX_RE = re.compile(r"[0-9]+(?:\.[0-9]+){0,3}")
+_JOURNAL_MODES = frozenset({"delete", "truncate", "persist", "memory", "wal", "off"})
+
+
+def _checkout_root() -> Path | None:
+    """Return the checkout containing the imported package, when present."""
+
+    root = Path(__file__).resolve().parent.parent
+    return root if (root / ".git").exists() else None
+
+
+def package_revision() -> str | None:
+    """Return a validated full HEAD revision without contacting a remote."""
+
+    root = _checkout_root()
+    if root is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            check=False,
+            timeout=2,
+        )
+    except (OSError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    revision = result.stdout.decode("ascii", "replace").strip()
+    return revision.lower() if _REVISION_RE.fullmatch(revision) else None
+
+
+def version_string() -> str:
+    """Return the human CLI version, including checkout HEAD when available."""
+
+    revision = package_revision()
+    suffix = f" ({revision[:7]})" if revision else ""
+    return f"clawjournal {__version__}{suffix}"
+
+
+def _expected_schema_version() -> int | None:
+    """Read the schema sentinel without opening or initializing the index."""
+
+    try:
+        from .workbench.index import WORKBENCH_SCHEMA_VERSION
+    except Exception:  # A partial install must still produce diagnostics.
+        return None
+    return (
+        WORKBENCH_SCHEMA_VERSION
+        if isinstance(WORKBENCH_SCHEMA_VERSION, int)
+        else None
+    )
+
+
+def _storage_report(state_dir: Path) -> dict[str, object]:
+    """Storage-inspection integration seam.
+
+    The storage guard owns platform-specific mount discovery.  Keeping this
+    adapter narrow lets ``doctor`` degrade safely on partial/older installs and
+    ensures no mount source or absolute path enters the support payload.
+    """
+
+    try:
+        from .filesystem import classify_filesystem, sanitized_filesystem_type
+    except (ImportError, AttributeError):
+        return {
+            "filesystem_type": "unknown",
+            "storage_risk": "unknown",
+            "storage_migration_required": False,
+        }
+
+    try:
+        raw = classify_filesystem(state_dir)
+    except Exception:
+        raw = None
+
+    if isinstance(raw, Mapping):
+        filesystem_type = raw.get("filesystem_type")
+        storage_risk = raw.get("storage_risk")
+        migration_required = raw.get("storage_migration_required")
+    else:
+        filesystem_type = getattr(raw, "filesystem_type", None)
+        storage_risk = getattr(raw, "storage_risk", None)
+        migration_required = getattr(raw, "storage_migration_required", None)
+
+    normalized_type = sanitized_filesystem_type(filesystem_type)
+    normalized_risk = str(storage_risk or "unknown").strip().lower()
+    if normalized_risk not in {"network", "local", "unknown"}:
+        normalized_risk = "unknown"
+    return {
+        "filesystem_type": normalized_type,
+        "storage_risk": normalized_risk,
+        "storage_migration_required": migration_required is True,
+    }
+
+
+def _empty_quick_check(status: str = "not_run") -> dict[str, object]:
+    return {"status": status, "issue_count": 0, "truncated": False}
+
+
+def _empty_foreign_key_check(status: str = "not_run") -> dict[str, object]:
+    return {
+        "status": status,
+        "returned_count": 0,
+        "truncated": False,
+        "violations": [],
+    }
+
+
+def _safe_schema_identifier(value: object) -> str:
+    text = str(value) if value is not None else ""
+    return text if text in _KNOWN_SCHEMA_IDENTIFIERS else "redacted"
+
+
+def _safe_os_family(value: object) -> str:
+    return _OS_FAMILY_ALIASES.get(str(value or "").strip().lower(), "unknown")
+
+
+def _safe_os_release(value: object) -> str:
+    """Return only the numeric OS/kernel prefix, never a custom build suffix."""
+
+    match = _OS_RELEASE_PREFIX_RE.match(str(value or "").strip())
+    return match.group(0) if match else "unknown"
+
+
+def _safe_architecture(value: object) -> str:
+    return _ARCHITECTURE_ALIASES.get(
+        str(value or "").strip().lower(),
+        "unknown",
+    )
+
+
+def _classify_open_error(exc: BaseException) -> str:
+    """Map SQLite/OS messages to fixed codes; never return their raw text."""
+
+    message = str(exc).lower()
+    if "locked" in message or "busy" in message:
+        return "locked"
+    if "not a database" in message or "malformed" in message or "corrupt" in message:
+        return "corrupt"
+    if "permission" in message or "access is denied" in message:
+        return "permission_denied"
+    return "unreadable"
+
+
+def _header_journal_mode(database: Path) -> str | None:
+    """Read the SQLite header's persistent rollback/WAL format marker."""
+
+    try:
+        with database.open("rb") as file:
+            header = file.read(20)
+    except OSError:
+        return None
+    if len(header) < 20 or header[:16] != b"SQLite format 3\x00":
+        return None
+    write_version, read_version = header[18], header[19]
+    if 2 in {write_version, read_version}:
+        return "wal"
+    if write_version == read_version == 1:
+        return "delete"
+    return None
+
+
+def _connect_readonly(database: Path) -> sqlite3.Connection:
+    # SQLite's ordinary mode=ro can still create shared-memory/WAL sidecars.
+    # immutable=1 guarantees this evidence probe never writes beside the DB.
+    # Callers decline to open databases with existing sidecars because an
+    # immutable main-file view would omit their uncheckpointed state.
+    uri = database.resolve().as_uri() + "?mode=ro&immutable=1"
+    conn = sqlite3.connect(uri, uri=True, timeout=1.0, isolation_level=None)
+    conn.execute("PRAGMA query_only=ON")
+    conn.execute("PRAGMA temp_store=MEMORY")
+    conn.execute("PRAGMA busy_timeout=1000")
+    return conn
+
+
+def _read_scalar_pragma(conn: sqlite3.Connection, pragma: str) -> object | None:
+    try:
+        row = conn.execute(pragma).fetchone()
+    except sqlite3.Error:
+        return None
+    return row[0] if row else None
+
+
+def _run_quick_check(conn: sqlite3.Connection) -> dict[str, object]:
+    try:
+        rows = conn.execute(
+            f"PRAGMA quick_check({MAX_QUICK_CHECK_ISSUES})"
+        ).fetchmany(MAX_QUICK_CHECK_ISSUES)
+    except sqlite3.Error as exc:
+        error_code = _classify_open_error(exc)
+        return _empty_quick_check(
+            error_code if error_code in {"locked", "corrupt"} else "unavailable"
+        )
+
+    results = [str(row[0]) for row in rows if row]
+    if results == ["ok"]:
+        return _empty_quick_check("ok")
+    return {
+        "status": "failed",
+        # Raw integrity messages can contain schema identifiers controlled by
+        # a damaged database.  A support report needs only the bounded count.
+        "issue_count": len(results),
+        "truncated": len(results) >= MAX_QUICK_CHECK_ISSUES,
+    }
+
+
+def _run_foreign_key_check(conn: sqlite3.Connection) -> dict[str, object]:
+    try:
+        rows = conn.execute("PRAGMA foreign_key_check").fetchmany(
+            MAX_FOREIGN_KEY_VIOLATIONS + 1
+        )
+    except sqlite3.Error as exc:
+        error_code = _classify_open_error(exc)
+        return _empty_foreign_key_check(
+            error_code if error_code in {"locked", "corrupt"} else "unavailable"
+        )
+
+    truncated = len(rows) > MAX_FOREIGN_KEY_VIOLATIONS
+    rows = rows[:MAX_FOREIGN_KEY_VIOLATIONS]
+    violations: list[dict[str, object]] = []
+    for row in rows:
+        row_id = row[1] if len(row) > 1 and isinstance(row[1], int) else None
+        foreign_key_id = row[3] if len(row) > 3 and isinstance(row[3], int) else None
+        violations.append(
+            {
+                "table": _safe_schema_identifier(row[0] if len(row) > 0 else None),
+                "row_id": row_id,
+                "parent": _safe_schema_identifier(row[2] if len(row) > 2 else None),
+                "foreign_key_id": foreign_key_id,
+            }
+        )
+    return {
+        "status": "violations" if violations else "ok",
+        "returned_count": len(violations),
+        "truncated": truncated,
+        "violations": violations,
+    }
+
+
+def _index_report(database: Path, expected_schema: int | None) -> dict[str, object]:
+    base: dict[str, object] = {
+        "exists": False,
+        "health_code": "missing",
+        "user_version": None,
+        "journal_mode": None,
+        "quick_check": _empty_quick_check(),
+        "foreign_key_check": _empty_foreign_key_check(),
+    }
+    try:
+        exists = database.is_file()
+    except OSError:
+        base["exists"] = None
+        base["health_code"] = "unreadable"
+        return base
+    if not exists:
+        return base
+
+    base["exists"] = True
+    header_journal_mode = _header_journal_mode(database)
+    try:
+        live_sidecars = [
+            suffix
+            for suffix in ("-wal", "-shm", "-journal")
+            if Path(str(database) + suffix).is_file()
+        ]
+    except OSError:
+        base["health_code"] = "unreadable"
+        return base
+    if live_sidecars:
+        # Opening an immutable main file would silently ignore WAL contents;
+        # an ordinary read-only open can create/modify sidecars. Report the
+        # bounded condition and leave an offline-copy inspection to the user.
+        base["health_code"] = "sidecar_snapshot_not_inspected"
+        base["journal_mode"] = (
+            "wal"
+            if "-wal" in live_sidecars or header_journal_mode == "wal"
+            else None
+        )
+        return base
+    try:
+        conn = _connect_readonly(database)
+    except (OSError, sqlite3.Error) as exc:
+        base["health_code"] = _classify_open_error(exc)
+        return base
+
+    try:
+        raw_user_version = _read_scalar_pragma(conn, "PRAGMA user_version")
+        base["user_version"] = (
+            raw_user_version if isinstance(raw_user_version, int) else None
+        )
+        raw_journal_mode = _read_scalar_pragma(conn, "PRAGMA journal_mode")
+        journal_mode = header_journal_mode or str(
+            raw_journal_mode or ""
+        ).strip().lower()
+        base["journal_mode"] = journal_mode if journal_mode in _JOURNAL_MODES else None
+        quick_check = _run_quick_check(conn)
+        foreign_key_check = _run_foreign_key_check(conn)
+        base["quick_check"] = quick_check
+        base["foreign_key_check"] = foreign_key_check
+    finally:
+        conn.close()
+
+    if "corrupt" in {quick_check["status"], foreign_key_check["status"]}:
+        base["health_code"] = "corrupt"
+    elif "locked" in {quick_check["status"], foreign_key_check["status"]}:
+        base["health_code"] = "locked"
+    elif quick_check["status"] == "failed":
+        base["health_code"] = "integrity_check_failed"
+    elif foreign_key_check["status"] == "violations":
+        base["health_code"] = "foreign_key_violations"
+    elif quick_check["status"] != "ok" or foreign_key_check["status"] != "ok":
+        base["health_code"] = "inspection_partial"
+    elif expected_schema is None or base["user_version"] is None:
+        base["health_code"] = "schema_unknown"
+    elif base["user_version"] < expected_schema:
+        base["health_code"] = "schema_outdated"
+    elif base["user_version"] > expected_schema:
+        base["health_code"] = "schema_newer"
+    elif base["journal_mode"] != "delete":
+        base["health_code"] = "unexpected_journal_mode"
+    else:
+        base["health_code"] = "healthy"
+    return base
+
+
+def collect_index_diagnostics(*, state_dir: Path | None = None) -> dict[str, object]:
+    """Collect a read-only, privacy-bounded diagnostic payload."""
+
+    if state_dir is None:
+        # Resolve dynamically so embedders/tests can relocate the coupled state
+        # root without this module retaining an import-time path.
+        from . import config
+
+        state_dir = config.CONFIG_DIR
+    state_dir = Path(state_dir)
+    expected_schema = _expected_schema_version()
+    revision = package_revision()
+    storage = _storage_report(state_dir)
+    if storage.get("storage_migration_required") is True:
+        # Do not stat or open a database once the mount table already proves
+        # that it is network-backed. This keeps doctor responsive on a hard,
+        # disconnected NFS mount and avoids SQLite side effects there.
+        index = {
+            "exists": None,
+            "health_code": "network_storage_not_inspected",
+            "user_version": None,
+            "journal_mode": None,
+            "quick_check": _empty_quick_check(),
+            "foreign_key_check": _empty_foreign_key_check(),
+        }
+    else:
+        index = _index_report(state_dir / "index.db", expected_schema)
+    return {
+        "support_diagnostics_schema_version": SUPPORT_DIAGNOSTICS_SCHEMA_VERSION,
+        "kind": "index",
+        "package": {"version": __version__, "revision": revision},
+        "runtime": {
+            "python_version": platform.python_version(),
+            "sqlite_version": sqlite3.sqlite_version,
+            "os_family": _safe_os_family(platform.system()),
+            "os_release": _safe_os_release(platform.release()),
+            "architecture": _safe_architecture(platform.machine()),
+        },
+        "schema": {"expected_user_version": expected_schema},
+        "storage": storage,
+        "index": index,
+    }
+
+
+def diagnostics_exit_code(report: Mapping[str, object]) -> int:
+    storage = report.get("storage")
+    index = report.get("index")
+    migration_required = (
+        isinstance(storage, Mapping)
+        and storage.get("storage_migration_required") is True
+    )
+    health_code = index.get("health_code") if isinstance(index, Mapping) else None
+    return 0 if health_code == "healthy" and not migration_required else 1
+
+
+def render_index_diagnostics(report: Mapping[str, object]) -> str:
+    """Render the same allowlisted values without exposing the state path."""
+
+    package = report.get("package") if isinstance(report.get("package"), Mapping) else {}
+    runtime = report.get("runtime") if isinstance(report.get("runtime"), Mapping) else {}
+    schema = report.get("schema") if isinstance(report.get("schema"), Mapping) else {}
+    storage = report.get("storage") if isinstance(report.get("storage"), Mapping) else {}
+    index = report.get("index") if isinstance(report.get("index"), Mapping) else {}
+    revision = package.get("revision")
+    version = str(package.get("version") or "unknown")
+    if isinstance(revision, str) and _REVISION_RE.fullmatch(revision):
+        version += f" ({revision[:7]})"
+    migration = "required" if storage.get("storage_migration_required") is True else "not required"
+    return "\n".join(
+        [
+            f"ClawJournal index diagnostics: {index.get('health_code') or 'unknown'}",
+            f"Version: {version}",
+            (
+                "Runtime: Python "
+                f"{runtime.get('python_version') or 'unknown'}; SQLite "
+                f"{runtime.get('sqlite_version') or 'unknown'}; "
+                f"{runtime.get('os_family') or 'unknown'} "
+                f"{runtime.get('os_release') or 'unknown'} "
+                f"({runtime.get('architecture') or 'unknown'})"
+            ),
+            (
+                f"Storage: {storage.get('filesystem_type') or 'unknown'} "
+                f"({storage.get('storage_risk') or 'unknown'}; migration {migration})"
+            ),
+            (
+                f"Index: exists={index.get('exists')}; "
+                f"schema={index.get('user_version')}/"
+                f"{schema.get('expected_user_version')}; "
+                f"journal={index.get('journal_mode') or 'unknown'}"
+            ),
+            (
+                "Checks: quick_check="
+                f"{(index.get('quick_check') or {}).get('status', 'unknown')}; "
+                "foreign_key_check="
+                f"{(index.get('foreign_key_check') or {}).get('status', 'unknown')}"
+            ),
+        ]
+    )

--- a/clawjournal/web/frontend/src/components/IndexRecoveryScreen.test.tsx
+++ b/clawjournal/web/frontend/src/components/IndexRecoveryScreen.test.tsx
@@ -50,6 +50,89 @@ describe('IndexRecoveryScreen', () => {
     expect(screen.getByText(/Sharing and automatic uploads stay blocked/)).toBeInTheDocument();
   });
 
+  it.each([
+    { storage_risk: 'unknown' as const, filesystem_type: 'unknown' },
+    { storage_risk: 'local' as const, filesystem_type: 'ext4' },
+  ])('keeps recovery available for $storage_risk storage', storage => {
+    render(
+      <IndexRecoveryScreen
+        health={recoveryRequired({
+          ...storage,
+          storage_migration_required: false,
+        })}
+        onHealthChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: 'Back up and rebuild index' })).toBeEnabled();
+  });
+
+  it('requires a complete home migration and withholds sensitive storage diagnostics', () => {
+    const rebuild = vi.spyOn(api.index, 'rebuild');
+    render(
+      <IndexRecoveryScreen
+        health={recoveryRequired({
+          storage_risk: 'network',
+          filesystem_type: 'nfs',
+          storage_migration_required: true,
+          database_path: '/network/users/alice/.clawjournal/index.db',
+          backup_path: '/network/users/alice/.clawjournal/index-backups/recovery-1',
+          detail: 'Mounted from server:/private/home.',
+        })}
+        onHealthChange={vi.fn()}
+      />,
+    );
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveAccessibleName('Copy ClawJournal state to local storage first');
+    expect(screen.getByRole('list', { name: 'Required storage migration steps' })).toHaveTextContent(
+      'Copy the entire CLAWJOURNAL_HOME directory',
+    );
+    expect(alert).toHaveTextContent('Keep the original unchanged until recovery succeeds');
+    expect(alert).toHaveTextContent('Do not copy only the index database');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByText(/network\/users\/alice|server:\/private\/home/i)).not.toBeInTheDocument();
+    expect(rebuild).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when an older backend reports network risk without the migration flag', () => {
+    render(
+      <IndexRecoveryScreen
+        health={recoveryRequired({
+          storage_risk: 'network',
+          filesystem_type: 'nfs',
+        })}
+        onHealthChange={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole('heading', { name: 'Copy ClawJournal state to local storage first' })).toBeInTheDocument();
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('shows the same migration-only path for an unavailable healthy or missing index', () => {
+    render(
+      <IndexRecoveryScreen
+        health={{
+          status: 'unavailable',
+          message: 'This raw backend message must stay hidden.',
+          storage_risk: 'network',
+          filesystem_type: 'nfs4',
+          storage_migration_required: true,
+          database_path: '/private/cluster/alice/index.db',
+        }}
+        onHealthChange={vi.fn()}
+      />,
+    );
+
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveTextContent('will not open, create, or rebuild');
+    expect(alert).toHaveTextContent('offer repair only if it is still needed');
+    expect(alert).not.toHaveTextContent('raw backend message');
+    expect(alert).not.toHaveTextContent('/private/cluster/alice');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
   it('submits once, disables the action, and accepts an asynchronous rebuilding response', async () => {
     let resolveRebuild!: (value: IndexRebuildResponse) => void;
     const rebuild = vi.spyOn(api.index, 'rebuild').mockImplementationOnce(() => (

--- a/clawjournal/web/frontend/src/components/IndexRecoveryScreen.tsx
+++ b/clawjournal/web/frontend/src/components/IndexRecoveryScreen.tsx
@@ -54,9 +54,11 @@ export function IndexRecoveryScreen({
 }: IndexRecoveryScreenProps) {
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const storageMigrationRequired = health?.storage_migration_required === true
+    || health?.storage_risk === 'network';
 
   const startRecovery = async () => {
-    if (submitting) return;
+    if (submitting || storageMigrationRequired) return;
     setSubmitting(true);
     setError(null);
     try {
@@ -106,6 +108,34 @@ export function IndexRecoveryScreen({
         </p>
         <Spinner text={health.message || 'Backing up and rebuilding...'} />
         <DiagnosticDetails health={health} />
+      </div>
+    );
+  } else if (
+    storageMigrationRequired
+    && (health.status === 'recovery_required' || health.status === 'unavailable')
+  ) {
+    content = (
+      <div role="alert" aria-labelledby="storage-migration-heading">
+        <h1
+          id="storage-migration-heading"
+          style={{ margin: '0 0 8px', fontSize: 21, color: colors.gray900 }}
+        >
+          Copy ClawJournal state to local storage first
+        </h1>
+        <p style={{ margin: '0 0 12px', color: colors.red700, fontSize: 14, lineHeight: 1.55 }}>
+          ClawJournal detected shared or network storage. It will not open, create, or rebuild its writable index there. Move its state to persistent local storage first.
+        </p>
+        <ol
+          aria-label="Required storage migration steps"
+          style={{ margin: '0 0 14px', paddingLeft: 22, color: colors.gray600, fontSize: 14, lineHeight: 1.7 }}
+        >
+          <li>Stop ClawJournal completely.</li>
+          <li>Copy the entire <code>CLAWJOURNAL_HOME</code> directory to private, persistent local storage. Keep the original unchanged until recovery succeeds.</li>
+          <li>Set <code>CLAWJOURNAL_HOME</code> to the new directory, then restart ClawJournal.</li>
+        </ol>
+        <p style={{ margin: 0, color: colors.gray600, fontSize: 13.5, lineHeight: 1.55 }}>
+          Do not copy only the index database. Review decisions, recovery data, credentials, and other state must remain together. After restart, ClawJournal will recheck the new location and offer repair only if it is still needed.
+        </p>
       </div>
     );
   } else if (health.status === 'recovery_required') {

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -233,6 +233,11 @@ export interface IndexHealth {
   backup_path?: string | null;
   sqlite_version?: string | null;
   journal_mode?: string | null;
+  /** Normalized filesystem kind only; never a path or mount source. */
+  filesystem_type?: string | null;
+  storage_risk?: 'network' | 'local' | 'unknown';
+  /** Recovery must wait until the complete state directory is copied locally. */
+  storage_migration_required?: boolean;
   automatic_recovery_available?: boolean;
   interrupted_recovery?: boolean;
   unreadable_state?: string[];

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -15,8 +15,7 @@ from pathlib import Path
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any, BinaryIO, Iterator
 
-logger = logging.getLogger(__name__)
-
+from .. import filesystem as filesystem_module
 from ..redaction.secrets import (
     FindingsScannerProfile,
     _normalize_findings_scanner_profile,
@@ -35,12 +34,28 @@ from ..paths import ensure_install_files
 from ..pricing import estimate_cost
 from ..session_titles import append_fork_title_suffix
 
+logger = logging.getLogger(__name__)
+
 INDEX_DB = CONFIG_DIR / "index.db"
 BLOBS_DIR = CONFIG_DIR / "blobs"
 INDEX_JOURNAL_MODE = "delete"
 INDEX_CONNECTION_LEASE_FILENAME = "index-connections.lock"
 _INDEX_CONNECTION_LEASE_SLOTS = 256
 _INDEX_RECOVERY_ACCESS = threading.local()
+
+
+class UnsafeIndexStorageError(filesystem_module.UnsafeStateStorageError):
+    """The writable SQLite index is on known unsafe shared storage."""
+
+    def __init__(self, storage: filesystem_module.FilesystemInfo) -> None:
+        self.storage = storage
+        super().__init__(filesystem_module.storage_migration_message(storage))
+
+
+def _assert_safe_index_storage(database: Path) -> None:
+    storage = filesystem_module.classify_filesystem(database)
+    if storage.storage_migration_required:
+        raise UnsafeIndexStorageError(storage)
 
 
 def _set_index_recovery_access(enabled: bool) -> bool:
@@ -207,6 +222,10 @@ def open_existing_index(
 
     recovery_access = bool(getattr(_INDEX_RECOVERY_ACCESS, "enabled", False))
     path = Path(str(INDEX_DB)) if database is None else Path(database)
+    # Even a leased read-only connection creates/truncates the coordination
+    # lock file below. Refuse every normal index open on known network storage;
+    # support diagnostics use a separate, lease-free SQLite mode=ro path.
+    _assert_safe_index_storage(path)
     marker = _index_recovery_marker_path(path)
     if marker.exists() and not recovery_access:
         raise sqlite3.DatabaseError(
@@ -990,6 +1009,10 @@ def open_index() -> sqlite3.Connection:
     if they do not already exist. Returns a connection with
     row_factory set to sqlite3.Row for dict-like access.
     """
+    # Check before creating the install directory, lock file, secrets, or
+    # database.  Known network/cluster filesystems are not safe SQLite state
+    # storage, even for the recovery worker.
+    _assert_safe_index_storage(Path(str(INDEX_DB)))
     recovery_access = bool(getattr(_INDEX_RECOVERY_ACCESS, "enabled", False))
     if _index_recovery_marker_path().exists() and not recovery_access:
         raise sqlite3.DatabaseError(

--- a/clawjournal/workbench/index_recovery.py
+++ b/clawjournal/workbench/index_recovery.py
@@ -311,6 +311,19 @@ def _storage_migration_health(
     }
 
 
+def _require_safe_recovery_storage(
+    database: Path,
+) -> filesystem_module.FilesystemInfo:
+    """Recheck storage immediately before a recovery filesystem mutation."""
+
+    storage = filesystem_module.classify_filesystem(database)
+    if storage.storage_migration_required:
+        raise UnsafeIndexRecovery(
+            filesystem_module.storage_migration_message(storage)
+        )
+    return storage
+
+
 def _marker_path(database: Path) -> Path:
     return database.parent / RECOVERY_MARKER_FILENAME
 
@@ -328,6 +341,7 @@ def _fsync_directory(directory: Path) -> None:
 
 
 def _write_marker(database: Path, payload: dict[str, Any]) -> None:
+    _require_safe_recovery_storage(database)
     marker = _marker_path(database)
     temporary = marker.with_name(f".{marker.name}.{uuid.uuid4().hex}.tmp")
     try:
@@ -449,7 +463,15 @@ def begin_guided_rebuild() -> dict[str, Any]:
                 "started_at": datetime.now(timezone.utc).isoformat(),
                 "stage": "draining",
             }
-            _write_marker(database, marker)
+            try:
+                _write_marker(database, marker)
+            except UnsafeIndexRecovery:
+                storage = filesystem_module.classify_filesystem(database)
+                if storage.storage_migration_required:
+                    blocked = _storage_migration_health(database, storage)
+                    _INDEX_HEALTH.clear()
+                    _INDEX_HEALTH.update(blocked)
+                raise
         _INDEX_HEALTH.update({
             "status": "rebuilding",
             "stage": "draining",
@@ -864,13 +886,10 @@ def initialize_index_health() -> dict[str, Any]:
 
 
 def _backup_index_files(database: Path) -> tuple[Path, list[Path]]:
-    storage = filesystem_module.classify_filesystem(database)
-    if storage.storage_migration_required:
-        raise UnsafeIndexRecovery(
-            filesystem_module.storage_migration_message(storage)
-        )
+    _require_safe_recovery_storage(database)
     backup_root = database.parent / "index-backups"
     backup_root.mkdir(parents=True, exist_ok=True)
+    _require_safe_recovery_storage(database)
     state_root = database.parent.resolve()
     backup_root = backup_root.resolve()
     if backup_root.parent != state_root:
@@ -891,6 +910,7 @@ def _backup_index_files(database: Path) -> tuple[Path, list[Path]]:
     ):
         if not source.exists():
             continue
+        _require_safe_recovery_storage(database)
         destination = backup_dir / source.name
         shutil.copy2(source, destination)
         # Windows does not permit fsync on a read-only descriptor. Open the
@@ -905,6 +925,7 @@ def _backup_index_files(database: Path) -> tuple[Path, list[Path]]:
 
 
 def _remove_index_files(database: Path) -> None:
+    _require_safe_recovery_storage(database)
     for path in (
         database,
         Path(str(database) + "-wal"),
@@ -1974,6 +1995,7 @@ def _guided_rebuild_locked(
                 name: len(rows) for name, rows in snapshot.items()
             },
         }
+        _require_safe_recovery_storage(database)
         manifest_path = backup_dir / "recovery-manifest.json"
         with manifest_path.open("w", encoding="utf-8") as manifest_file:
             json.dump(manifest, manifest_file, indent=2, sort_keys=True)
@@ -2087,6 +2109,7 @@ def _guided_rebuild_locked(
         blocked = _storage_migration_health(database, final_storage)
         _set_health(blocked)
         raise UnsafeIndexRecovery(blocked["message"])
+    _require_safe_recovery_storage(database)
     _marker_path(database).unlink(missing_ok=True)
     _fsync_directory(database.parent)
     ready = {
@@ -2125,7 +2148,13 @@ def guided_rebuild(
             "started_at": datetime.now(timezone.utc).isoformat(),
             "stage": "preparing",
         }
-        _write_marker(database, marker)
+        try:
+            _write_marker(database, marker)
+        except UnsafeIndexRecovery:
+            storage = filesystem_module.classify_filesystem(database)
+            if storage.storage_migration_required:
+                _set_health(_storage_migration_health(database, storage))
+            raise
     lease = index_module._exclusive_index_recovery_lease(timeout=30.0)
     try:
         lease.__enter__()
@@ -2145,9 +2174,15 @@ def guided_rebuild(
         _set_health(failed)
         raise UnsafeIndexRecovery(failed["message"]) from exc
     try:
-        return _guided_rebuild_locked(
-            scan_callback,
-            on_source_retired=on_source_retired,
-        )
+        try:
+            return _guided_rebuild_locked(
+                scan_callback,
+                on_source_retired=on_source_retired,
+            )
+        except UnsafeIndexRecovery:
+            storage = filesystem_module.classify_filesystem(database)
+            if storage.storage_migration_required:
+                _set_health(_storage_migration_health(database, storage))
+            raise
     finally:
         lease.__exit__(None, None, None)

--- a/clawjournal/workbench/index_recovery.py
+++ b/clawjournal/workbench/index_recovery.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import shutil
 import sqlite3
 import threading
@@ -20,16 +21,24 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable
 
+from .. import filesystem as filesystem_module
 from . import index as index_module
 
 logger = logging.getLogger(__name__)
 
 RECOVERY_MARKER_FILENAME = index_module.INDEX_RECOVERY_MARKER_FILENAME
+RECOVERY_MARKER_VERSION = 2
+_BACKUP_DIRECTORY_RE = re.compile(
+    r"index-recovery-[0-9]{8}T[0-9]{6}Z-[0-9a-f]{8}\Z"
+)
 
 _STATE_LOCK = threading.Lock()
 _INDEX_HEALTH: dict[str, Any] = {
     "status": "ready",
     "message": "The workbench index is ready.",
+    "filesystem_type": "unknown",
+    "storage_risk": "unknown",
+    "storage_migration_required": False,
 }
 
 _SESSION_STATE_COLUMNS = (
@@ -275,6 +284,33 @@ def _index_path() -> Path:
     return Path(str(index_module.INDEX_DB))
 
 
+def _filesystem_health_fields(database: Path) -> dict[str, str | bool]:
+    return filesystem_module.classify_filesystem(database).health_fields()
+
+
+def _storage_migration_health(
+    database: Path,
+    storage: filesystem_module.FilesystemInfo | None = None,
+) -> dict[str, Any]:
+    classification = storage or filesystem_module.classify_filesystem(database)
+    return {
+        "status": "unavailable",
+        "code": "storage_migration_required",
+        "message": filesystem_module.storage_migration_message(classification),
+        "detail": (
+            "The workbench SQLite index will not be opened, created, or rebuilt "
+            "on this filesystem."
+        ),
+        # The network classification is already conclusive.  Avoid resolve(),
+        # which can block indefinitely on a disconnected hard-NFS mount.
+        "database_path": str(Path(os.path.abspath(database))),
+        "sqlite_version": sqlite3.sqlite_version,
+        "journal_mode": index_module.INDEX_JOURNAL_MODE,
+        "automatic_recovery_available": False,
+        **classification.health_fields(),
+    }
+
+
 def _marker_path(database: Path) -> Path:
     return database.parent / RECOVERY_MARKER_FILENAME
 
@@ -329,6 +365,9 @@ def begin_index_health_check() -> dict[str, Any]:
     """Publish the fail-closed startup state before HTTP begins serving."""
 
     database = _index_path()
+    storage = filesystem_module.classify_filesystem(database)
+    if storage.storage_migration_required:
+        return _set_health(_storage_migration_health(database, storage))
     return _set_health({
         "status": "checking",
         "message": "Checking the local index before enabling database work...",
@@ -336,6 +375,7 @@ def begin_index_health_check() -> dict[str, Any]:
         "sqlite_version": sqlite3.sqlite_version,
         "journal_mode": index_module.INDEX_JOURNAL_MODE,
         "automatic_recovery_available": False,
+        **storage.health_fields(),
     })
 
 
@@ -355,6 +395,17 @@ def synchronize_index_health() -> dict[str, Any]:
     """
 
     health = current_index_health()
+    database = _index_path()
+    storage = filesystem_module.classify_filesystem(database)
+    if storage.storage_migration_required:
+        return _set_health(_storage_migration_health(database, storage))
+    if (
+        health.get("storage_migration_required") is True
+        and storage.storage_risk == "local"
+    ):
+        # A definite local remount may safely be inspected again. Unknown
+        # storage never clears a prior fail-closed network diagnosis.
+        return initialize_index_health()
     marker_exists = recovery_marker_exists()
     if (
         marker_exists
@@ -375,6 +426,13 @@ def begin_guided_rebuild() -> dict[str, Any]:
     """Reserve the worker and publish the cross-process gate before returning."""
 
     with _STATE_LOCK:
+        database = _index_path()
+        storage = filesystem_module.classify_filesystem(database)
+        if storage.storage_migration_required:
+            blocked = _storage_migration_health(database, storage)
+            _INDEX_HEALTH.clear()
+            _INDEX_HEALTH.update(blocked)
+            raise UnsafeIndexRecovery(blocked["message"])
         if _INDEX_HEALTH.get("status") == "rebuilding":
             return dict(_INDEX_HEALTH)
         if _INDEX_HEALTH.get("status") != "recovery_required":
@@ -383,11 +441,10 @@ def begin_guided_rebuild() -> dict[str, Any]:
             raise UnsafeIndexRecovery(
                 "Automatic recovery is not available for this index state."
             )
-        database = _index_path()
         marker = _load_marker(database)
         if marker is None:
             marker = {
-                "version": 1,
+                "version": RECOVERY_MARKER_VERSION,
                 "database_path": str(database.resolve()),
                 "started_at": datetime.now(timezone.utc).isoformat(),
                 "stage": "draining",
@@ -415,6 +472,9 @@ def _read_only_connection(path: Path) -> sqlite3.Connection:
 def _exclusive_source_connection(path: Path) -> sqlite3.Connection:
     """Hold the source stable while its decisions and exact files are copied."""
 
+    # Recheck immediately next to the write-capable SQLite open.  The mount
+    # may have changed after the worker's earlier admission check.
+    index_module._assert_safe_index_storage(path)
     conn = sqlite3.connect(
         path.resolve().as_uri() + "?mode=rw",
         uri=True,
@@ -588,18 +648,31 @@ def _snapshot_from_path(
 
 def inspect_index_health(path: Path | None = None) -> dict[str, Any]:
     database = Path(path) if path is not None else _index_path()
+    storage = filesystem_module.classify_filesystem(database)
+    if storage.storage_migration_required:
+        return _storage_migration_health(database, storage)
     base: dict[str, Any] = {
         "database_path": str(database.resolve()),
         "sqlite_version": sqlite3.sqlite_version,
         "journal_mode": index_module.INDEX_JOURNAL_MODE,
         "automatic_recovery_available": False,
+        **storage.health_fields(),
     }
     marker = _load_marker(database)
     if marker is not None:
         raw_backup = marker.get("backup_path")
-        if isinstance(raw_backup, str) and raw_backup:
+        raw_backup_directory = marker.get("backup_directory")
+        has_backup_reference = bool(
+            (
+                isinstance(raw_backup, str) and raw_backup
+            ) or (
+                isinstance(raw_backup_directory, str) and raw_backup_directory
+            )
+        )
+        verified_backup_dir: Path | None = None
+        if has_backup_reference:
             try:
-                _backup_from_marker(database, marker)
+                verified_backup_dir, _ = _backup_from_marker(database, marker)
             except UnsafeIndexRecovery as exc:
                 return {
                     **base,
@@ -644,7 +717,11 @@ def inspect_index_health(path: Path | None = None) -> dict[str, Any]:
             "status": "recovery_required",
             "message": message,
             "automatic_recovery_available": True,
-            "backup_path": raw_backup if raw_backup else None,
+            "backup_path": (
+                str(verified_backup_dir)
+                if verified_backup_dir is not None
+                else None
+            ),
             "interrupted_recovery": True,
         }
     if _marker_path(database).exists():
@@ -718,6 +795,8 @@ def inspect_index_health(path: Path | None = None) -> dict[str, Any]:
             "unreadable_state": errors,
             "recoverable_state_counts": counts,
         }
+    except index_module.UnsafeIndexStorageError as exc:
+        return _storage_migration_health(database, exc.storage)
     except (OSError, sqlite3.DatabaseError) as exc:
         if isinstance(exc, OSError) or _is_storage_or_lock_error(exc):
             return {
@@ -764,6 +843,7 @@ def initialize_index_health() -> dict[str, Any]:
             "sqlite_version": sqlite3.sqlite_version,
             "journal_mode": index_module.INDEX_JOURNAL_MODE,
             "automatic_recovery_available": False,
+            **_filesystem_health_fields(_index_path()),
         })
     if report["status"] != "ready":
         return _set_health(report)
@@ -784,8 +864,19 @@ def initialize_index_health() -> dict[str, Any]:
 
 
 def _backup_index_files(database: Path) -> tuple[Path, list[Path]]:
+    storage = filesystem_module.classify_filesystem(database)
+    if storage.storage_migration_required:
+        raise UnsafeIndexRecovery(
+            filesystem_module.storage_migration_message(storage)
+        )
     backup_root = database.parent / "index-backups"
     backup_root.mkdir(parents=True, exist_ok=True)
+    state_root = database.parent.resolve()
+    backup_root = backup_root.resolve()
+    if backup_root.parent != state_root:
+        raise UnsafeIndexRecovery(
+            "The index backup directory is outside the ClawJournal state root."
+        )
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
     backup_dir = backup_root / f"index-recovery-{timestamp}-{uuid.uuid4().hex[:8]}"
     backup_dir.mkdir(parents=False, exist_ok=False)
@@ -823,29 +914,115 @@ def _remove_index_files(database: Path) -> None:
         path.unlink(missing_ok=True)
 
 
-def _backup_from_marker(database: Path, marker: dict[str, Any]) -> tuple[Path, list[Path]]:
-    raw_backup = marker.get("backup_path")
-    if not isinstance(raw_backup, str) or not raw_backup:
-        raise UnsafeIndexRecovery("The interrupted recovery backup path is missing.")
-    backup_dir = Path(raw_backup).resolve()
+def _backup_from_marker(
+    database: Path,
+    marker: dict[str, Any],
+) -> tuple[Path, list[Path]]:
+    marker_version = marker.get("version")
+    if type(marker_version) is not int or marker_version not in {1, 2}:
+        raise UnsafeIndexRecovery(
+            "The interrupted recovery marker version is unsupported."
+        )
+    state_root = database.parent.resolve()
     guarded_root = (database.parent / "index-backups").resolve()
-    if not backup_dir.is_relative_to(guarded_root) or not backup_dir.is_dir():
+    if guarded_root.parent != state_root:
+        raise UnsafeIndexRecovery(
+            "The interrupted recovery backup root is invalid."
+        )
+    backup_dir: Path | None = None
+    require_manifest = False
+
+    # v2 binds the backup to a generated directory beneath the *current* state
+    # root. This survives a cold copy of CLAWJOURNAL_HOME and cannot smuggle an
+    # absolute source-OS path into the destination.
+    backup_directory = marker.get("backup_directory")
+    if (
+        marker_version == RECOVERY_MARKER_VERSION
+        and isinstance(backup_directory, str)
+        and _BACKUP_DIRECTORY_RE.fullmatch(backup_directory)
+    ):
+        backup_dir = guarded_root / backup_directory
+        require_manifest = True
+    elif (
+        marker_version == RECOVERY_MARKER_VERSION
+        or backup_directory is not None
+    ):
+        raise UnsafeIndexRecovery(
+            "The interrupted recovery backup identity is invalid."
+        )
+    else:
+        raw_backup = marker.get("backup_path")
+        if not isinstance(raw_backup, str) or not raw_backup:
+            raise UnsafeIndexRecovery(
+                "The interrupted recovery backup path is missing."
+            )
+        raw_path = Path(raw_backup)
+        lexical_guard = Path(os.path.abspath(guarded_root))
+        lexical_raw = Path(os.path.abspath(raw_path))
+        if lexical_raw.is_relative_to(lexical_guard):
+            # Same-root v1 marker. Resolve only after the lexical containment
+            # check so a migrated marker never touches its old network path.
+            backup_dir = raw_path
+        else:
+            # Safely rebase a production v1 marker after the complete state
+            # directory was copied. The old database and backup paths must
+            # agree structurally; only the generated basename crosses roots.
+            raw_database = marker.get("database_path")
+            normalized_backup = raw_backup.replace("\\", "/").rstrip("/")
+            normalized_database = (
+                raw_database.replace("\\", "/").rstrip("/")
+                if isinstance(raw_database, str)
+                else ""
+            )
+            backup_parts = normalized_backup.split("/")
+            database_parts = normalized_database.split("/")
+            backup_name = backup_parts[-1] if backup_parts else ""
+            old_backup_parent = "/".join(backup_parts[:-2])
+            old_database_parent = "/".join(database_parts[:-1])
+            if not (
+                _BACKUP_DIRECTORY_RE.fullmatch(backup_name)
+                and len(backup_parts) >= 2
+                and backup_parts[-2] == "index-backups"
+                and old_backup_parent == old_database_parent
+            ):
+                raise UnsafeIndexRecovery(
+                    "The interrupted recovery backup path is invalid."
+                )
+            backup_dir = guarded_root / backup_name
+
+    backup_dir = backup_dir.resolve()
+    if (
+        backup_dir.parent != guarded_root
+        or not backup_dir.is_relative_to(guarded_root)
+        or not backup_dir.is_dir()
+    ):
         raise UnsafeIndexRecovery("The interrupted recovery backup path is invalid.")
-    database_backup = backup_dir / database.name
-    if not database_backup.is_file():
+    database_backup = (backup_dir / database.name).resolve()
+    if database_backup.parent != backup_dir or not database_backup.is_file():
         raise UnsafeIndexRecovery(
             "The interrupted recovery database backup is missing."
         )
+    if require_manifest:
+        manifest = (backup_dir / "recovery-manifest.json").resolve()
+        if manifest.parent != backup_dir or not manifest.is_file():
+            raise UnsafeIndexRecovery(
+                "The interrupted recovery backup manifest is missing."
+            )
     backups = [database_backup]
-    backups.extend(
-        backup_dir / name
-        for name in (
-            database.name + "-wal",
-            database.name + "-shm",
-            database.name + "-journal",
-        )
-        if (backup_dir / name).is_file()
-    )
+    for name in (
+        database.name + "-wal",
+        database.name + "-shm",
+        database.name + "-journal",
+    ):
+        candidate = backup_dir / name
+        if not candidate.exists():
+            continue
+        resolved = candidate.resolve()
+        if resolved.parent != backup_dir or not resolved.is_file():
+            raise UnsafeIndexRecovery(
+                "The interrupted recovery backup contains an invalid sidecar."
+            )
+        backups.append(resolved)
     return backup_dir, backups
 
 
@@ -1696,6 +1873,14 @@ def _guided_rebuild_locked(
     """Back up, rebuild, rescan, and restore durable state synchronously."""
 
     database = _index_path()
+    # The worker rechecks after acquiring the exclusive connection lease and
+    # before publishing a marker or creating the one authoritative backup.
+    # This closes the Queue -> worker mount-change window.
+    storage = filesystem_module.classify_filesystem(database)
+    if storage.storage_migration_required:
+        blocked = _storage_migration_health(database, storage)
+        _set_health(blocked)
+        raise UnsafeIndexRecovery(blocked["message"])
     marker = _load_marker(database)
     backup_dir: Path | None = None
     backup_files: list[Path] = []
@@ -1707,7 +1892,14 @@ def _guided_rebuild_locked(
     })
 
     raw_backup = marker.get("backup_path") if marker is not None else None
-    if isinstance(raw_backup, str) and raw_backup:
+    raw_backup_directory = (
+        marker.get("backup_directory") if marker is not None else None
+    )
+    if (
+        isinstance(raw_backup, str) and raw_backup
+    ) or (
+        isinstance(raw_backup_directory, str) and raw_backup_directory
+    ):
         backup_dir, backup_files = _backup_from_marker(database, marker)
         recovery_source = backup_dir / database.name
         snapshot, errors = _snapshot_from_path(recovery_source)
@@ -1721,11 +1913,12 @@ def _guided_rebuild_locked(
         marker = dict(marker or {})
         marker.setdefault("started_at", datetime.now(timezone.utc).isoformat())
         marker.update({
-            "version": 1,
+            "version": RECOVERY_MARKER_VERSION,
             "database_path": str(database.resolve()),
             "stage": "preparing",
         })
         marker.pop("backup_path", None)
+        marker.pop("backup_directory", None)
         marker.pop("error", None)
         # Publish the cross-process gate before reading or copying the source.
         # A crash in this stage leaves the original untouched; the same marker
@@ -1738,6 +1931,10 @@ def _guided_rebuild_locked(
         try:
             try:
                 source_guard = _exclusive_source_connection(database)
+            except index_module.UnsafeIndexStorageError as exc:
+                blocked = _storage_migration_health(database, exc.storage)
+                _set_health(blocked)
+                raise UnsafeIndexRecovery(blocked["message"]) from exc
             except sqlite3.DatabaseError as exc:
                 if _is_storage_or_lock_error(exc):
                     raise UnsafeIndexRecovery(
@@ -1784,9 +1981,10 @@ def _guided_rebuild_locked(
             os.fsync(manifest_file.fileno())
         _fsync_directory(backup_dir)
     marker.update({
-        "version": 1,
+        "version": RECOVERY_MARKER_VERSION,
         "database_path": str(database.resolve()),
         "backup_path": str(backup_dir),
+        "backup_directory": backup_dir.name,
         "stage": "backed_up",
     })
     marker.pop("error", None)
@@ -1852,6 +2050,14 @@ def _guided_rebuild_locked(
         finally:
             rebuilt.close()
     except Exception as exc:
+        failed_storage = filesystem_module.classify_filesystem(database)
+        if failed_storage.storage_migration_required:
+            # Do not update even the recovery marker after a remount. Its last
+            # local, durable stage and v2 backup identity are sufficient for a
+            # cold-copy retry from the new state root.
+            blocked = _storage_migration_health(database, failed_storage)
+            _set_health(blocked)
+            raise UnsafeIndexRecovery(blocked["message"]) from exc
         logger.exception("Guided workbench-index recovery failed")
         marker["stage"] = "failed"
         marker["error"] = str(exc)
@@ -1869,12 +2075,18 @@ def _guided_rebuild_locked(
             "backup_path": str(backup_dir),
             "automatic_recovery_available": True,
             "interrupted_recovery": True,
+            **_filesystem_health_fields(database),
         }
         _set_health(failed)
         raise
     finally:
         index_module._set_index_recovery_access(previous_recovery_access)
 
+    final_storage = filesystem_module.classify_filesystem(database)
+    if final_storage.storage_migration_required:
+        blocked = _storage_migration_health(database, final_storage)
+        _set_health(blocked)
+        raise UnsafeIndexRecovery(blocked["message"])
     _marker_path(database).unlink(missing_ok=True)
     _fsync_directory(database.parent)
     ready = {
@@ -1887,6 +2099,7 @@ def _guided_rebuild_locked(
         "backup_path": str(backup_dir),
         "restored_state_counts": restored_counts,
         "warnings": warnings,
+        **final_storage.health_fields(),
     }
     return _set_health(ready)
 
@@ -1899,10 +2112,15 @@ def guided_rebuild(
     """Rebuild only after every guarded cross-process connection has closed."""
 
     database = _index_path()
+    storage = filesystem_module.classify_filesystem(database)
+    if storage.storage_migration_required:
+        blocked = _storage_migration_health(database, storage)
+        _set_health(blocked)
+        raise UnsafeIndexRecovery(blocked["message"])
     marker = _load_marker(database)
     if marker is None:
         marker = {
-            "version": 1,
+            "version": RECOVERY_MARKER_VERSION,
             "database_path": str(database.resolve()),
             "started_at": datetime.now(timezone.utc).isoformat(),
             "stage": "preparing",

--- a/tests/test_selfupdate.py
+++ b/tests/test_selfupdate.py
@@ -613,9 +613,8 @@ def test_cli_should_auto_update_skips_help_and_version():
     assert _should_auto_update(["clawjournal", "-h"]) is False
     assert _should_auto_update(["clawjournal", "--help"]) is False
     assert _should_auto_update(["clawjournal", "--version"]) is False
-    # But -h paired with a real subcommand still updates — the user is
-    # asking for subcommand help and may proceed to run it.
-    assert _should_auto_update(["clawjournal", "scan", "--help"]) is True
+    # Subcommand help is just as read-only and short-lived as root help.
+    assert _should_auto_update(["clawjournal", "scan", "--help"]) is False
 
 
 @pytest.mark.parametrize("json_mode", [False, True])

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from clawjournal import share_cli
+from clawjournal.filesystem import UnsafeStateStorageError
 from clawjournal.scoring.backends import DEFAULT_CODEX_MODEL
 
 
@@ -17,6 +18,31 @@ def _parse(argv):
     p = argparse.ArgumentParser()
     share_cli.add_share_cli_args(p)
     return p.parse_args(argv)
+
+
+def test_clawshare_network_refusal_is_one_line_without_traceback(
+    monkeypatch,
+    capsys,
+):
+    monkeypatch.setattr(
+        share_cli,
+        "run",
+        lambda _args: (_ for _ in ()).throw(
+            UnsafeStateStorageError(
+                "state is on nfs; set CLAWJOURNAL_HOME to local storage"
+            )
+        ),
+    )
+
+    with pytest.raises(SystemExit) as exc:
+        share_cli.main([])
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.count("\n") == 1
+    assert "Traceback" not in captured.err
+    assert "CLAWJOURNAL_HOME" in captured.err
 
 
 def test_arg_parsing_defaults():

--- a/tests/test_support_diagnostics.py
+++ b/tests/test_support_diagnostics.py
@@ -1,0 +1,417 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+from clawjournal import cli
+from clawjournal import filesystem
+from clawjournal import selfupdate
+from clawjournal import support_diagnostics as diagnostics
+
+
+def _create_index(path: Path, *, violations: int = 0) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(path)
+    try:
+        conn.execute("PRAGMA journal_mode=delete")
+        conn.execute("PRAGMA user_version=12")
+        conn.execute("CREATE TABLE sessions (session_id TEXT PRIMARY KEY)")
+        conn.execute(
+            "CREATE TABLE share_sessions ("
+            "share_id TEXT PRIMARY KEY, "
+            "session_id TEXT REFERENCES sessions(session_id))"
+        )
+        for number in range(violations):
+            conn.execute(
+                "INSERT INTO share_sessions(share_id, session_id) VALUES (?, ?)",
+                (f"share-{number}", f"missing-{number}"),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _healthy_report() -> dict[str, object]:
+    return {
+        "support_diagnostics_schema_version": 1,
+        "kind": "index",
+        "package": {"version": "0.2.0", "revision": "a" * 40},
+        "runtime": {"python_version": "3.13.0", "sqlite_version": "3.49.0"},
+        "schema": {"expected_user_version": 12},
+        "storage": {
+            "filesystem_type": "ext4",
+            "storage_risk": "local",
+            "storage_migration_required": False,
+        },
+        "index": {
+            "exists": True,
+            "health_code": "healthy",
+            "user_version": 12,
+            "journal_mode": "delete",
+            "quick_check": {"status": "ok", "issue_count": 0, "truncated": False},
+            "foreign_key_check": {
+                "status": "ok",
+                "returned_count": 0,
+                "truncated": False,
+                "violations": [],
+            },
+        },
+    }
+
+
+def test_version_string_includes_valid_checkout_revision(monkeypatch):
+    monkeypatch.setattr(diagnostics, "package_revision", lambda: "a" * 40)
+    assert diagnostics.version_string() == "clawjournal 0.2.0 (aaaaaaa)"
+
+
+def test_invalid_git_output_is_not_exposed(monkeypatch, tmp_path):
+    class Result:
+        returncode = 0
+        stdout = b"/home/alice/private\n"
+
+    monkeypatch.setattr(diagnostics, "_checkout_root", lambda: tmp_path)
+    monkeypatch.setattr(diagnostics.subprocess, "run", lambda *args, **kwargs: Result())
+    assert diagnostics.package_revision() is None
+
+
+def test_global_version_is_quiet_and_does_not_selfupdate(monkeypatch, capsys):
+    monkeypatch.setattr(
+        selfupdate,
+        "maybe_self_update",
+        lambda: pytest.fail("--version must not trigger selfupdate"),
+    )
+    monkeypatch.setattr(diagnostics, "package_revision", lambda: "b" * 40)
+    monkeypatch.setattr(sys, "argv", ["clawjournal", "--version"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 0
+    captured = capsys.readouterr()
+    assert captured.out == "clawjournal 0.2.0 (bbbbbbb)\n"
+    assert captured.err == ""
+
+
+def test_top_level_doctor_is_read_only_with_respect_to_selfupdate():
+    assert diagnostics is not None
+    assert cli._should_auto_update(["clawjournal", "doctor", "index", "--json"]) is False
+
+
+def test_network_storage_refusal_has_one_line_cli_error(monkeypatch, capsys):
+    from clawjournal.workbench.index import UnsafeIndexStorageError
+
+    def refuse_scan(*args, **kwargs):
+        raise UnsafeIndexStorageError(filesystem.FilesystemInfo("nfs", "network"))
+
+    monkeypatch.setattr(cli, "_run_scan", refuse_scan)
+    monkeypatch.setattr(cli, "_should_auto_update", lambda argv=None: False)
+    monkeypatch.setattr(sys, "argv", ["clawjournal", "scan"])
+
+    with pytest.raises(SystemExit) as exc:
+        cli.main()
+
+    assert exc.value.code == 1
+    captured = capsys.readouterr()
+    assert captured.out == ""
+    assert captured.err.startswith("error: ClawJournal's state directory")
+    assert captured.err.count("\n") == 1
+    assert "Traceback" not in captured.err
+    assert "CLAWJOURNAL_HOME" in captured.err
+
+
+def test_healthy_index_report_is_allowlisted_and_contains_no_path(
+    monkeypatch, tmp_path
+):
+    state_dir = tmp_path / "private" / "alice-at-purdue"
+    _create_index(state_dir / "index.db")
+    monkeypatch.setattr(diagnostics, "_expected_schema_version", lambda: 12)
+    monkeypatch.setattr(diagnostics, "package_revision", lambda: "c" * 40)
+    monkeypatch.setattr(
+        filesystem,
+        "classify_filesystem",
+        lambda path: filesystem.FilesystemInfo("ext4", "local"),
+    )
+    before_files = sorted(path.name for path in state_dir.iterdir())
+    before_bytes = (state_dir / "index.db").read_bytes()
+
+    report = diagnostics.collect_index_diagnostics(state_dir=state_dir)
+
+    assert set(report) == {
+        "support_diagnostics_schema_version",
+        "kind",
+        "package",
+        "runtime",
+        "schema",
+        "storage",
+        "index",
+    }
+    assert report["storage"] == {
+        "filesystem_type": "ext4",
+        "storage_risk": "local",
+        "storage_migration_required": False,
+    }
+    assert set(report["runtime"]) == {
+        "python_version",
+        "sqlite_version",
+        "os_family",
+        "os_release",
+        "architecture",
+    }
+    assert report["index"]["health_code"] == "healthy"
+    assert report["index"]["quick_check"]["status"] == "ok"
+    assert report["index"]["foreign_key_check"]["status"] == "ok"
+    assert diagnostics.diagnostics_exit_code(report) == 0
+    assert sorted(path.name for path in state_dir.iterdir()) == before_files
+    assert (state_dir / "index.db").read_bytes() == before_bytes
+    assert str(tmp_path) not in json.dumps(report)
+    rendered = diagnostics.render_index_diagnostics(report)
+    assert "alice-at-purdue" not in rendered
+    assert "\r" not in rendered
+
+
+def test_network_storage_is_reported_without_mount_source(monkeypatch, tmp_path):
+    _create_index(tmp_path / "index.db")
+    monkeypatch.setattr(diagnostics, "_expected_schema_version", lambda: 12)
+    monkeypatch.setattr(
+        filesystem,
+        "classify_filesystem",
+        lambda path: filesystem.FilesystemInfo("nfs", "network"),
+    )
+
+    report = diagnostics.collect_index_diagnostics(state_dir=tmp_path)
+
+    assert report["storage"] == {
+        "filesystem_type": "nfs",
+        "storage_risk": "network",
+        "storage_migration_required": True,
+    }
+    assert report["index"]["exists"] is None
+    assert report["index"]["health_code"] == "network_storage_not_inspected"
+    assert diagnostics.diagnostics_exit_code(report) == 1
+    serialized = json.dumps(report)
+    assert str(tmp_path) not in serialized
+    assert "server:" not in serialized
+
+
+def test_network_storage_never_touches_the_index(monkeypatch, tmp_path):
+    monkeypatch.setattr(
+        filesystem,
+        "classify_filesystem",
+        lambda path: filesystem.FilesystemInfo("nfs4", "network"),
+    )
+    monkeypatch.setattr(
+        diagnostics,
+        "_index_report",
+        lambda *_args, **_kwargs: pytest.fail(
+            "network storage must not be statted or opened"
+        ),
+    )
+
+    report = diagnostics.collect_index_diagnostics(
+        state_dir=tmp_path / "disconnected-network-home"
+    )
+
+    assert report["index"]["health_code"] == "network_storage_not_inspected"
+
+
+def test_live_wal_snapshot_is_reported_without_opening_or_mutating_it(
+    monkeypatch,
+    tmp_path,
+):
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    database = state_dir / "index.db"
+    conn = sqlite3.connect(database)
+    try:
+        assert conn.execute("PRAGMA journal_mode=wal").fetchone()[0] == "wal"
+        conn.execute("PRAGMA wal_autocheckpoint=0")
+        conn.execute("PRAGMA user_version=12")
+        conn.execute("CREATE TABLE sessions (session_id TEXT PRIMARY KEY)")
+        conn.execute("INSERT INTO sessions VALUES ('uncheckpointed')")
+        conn.commit()
+        before = {
+            path.name: path.read_bytes()
+            for path in state_dir.iterdir()
+            if path.is_file()
+        }
+        assert "index.db-wal" in before
+        monkeypatch.setattr(diagnostics, "_expected_schema_version", lambda: 12)
+        monkeypatch.setattr(
+            filesystem,
+            "classify_filesystem",
+            lambda path: filesystem.FilesystemInfo("ext4", "local"),
+        )
+
+        report = diagnostics.collect_index_diagnostics(state_dir=state_dir)
+
+        after = {
+            path.name: path.read_bytes()
+            for path in state_dir.iterdir()
+            if path.is_file()
+        }
+        assert report["index"]["health_code"] == (
+            "sidecar_snapshot_not_inspected"
+        )
+        assert report["index"]["quick_check"]["status"] == "not_run"
+        assert report["index"]["foreign_key_check"]["status"] == "not_run"
+        assert after == before
+    finally:
+        conn.close()
+
+
+def test_closed_wal_header_is_not_misreported_as_delete(monkeypatch, tmp_path):
+    state_dir = tmp_path / "state"
+    database = state_dir / "index.db"
+    state_dir.mkdir()
+    conn = sqlite3.connect(database)
+    try:
+        assert conn.execute("PRAGMA journal_mode=wal").fetchone()[0] == "wal"
+        conn.execute("PRAGMA user_version=12")
+        conn.execute("CREATE TABLE sessions (session_id TEXT PRIMARY KEY)")
+        conn.commit()
+    finally:
+        conn.close()
+    assert diagnostics._header_journal_mode(database) == "wal"
+    assert not Path(str(database) + "-wal").exists()
+    monkeypatch.setattr(diagnostics, "_expected_schema_version", lambda: 12)
+    monkeypatch.setattr(
+        filesystem,
+        "classify_filesystem",
+        lambda path: filesystem.FilesystemInfo("ext4", "local"),
+    )
+
+    report = diagnostics.collect_index_diagnostics(state_dir=state_dir)
+
+    assert report["index"]["journal_mode"] == "wal"
+    assert report["index"]["health_code"] == "unexpected_journal_mode"
+
+
+def test_runtime_canary_cannot_leak_username_or_path(monkeypatch, tmp_path):
+    private_marker = "alice-private-state"
+    state_dir = tmp_path / private_marker
+    monkeypatch.setattr(
+        diagnostics.platform,
+        "system",
+        lambda: f"Linux {private_marker}",
+    )
+    monkeypatch.setattr(
+        diagnostics.platform,
+        "release",
+        lambda: f"6.8.0 /home/{private_marker}",
+    )
+    monkeypatch.setattr(
+        diagnostics.platform,
+        "machine",
+        lambda: f"x86_64-{private_marker}",
+    )
+    monkeypatch.setattr(
+        filesystem,
+        "classify_filesystem",
+        lambda path: filesystem.FilesystemInfo("nfs", "network"),
+    )
+
+    report = diagnostics.collect_index_diagnostics(state_dir=state_dir)
+    serialized = json.dumps(report)
+
+    assert report["runtime"] == {
+        "python_version": diagnostics.platform.python_version(),
+        "sqlite_version": sqlite3.sqlite_version,
+        "os_family": "unknown",
+        "os_release": "6.8.0",
+        "architecture": "unknown",
+    }
+    assert private_marker not in serialized
+    assert "/home/" not in serialized
+
+
+def test_user_chosen_fuse_subtype_is_never_returned(monkeypatch, tmp_path):
+    private_subtype = "fuse.alice_private_project"
+    monkeypatch.setattr(
+        filesystem,
+        "classify_filesystem",
+        lambda path: filesystem.FilesystemInfo(private_subtype, "unknown"),
+    )
+
+    report = diagnostics.collect_index_diagnostics(state_dir=tmp_path)
+    serialized = json.dumps(report)
+
+    assert report["storage"]["filesystem_type"] == "unknown"
+    assert private_subtype not in serialized
+
+
+def test_foreign_key_violations_are_bounded(monkeypatch, tmp_path):
+    _create_index(tmp_path / "index.db", violations=25)
+    monkeypatch.setattr(diagnostics, "_expected_schema_version", lambda: 12)
+
+    report = diagnostics.collect_index_diagnostics(state_dir=tmp_path)
+    check = report["index"]["foreign_key_check"]
+
+    assert report["index"]["health_code"] == "foreign_key_violations"
+    assert check["status"] == "violations"
+    assert check["returned_count"] == diagnostics.MAX_FOREIGN_KEY_VIOLATIONS
+    assert check["truncated"] is True
+    assert len(check["violations"]) == diagnostics.MAX_FOREIGN_KEY_VIOLATIONS
+    assert check["violations"][0] == {
+        "table": "share_sessions",
+        "row_id": 1,
+        "parent": "sessions",
+        "foreign_key_id": 0,
+    }
+
+
+def test_unknown_schema_identifiers_are_never_returned():
+    assert diagnostics._safe_schema_identifier("sessions") == "sessions"
+    assert diagnostics._safe_schema_identifier("alice_private_table") == "redacted"
+
+
+def test_quick_check_never_returns_raw_database_messages():
+    class Cursor:
+        def fetchmany(self, _limit):
+            return [("failure mentions /home/alice/private-trace",)]
+
+    class Connection:
+        def execute(self, _query):
+            return Cursor()
+
+    result = diagnostics._run_quick_check(Connection())
+    assert result == {"status": "failed", "issue_count": 1, "truncated": False}
+    assert "alice" not in json.dumps(result)
+
+
+def test_corrupt_and_missing_indexes_return_partial_reports(monkeypatch, tmp_path):
+    monkeypatch.setattr(diagnostics, "_expected_schema_version", lambda: 12)
+    missing = diagnostics.collect_index_diagnostics(state_dir=tmp_path / "missing")
+    assert missing["index"]["health_code"] == "missing"
+    assert diagnostics.diagnostics_exit_code(missing) == 1
+    assert not (tmp_path / "missing").exists()
+
+    state_dir = tmp_path / "corrupt"
+    state_dir.mkdir()
+    (state_dir / "index.db").write_bytes(b"not a sqlite database; /home/alice")
+    corrupt = diagnostics.collect_index_diagnostics(state_dir=state_dir)
+    assert corrupt["index"]["health_code"] == "corrupt"
+    assert str(tmp_path) not in json.dumps(corrupt)
+    assert "alice" not in json.dumps(corrupt)
+
+
+def test_doctor_index_json_uses_machine_readable_payload(monkeypatch, capsys):
+    report = _healthy_report()
+    monkeypatch.setattr(diagnostics, "collect_index_diagnostics", lambda: report)
+    monkeypatch.setattr(sys, "argv", ["clawjournal", "doctor", "index", "--json"])
+
+    cli.main()
+
+    captured = capsys.readouterr()
+    assert json.loads(captured.out) == report
+    assert captured.err == ""
+
+
+def test_human_diagnostics_use_portable_newlines():
+    rendered = diagnostics.render_index_diagnostics(_healthy_report())
+
+    assert "\r" not in rendered
+    assert rendered.count("\n") == 5

--- a/tests/workbench/test_index_recovery.py
+++ b/tests/workbench/test_index_recovery.py
@@ -496,6 +496,133 @@ def test_guided_rebuild_rechecks_storage_next_to_source_rw_open(
     assert index_recovery._load_marker(database)["stage"] == "preparing"
 
 
+def test_remount_after_fresh_backup_preserves_live_index(
+    recovery_install,
+    monkeypatch,
+):
+    conn = index_module.open_index()
+    conn.close()
+    database = recovery_install / "index.db"
+    original = database.read_bytes()
+    index_recovery._set_health({
+        "status": "recovery_required",
+        "automatic_recovery_available": True,
+        "message": "test recovery",
+    })
+    remounted = False
+    real_backup = index_recovery._backup_index_files
+
+    def backup_then_remount(path):
+        nonlocal remounted
+        result = real_backup(path)
+        remounted = True
+        return result
+
+    monkeypatch.setattr(index_recovery, "_backup_index_files", backup_then_remount)
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo(
+            "nfs4" if remounted else "ext4",
+            "network" if remounted else "local",
+        ),
+    )
+
+    with pytest.raises(index_recovery.UnsafeIndexRecovery):
+        index_recovery.guided_rebuild(
+            lambda: pytest.fail("a remounted recovery must not start scanning")
+        )
+
+    assert database.is_file()
+    assert database.read_bytes() == original
+    assert index_recovery._load_marker(database)["stage"] == "preparing"
+    assert index_recovery.current_index_health()["code"] == (
+        "storage_migration_required"
+    )
+
+
+def test_remount_after_existing_backup_snapshot_preserves_live_index(
+    recovery_install,
+    monkeypatch,
+):
+    conn = index_module.open_index()
+    conn.close()
+    database = recovery_install / "index.db"
+    original = database.read_bytes()
+    backup_name = "index-recovery-20260816T020304Z-1234abcd"
+    backup = recovery_install / "index-backups" / backup_name
+    backup.mkdir(parents=True)
+    (backup / "index.db").write_bytes(original)
+    (backup / "recovery-manifest.json").write_text("{}", encoding="utf-8")
+    index_recovery._write_marker(
+        database,
+        {
+            "version": 2,
+            "database_path": str(database.resolve()),
+            "backup_path": str(backup.resolve()),
+            "backup_directory": backup_name,
+            "stage": "failed",
+        },
+    )
+    index_recovery._set_health({
+        "status": "recovery_required",
+        "automatic_recovery_available": True,
+        "message": "retry recovery",
+    })
+    remounted = False
+    real_snapshot = index_recovery._snapshot_from_path
+
+    def snapshot_then_remount(path):
+        nonlocal remounted
+        result = real_snapshot(path)
+        remounted = True
+        return result
+
+    monkeypatch.setattr(index_recovery, "_snapshot_from_path", snapshot_then_remount)
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo(
+            "nfs" if remounted else "ext4",
+            "network" if remounted else "local",
+        ),
+    )
+
+    with pytest.raises(index_recovery.UnsafeIndexRecovery):
+        index_recovery.guided_rebuild(
+            lambda: pytest.fail("a remounted retry must not start scanning")
+        )
+
+    assert database.is_file()
+    assert database.read_bytes() == original
+    assert index_recovery._load_marker(database)["stage"] == "failed"
+    assert index_recovery.current_index_health()["code"] == (
+        "storage_migration_required"
+    )
+
+
+def test_remove_index_files_rechecks_storage_before_unlink(
+    recovery_install,
+    monkeypatch,
+):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    database.write_bytes(b"live index")
+    journal = Path(str(database) + "-journal")
+    journal.write_bytes(b"live journal")
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo("nfs4", "network"),
+    )
+
+    with pytest.raises(index_recovery.UnsafeIndexRecovery):
+        index_recovery._remove_index_files(database)
+
+    assert database.read_bytes() == b"live index"
+    assert journal.read_bytes() == b"live journal"
+
+
 def test_initialize_new_index_uses_delete_journal(recovery_install):
     report = index_recovery.initialize_index_health()
 

--- a/tests/workbench/test_index_recovery.py
+++ b/tests/workbench/test_index_recovery.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import sqlite3
 import subprocess
 import sys
@@ -12,6 +13,7 @@ from threading import Thread
 
 import pytest
 
+from clawjournal import filesystem as filesystem_module
 from clawjournal.workbench import index as index_module
 from clawjournal.workbench import index_recovery
 
@@ -103,6 +105,395 @@ def _scan_one_session_with_finding() -> dict[str, object]:
     finally:
         conn.close()
     return {"ok": True}
+
+
+def test_linux_mountinfo_uses_most_specific_mount_without_source_details():
+    mountinfo = "\n".join((
+        "36 25 0:32 / / rw,relatime - ext4 /dev/root rw",
+        r"40 36 0:44 / /cluster\040home rw,relatime - nfs4 "
+        r"server.example:/private/export rw",
+    ))
+
+    storage = filesystem_module._classify_linux_mountinfo(
+        Path("/cluster home/user/.clawjournal/index.db"),
+        mountinfo,
+    )
+
+    assert storage.health_fields() == {
+        "filesystem_type": "nfs4",
+        "storage_risk": "network",
+        "storage_migration_required": True,
+    }
+    assert "server.example" not in repr(storage)
+    assert "cluster home" not in repr(storage)
+
+
+def test_filesystem_classifier_does_not_resolve_a_direct_network_path(
+    monkeypatch,
+):
+    mountinfo = "\n".join((
+        "36 25 0:32 / / rw,relatime - ext4 /dev/root rw",
+        "40 36 0:44 / /cluster rw,relatime - nfs4 server:/private rw",
+    ))
+    monkeypatch.setattr(filesystem_module.sys, "platform", "linux")
+    monkeypatch.setattr(
+        filesystem_module.os.path,
+        "abspath",
+        lambda _path: "/cluster/users/alice/.clawjournal/index.db",
+    )
+    monkeypatch.setattr(
+        filesystem_module,
+        "_read_linux_mountinfo",
+        lambda: mountinfo,
+    )
+    monkeypatch.setattr(
+        filesystem_module.Path,
+        "resolve",
+        lambda *_args, **_kwargs: pytest.fail(
+            "a directly mounted network path must not be resolved"
+        ),
+    )
+
+    storage = filesystem_module.classify_filesystem(
+        Path("/cluster/users/alice/.clawjournal/index.db")
+    )
+
+    assert storage == filesystem_module.FilesystemInfo("nfs4", "network")
+
+
+def test_filesystem_classifier_refreshes_mounts_after_resolving_symlink(
+    monkeypatch,
+):
+    initial = "36 25 0:32 / / rw,relatime - ext4 /dev/root rw"
+    refreshed = "\n".join((
+        initial,
+        "40 36 0:44 / /autofs/home rw,relatime - nfs server:/home rw",
+    ))
+    snapshots = iter((initial, refreshed))
+    monkeypatch.setattr(filesystem_module.sys, "platform", "linux")
+    monkeypatch.setattr(
+        filesystem_module,
+        "_read_linux_mountinfo",
+        lambda: next(snapshots),
+    )
+    monkeypatch.setattr(
+        filesystem_module.Path,
+        "resolve",
+        lambda *_args, **_kwargs: Path("/autofs/home/alice/index.db"),
+    )
+
+    storage = filesystem_module.classify_filesystem(Path("/home/alice/index.db"))
+
+    assert storage == filesystem_module.FilesystemInfo("nfs", "network")
+
+
+def test_filesystem_classifier_degrades_on_legacy_symlink_loop_error(
+    monkeypatch,
+):
+    mountinfo = "36 25 0:32 / / rw,relatime - ext4 /dev/root rw"
+    monkeypatch.setattr(filesystem_module.sys, "platform", "linux")
+    monkeypatch.setattr(
+        filesystem_module.os.path,
+        "abspath",
+        lambda _path: "/local/index.db",
+    )
+    monkeypatch.setattr(
+        filesystem_module,
+        "_read_linux_mountinfo",
+        lambda: mountinfo,
+    )
+    monkeypatch.setattr(
+        filesystem_module.Path,
+        "resolve",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("symlink loop")
+        ),
+    )
+
+    storage = filesystem_module.classify_filesystem(Path("/local/index.db"))
+
+    assert storage == filesystem_module.FilesystemInfo("ext4", "local")
+
+
+def test_linux_mountinfo_prefers_visible_overmount_at_same_path():
+    mountinfo = "\n".join((
+        "36 25 0:32 / / rw,relatime - ext4 /dev/root rw",
+        "40 36 0:44 / /cluster rw,relatime - ext4 /dev/local rw",
+        "57 36 0:45 / /cluster rw,relatime - nfs4 server:/cluster rw",
+    ))
+
+    storage = filesystem_module._classify_linux_mountinfo(
+        Path("/cluster/users/alice/index.db"),
+        mountinfo,
+    )
+
+    assert storage == filesystem_module.FilesystemInfo("nfs4", "network")
+
+
+def test_linux_mountinfo_never_uses_mount_id_to_hide_network_candidate():
+    mountinfo = "\n".join((
+        "36 25 0:32 / / rw,relatime - ext4 /dev/root rw",
+        "100 36 0:44 / /cluster rw,relatime - ext4 /dev/local rw",
+        "40 36 0:45 / /cluster rw,relatime - nfs server:/cluster rw",
+    ))
+
+    storage = filesystem_module._classify_linux_mountinfo(
+        Path("/cluster/users/alice/index.db"),
+        mountinfo,
+    )
+
+    assert storage == filesystem_module.FilesystemInfo("nfs", "network")
+
+
+@pytest.mark.parametrize(
+    "filesystem_type",
+    ("../../private", "evil<script>", "x" * 33, "fuse.alice_private"),
+)
+def test_malformed_filesystem_type_is_redacted_to_unknown(filesystem_type):
+    storage = filesystem_module._filesystem_info(filesystem_type)
+
+    assert storage.health_fields() == {
+        "filesystem_type": "unknown",
+        "storage_risk": "unknown",
+        "storage_migration_required": False,
+    }
+    assert filesystem_type not in repr(storage)
+
+
+@pytest.mark.parametrize(
+    ("filesystem_type", "risk"),
+    (("ext4", "local"), ("overlay", "unknown")),
+)
+def test_unknown_and_local_filesystem_kinds_are_not_blocked(
+    recovery_install,
+    monkeypatch,
+    filesystem_type,
+    risk,
+):
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo(filesystem_type, risk),
+    )
+
+    conn = index_module.open_index()
+    conn.close()
+
+    assert (recovery_install / "index.db").is_file()
+
+
+def test_missing_index_on_network_storage_fails_closed_without_creating_files(
+    recovery_install,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo("nfs4", "network"),
+    )
+
+    report = index_recovery.inspect_index_health()
+
+    assert report["status"] == "unavailable"
+    assert report["code"] == "storage_migration_required"
+    assert report["filesystem_type"] == "nfs4"
+    assert report["storage_risk"] == "network"
+    assert report["storage_migration_required"] is True
+    assert report["automatic_recovery_available"] is False
+    assert "CLAWJOURNAL_HOME" in report["message"]
+    assert not (recovery_install / "index.db").exists()
+    assert not (recovery_install / "index-connections.lock").exists()
+
+
+def test_startup_health_refuses_network_storage_without_resolving_it(
+    recovery_install,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo("nfs4", "network"),
+    )
+    monkeypatch.setattr(
+        index_recovery.Path,
+        "resolve",
+        lambda *_args, **_kwargs: pytest.fail(
+            "startup must not resolve a known hard-NFS path"
+        ),
+    )
+
+    report = index_recovery.begin_index_health_check()
+
+    assert report["status"] == "unavailable"
+    assert report["code"] == "storage_migration_required"
+    assert report["storage_migration_required"] is True
+
+
+def test_healthy_existing_index_on_network_storage_is_not_inspected(
+    recovery_install,
+    monkeypatch,
+):
+    conn = index_module.open_index()
+    conn.close()
+    database = recovery_install / "index.db"
+    original = database.read_bytes()
+
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo("cifs", "network"),
+    )
+    monkeypatch.setattr(
+        index_recovery,
+        "_health_connection",
+        lambda _path: pytest.fail("network storage must not be opened"),
+    )
+
+    report = index_recovery.inspect_index_health()
+
+    assert report["status"] == "unavailable"
+    assert report["filesystem_type"] == "cifs"
+    assert report["storage_migration_required"] is True
+    assert database.read_bytes() == original
+
+
+def test_open_index_rejects_network_storage_before_bootstrap(
+    recovery_install,
+    monkeypatch,
+):
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo("lustre", "network"),
+    )
+
+    with pytest.raises(index_module.UnsafeIndexStorageError) as exc_info:
+        index_module.open_index()
+
+    assert "CLAWJOURNAL_HOME" in str(exc_info.value)
+    assert "lustre" in str(exc_info.value)
+    assert not (recovery_install / "index.db").exists()
+    assert not (recovery_install / "index-connections.lock").exists()
+    assert not (recovery_install / "blobs").exists()
+
+
+def test_all_leased_index_opens_are_blocked_but_lease_free_evidence_is_readable(
+    recovery_install,
+    monkeypatch,
+):
+    database = recovery_install / "index.db"
+    recovery_install.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(database)
+    conn.execute("CREATE TABLE sample (value TEXT)")
+    conn.commit()
+    conn.close()
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo("ceph", "network"),
+    )
+
+    with pytest.raises(index_module.UnsafeIndexStorageError):
+        index_module.open_existing_index(database=database, readonly=True)
+    with pytest.raises(index_module.UnsafeIndexStorageError):
+        index_module.open_existing_index(database=database)
+
+    evidence = index_recovery._read_only_connection(database)
+    evidence.close()
+    assert not (recovery_install / "index-connections.lock").exists()
+
+
+def test_begin_guided_rebuild_rechecks_storage_before_creating_marker(
+    recovery_install,
+    monkeypatch,
+):
+    index_recovery._set_health({
+        "status": "recovery_required",
+        "message": "Test damage",
+        "automatic_recovery_available": True,
+    })
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo("sshfs", "network"),
+    )
+
+    with pytest.raises(index_recovery.UnsafeIndexRecovery) as exc_info:
+        index_recovery.begin_guided_rebuild()
+
+    assert "CLAWJOURNAL_HOME" in str(exc_info.value)
+    health = index_recovery.current_index_health()
+    assert health["status"] == "unavailable"
+    assert health["code"] == "storage_migration_required"
+    assert health["storage_migration_required"] is True
+    assert not (recovery_install / index_recovery.RECOVERY_MARKER_FILENAME).exists()
+
+
+def test_direct_guided_rebuild_rechecks_storage_before_backup(
+    recovery_install,
+    monkeypatch,
+):
+    callback_called = False
+
+    def scan_callback():
+        nonlocal callback_called
+        callback_called = True
+        return {"ok": True}
+
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo("smbfs", "network"),
+    )
+
+    with pytest.raises(index_recovery.UnsafeIndexRecovery):
+        index_recovery.guided_rebuild(scan_callback)
+
+    assert callback_called is False
+    assert not (recovery_install / index_recovery.RECOVERY_MARKER_FILENAME).exists()
+    assert not (recovery_install / "index-backups").exists()
+
+
+def test_guided_rebuild_rechecks_storage_next_to_source_rw_open(
+    recovery_install,
+    monkeypatch,
+):
+    database = recovery_install / "index.db"
+    recovery_install.mkdir(parents=True, exist_ok=True)
+    original = b"damaged sqlite bytes"
+    database.write_bytes(original)
+    classification_calls = 0
+
+    def changing_storage(_path):
+        nonlocal classification_calls
+        classification_calls += 1
+        if classification_calls <= 2:
+            return filesystem_module.FilesystemInfo("ext4", "local")
+        return filesystem_module.FilesystemInfo("nfs", "network")
+
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        changing_storage,
+    )
+    monkeypatch.setattr(
+        index_recovery.sqlite3,
+        "connect",
+        lambda *_args, **_kwargs: pytest.fail(
+            "network storage must be rejected before SQLite opens it read/write"
+        ),
+    )
+
+    with pytest.raises(index_recovery.UnsafeIndexRecovery):
+        index_recovery.guided_rebuild(lambda: {"ok": True})
+
+    assert classification_calls >= 3
+    assert database.read_bytes() == original
+    assert not (recovery_install / "index-backups").exists()
+    assert index_recovery.current_index_health()["code"] == (
+        "storage_migration_required"
+    )
+    assert index_recovery._load_marker(database)["stage"] == "preparing"
 
 
 def test_initialize_new_index_uses_delete_journal(recovery_install):
@@ -348,6 +739,133 @@ def test_marker_with_missing_backup_fails_closed(recovery_install):
     assert report["status"] == "unavailable"
     assert report["automatic_recovery_available"] is False
     assert report["interrupted_recovery"] is True
+
+
+@pytest.mark.parametrize("marker_version", (1, 2))
+def test_complete_state_copy_rebases_interrupted_recovery_backup(
+    recovery_install,
+    tmp_path,
+    monkeypatch,
+    marker_version,
+):
+    old_state = recovery_install
+    database = old_state / "index.db"
+    database.parent.mkdir(parents=True)
+    database.write_bytes(b"partial rebuilt index")
+    backup_name = "index-recovery-20260816T010203Z-abcdef12"
+    backup = old_state / "index-backups" / backup_name
+    backup.mkdir(parents=True)
+    (backup / "index.db").write_bytes(b"original index bytes")
+    (backup / "recovery-manifest.json").write_text("{}", encoding="utf-8")
+    marker = {
+        "version": marker_version,
+        "database_path": str(database.resolve()),
+        "backup_path": str(backup.resolve()),
+        "stage": "failed",
+    }
+    if marker_version == 2:
+        marker["backup_directory"] = backup_name
+    index_recovery._write_marker(database, marker)
+
+    local_state = tmp_path / "local-state"
+    shutil.copytree(old_state, local_state)
+    old_state.rename(tmp_path / "disconnected-network-state")
+    monkeypatch.setattr(index_module, "CONFIG_DIR", local_state)
+    monkeypatch.setattr(index_module, "INDEX_DB", local_state / "index.db")
+    monkeypatch.setattr(index_module, "BLOBS_DIR", local_state / "blobs")
+
+    report = index_recovery.inspect_index_health()
+
+    expected_backup = local_state / "index-backups" / backup_name
+    assert report["status"] == "recovery_required"
+    assert report["automatic_recovery_available"] is True
+    assert Path(report["backup_path"]) == expected_backup.resolve()
+    assert (expected_backup / "index.db").read_bytes() == b"original index bytes"
+
+    result = index_recovery.guided_rebuild(_scan_one_session)
+
+    assert result["status"] == "ready"
+    assert Path(result["backup_path"]) == expected_backup.resolve()
+    assert not (
+        local_state / index_recovery.RECOVERY_MARKER_FILENAME
+    ).exists()
+    rebuilt = index_module.open_index()
+    try:
+        assert rebuilt.execute(
+            "SELECT COUNT(*) FROM sessions WHERE session_id = ?",
+            ("session-recovery",),
+        ).fetchone()[0] == 1
+    finally:
+        rebuilt.close()
+
+
+def test_v2_marker_rejects_non_generated_backup_identity(recovery_install):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    database.write_bytes(b"partial rebuilt index")
+    index_recovery._write_marker(
+        database,
+        {
+            "version": 2,
+            "backup_directory": "../outside",
+            "stage": "failed",
+        },
+    )
+
+    report = index_recovery.inspect_index_health()
+
+    assert report["status"] == "unavailable"
+    assert report["automatic_recovery_available"] is False
+    assert report["interrupted_recovery"] is True
+
+
+def test_unknown_recovery_marker_version_fails_closed(recovery_install):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    database.write_bytes(b"partial rebuilt index")
+    backup = recovery_install / "index-backups" / "legacy-backup"
+    backup.mkdir(parents=True)
+    (backup / "index.db").write_bytes(b"original index")
+    index_recovery._write_marker(
+        database,
+        {
+            "version": 999,
+            "backup_path": str(backup),
+            "stage": "failed",
+        },
+    )
+
+    report = index_recovery.inspect_index_health()
+
+    assert report["status"] == "unavailable"
+    assert report["automatic_recovery_available"] is False
+    assert "version is unsupported" in report["detail"]
+
+
+def test_backup_root_symlink_cannot_escape_state_directory(
+    recovery_install,
+    tmp_path,
+):
+    database = recovery_install / "index.db"
+    database.parent.mkdir(parents=True)
+    database.write_bytes(b"damaged index")
+    outside = tmp_path / "outside-backups"
+    outside.mkdir()
+    try:
+        (recovery_install / "index-backups").symlink_to(
+            outside,
+            target_is_directory=True,
+        )
+    except OSError:
+        pytest.skip("directory symlinks are not available on this platform")
+
+    with pytest.raises(
+        index_recovery.UnsafeIndexRecovery,
+        match="outside the ClawJournal state root",
+    ):
+        index_recovery._backup_index_files(database)
+
+    assert list(outside.iterdir()) == []
 
 
 def test_marker_with_only_sidecar_backup_fails_closed(recovery_install):
@@ -651,6 +1169,62 @@ def test_marker_transition_refreshes_cached_health(recovery_install):
     (recovery_install / index_recovery.RECOVERY_MARKER_FILENAME).unlink()
     resumed = index_recovery.synchronize_index_health()
     assert resumed["status"] == "ready"
+
+
+def test_runtime_network_remount_replaces_cached_ready_health(
+    recovery_install,
+    monkeypatch,
+):
+    index_recovery._set_health({
+        "status": "ready",
+        "message": "cached local health",
+        "storage_risk": "local",
+        "storage_migration_required": False,
+    })
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo("nfs4", "network"),
+    )
+    monkeypatch.setattr(
+        index_recovery,
+        "recovery_marker_exists",
+        lambda *_args, **_kwargs: pytest.fail(
+            "a network remount must fail closed before marker inspection"
+        ),
+    )
+
+    blocked = index_recovery.synchronize_index_health()
+
+    assert blocked["status"] == "unavailable"
+    assert blocked["code"] == "storage_migration_required"
+    assert blocked["storage_risk"] == "network"
+    assert blocked["storage_migration_required"] is True
+    assert index_recovery.current_index_health() == blocked
+
+
+def test_unknown_storage_does_not_clear_cached_network_block(
+    recovery_install,
+    monkeypatch,
+):
+    blocked = index_recovery._set_health({
+        "status": "unavailable",
+        "code": "storage_migration_required",
+        "storage_risk": "network",
+        "storage_migration_required": True,
+    })
+    monkeypatch.setattr(
+        filesystem_module,
+        "classify_filesystem",
+        lambda _path: filesystem_module.FilesystemInfo("unknown", "unknown"),
+    )
+    monkeypatch.setattr(
+        index_recovery,
+        "initialize_index_health",
+        lambda: pytest.fail("unknown storage must not clear a network block"),
+    )
+
+    assert index_recovery.synchronize_index_health() == blocked
 
 
 def test_legacy_enrollment_scope_is_restored_paused():


### PR DESCRIPTION
## Summary

Relates to #197, but intentionally does **not** close it: the reporter confirmed an NFS-backed cluster home, while the foreign-key failure's original writer is still unproven and the ~400-session scoring symptom is a separate scheduling problem.

This PR makes the confirmed cluster-storage situation safe and diagnosable:

- classifies Linux mounts from `/proc/self/mountinfo` with longest-mount matching, autofs refresh, conservative stacked-mount handling, and a fixed privacy-safe filesystem allowlist;
- refuses every normal mutable/leased index open, creation, or rebuild on a positively identified network/shared filesystem before ClawJournal creates state files;
- rechecks storage at startup, on API health synchronization, and throughout guided recovery so a runtime remount fails closed;
- adds a migration-only recovery screen that tells users to stop ClawJournal, cold-copy the complete `CLAWJOURNAL_HOME`, retain the original, and restart on persistent local storage;
- upgrades interrupted-recovery markers to v2 using a generated backup identity under the current state root, while safely rebasing validated v1 markers after a complete state copy;
- adds `clawjournal --version` and `clawjournal doctor index [--json]` so cluster users do not need an external `sqlite3` binary;
- keeps diagnostics strictly bounded and path/content-free, uses immutable SQLite reads, and declines to open known network storage or a live sidecar snapshot;
- gives both `clawjournal` and `clawshare` a one-line, traceback-free storage refusal.

## Safety and compatibility

- Unknown filesystem kinds remain non-blocking; this avoids guessing on unsupported platforms.
- Positive network-filesystem detection is currently Linux-specific. Windows/macOS remain `unknown` and are not claimed as protected by this PR.
- The recovery flow never deletes the original during migration guidance. Existing v1 backups remain supported, and v2 backup paths cannot escape the current state root through traversal or symlinks.
- Diagnostics omit paths, mount sources, hostname, username, raw errors, session identifiers/content, and user-defined FUSE subtype strings.
- No database schema migration is introduced.

## Non-goals

- This does not implement the proposed durable/fair AI-scoring queue or claim that scoring caused the foreign-key violation.
- This does not add #198's report submission UI or upload screenshots.

## Verification

- Final storage/recovery/diagnostics/CLI subset: **128 passed, 1 platform skip**
- Additional CLI/events/auto-upload/daemon regression run: **655 passed**
- Broader recovery/config/auto-upload-index subset: **268 passed, 15 skipped**
- Frontend: **15 files / 127 tests passed**
- ESLint, TypeScript, Share Queue state test, production Vite build, `compileall`, and `git diff --check` passed