### PR TITLE
Add privacy-bounded local bug report drafts

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -6,6 +6,7 @@ ClawJournal is designed to be usable without uploading anything.
 
 - `clawjournal scan`, `serve`, `inbox`, `search`, `score`, `export`, and `bundle-export` run locally.
 - The browser workbench is local. If you install from source, `clawjournal serve` opens your own machine at `localhost:8384`.
+- **Report a problem** creates an editable draft in browser memory. Its loopback diagnostic request uses a fixed allowlist and excludes transcripts, logs, paths, raw URLs, identifiers, and raw error text. It does not take a screenshot or upload anything; copy/download and opening a blank GitHub issue leave final review and submission to you.
 - `bundle-export` writes files to disk. It does not contact a server.
 - If you never use the workbench Submit step, never explicitly enable Automatic uploads, and never configure `CLAWJOURNAL_INGEST_URL` or run `bundle-share`, nothing is uploaded.
 - If you are explicitly enrolled in OpenRefinery Agent Failure Sharing, the optional agent hook only shows a local reminder and can open the existing Share workflow. The hook does not read transcripts, package bundles, or upload data by itself.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ If you are unsure at any point, stop before **Submit**. Your review and package 
 ## Privacy in plain English
 
 - **Local by default.** Scanning and reviewing create a local index and local copies of your agent sessions. Those copies can contain the original text.
+- **Problem reports start as local drafts.** **Report a problem** does not capture your screen, upload a report, or put its text in a URL. It builds an editable in-memory draft from your description and a small allowlist of path-free diagnostics, then lets you copy or download it before opening a blank GitHub issue.
 - **Index recovery is backup-first.** The workbench checks its local SQLite index at startup. If the index is damaged, database-backed work and uploads stay stopped while the UI offers one guided action that backs up the old index before rebuilding it from the original agent logs.
 - **AI features are optional.** If you enable them, ClawJournal removes home-folder paths and usernames locally first. The remaining session text is sent to the AI service you choose and may still contain identifying details.
 - **Sharing has safety checks.** Redaction and secret scans run before a package can be submitted. One scanner may contact a credential provider to check whether a suspected secret is live. A missing or failed required scan blocks sharing.

--- a/clawjournal/support_context.py
+++ b/clawjournal/support_context.py
@@ -1,0 +1,460 @@
+"""Strictly bounded runtime context for local support-report drafts.
+
+The HTTP endpoint that consumes this module must remain usable while the
+workbench index is unavailable.  Collection is therefore split in two:
+
+* :func:`capture_support_environment` runs once while the daemon starts and
+  records only coarse, allowlisted process metadata.
+* :func:`collect_support_context` projects that immutable snapshot together
+  with the already-cached index-health mapping.  It performs no filesystem,
+  SQLite, subprocess, Git, or network work.
+
+Neither function accepts request data.  Unknown and malformed values degrade
+to fixed placeholders instead of being stringified into the report.
+"""
+
+from __future__ import annotations
+
+import platform
+import re
+import sys
+from dataclasses import dataclass
+from typing import Mapping
+
+from . import __version__
+
+
+SUPPORT_CONTEXT_SCHEMA_VERSION = 1
+
+_SAFE_PACKAGE_VERSION_RE = re.compile(r"[0-9A-Za-z][0-9A-Za-z.+_-]{0,63}\Z")
+_SAFE_REVISION_RE = re.compile(r"[0-9a-fA-F]{7,64}\Z")
+_NUMERIC_VERSION_RE = re.compile(r"[0-9]+(?:\.[0-9]+){0,3}\Z")
+_OS_RELEASE_PREFIX_RE = re.compile(r"[0-9]+(?:\.[0-9]+){0,3}")
+
+_OS_FAMILY_ALIASES = {
+    "darwin": "macOS",
+    "freebsd": "FreeBSD",
+    "linux": "Linux",
+    "windows": "Windows",
+}
+_ARCHITECTURE_ALIASES = {
+    "aarch64": "arm64",
+    "amd64": "x86_64",
+    "arm64": "arm64",
+    "i386": "x86",
+    "i686": "x86",
+    "ppc64le": "ppc64le",
+    "riscv64": "riscv64",
+    "s390x": "s390x",
+    "x86": "x86",
+    "x86_64": "x86_64",
+}
+_INDEX_HEALTH_STATUSES = frozenset({
+    "ready",
+    "checking",
+    "recovery_required",
+    "rebuilding",
+    "unavailable",
+})
+_STORAGE_RISKS = frozenset({"network", "local", "unknown"})
+_FILESYSTEM_TYPES = frozenset({
+    "unknown",
+    "9p",
+    "afs",
+    "beegfs",
+    "blobfuse",
+    "ceph",
+    "cifs",
+    "cvmfs",
+    "davfs",
+    "gfs2",
+    "gcsfuse",
+    "glusterfs",
+    "gpfs",
+    "juicefs",
+    "lustre",
+    "nfs",
+    "nfs4",
+    "ocfs2",
+    "orangefs",
+    "panfs",
+    "rclone",
+    "s3fs",
+    "smbfs",
+    "sshfs",
+    "virtiofs",
+    "weka",
+    "apfs",
+    "btrfs",
+    "exfat",
+    "ext2",
+    "ext3",
+    "ext4",
+    "f2fs",
+    "hfs",
+    "hfsplus",
+    "jfs",
+    "ntfs",
+    "ntfs3",
+    "ramfs",
+    "reiserfs",
+    "tmpfs",
+    "ufs",
+    "vfat",
+    "xfs",
+    "zfs",
+    "autofs",
+    "cgroup",
+    "cgroup2",
+    "devtmpfs",
+    "ecryptfs",
+    "fuse",
+    "fuseblk",
+    "iso9660",
+    "nsfs",
+    "overlay",
+    "proc",
+    "squashfs",
+    "sysfs",
+    "udf",
+})
+_UNAVAILABLE_SECTION_ORDER = (
+    "package_version",
+    "package_revision",
+    "runtime_python",
+    "runtime_sqlite",
+    "runtime_os",
+    "runtime_architecture",
+    "expected_schema",
+    "cached_index_health",
+)
+
+
+@dataclass(frozen=True)
+class SupportEnvironment:
+    """Immutable, privacy-bounded metadata captured at daemon startup."""
+
+    package_version: str
+    package_revision: str | None
+    python_version: str
+    sqlite_version: str
+    os_family: str
+    os_release: str
+    architecture: str
+    expected_user_version: int | None
+    unavailable_sections: tuple[str, ...] = ()
+
+
+def _safe_package_version(value: object) -> str:
+    if not isinstance(value, str):
+        return "unknown"
+    value = value.strip()
+    return value if _SAFE_PACKAGE_VERSION_RE.fullmatch(value) else "unknown"
+
+
+def _safe_revision(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    value = value.strip().lower()
+    if _SAFE_REVISION_RE.fullmatch(value) is None:
+        return None
+    # A short source revision distinguishes editable builds without exposing
+    # any machine- or participant-specific identifier.
+    return value[:12]
+
+
+def _safe_numeric_version(value: object) -> str:
+    if not isinstance(value, str):
+        return "unknown"
+    value = value.strip()
+    return value if _NUMERIC_VERSION_RE.fullmatch(value) else "unknown"
+
+
+def _safe_os_family(value: object) -> str:
+    if not isinstance(value, str):
+        return "unknown"
+    return _OS_FAMILY_ALIASES.get(value.strip().lower(), "unknown")
+
+
+def _safe_os_release(value: object) -> str:
+    if not isinstance(value, str):
+        return "unknown"
+    match = _OS_RELEASE_PREFIX_RE.match(value.strip())
+    return match.group(0) if match else "unknown"
+
+
+def _safe_architecture(value: object) -> str:
+    if not isinstance(value, str):
+        return "unknown"
+    return _ARCHITECTURE_ALIASES.get(value.strip().lower(), "unknown")
+
+
+def _safe_expected_schema(value: object) -> int | None:
+    if isinstance(value, bool) or not isinstance(value, int):
+        return None
+    return value if 0 <= value <= 1_000_000 else None
+
+
+def _safe_filesystem_type(value: object) -> str:
+    if not isinstance(value, str):
+        return "unknown"
+    value = value.strip().lower()
+    return value if value in _FILESYSTEM_TYPES else "unknown"
+
+
+def _ordered_unavailable(values: list[str] | tuple[str, ...]) -> tuple[str, ...]:
+    requested = set(values)
+    return tuple(
+        section for section in _UNAVAILABLE_SECTION_ORDER if section in requested
+    )
+
+
+def unavailable_support_environment() -> SupportEnvironment:
+    """Return a fixed startup snapshot for an unexpected collection failure."""
+
+    return SupportEnvironment(
+        package_version="unknown",
+        package_revision=None,
+        python_version="unknown",
+        sqlite_version="unknown",
+        os_family="unknown",
+        os_release="unknown",
+        architecture="unknown",
+        expected_user_version=None,
+        unavailable_sections=_UNAVAILABLE_SECTION_ORDER[:-1],
+    )
+
+
+def capture_support_environment(
+    *,
+    revision: object,
+    expected_user_version: object,
+    sqlite_version: object,
+) -> SupportEnvironment:
+    """Capture coarse process metadata once, without reading user state."""
+
+    unavailable: list[str] = []
+
+    package_version = _safe_package_version(__version__)
+    if package_version == "unknown":
+        unavailable.append("package_version")
+
+    package_revision = _safe_revision(revision)
+    if package_revision is None:
+        unavailable.append("package_revision")
+
+    python_version = _safe_numeric_version(
+        f"{sys.version_info.major}.{sys.version_info.minor}.{sys.version_info.micro}"
+    )
+    if python_version == "unknown":
+        unavailable.append("runtime_python")
+
+    safe_sqlite_version = _safe_numeric_version(sqlite_version)
+    if safe_sqlite_version == "unknown":
+        unavailable.append("runtime_sqlite")
+
+    try:
+        raw_os_family = platform.system()
+        raw_os_release = platform.release()
+    except Exception:
+        raw_os_family = None
+        raw_os_release = None
+        unavailable.append("runtime_os")
+    os_family = _safe_os_family(raw_os_family)
+    os_release = _safe_os_release(raw_os_release)
+    if (
+        "runtime_os" not in unavailable
+        and (os_family == "unknown" or os_release == "unknown")
+    ):
+        unavailable.append("runtime_os")
+
+    try:
+        raw_architecture = platform.machine()
+    except Exception:
+        raw_architecture = None
+        unavailable.append("runtime_architecture")
+    architecture = _safe_architecture(raw_architecture)
+    if architecture == "unknown" and "runtime_architecture" not in unavailable:
+        unavailable.append("runtime_architecture")
+
+    expected_schema = _safe_expected_schema(expected_user_version)
+    if expected_schema is None:
+        unavailable.append("expected_schema")
+
+    return SupportEnvironment(
+        package_version=package_version,
+        package_revision=package_revision,
+        python_version=python_version,
+        sqlite_version=safe_sqlite_version,
+        os_family=os_family,
+        os_release=os_release,
+        architecture=architecture,
+        expected_user_version=expected_schema,
+        unavailable_sections=_ordered_unavailable(unavailable),
+    )
+
+
+def _project_environment(value: object) -> SupportEnvironment:
+    """Revalidate even the process-local snapshot before serialization."""
+
+    if not isinstance(value, SupportEnvironment):
+        return unavailable_support_environment()
+    unavailable = [
+        section
+        for section in value.unavailable_sections
+        if isinstance(section, str) and section in _UNAVAILABLE_SECTION_ORDER
+    ]
+
+    package_version = _safe_package_version(value.package_version)
+    if package_version == "unknown":
+        unavailable.append("package_version")
+    package_revision = _safe_revision(value.package_revision)
+    if package_revision is None:
+        unavailable.append("package_revision")
+    python_version = _safe_numeric_version(value.python_version)
+    if python_version == "unknown":
+        unavailable.append("runtime_python")
+    sqlite_version = _safe_numeric_version(value.sqlite_version)
+    if sqlite_version == "unknown":
+        unavailable.append("runtime_sqlite")
+    os_family = _safe_os_family(value.os_family)
+    os_release = _safe_os_release(value.os_release)
+    if os_family == "unknown" or os_release == "unknown":
+        unavailable.append("runtime_os")
+    architecture = _safe_architecture(value.architecture)
+    if architecture == "unknown":
+        unavailable.append("runtime_architecture")
+    expected_user_version = _safe_expected_schema(value.expected_user_version)
+    if expected_user_version is None:
+        unavailable.append("expected_schema")
+
+    return SupportEnvironment(
+        package_version=package_version,
+        package_revision=package_revision,
+        python_version=python_version,
+        sqlite_version=sqlite_version,
+        os_family=os_family,
+        os_release=os_release,
+        architecture=architecture,
+        expected_user_version=expected_user_version,
+        unavailable_sections=_ordered_unavailable(unavailable),
+    )
+
+
+def _unknown_health() -> dict[str, object]:
+    return {
+        "filesystem_type": "unknown",
+        "storage_risk": "unknown",
+        "storage_migration_required": False,
+        "status": "unknown",
+        "condition": None,
+    }
+
+
+def _project_cached_health(value: object) -> tuple[dict[str, object], bool]:
+    """Project only fixed fields from the in-memory health snapshot."""
+
+    if not isinstance(value, Mapping):
+        return _unknown_health(), False
+    try:
+        raw_filesystem_type = value.get("filesystem_type")
+        raw_storage_risk = value.get("storage_risk")
+        raw_migration_required = value.get("storage_migration_required")
+        raw_status = value.get("status")
+        raw_code = value.get("code")
+        interrupted_recovery = value.get("interrupted_recovery")
+    except Exception:
+        return _unknown_health(), False
+
+    filesystem_type = _safe_filesystem_type(raw_filesystem_type)
+    storage_risk = (
+        raw_storage_risk
+        if isinstance(raw_storage_risk, str)
+        and raw_storage_risk in _STORAGE_RISKS
+        else "unknown"
+    )
+    status = (
+        raw_status
+        if isinstance(raw_status, str) and raw_status in _INDEX_HEALTH_STATUSES
+        else "unknown"
+    )
+    migration_required = (
+        raw_migration_required is True or storage_risk == "network"
+    )
+
+    condition: str | None = None
+    if (
+        isinstance(raw_code, str)
+        and raw_code == "storage_migration_required"
+    ) or migration_required:
+        condition = "storage_migration_required"
+    elif interrupted_recovery is True:
+        condition = "interrupted_recovery"
+    elif status == "recovery_required":
+        condition = "recovery_required"
+    elif status == "unavailable":
+        condition = "unavailable"
+
+    projected = {
+        "filesystem_type": filesystem_type,
+        "storage_risk": storage_risk,
+        "storage_migration_required": migration_required,
+        "status": status,
+        "condition": condition,
+    }
+    return projected, status != "unknown"
+
+
+def collect_support_context(
+    environment: object,
+    cached_index_health: object,
+) -> dict[str, object]:
+    """Build the exact support-context response from process-local snapshots."""
+
+    safe_environment = _project_environment(environment)
+    unavailable = list(safe_environment.unavailable_sections)
+
+    health, health_available = _project_cached_health(cached_index_health)
+    if not health_available:
+        unavailable.append("cached_index_health")
+    unavailable_sections = _ordered_unavailable(unavailable)
+
+    return {
+        "support_context_schema_version": SUPPORT_CONTEXT_SCHEMA_VERSION,
+        "kind": "workbench",
+        "package": {
+            "version": safe_environment.package_version,
+            "revision": safe_environment.package_revision,
+        },
+        "runtime": {
+            "python_version": safe_environment.python_version,
+            "sqlite_version": safe_environment.sqlite_version,
+            "os_family": safe_environment.os_family,
+            "os_release": safe_environment.os_release,
+            "architecture": safe_environment.architecture,
+        },
+        "schema": {
+            "expected_user_version": safe_environment.expected_user_version,
+        },
+        "storage": {
+            "filesystem_type": health["filesystem_type"],
+            "storage_risk": health["storage_risk"],
+            "storage_migration_required": health[
+                "storage_migration_required"
+            ],
+        },
+        "index": {
+            "status": health["status"],
+            "condition": health["condition"],
+        },
+        "collection": {
+            "status": "partial" if unavailable_sections else "complete",
+            "unavailable_sections": list(unavailable_sections),
+        },
+    }
+
+
+def unavailable_support_context() -> dict[str, object]:
+    """Return a fixed partial response after an unexpected handler failure."""
+
+    return collect_support_context(None, None)

--- a/clawjournal/web/frontend/src/api.test.ts
+++ b/clawjournal/web/frontend/src/api.test.ts
@@ -55,6 +55,35 @@ describe('index recovery API', () => {
   });
 });
 
+describe('support context API', () => {
+  afterEach(() => {
+    delete window.__CLAWJOURNAL_API_TOKEN__;
+    vi.unstubAllGlobals();
+  });
+
+  it('uses the authenticated DB-free endpoint and forwards its abort signal', async () => {
+    window.__CLAWJOURNAL_API_TOKEN__ = 'support-context-token';
+    const payload = {
+      support_context_schema_version: 1,
+      kind: 'workbench',
+      collection: { status: 'partial', unavailable_sections: ['cached_index_health'] },
+    };
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => payload,
+    });
+    vi.stubGlobal('fetch', fetchMock);
+    const controller = new AbortController();
+
+    await expect(api.support.context(controller.signal)).resolves.toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith('/api/support-context', {
+      headers: { Authorization: 'Bearer support-context-token' },
+      signal: controller.signal,
+    });
+  });
+});
+
 describe('automatic-upload API normalization', () => {
   afterEach(() => {
     vi.unstubAllGlobals();

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -333,6 +333,12 @@ export const api = {
     return request('/features');
   },
 
+  support: {
+    context(signal?: AbortSignal): Promise<unknown> {
+      return request('/support-context', { signal });
+    },
+  },
+
   index: {
     rebuild(): Promise<IndexRebuildResponse> {
       return request('/index/rebuild', { method: 'POST' });

--- a/clawjournal/web/frontend/src/bugReportDraft.test.ts
+++ b/clawjournal/web/frontend/src/bugReportDraft.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBugReportDraft,
+  deriveBrowserHost,
+  projectSupportContext,
+  safeRouteTemplate,
+} from './bugReportDraft.ts';
+
+const validContext = {
+  support_context_schema_version: 1,
+  kind: 'workbench',
+  package: { version: '0.2.0', revision: 'abcdef123456' },
+  runtime: {
+    python_version: '3.13.7',
+    sqlite_version: '3.49.1',
+    os_family: 'Linux',
+    os_release: '6.8.0',
+    architecture: 'x86_64',
+  },
+  schema: { expected_user_version: 12 },
+  storage: {
+    filesystem_type: 'nfs4',
+    storage_risk: 'network',
+    storage_migration_required: true,
+  },
+  index: { status: 'unavailable', condition: 'storage_migration_required' },
+  collection: { status: 'complete', unavailable_sections: [] },
+};
+
+describe('safeRouteTemplate', () => {
+  it('removes session ids, hashes, and all non-allowlisted query values', () => {
+    const canary = 'alice@purdue.edu-private-session';
+    expect(safeRouteTemplate({
+      pathname: `/session/${canary}`,
+      search: `?token=${canary}`,
+    })).toBe('/session/:id');
+    expect(safeRouteTemplate({
+      pathname: '/share',
+      search: `?step=review&ids=${canary}&queue_ref=${canary}`,
+    })).toBe('/share?step=review');
+    expect(safeRouteTemplate({ pathname: `/unknown/${canary}` })).toBe('/unknown');
+  });
+
+  it('does not echo malformed or unrecognized share steps', () => {
+    expect(safeRouteTemplate({ pathname: '/share', search: '?step=secret-project' })).toBe('/share');
+    expect(safeRouteTemplate({ pathname: '//evil.example/secret' })).toBe('/unknown');
+  });
+});
+
+describe('projectSupportContext', () => {
+  it('accepts the exact v1 allowlist and ignores unknown response fields', () => {
+    const canary = '/home/alice/session-123?token=secret';
+    const projected = projectSupportContext({
+      ...validContext,
+      database_path: canary,
+      error: canary,
+      package: { ...validContext.package, checkout_path: canary },
+    });
+    expect(projected).not.toBeNull();
+    expect(JSON.stringify(projected)).not.toContain(canary);
+    expect(projected?.index).toEqual(validContext.index);
+  });
+
+  it('rejects doctor payloads and malicious values in known fields', () => {
+    expect(projectSupportContext({
+      support_diagnostics_schema_version: 1,
+      kind: 'index',
+      index: { quick_check: { status: 'ok' } },
+    })).toBeNull();
+    expect(projectSupportContext({
+      ...validContext,
+      storage: { ...validContext.storage, filesystem_type: '/home/alice/private' },
+    })).toBeNull();
+    expect(projectSupportContext({
+      ...validContext,
+      collection: { status: 'partial', unavailable_sections: ['private_path'] },
+    })).toBeNull();
+  });
+
+  it('accepts safe partial context but rejects inconsistent collection status', () => {
+    expect(projectSupportContext({
+      ...validContext,
+      package: { ...validContext.package, revision: null },
+      collection: { status: 'partial', unavailable_sections: ['package_revision'] },
+    })?.collection).toEqual({
+      status: 'partial',
+      unavailable_sections: ['package_revision'],
+    });
+    expect(projectSupportContext({
+      ...validContext,
+      collection: { status: 'complete', unavailable_sections: ['package_revision'] },
+    })).toBeNull();
+    expect(projectSupportContext({
+      ...validContext,
+      collection: { status: 'partial', unavailable_sections: [] },
+    })).toBeNull();
+  });
+});
+
+describe('browser-host projection and draft rendering', () => {
+  it('derives only a fixed browser enum, major, and bounded display numbers', () => {
+    const canary = 'private-user-token';
+    const browser = deriveBrowserHost({
+      userAgent: `Mozilla/5.0 ${canary} Chrome/142.0.1 Safari/537.36`,
+      innerWidth: 1440.4,
+      innerHeight: 900.2,
+      devicePixelRatio: 1.257,
+    });
+    expect(browser).toEqual({
+      browser: 'Chrome',
+      major_version: 142,
+      viewport_css_pixels: { width: 1440, height: 900 },
+      device_pixel_ratio: 1.26,
+    });
+    expect(JSON.stringify(browser)).not.toContain(canary);
+
+    expect(deriveBrowserHost({
+      userAgent: 'private-only-agent',
+      innerWidth: 99_999,
+      innerHeight: -1,
+      devicePixelRatio: 100,
+    })).toEqual({
+      browser: 'unknown',
+      major_version: null,
+      viewport_css_pixels: { width: null, height: null },
+      device_pixel_ratio: null,
+    });
+  });
+
+  it('keeps browser and daemon context separate without raw route data', () => {
+    const routeCanary = 'session-alice-private';
+    const errorCanary = 'render failed at /home/alice/private';
+    const supportContext = projectSupportContext({ ...validContext, error: errorCanary });
+    const draft = buildBugReportDraft({
+      summary: 'Index unavailable',
+      whatHappened: 'The recovery screen remained open.',
+      expectedBehavior: 'The workbench should open.',
+      routeTemplate: safeRouteTemplate({ pathname: `/session/${routeCanary}` }),
+      surface: 'ui_render_error',
+      browserHost: deriveBrowserHost({
+        userAgent: `secret ${errorCanary} Firefox/141.0`,
+        innerWidth: 1200,
+        innerHeight: 800,
+        devicePixelRatio: 2,
+      }),
+      supportContext,
+    });
+
+    expect(draft).toContain('### Browser host');
+    expect(draft).toContain('### ClawJournal daemon runtime');
+    expect(draft).toContain('- Route: `/session/:id`');
+    expect(draft).toContain('- Screenshot: not captured');
+    expect(draft).not.toContain(routeCanary);
+    expect(draft).not.toContain(errorCanary);
+  });
+});

--- a/clawjournal/web/frontend/src/bugReportDraft.ts
+++ b/clawjournal/web/frontend/src/bugReportDraft.ts
@@ -1,0 +1,280 @@
+import type { SupportContext } from './types.ts';
+
+export const BUG_REPORT_URL = 'https://github.com/rayward-external/clawjournal/issues/new';
+export const BUG_REPORT_FILENAME = 'clawjournal-bug-report.md';
+export const BUG_REPORT_CONTEXT_TIMEOUT_MS = 5_000;
+export const MAX_BUG_REPORT_DRAFT_LENGTH = 20_000;
+
+export type BugReportSurface = 'workbench' | 'ui_render_error';
+export type BrowserName = 'Edge' | 'Chrome' | 'Firefox' | 'Safari' | 'unknown';
+
+export interface BugReportLocation {
+  pathname: string;
+  search?: string;
+}
+
+export interface BrowserHost {
+  browser: BrowserName;
+  major_version: number | null;
+  viewport_css_pixels: { width: number | null; height: number | null };
+  device_pixel_ratio: number | null;
+}
+
+export interface BrowserHostSource {
+  userAgent: string;
+  innerWidth: number;
+  innerHeight: number;
+  devicePixelRatio: number;
+}
+
+export interface BugReportDraftInput {
+  summary: string;
+  whatHappened: string;
+  expectedBehavior: string;
+  routeTemplate: string;
+  surface: BugReportSurface;
+  browserHost: BrowserHost;
+  supportContext: SupportContext | null;
+}
+
+const STATIC_ROUTE_TEMPLATES = new Set([
+  '/', '/search', '/analytics', '/analytics/insights', '/analytics/benchmark',
+  '/share', '/share/rules', '/settings',
+  // Pre-regroup routes remain valid bookmarks in App.tsx.
+  '/dashboard', '/insights', '/benchmark', '/bundles', '/policies',
+]);
+const SHARE_STEPS = new Set(['queue', 'redact', 'review', 'package', 'submit', 'done']);
+
+/** Return a finite route label without decoding or echoing identifiers or URLs. */
+export function safeRouteTemplate(location: BugReportLocation): string {
+  const pathname = typeof location.pathname === 'string' ? location.pathname : '';
+  if (/^\/session\/[^/]+\/?$/.test(pathname)) return '/session/:id';
+  if (!STATIC_ROUTE_TEMPLATES.has(pathname)) return '/unknown';
+  if (pathname !== '/share') return pathname;
+  const step = new URLSearchParams(location.search ?? '').get('step');
+  return step && SHARE_STEPS.has(step) ? `/share?step=${step}` : '/share';
+}
+
+type UnknownRecord = Record<string, unknown>;
+
+function record(value: unknown): UnknownRecord | null {
+  return value !== null && typeof value === 'object' && !Array.isArray(value)
+    ? value as UnknownRecord
+    : null;
+}
+
+function oneOf<const T extends string>(value: unknown, choices: readonly T[]): T | null {
+  return typeof value === 'string' && choices.includes(value as T) ? value as T : null;
+}
+
+function nullableSchemaVersion(value: unknown): number | null | undefined {
+  if (value === null) return null;
+  return Number.isInteger(value) && (value as number) >= 0 && (value as number) <= 1_000_000
+    ? value as number
+    : undefined;
+}
+
+function safePackageVersion(value: unknown): string | null {
+  return typeof value === 'string' && /^[0-9A-Za-z][0-9A-Za-z.+_-]{0,63}$/.test(value)
+    ? value
+    : null;
+}
+
+function safeNumericVersion(value: unknown): string | null {
+  return typeof value === 'string' && (value === 'unknown' || /^\d+(?:\.\d+){0,3}$/.test(value))
+    ? value
+    : null;
+}
+
+const OS_FAMILIES = ['Linux', 'Windows', 'macOS', 'FreeBSD', 'unknown'] as const;
+const ARCHITECTURES = ['x86', 'x86_64', 'arm64', 'ppc64le', 'riscv64', 's390x', 'unknown'] as const;
+const STORAGE_RISKS = ['network', 'local', 'unknown'] as const;
+const INDEX_STATUSES = ['ready', 'checking', 'recovery_required', 'rebuilding', 'unavailable', 'unknown'] as const;
+const INDEX_CONDITIONS = ['storage_migration_required', 'interrupted_recovery', 'recovery_required', 'unavailable'] as const;
+const COLLECTION_STATUSES = ['complete', 'partial'] as const;
+const UNAVAILABLE_SECTIONS = [
+  'package_version', 'package_revision', 'runtime_python', 'runtime_sqlite',
+  'runtime_os', 'runtime_architecture', 'expected_schema', 'cached_index_health',
+] as const;
+const FILESYSTEM_TYPES = new Set([
+  'unknown',
+  '9p', 'afs', 'beegfs', 'blobfuse', 'ceph', 'cifs', 'cvmfs', 'davfs',
+  'gfs2', 'gcsfuse', 'glusterfs', 'gpfs', 'juicefs', 'lustre', 'nfs', 'nfs4',
+  'ocfs2', 'orangefs', 'panfs', 'rclone', 's3fs', 'smbfs', 'sshfs', 'virtiofs', 'weka',
+  'apfs', 'btrfs', 'exfat', 'ext2', 'ext3', 'ext4', 'f2fs', 'hfs', 'hfsplus',
+  'jfs', 'ntfs', 'ntfs3', 'ramfs', 'reiserfs', 'tmpfs', 'ufs', 'vfat', 'xfs', 'zfs',
+  'autofs', 'cgroup', 'cgroup2', 'devtmpfs', 'ecryptfs', 'fuse', 'fuseblk',
+  'iso9660', 'nsfs', 'overlay', 'proc', 'squashfs', 'sysfs', 'udf',
+]);
+
+/**
+ * Project the v1 endpoint again in the browser. A doctor payload, future
+ * schema, extra object fields, and arbitrary strings can never reach a draft.
+ */
+export function projectSupportContext(value: unknown): SupportContext | null {
+  const root = record(value);
+  const packageInfo = record(root?.package);
+  const runtime = record(root?.runtime);
+  const schema = record(root?.schema);
+  const storage = record(root?.storage);
+  const index = record(root?.index);
+  const collection = record(root?.collection);
+  if (
+    !root || root.support_context_schema_version !== 1 || root.kind !== 'workbench'
+    || !packageInfo || !runtime || !schema || !storage || !index || !collection
+  ) return null;
+
+  const version = safePackageVersion(packageInfo.version);
+  const revision = packageInfo.revision === null
+    ? null
+    : typeof packageInfo.revision === 'string' && /^[0-9a-fA-F]{7,12}$/.test(packageInfo.revision)
+      ? packageInfo.revision.toLowerCase()
+      : undefined;
+  const pythonVersion = safeNumericVersion(runtime.python_version);
+  const sqliteVersion = safeNumericVersion(runtime.sqlite_version);
+  const osFamily = oneOf(runtime.os_family, OS_FAMILIES);
+  const osRelease = safeNumericVersion(runtime.os_release);
+  const architecture = oneOf(runtime.architecture, ARCHITECTURES);
+  const expectedUserVersion = nullableSchemaVersion(schema.expected_user_version);
+  const filesystemType = typeof storage.filesystem_type === 'string'
+    && FILESYSTEM_TYPES.has(storage.filesystem_type) ? storage.filesystem_type : null;
+  const storageRisk = oneOf(storage.storage_risk, STORAGE_RISKS);
+  const indexStatus = oneOf(index.status, INDEX_STATUSES);
+  const condition = index.condition === null
+    ? null : oneOf(index.condition, INDEX_CONDITIONS) ?? undefined;
+  const collectionStatus = oneOf(collection.status, COLLECTION_STATUSES);
+  const unavailable = Array.isArray(collection.unavailable_sections)
+    && collection.unavailable_sections.length <= UNAVAILABLE_SECTIONS.length
+    && collection.unavailable_sections.every(item => typeof item === 'string')
+    ? collection.unavailable_sections as string[] : null;
+  const unavailableSet = unavailable ? new Set(unavailable) : null;
+  const unavailableIsOrdered = unavailable !== null
+    && unavailableSet?.size === unavailable.length
+    && UNAVAILABLE_SECTIONS.filter(section => unavailableSet.has(section)).every(
+      (section, index) => unavailable[index] === section,
+    )
+    && unavailable.every(item => (UNAVAILABLE_SECTIONS as readonly string[]).includes(item));
+  const collectionIsConsistent = collectionStatus === 'complete'
+    ? unavailable?.length === 0
+    : (unavailable?.length ?? 0) > 0;
+
+  if (
+    !version || revision === undefined || !pythonVersion || !sqliteVersion
+    || !osFamily || !osRelease || !architecture || expectedUserVersion === undefined
+    || !filesystemType || !storageRisk || typeof storage.storage_migration_required !== 'boolean'
+    || !indexStatus || condition === undefined || !collectionStatus
+    || !unavailableIsOrdered || !collectionIsConsistent
+  ) return null;
+
+  return {
+    support_context_schema_version: 1,
+    kind: 'workbench',
+    package: { version, revision },
+    runtime: {
+      python_version: pythonVersion,
+      sqlite_version: sqliteVersion,
+      os_family: osFamily,
+      os_release: osRelease,
+      architecture,
+    },
+    schema: { expected_user_version: expectedUserVersion },
+    storage: {
+      filesystem_type: filesystemType,
+      storage_risk: storageRisk,
+      storage_migration_required: storage.storage_migration_required,
+    },
+    index: { status: indexStatus, condition },
+    collection: {
+      status: collectionStatus,
+      unavailable_sections: unavailable as SupportContext['collection']['unavailable_sections'],
+    },
+  };
+}
+
+function safeDimension(value: number): number | null {
+  return Number.isFinite(value) && value >= 0 && value <= 20_000 ? Math.round(value) : null;
+}
+
+function safeDevicePixelRatio(value: number): number | null {
+  return Number.isFinite(value) && value >= 0.1 && value <= 10
+    ? Math.round(value * 100) / 100 : null;
+}
+
+function browserIdentity(userAgent: string): Pick<BrowserHost, 'browser' | 'major_version'> {
+  const patterns: Array<[Exclude<BrowserName, 'unknown'>, RegExp]> = [
+    ['Edge', /\bEdg(?:A|iOS)?\/(\d{1,3})/],
+    ['Chrome', /\b(?:Chrome|CriOS)\/(\d{1,3})/],
+    ['Firefox', /\b(?:Firefox|FxiOS)\/(\d{1,3})/],
+  ];
+  for (const [browser, pattern] of patterns) {
+    const match = pattern.exec(userAgent);
+    if (match) {
+      const major = Number(match[1]);
+      return { browser, major_version: major >= 1 && major <= 999 ? major : null };
+    }
+  }
+  const safari = /\bSafari\//.test(userAgent) && /\bVersion\/(\d{1,3})/.exec(userAgent);
+  if (safari) {
+    const major = Number(safari[1]);
+    return { browser: 'Safari', major_version: major >= 1 && major <= 999 ? major : null };
+  }
+  return { browser: 'unknown', major_version: null };
+}
+
+/** Derive only a fixed browser enum and bounded numeric display properties. */
+export function deriveBrowserHost(source: BrowserHostSource): BrowserHost {
+  const identity = browserIdentity(
+    typeof source.userAgent === 'string' ? source.userAgent.slice(0, 512) : '',
+  );
+  return {
+    ...identity,
+    viewport_css_pixels: {
+      width: safeDimension(source.innerWidth),
+      height: safeDimension(source.innerHeight),
+    },
+    device_pixel_ratio: safeDevicePixelRatio(source.devicePixelRatio),
+  };
+}
+
+function singleLine(value: string, limit: number): string {
+  return value.replace(/[\r\n]+/g, ' ').split('\u0000').join('').trim().slice(0, limit);
+}
+
+function multiline(value: string, limit: number): string {
+  return value.replace(/\r\n?/g, '\n').split('\u0000').join('').trim().slice(0, limit);
+}
+
+function safeRouteTemplateLabel(value: string): string {
+  if (value === '/session/:id') return value;
+  if (/^\/share\?step=(queue|redact|review|package|submit|done)$/.test(value)) return value;
+  return safeRouteTemplate({ pathname: value });
+}
+
+export function buildBugReportDraft(input: BugReportDraftInput): string {
+  const summary = singleLine(input.summary, 120);
+  const whatHappened = multiline(input.whatHappened, 4_000);
+  const expectedBehavior = multiline(input.expectedBehavior, 2_000);
+  const surface = input.surface === 'ui_render_error' ? 'UI render error' : 'Workbench';
+  const route = safeRouteTemplateLabel(input.routeTemplate);
+  const daemonContext = input.supportContext
+    ? `\`\`\`json\n${JSON.stringify(input.supportContext, null, 2)}\n\`\`\``
+    : 'Daemon support context unavailable.';
+
+  return [
+    `# Bug report: ${summary}`,
+    '',
+    '## What happened / how to reproduce', '', whatHappened,
+    '',
+    '## Expected behavior', '', expectedBehavior || 'Not provided.',
+    '',
+    '## Report context', '',
+    `- Surface: ${surface}`,
+    `- Route: \`${route}\``,
+    '- Screenshot: not captured',
+    '',
+    '### Browser host', '',
+    `\`\`\`json\n${JSON.stringify(input.browserHost, null, 2)}\n\`\`\``,
+    '',
+    '### ClawJournal daemon runtime', '', daemonContext,
+  ].join('\n').slice(0, MAX_BUG_REPORT_DRAFT_LENGTH);
+}

--- a/clawjournal/web/frontend/src/components/BugReportDialog.test.tsx
+++ b/clawjournal/web/frontend/src/components/BugReportDialog.test.tsx
@@ -1,0 +1,221 @@
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../api.ts';
+import { BUG_REPORT_CONTEXT_TIMEOUT_MS, BUG_REPORT_FILENAME, BUG_REPORT_URL } from '../bugReportDraft.ts';
+import { BugReportDialog } from './BugReportDialog.tsx';
+
+const originalCreateObjectURL = Object.getOwnPropertyDescriptor(URL, 'createObjectURL');
+const originalRevokeObjectURL = Object.getOwnPropertyDescriptor(URL, 'revokeObjectURL');
+
+function restoreUrlMethod(name: 'createObjectURL' | 'revokeObjectURL', descriptor?: PropertyDescriptor) {
+  if (descriptor) Object.defineProperty(URL, name, descriptor);
+  else delete (URL as unknown as Record<string, unknown>)[name];
+}
+
+const supportContext = {
+  support_context_schema_version: 1,
+  kind: 'workbench',
+  package: { version: '0.2.0', revision: 'abcdef123456' },
+  runtime: {
+    python_version: '3.13.7',
+    sqlite_version: '3.49.1',
+    os_family: 'Linux',
+    os_release: '6.8.0',
+    architecture: 'x86_64',
+  },
+  schema: { expected_user_version: 12 },
+  storage: { filesystem_type: 'ext4', storage_risk: 'local', storage_migration_required: false },
+  index: { status: 'ready', condition: null },
+  collection: { status: 'complete', unavailable_sections: [] },
+};
+
+function fillRequiredFields() {
+  fireEvent.change(screen.getByLabelText(/Summary/), { target: { value: 'Workbench froze' } });
+  fireEvent.change(screen.getByLabelText(/What happened/), {
+    target: { value: 'I opened the review screen and the controls stopped responding.' },
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  delete (navigator as unknown as { clipboard?: Clipboard }).clipboard;
+  delete (navigator as unknown as { mediaDevices?: MediaDevices }).mediaDevices;
+  restoreUrlMethod('createObjectURL', originalCreateObjectURL);
+  restoreUrlMethod('revokeObjectURL', originalRevokeObjectURL);
+});
+
+describe('BugReportDialog', () => {
+  it('keeps collection local, enforces field bounds, and renders a reviewable draft', async () => {
+    const getDisplayMedia = vi.fn();
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getDisplayMedia },
+    });
+    const localSet = vi.spyOn(window.localStorage, 'setItem');
+    const sessionSet = vi.spyOn(window.sessionStorage, 'setItem');
+    vi.spyOn(api.support, 'context').mockResolvedValue({
+      ...supportContext,
+      raw_url: 'https://localhost/session/private?token=secret',
+      stack: 'at /home/alice/private.ts:1',
+    });
+    render(
+      <BugReportDialog
+        open
+        onClose={() => {}}
+        surface="workbench"
+        location={{ pathname: '/session/private-session-id', search: '?token=secret' }}
+      />,
+    );
+
+    expect(screen.getByText(/does not capture a screenshot, upload the draft, or submit an issue/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Summary/)).toHaveAttribute('maxlength', '120');
+    expect(screen.getByLabelText(/What happened/)).toHaveAttribute('maxlength', '4000');
+    expect(screen.getByLabelText(/Expected behavior/)).toHaveAttribute('maxlength', '2000');
+    await screen.findByText('Privacy-bounded local diagnostics are ready for review.');
+
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
+    const draft = screen.getByLabelText(/Review and edit the exact Markdown/) as HTMLTextAreaElement;
+    expect(draft.value).toContain('- Route: `/session/:id`');
+    expect(draft.value).toContain('### Browser host');
+    expect(draft.value).toContain('### ClawJournal daemon runtime');
+    expect(draft.value).not.toContain('private-session-id');
+    expect(draft.value).not.toContain('token=secret');
+    expect(draft.value).not.toContain('/home/alice');
+    expect(draft).toHaveAttribute('maxlength', '20000');
+    expect(getDisplayMedia).not.toHaveBeenCalled();
+    expect(localSet).not.toHaveBeenCalled();
+    expect(sessionSet).not.toHaveBeenCalled();
+  });
+
+  it('continues without diagnostics when the daemon is down', async () => {
+    vi.spyOn(api.support, 'context').mockRejectedValue(new TypeError('private daemon error /home/alice'));
+    render(<BugReportDialog open onClose={() => {}} surface="workbench" />);
+
+    expect(await screen.findByText(/Local diagnostics are unavailable/)).toBeInTheDocument();
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
+    const draft = screen.getByLabelText(/Review and edit the exact Markdown/) as HTMLTextAreaElement;
+    expect(draft.value).toContain('Daemon support context unavailable.');
+    expect(draft.value).not.toContain('private daemon error');
+    expect(screen.getByRole('button', { name: 'Copy draft' })).toBeEnabled();
+    expect(screen.getByRole('button', { name: 'Download .md' })).toBeEnabled();
+  });
+
+  it('times out a stuck local context request without trapping the reporter', async () => {
+    vi.useFakeTimers();
+    vi.spyOn(api.support, 'context').mockImplementation(signal => new Promise((_resolve, reject) => {
+      signal?.addEventListener('abort', () => reject(new DOMException('private timeout detail', 'AbortError')));
+    }));
+    render(<BugReportDialog open onClose={() => {}} surface="workbench" />);
+
+    await act(async () => {
+      vi.advanceTimersByTime(BUG_REPORT_CONTEXT_TIMEOUT_MS);
+      await Promise.resolve();
+    });
+    expect(screen.getByText(/Local diagnostics are unavailable/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Close bug report' })).toBeEnabled();
+  });
+
+  it('copies the exact edited draft and falls back to selecting it on denial', async () => {
+    vi.spyOn(api.support, 'context').mockResolvedValue(supportContext);
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } });
+    render(<BugReportDialog open onClose={() => {}} surface="workbench" />);
+    await screen.findByText('Privacy-bounded local diagnostics are ready for review.');
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
+    const draft = screen.getByLabelText(/Review and edit the exact Markdown/) as HTMLTextAreaElement;
+    fireEvent.change(draft, { target: { value: 'reviewed exact markdown' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Copy draft' }));
+    await waitFor(() => expect(writeText).toHaveBeenCalledWith('reviewed exact markdown'));
+
+    writeText.mockRejectedValueOnce(new DOMException('denied', 'NotAllowedError'));
+    fireEvent.click(screen.getByRole('button', { name: 'Copy draft' }));
+    expect(await screen.findByText(/press Ctrl\+C or Command\+C/)).toBeInTheDocument();
+    expect(draft).toHaveFocus();
+    expect(draft.selectionStart).toBe(0);
+    expect(draft.selectionEnd).toBe(draft.value.length);
+  });
+
+  it('downloads the exact edited Markdown with a fixed name and opens only a blank issue URL', async () => {
+    vi.spyOn(api.support, 'context').mockResolvedValue(supportContext);
+    let downloadedBlob: Blob | null = null;
+    const createObjectURL = vi.fn((blob: Blob) => {
+      downloadedBlob = blob;
+      return 'blob:test-report';
+    });
+    const revokeObjectURL = vi.fn();
+    Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL });
+    Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL });
+    let downloadedName = '';
+    const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+      downloadedName = this.download;
+    });
+    const { rerender } = render(
+      <BugReportDialog open onClose={() => {}} surface="workbench" />,
+    );
+    await screen.findByText('Privacy-bounded local diagnostics are ready for review.');
+    fillRequiredFields();
+    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
+    const draft = screen.getByLabelText(/Review and edit the exact Markdown/);
+    fireEvent.change(draft, { target: { value: 'final local draft' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Download .md' }));
+    expect(createObjectURL).toHaveBeenCalledOnce();
+    expect(downloadedName).toBe(BUG_REPORT_FILENAME);
+    expect(click).toHaveBeenCalledOnce();
+    expect(downloadedBlob).toBeInstanceOf(Blob);
+    const downloadedText = await new Promise<string>((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(String(reader.result));
+      reader.onerror = () => reject(reader.error);
+      reader.readAsText(downloadedBlob as Blob);
+    });
+    expect(downloadedText).toBe('final local draft');
+
+    const github = screen.getByRole('link', { name: 'Open blank GitHub issue' });
+    expect(github).toHaveAttribute('href', BUG_REPORT_URL);
+    expect(github.getAttribute('href')).not.toContain('?');
+    expect(github).toHaveAttribute('rel', 'noopener noreferrer');
+
+    rerender(<BugReportDialog open={false} onClose={() => {}} surface="workbench" />);
+    expect(revokeObjectURL).toHaveBeenCalledWith('blob:test-report');
+  });
+
+  it('traps focus, restores it on Escape, and preserves textarea Enter', async () => {
+    vi.spyOn(api.support, 'context').mockResolvedValue(supportContext);
+
+    function Harness() {
+      const [open, setOpen] = useState(false);
+      return (
+        <>
+          <button type="button" onClick={() => setOpen(true)}>Open reporter</button>
+          <BugReportDialog open={open} onClose={() => setOpen(false)} surface="workbench" />
+        </>
+      );
+    }
+
+    render(<Harness />);
+    const opener = screen.getByRole('button', { name: 'Open reporter' });
+    opener.focus();
+    fireEvent.click(opener);
+    const summary = screen.getByLabelText(/Summary/);
+    expect(summary).toHaveFocus();
+
+    const happened = screen.getByLabelText(/What happened/);
+    expect(fireEvent.keyDown(happened, { key: 'Enter' })).toBe(true);
+    fillRequiredFields();
+
+    const close = screen.getByRole('button', { name: 'Close bug report' });
+    close.focus();
+    fireEvent.keyDown(close, { key: 'Tab', shiftKey: true });
+    expect(screen.getByRole('button', { name: 'Review draft' })).toHaveFocus();
+
+    fireEvent.keyDown(document.activeElement as HTMLElement, { key: 'Escape' });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(opener).toHaveFocus();
+  });
+});

--- a/clawjournal/web/frontend/src/components/BugReportDialog.tsx
+++ b/clawjournal/web/frontend/src/components/BugReportDialog.tsx
@@ -1,0 +1,394 @@
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
+import { api } from '../api.ts';
+import {
+  BUG_REPORT_CONTEXT_TIMEOUT_MS,
+  BUG_REPORT_FILENAME,
+  BUG_REPORT_URL,
+  MAX_BUG_REPORT_DRAFT_LENGTH,
+  buildBugReportDraft,
+  deriveBrowserHost,
+  projectSupportContext,
+  safeRouteTemplate,
+} from '../bugReportDraft.ts';
+import type { BugReportLocation, BugReportSurface } from '../bugReportDraft.ts';
+import type { SupportContext } from '../types.ts';
+import { btnPrimary, btnSecondary, colors, fontFamily, inputStyle, labelStyle } from '../theme.ts';
+
+interface BugReportDialogProps {
+  open: boolean;
+  onClose: () => void;
+  surface: BugReportSurface;
+  location?: BugReportLocation;
+}
+
+type DiagnosticsState = 'loading' | 'ready' | 'unavailable';
+type DialogStage = 'compose' | 'review';
+
+const FOCUSABLE_SELECTOR = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'textarea:not([disabled])',
+  'select:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+export function BugReportDialog({ open, onClose, surface, location }: BugReportDialogProps) {
+  const [stage, setStage] = useState<DialogStage>('compose');
+  const [summary, setSummary] = useState('');
+  const [whatHappened, setWhatHappened] = useState('');
+  const [expectedBehavior, setExpectedBehavior] = useState('');
+  const [diagnosticsState, setDiagnosticsState] = useState<DiagnosticsState>('loading');
+  const [supportContext, setSupportContext] = useState<SupportContext | null>(null);
+  const [draft, setDraft] = useState('');
+  const [actionStatus, setActionStatus] = useState('');
+  const dialogRef = useRef<HTMLDivElement>(null);
+  const summaryRef = useRef<HTMLInputElement>(null);
+  const draftRef = useRef<HTMLTextAreaElement>(null);
+  const downloadUrlRef = useRef<string | null>(null);
+  const downloadTimerRef = useRef<number | null>(null);
+  const titleId = useId();
+  const privacyId = useId();
+  const diagnosticsId = useId();
+
+  const releaseDownloadUrl = useCallback(() => {
+    if (downloadTimerRef.current !== null) {
+      window.clearTimeout(downloadTimerRef.current);
+      downloadTimerRef.current = null;
+    }
+    if (downloadUrlRef.current !== null) {
+      URL.revokeObjectURL(downloadUrlRef.current);
+      downloadUrlRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      releaseDownloadUrl();
+      return;
+    }
+    return releaseDownloadUrl;
+  }, [open, releaseDownloadUrl]);
+
+  useEffect(() => {
+    if (!open) return;
+    const previousFocus = document.activeElement as HTMLElement | null;
+    return () => previousFocus?.focus?.();
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    if (stage === 'review') draftRef.current?.focus();
+    else summaryRef.current?.focus();
+  }, [open, stage]);
+
+  useEffect(() => {
+    if (!open) return;
+    const controller = new AbortController();
+    let active = true;
+    setDiagnosticsState('loading');
+    setSupportContext(null);
+    const timeout = window.setTimeout(
+      () => controller.abort(),
+      BUG_REPORT_CONTEXT_TIMEOUT_MS,
+    );
+
+    void api.support.context(controller.signal)
+      .then(raw => {
+        if (!active) return;
+        const projected = projectSupportContext(raw);
+        setSupportContext(projected);
+        setDiagnosticsState(projected ? 'ready' : 'unavailable');
+      })
+      .catch(() => {
+        if (!active) return;
+        setSupportContext(null);
+        setDiagnosticsState('unavailable');
+      })
+      .finally(() => window.clearTimeout(timeout));
+
+    return () => {
+      active = false;
+      controller.abort();
+      window.clearTimeout(timeout);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        event.stopPropagation();
+        onClose();
+        return;
+      }
+      if (event.key !== 'Tab') {
+        // Keep route-level shortcuts from acting behind the modal. In
+        // particular, Enter remains untouched so textareas keep newlines.
+        event.stopPropagation();
+        return;
+      }
+
+      const focusables = Array.from(
+        dialogRef.current?.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR) ?? [],
+      ).filter(element => element.getAttribute('aria-hidden') !== 'true');
+      if (focusables.length === 0) {
+        event.preventDefault();
+        event.stopPropagation();
+        return;
+      }
+      const first = focusables[0];
+      const last = focusables[focusables.length - 1];
+      if (!dialogRef.current?.contains(document.activeElement)) {
+        event.preventDefault();
+        first.focus();
+      } else if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+      event.stopPropagation();
+    };
+    window.addEventListener('keydown', handleKeyDown, true);
+    return () => window.removeEventListener('keydown', handleKeyDown, true);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const reviewDraft = () => {
+    const currentLocation = location ?? {
+      pathname: window.location.pathname,
+      search: window.location.search,
+    };
+    setDraft(buildBugReportDraft({
+      summary,
+      whatHappened,
+      expectedBehavior,
+      routeTemplate: safeRouteTemplate(currentLocation),
+      surface,
+      browserHost: deriveBrowserHost({
+        userAgent: navigator.userAgent,
+        innerWidth: window.innerWidth,
+        innerHeight: window.innerHeight,
+        devicePixelRatio: window.devicePixelRatio,
+      }),
+      supportContext: diagnosticsState === 'ready' ? supportContext : null,
+    }));
+    setActionStatus('');
+    setStage('review');
+  };
+
+  const copyDraft = async () => {
+    try {
+      if (!navigator.clipboard?.writeText) throw new Error('clipboard unavailable');
+      await navigator.clipboard.writeText(draft);
+      setActionStatus('Draft copied to the clipboard.');
+    } catch {
+      draftRef.current?.focus();
+      draftRef.current?.select();
+      setActionStatus('Clipboard access was unavailable. The draft is selected; press Ctrl+C or Command+C.');
+    }
+  };
+
+  const downloadDraft = () => {
+    releaseDownloadUrl();
+    const blob = new Blob([draft], { type: 'text/markdown;charset=utf-8' });
+    const url = URL.createObjectURL(blob);
+    downloadUrlRef.current = url;
+    const anchor = document.createElement('a');
+    anchor.href = url;
+    anchor.download = BUG_REPORT_FILENAME;
+    anchor.rel = 'noopener';
+    document.body.appendChild(anchor);
+    anchor.click();
+    anchor.remove();
+    downloadTimerRef.current = window.setTimeout(() => {
+      if (downloadUrlRef.current === url) {
+        URL.revokeObjectURL(url);
+        downloadUrlRef.current = null;
+      }
+      downloadTimerRef.current = null;
+    }, 60_000);
+    setActionStatus(`Downloaded ${BUG_REPORT_FILENAME}.`);
+  };
+
+  const canReview = summary.trim().length > 0 && whatHappened.trim().length > 0;
+
+  return (
+    <div style={{
+      position: 'fixed',
+      inset: 0,
+      zIndex: 10_000,
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      padding: 20,
+      background: 'rgba(27, 26, 23, 0.42)',
+      fontFamily,
+    }}>
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        aria-describedby={`${privacyId} ${diagnosticsId}`}
+        style={{
+          width: 'min(680px, 100%)',
+          maxHeight: '90vh',
+          overflow: 'auto',
+          padding: '24px 26px',
+          borderRadius: 12,
+          border: `1px solid ${colors.gray200}`,
+          background: colors.white,
+          boxShadow: '0 18px 60px rgba(27, 26, 23, 0.24)',
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'flex-start', gap: 16 }}>
+          <div style={{ flex: 1 }}>
+            <h2 id={titleId} style={{ margin: '0 0 6px', color: colors.gray900, fontSize: 20 }}>
+              Report a problem
+            </h2>
+            <p id={privacyId} style={{ margin: 0, color: colors.gray600, fontSize: 13.5, lineHeight: 1.55 }}>
+              This draft stays in this browser tab. ClawJournal does not capture a screenshot, upload the draft, or submit an issue. Review and remove sensitive information before sharing it.
+            </p>
+          </div>
+          <button type="button" onClick={onClose} aria-label="Close bug report" style={{
+            ...btnSecondary,
+            flexShrink: 0,
+            padding: '5px 10px',
+          }}>
+            Close
+          </button>
+        </div>
+
+        <div id={diagnosticsId} role="status" aria-live="polite" style={{
+          marginTop: 14,
+          padding: '8px 10px',
+          borderRadius: 7,
+          background: diagnosticsState === 'unavailable' ? colors.yellow50 : colors.gray50,
+          color: diagnosticsState === 'unavailable' ? colors.yellow700 : colors.gray500,
+          fontSize: 12.5,
+        }}>
+          {diagnosticsState === 'loading' && 'Checking privacy-bounded local diagnostics… You can continue without waiting.'}
+          {diagnosticsState === 'ready' && 'Privacy-bounded local diagnostics are ready for review.'}
+          {diagnosticsState === 'unavailable' && 'Local diagnostics are unavailable. You can still create, copy, and download the report.'}
+        </div>
+
+        {stage === 'compose' ? (
+          <form onSubmit={event => { event.preventDefault(); if (canReview) reviewDraft(); }} style={{ marginTop: 16 }}>
+            <label htmlFor={`${titleId}-summary`} style={labelStyle}>
+              Summary <span aria-hidden="true">*</span>
+            </label>
+            <input
+              ref={summaryRef}
+              id={`${titleId}-summary`}
+              required
+              maxLength={120}
+              value={summary}
+              onChange={event => setSummary(event.target.value)}
+              style={inputStyle}
+            />
+            <div style={{ textAlign: 'right', color: colors.gray400, fontSize: 11.5 }}>{summary.length}/120</div>
+
+            <label htmlFor={`${titleId}-happened`} style={labelStyle}>
+              What happened / how to reproduce <span aria-hidden="true">*</span>
+            </label>
+            <textarea
+              id={`${titleId}-happened`}
+              required
+              maxLength={4_000}
+              rows={7}
+              value={whatHappened}
+              onChange={event => setWhatHappened(event.target.value)}
+              style={{ ...inputStyle, resize: 'vertical', lineHeight: 1.45 }}
+            />
+            <div style={{ textAlign: 'right', color: colors.gray400, fontSize: 11.5 }}>{whatHappened.length}/4000</div>
+
+            <label htmlFor={`${titleId}-expected`} style={labelStyle}>Expected behavior (optional)</label>
+            <textarea
+              id={`${titleId}-expected`}
+              maxLength={2_000}
+              rows={4}
+              value={expectedBehavior}
+              onChange={event => setExpectedBehavior(event.target.value)}
+              style={{ ...inputStyle, resize: 'vertical', lineHeight: 1.45 }}
+            />
+            <div style={{ textAlign: 'right', color: colors.gray400, fontSize: 11.5 }}>{expectedBehavior.length}/2000</div>
+
+            <div style={{ display: 'flex', justifyContent: 'flex-end', marginTop: 18 }}>
+              <button
+                type="submit"
+                disabled={!canReview}
+                style={{
+                  ...btnPrimary,
+                  opacity: canReview ? 1 : 0.55,
+                  cursor: canReview ? 'pointer' : 'not-allowed',
+                }}
+              >
+                Review draft
+              </button>
+            </div>
+          </form>
+        ) : (
+          <div style={{ marginTop: 16 }}>
+            <label htmlFor={`${titleId}-draft`} style={{ ...labelStyle, marginTop: 0 }}>
+              Review and edit the exact Markdown that you may choose to share
+            </label>
+            <textarea
+              ref={draftRef}
+              id={`${titleId}-draft`}
+              maxLength={MAX_BUG_REPORT_DRAFT_LENGTH}
+              rows={18}
+              value={draft}
+              onChange={event => {
+                setDraft(event.target.value.slice(0, MAX_BUG_REPORT_DRAFT_LENGTH));
+                setActionStatus('');
+              }}
+              style={{
+                ...inputStyle,
+                resize: 'vertical',
+                lineHeight: 1.45,
+                fontFamily: "ui-monospace, SFMono-Regular, Consolas, monospace",
+                fontSize: 12.5,
+              }}
+            />
+            <p style={{ margin: '8px 0 0', color: colors.gray500, fontSize: 12.5, lineHeight: 1.5 }}>
+              Copy or download only after reviewing this text. Opening GitHub sends none of it automatically.
+            </p>
+            <div role="status" aria-live="polite" style={{ minHeight: 20, marginTop: 6, color: colors.blue700, fontSize: 12.5 }}>
+              {actionStatus}
+            </div>
+            <div style={{
+              display: 'flex',
+              flexWrap: 'wrap',
+              justifyContent: 'flex-end',
+              gap: 8,
+              marginTop: 10,
+            }}>
+              <button type="button" onClick={() => { setStage('compose'); setActionStatus(''); }} style={btnSecondary}>
+                Back
+              </button>
+              <button type="button" onClick={() => void copyDraft()} style={btnSecondary}>
+                Copy draft
+              </button>
+              <button type="button" onClick={downloadDraft} style={btnSecondary}>
+                Download .md
+              </button>
+              <a
+                href={BUG_REPORT_URL}
+                target="_blank"
+                rel="noopener noreferrer"
+                style={{ ...btnPrimary, display: 'inline-block', textDecoration: 'none' }}
+              >
+                Open blank GitHub issue
+              </a>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/clawjournal/web/frontend/src/components/ErrorBoundary.tsx
+++ b/clawjournal/web/frontend/src/components/ErrorBoundary.tsx
@@ -6,13 +6,19 @@ interface State {
   message: string;
 }
 
+interface ErrorBoundaryProps {
+  children: ReactNode;
+  /** Reports only that a render failure occurred; raw error data stays local. */
+  onError?: () => void;
+}
+
 /**
  * App-wide error boundary. A render-time exception anywhere in the tree would
  * otherwise white-screen the workbench; this shows a styled fallback with the
  * error message and a reload affordance instead. Must be a class component —
  * React error boundaries cannot be function components.
  */
-export class ErrorBoundary extends Component<{ children: ReactNode }, State> {
+export class ErrorBoundary extends Component<ErrorBoundaryProps, State> {
   state: State = { hasError: false, message: '' };
 
   static getDerivedStateFromError(err: unknown): State {
@@ -21,6 +27,7 @@ export class ErrorBoundary extends Component<{ children: ReactNode }, State> {
 
   componentDidCatch(err: unknown): void {
     console.error('ClawJournal UI error:', err);
+    this.props.onError?.();
   }
 
   render(): ReactNode {

--- a/clawjournal/web/frontend/src/components/GlobalBugReport.test.tsx
+++ b/clawjournal/web/frontend/src/components/GlobalBugReport.test.tsx
@@ -1,0 +1,54 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../api.ts';
+import { IndexRecoveryScreen } from './IndexRecoveryScreen.tsx';
+import { GlobalBugReport } from './GlobalBugReport.tsx';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('GlobalBugReport', () => {
+  it('keeps a non-overlapping global launcher on the normal workbench', () => {
+    render(<GlobalBugReport><main>Normal workbench</main></GlobalBugReport>);
+    expect(screen.getByText('Normal workbench')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Report a problem' })).toHaveStyle({ bottom: '72px' });
+  });
+
+  it.each([
+    ['recovery_required' as const, 'Your local index needs repair'],
+    ['unavailable' as const, 'The local index is unavailable'],
+  ])('keeps the launcher available while index state is %s', (status, heading) => {
+    render(
+      <GlobalBugReport>
+        <IndexRecoveryScreen
+          health={{ status, message: 'The local index cannot serve workbench views.' }}
+          onHealthChange={() => {}}
+        />
+      </GlobalBugReport>,
+    );
+    expect(screen.getByRole('heading', { name: heading })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Report a problem' })).toBeInTheDocument();
+  });
+
+  it('survives a React render crash without adding the raw error to the draft', async () => {
+    const canary = 'render failed at /home/alice/private-session?token=secret';
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(api.support, 'context').mockRejectedValue(new TypeError('daemon unavailable'));
+    function Crasher(): never {
+      throw new Error(canary);
+    }
+
+    render(<GlobalBugReport><Crasher /></GlobalBugReport>);
+    expect(await screen.findByRole('heading', { name: 'Something went wrong' })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: 'Report a problem' }));
+    fireEvent.change(screen.getByLabelText(/Summary/), { target: { value: 'Unexpected UI failure' } });
+    fireEvent.change(screen.getByLabelText(/What happened/), { target: { value: 'The page stopped rendering.' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Review draft' }));
+
+    const draft = screen.getByLabelText(/Review and edit the exact Markdown/) as HTMLTextAreaElement;
+    expect(draft.value).toContain('- Surface: UI render error');
+    expect(draft.value).not.toContain(canary);
+    expect(draft.value).not.toContain('/home/alice');
+  });
+});

--- a/clawjournal/web/frontend/src/components/GlobalBugReport.tsx
+++ b/clawjournal/web/frontend/src/components/GlobalBugReport.tsx
@@ -1,0 +1,79 @@
+import { Component, useState } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+import { BUG_REPORT_URL } from '../bugReportDraft.ts';
+import type { BugReportSurface } from '../bugReportDraft.ts';
+import { colors, fontFamily } from '../theme.ts';
+import { ErrorBoundary } from './ErrorBoundary.tsx';
+import { BugReportDialog } from './BugReportDialog.tsx';
+
+class BugReportSafetyBoundary extends Component<{ children: ReactNode }, { failed: boolean }> {
+  state = { failed: false };
+
+  static getDerivedStateFromError(): { failed: boolean } {
+    return { failed: true };
+  }
+
+  render(): ReactNode {
+    if (!this.state.failed) return this.props.children;
+    return (
+      <a
+        href={BUG_REPORT_URL}
+        target="_blank"
+        rel="noopener noreferrer"
+        style={launcherStyle}
+      >
+        Open GitHub issues
+      </a>
+    );
+  }
+}
+
+const launcherStyle: CSSProperties = {
+  position: 'fixed',
+  right: 20,
+  // Toasts occupy bottom/right=20 at z-index 9999.
+  bottom: 72,
+  zIndex: 9_500,
+  padding: '8px 12px',
+  border: `1px solid ${colors.gray300}`,
+  borderRadius: 999,
+  background: colors.white,
+  color: colors.gray700,
+  boxShadow: '0 4px 16px rgba(42, 40, 37, 0.12)',
+  cursor: 'pointer',
+  fontFamily,
+  fontSize: 12.5,
+  fontWeight: 600,
+  lineHeight: 1.2,
+  textDecoration: 'none',
+};
+
+function BugReportLauncher({ surface }: { surface: BugReportSurface }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <button type="button" onClick={() => setOpen(true)} style={launcherStyle}>
+        Report a problem
+      </button>
+      <BugReportDialog open={open} onClose={() => setOpen(false)} surface={surface} />
+    </>
+  );
+}
+
+/**
+ * Keep the reporter outside the workbench error boundary so ready, recovery,
+ * unavailable, and render-crash screens all retain the same local-only entry.
+ */
+export function GlobalBugReport({ children }: { children: ReactNode }) {
+  const [surface, setSurface] = useState<BugReportSurface>('workbench');
+  return (
+    <>
+      <ErrorBoundary onError={() => setSurface('ui_render_error')}>
+        {children}
+      </ErrorBoundary>
+      <BugReportSafetyBoundary>
+        <BugReportLauncher surface={surface} />
+      </BugReportSafetyBoundary>
+    </>
+  );
+}

--- a/clawjournal/web/frontend/src/main.tsx
+++ b/clawjournal/web/frontend/src/main.tsx
@@ -2,14 +2,14 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import './index.css'
 import App from './App.tsx'
-import { ErrorBoundary } from './components/ErrorBoundary.tsx'
+import { GlobalBugReport } from './components/GlobalBugReport.tsx'
 import { api } from './api.ts'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <ErrorBoundary>
+    <GlobalBugReport>
       <App />
-    </ErrorBoundary>
+    </GlobalBugReport>
   </StrictMode>,
 )
 

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -263,6 +263,52 @@ export interface Features {
   index_health: IndexHealth;
 }
 
+/**
+ * The privacy-bounded subset accepted by the bug-report UI. The browser
+ * constructs this value with a strict allowlist instead of trusting the raw
+ * daemon response.
+ */
+export interface SupportContext {
+  support_context_schema_version: 1;
+  kind: 'workbench';
+  package: {
+    version: string;
+    revision: string | null;
+  };
+  runtime: {
+    python_version: string;
+    sqlite_version: string;
+    os_family: 'Linux' | 'Windows' | 'macOS' | 'FreeBSD' | 'unknown';
+    os_release: string;
+    architecture: 'x86' | 'x86_64' | 'arm64' | 'ppc64le' | 'riscv64' | 's390x' | 'unknown';
+  };
+  schema: {
+    expected_user_version: number | null;
+  };
+  storage: {
+    filesystem_type: string;
+    storage_risk: 'network' | 'local' | 'unknown';
+    storage_migration_required: boolean;
+  };
+  index: {
+    status: 'ready' | 'checking' | 'recovery_required' | 'rebuilding' | 'unavailable' | 'unknown';
+    condition: 'storage_migration_required' | 'interrupted_recovery' | 'recovery_required' | 'unavailable' | null;
+  };
+  collection: {
+    status: 'complete' | 'partial';
+    unavailable_sections: Array<
+      | 'package_version'
+      | 'package_revision'
+      | 'runtime_python'
+      | 'runtime_sqlite'
+      | 'runtime_os'
+      | 'runtime_architecture'
+      | 'expected_schema'
+      | 'cached_index_health'
+    >;
+  };
+}
+
 export interface WorkbenchConfig {
   source: string | null;
   projects_confirmed: boolean;

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -49,6 +49,12 @@ from ..scoring.overrides import (
     normalize_failure_evidence,
     requires_failure_evidence,
 )
+from ..support_context import (
+    SupportEnvironment,
+    capture_support_environment,
+    collect_support_context,
+    unavailable_support_context,
+)
 from ..config import (
     CONFIG_DIR,
     RECURRING_ENROLLMENT_GRANT_CONFIG_KEYS,
@@ -99,6 +105,7 @@ from .index import (
     _validate_hold_target,
     update_session,
     upsert_sessions,
+    WORKBENCH_SCHEMA_VERSION,
 )
 from .index_recovery import (
     UnsafeIndexRecovery,
@@ -109,6 +116,7 @@ from .index_recovery import (
     initialize_index_health,
     inspect_index_health,
     synchronize_index_health,
+    try_current_index_health,
 )
 from .timeline import (
     canonical_session_path,
@@ -1357,12 +1365,20 @@ def _api_token_cookie_header(token: str) -> str:
     )
 
 
-def _json_response(handler: BaseHTTPRequestHandler, data: Any, status: int = 200) -> None:
+def _json_response(
+    handler: BaseHTTPRequestHandler,
+    data: Any,
+    status: int = 200,
+    *,
+    cache_control: str | None = None,
+) -> None:
     """Send a JSON response."""
     body = json.dumps(data, default=str).encode("utf-8")
     handler.send_response(status)
     handler.send_header("Content-Type", "application/json")
     handler.send_header("Content-Length", str(len(body)))
+    if cache_control is not None:
+        handler.send_header("Cache-Control", cache_control)
     origin = _cors_origin(handler)
     if origin:
         handler.send_header("Access-Control-Allow-Origin", origin)
@@ -3991,6 +4007,10 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         # can render recovery guidance without touching the damaged index.
         elif path == "/api/features":
             self._handle_features()
+        # Support drafting must remain available when the index is unhealthy.
+        # It projects only startup metadata and the in-memory health snapshot.
+        elif path == "/api/support-context":
+            self._handle_support_context()
         elif path.startswith("/api/") and self._reject_unhealthy_index():
             return
         # API routes
@@ -5128,6 +5148,21 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             "scoring_warmup_declined": bool(config.get("scoring_warmup_declined", False)),
             "index_health": synchronize_index_health(),
         })
+
+    def _handle_support_context(self) -> None:
+        """Return a DB-free, strictly allowlisted support-report snapshot."""
+
+        try:
+            environment = getattr(self.server, "_support_environment", None)
+            payload = collect_support_context(
+                environment,
+                try_current_index_health(),
+            )
+        except Exception:
+            # Never place exception text or a traceback in the response. The
+            # local report draft remains useful with a fixed partial marker.
+            payload = unavailable_support_context()
+        _json_response(self, payload, cache_control="no-store")
 
     def _handle_index_rebuild(self) -> None:
         """Start the one-click, backup-first index rebuild in the background."""
@@ -7254,6 +7289,7 @@ def _try_serve_ipv6_loopback(
     port: int,
     scanner: "Scanner",
     frontend_snapshot: FrontendSnapshot | None = None,
+    support_environment: SupportEnvironment | None = None,
 ) -> ThreadingHTTPServer | None:
     """Start a companion IPv6 (``::1``) loopback server on ``port``, serving in a
     daemon thread with the same handler/scanner as the primary IPv4 server.
@@ -7277,6 +7313,7 @@ def _try_serve_ipv6_loopback(
         return None
     v6._scanner = scanner  # type: ignore[attr-defined]
     v6._frontend_snapshot = frontend_snapshot  # type: ignore[attr-defined]
+    v6._support_environment = support_environment  # type: ignore[attr-defined]
     threading.Thread(target=v6.serve_forever, daemon=True).start()
     return v6
 
@@ -7309,6 +7346,21 @@ def run_server(
     scanner = Scanner(source_filter=source_filter)
     _open_request_admission()
 
+    support_revision = startup_head
+    if support_revision is None and frontend_snapshot is not None:
+        support_revision = frontend_snapshot.revision
+    try:
+        support_environment = capture_support_environment(
+            revision=support_revision,
+            expected_user_version=WORKBENCH_SCHEMA_VERSION,
+            # Reading this module constant does not open an SQLite database.
+            sqlite_version=sqlite3.sqlite_version,
+        )
+    except Exception:
+        # Collection is best-effort and must never prevent the workbench from
+        # starting. The endpoint will render this as a fixed partial payload.
+        support_environment = None
+
     # Start HTTP server first so it's responsive immediately. The primary socket
     # is IPv4 127.0.0.1 — what the CLI health probe, curl, and SSH `-L` tunnels
     # expect.
@@ -7321,6 +7373,7 @@ def run_server(
         port = server.server_address[1]
     server._scanner = scanner  # type: ignore[attr-defined]
     server._frontend_snapshot = frontend_snapshot  # type: ignore[attr-defined]
+    server._support_environment = support_environment  # type: ignore[attr-defined]
 
     # Publish a non-ready state only after the primary socket binds. A rejected
     # launch (for example, the desktop port is already occupied) must not leave
@@ -7333,7 +7386,12 @@ def run_server(
     # IPv4-only daemon leaves the workbench unreachable via localhost on
     # IPv6-preferring systems. Each family is its own ::1 / 127.0.0.1 loopback
     # socket — nothing is exposed beyond the local host.
-    v6_server = _try_serve_ipv6_loopback(port, scanner, frontend_snapshot)
+    v6_server = _try_serve_ipv6_loopback(
+        port,
+        scanner,
+        frontend_snapshot,
+        support_environment,
+    )
 
     url = f"http://localhost:{port}/"
     logger.info("Workbench running at %s", url)

--- a/clawjournal/workbench/index_recovery.py
+++ b/clawjournal/workbench/index_recovery.py
@@ -375,6 +375,23 @@ def current_index_health() -> dict[str, Any]:
         return dict(_INDEX_HEALTH)
 
 
+def try_current_index_health() -> dict[str, Any] | None:
+    """Return the cached health without waiting for recovery I/O.
+
+    Guided recovery deliberately holds ``_STATE_LOCK`` across parts of its
+    state transition. Support-report drafting must remain responsive even if
+    that work is blocked on storage, so its read path treats a busy lock as an
+    unavailable optional section instead of waiting.
+    """
+
+    if not _STATE_LOCK.acquire(blocking=False):
+        return None
+    try:
+        return dict(_INDEX_HEALTH)
+    finally:
+        _STATE_LOCK.release()
+
+
 def begin_index_health_check() -> dict[str, Any]:
     """Publish the fail-closed startup state before HTTP begins serving."""
 

--- a/tests/test_support_context.py
+++ b/tests/test_support_context.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import json
+
+from clawjournal import support_context
+
+
+def _environment(monkeypatch) -> support_context.SupportEnvironment:
+    monkeypatch.setattr(support_context.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(support_context.platform, "release", lambda: "6.8.0-generic")
+    monkeypatch.setattr(support_context.platform, "machine", lambda: "x86_64")
+    return support_context.capture_support_environment(
+        revision="a" * 40,
+        expected_user_version=12,
+        sqlite_version="3.49.1",
+    )
+
+
+def test_collect_support_context_has_an_exact_allowlisted_shape(monkeypatch):
+    environment = _environment(monkeypatch)
+
+    report = support_context.collect_support_context(
+        environment,
+        {
+            "status": "unavailable",
+            "code": "storage_migration_required",
+            "filesystem_type": "nfs4",
+            "storage_risk": "network",
+            "storage_migration_required": True,
+        },
+    )
+
+    assert report == {
+        "support_context_schema_version": 1,
+        "kind": "workbench",
+        "package": {"version": "0.2.0", "revision": "a" * 12},
+        "runtime": {
+            "python_version": (
+                f"{support_context.sys.version_info.major}."
+                f"{support_context.sys.version_info.minor}."
+                f"{support_context.sys.version_info.micro}"
+            ),
+            "sqlite_version": "3.49.1",
+            "os_family": "Linux",
+            "os_release": "6.8.0",
+            "architecture": "x86_64",
+        },
+        "schema": {"expected_user_version": 12},
+        "storage": {
+            "filesystem_type": "nfs4",
+            "storage_risk": "network",
+            "storage_migration_required": True,
+        },
+        "index": {
+            "status": "unavailable",
+            "condition": "storage_migration_required",
+        },
+        "collection": {"status": "complete", "unavailable_sections": []},
+    }
+
+
+def test_malicious_startup_and_health_fields_cannot_escape_allowlist(
+    monkeypatch,
+):
+    canary = "alice-private /home/alice/session-123?token=secret"
+    monkeypatch.setattr(support_context, "__version__", canary)
+    monkeypatch.setattr(support_context.platform, "system", lambda: canary)
+    monkeypatch.setattr(support_context.platform, "release", lambda: canary)
+    monkeypatch.setattr(support_context.platform, "machine", lambda: canary)
+    environment = support_context.capture_support_environment(
+        revision=canary,
+        expected_user_version=canary,
+        sqlite_version=canary,
+    )
+
+    report = support_context.collect_support_context(
+        environment,
+        {
+            "status": canary,
+            "code": canary,
+            "filesystem_type": "fuse.alice_private_mount",
+            "storage_risk": canary,
+            "message": canary,
+            "detail": canary,
+            "database_path": canary,
+            "backup_path": canary,
+            "session_id": canary,
+            "project": canary,
+        },
+    )
+    serialized = json.dumps(report)
+
+    assert canary not in serialized
+    assert "/home/" not in serialized
+    assert "session_id" not in serialized
+    assert "database_path" not in serialized
+    assert report["package"] == {"version": "unknown", "revision": None}
+    assert report["storage"] == {
+        "filesystem_type": "unknown",
+        "storage_risk": "unknown",
+        "storage_migration_required": False,
+    }
+    assert report["index"] == {"status": "unknown", "condition": None}
+    assert report["collection"]["status"] == "partial"
+    assert set(report["collection"]["unavailable_sections"]) == {
+        "package_version",
+        "package_revision",
+        "runtime_sqlite",
+        "runtime_os",
+        "runtime_architecture",
+        "expected_schema",
+        "cached_index_health",
+    }
+
+
+def test_process_local_environment_is_revalidated_before_serialization():
+    canary = "alice-private /home/alice/session-123?token=secret"
+    environment = support_context.SupportEnvironment(
+        package_version=canary,
+        package_revision=canary,
+        python_version=canary,
+        sqlite_version=canary,
+        os_family=canary,
+        os_release=canary,
+        architecture=canary,
+        expected_user_version=canary,  # type: ignore[arg-type]
+        unavailable_sections=(canary,),
+    )
+
+    report = support_context.collect_support_context(
+        environment,
+        {
+            "status": "ready",
+            "filesystem_type": "ext4",
+            "storage_risk": "local",
+            "storage_migration_required": False,
+        },
+    )
+
+    assert canary not in json.dumps(report)
+    assert report["package"] == {"version": "unknown", "revision": None}
+    assert report["runtime"] == {
+        "python_version": "unknown",
+        "sqlite_version": "unknown",
+        "os_family": "unknown",
+        "os_release": "unknown",
+        "architecture": "unknown",
+    }
+    assert report["schema"] == {"expected_user_version": None}
+    assert report["collection"]["status"] == "partial"
+
+
+def test_environment_collection_exceptions_return_fixed_partial_values(
+    monkeypatch,
+):
+    canary = "failure at /home/alice/private"
+
+    def fail():
+        raise RuntimeError(canary)
+
+    monkeypatch.setattr(support_context.platform, "system", fail)
+    monkeypatch.setattr(support_context.platform, "machine", fail)
+
+    environment = support_context.capture_support_environment(
+        revision=None,
+        expected_user_version=12,
+        sqlite_version="3.49.1",
+    )
+    report = support_context.collect_support_context(
+        environment,
+        {
+            "status": "ready",
+            "filesystem_type": "ext4",
+            "storage_risk": "local",
+            "storage_migration_required": False,
+        },
+    )
+
+    assert report["runtime"]["os_family"] == "unknown"
+    assert report["runtime"]["os_release"] == "unknown"
+    assert report["runtime"]["architecture"] == "unknown"
+    assert report["collection"] == {
+        "status": "partial",
+        "unavailable_sections": [
+            "package_revision",
+            "runtime_os",
+            "runtime_architecture",
+        ],
+    }
+    assert canary not in json.dumps(report)
+
+
+def test_unavailable_support_context_is_fixed_and_fully_partial():
+    report = support_context.unavailable_support_context()
+
+    assert report["collection"] == {
+        "status": "partial",
+        "unavailable_sections": [
+            "package_version",
+            "package_revision",
+            "runtime_python",
+            "runtime_sqlite",
+            "runtime_os",
+            "runtime_architecture",
+            "expected_schema",
+            "cached_index_health",
+        ],
+    }
+    assert report["index"] == {"status": "unknown", "condition": None}

--- a/tests/workbench/test_support_context_api.py
+++ b/tests/workbench/test_support_context_api.py
@@ -1,0 +1,272 @@
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import urllib.request
+from http.client import HTTPConnection
+from http.server import ThreadingHTTPServer
+from threading import Event, Thread
+from unittest.mock import MagicMock
+
+import pytest
+
+from clawjournal import filesystem, support_diagnostics
+from clawjournal.paths import ensure_api_token
+from clawjournal.workbench import daemon, index, index_recovery
+
+
+@pytest.fixture
+def support_server(tmp_path, monkeypatch):
+    monkeypatch.setattr(index, "INDEX_DB", tmp_path / "index.db")
+    token = ensure_api_token(tmp_path)
+    environment = daemon.capture_support_environment(
+        revision="b" * 40,
+        expected_user_version=index.WORKBENCH_SCHEMA_VERSION,
+        sqlite_version=sqlite3.sqlite_version,
+    )
+    server = ThreadingHTTPServer(("127.0.0.1", 0), daemon.WorkbenchHandler)
+    server._support_environment = environment
+    thread = Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server.server_address[1], token
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=2)
+
+
+def _get(port: int, token: str | None):
+    connection = HTTPConnection("127.0.0.1", port, timeout=5)
+    headers = {"Authorization": f"Bearer {token}"} if token is not None else {}
+    connection.request("GET", "/api/support-context", headers=headers)
+    response = connection.getresponse()
+    raw = response.read()
+    content_type = response.getheader("Content-Type", "")
+    body = json.loads(raw) if content_type.startswith("application/json") else raw.decode()
+    result = (
+        response.status,
+        {key.lower(): value for key, value in response.getheaders()},
+        body,
+    )
+    connection.close()
+    return result
+
+
+def test_support_context_requires_bearer_auth(support_server):
+    port, token = support_server
+
+    status, _headers, body = _get(port, None)
+    assert status == 401
+    assert body == ""
+
+    status, _headers, body = _get(port, f"wrong-{token}")
+    assert status == 401
+    assert body == ""
+
+
+def test_support_context_skips_diagnostic_io_before_the_health_gate(
+    support_server,
+    monkeypatch,
+):
+    port, token = support_server
+    canary = "private /home/alice/session-123?token=secret"
+
+    def forbidden(*_args, **_kwargs):
+        raise AssertionError("support context attempted forbidden I/O")
+
+    monkeypatch.setattr(
+        daemon,
+        "try_current_index_health",
+        lambda: {
+            "status": "recovery_required",
+            "filesystem_type": "ext4",
+            "storage_risk": "local",
+            "storage_migration_required": False,
+            "message": canary,
+            "detail": canary,
+            "database_path": canary,
+            "backup_path": canary,
+            "session_id": canary,
+        },
+    )
+    monkeypatch.setattr(daemon, "synchronize_index_health", forbidden)
+    monkeypatch.setattr(daemon, "open_index", forbidden)
+    monkeypatch.setattr(support_diagnostics, "collect_index_diagnostics", forbidden)
+    monkeypatch.setattr(filesystem, "classify_filesystem", forbidden)
+    monkeypatch.setattr(filesystem, "sanitized_filesystem_type", forbidden)
+    monkeypatch.setattr(sqlite3, "connect", forbidden)
+    monkeypatch.setattr(subprocess, "run", forbidden)
+    monkeypatch.setattr(urllib.request, "urlopen", forbidden)
+
+    status, headers, body = _get(port, token)
+
+    assert status == 200
+    assert headers["cache-control"] == "no-store"
+    assert body["index"] == {
+        "status": "recovery_required",
+        "condition": "recovery_required",
+    }
+    assert body["storage"] == {
+        "filesystem_type": "ext4",
+        "storage_risk": "local",
+        "storage_migration_required": False,
+    }
+    assert body["collection"]["status"] == "complete"
+    serialized = json.dumps(body)
+    assert canary not in serialized
+    assert "database_path" not in serialized
+    assert "session_id" not in serialized
+
+
+def test_support_context_collection_failure_returns_safe_partial(
+    support_server,
+    monkeypatch,
+):
+    port, token = support_server
+    canary = "collector failed at /home/alice/private"
+
+    def fail(*_args, **_kwargs):
+        raise RuntimeError(canary)
+
+    monkeypatch.setattr(daemon, "collect_support_context", fail)
+
+    status, headers, body = _get(port, token)
+
+    assert status == 200
+    assert headers["cache-control"] == "no-store"
+    assert body == daemon.unavailable_support_context()
+    assert body["collection"]["status"] == "partial"
+    assert canary not in json.dumps(body)
+
+
+@pytest.mark.parametrize(
+    ("health_status", "expected_condition"),
+    [
+        ("checking", None),
+        ("rebuilding", None),
+        ("unavailable", "unavailable"),
+    ],
+)
+def test_support_context_projects_each_cached_nonready_health_state(
+    support_server,
+    monkeypatch,
+    health_status,
+    expected_condition,
+):
+    port, token = support_server
+    monkeypatch.setattr(
+        daemon,
+        "try_current_index_health",
+        lambda: {
+            "status": health_status,
+            "filesystem_type": "unknown",
+            "storage_risk": "unknown",
+            "storage_migration_required": False,
+        },
+    )
+
+    status, _headers, body = _get(port, token)
+
+    assert status == 200
+    assert body["index"] == {
+        "status": health_status,
+        "condition": expected_condition,
+    }
+
+
+def test_support_context_does_not_wait_for_busy_recovery_health_lock(
+    support_server,
+):
+    port, token = support_server
+    finished = Event()
+    results = []
+
+    def request_context():
+        try:
+            results.append(_get(port, token))
+        finally:
+            finished.set()
+
+    index_recovery._STATE_LOCK.acquire()
+    request_thread = Thread(target=request_context, daemon=True)
+    try:
+        request_thread.start()
+        completed_without_lock = finished.wait(1.0)
+    finally:
+        index_recovery._STATE_LOCK.release()
+    request_thread.join(timeout=2)
+
+    assert completed_without_lock is True
+    assert len(results) == 1
+    status, headers, body = results[0]
+    assert status == 200
+    assert headers["cache-control"] == "no-store"
+    assert body["index"] == {"status": "unknown", "condition": None}
+    assert body["collection"]["status"] == "partial"
+    assert body["collection"]["unavailable_sections"] == [
+        "cached_index_health"
+    ]
+
+
+def test_run_server_shares_one_startup_environment_with_ipv4_and_ipv6(
+    monkeypatch,
+):
+    from clawjournal import selfupdate
+
+    environment = daemon.capture_support_environment(
+        revision="c" * 40,
+        expected_user_version=index.WORKBENCH_SCHEMA_VERSION,
+        sqlite_version=sqlite3.sqlite_version,
+    )
+    primary = MagicMock()
+    primary.server_address = ("127.0.0.1", 48123)
+    primary.serve_forever.side_effect = KeyboardInterrupt
+    scanner = MagicMock()
+    scanner._stop_event = Event()
+    captured = {}
+
+    def capture_ipv6(port, candidate_scanner, snapshot, candidate_environment):
+        captured.update({
+            "port": port,
+            "scanner": candidate_scanner,
+            "snapshot": snapshot,
+            "environment": candidate_environment,
+        })
+        return None
+
+    capture_calls = []
+
+    def capture_environment(**kwargs):
+        capture_calls.append(kwargs)
+        return environment
+
+    monkeypatch.setattr(daemon, "Scanner", lambda **_kwargs: scanner)
+    monkeypatch.setattr(daemon, "ThreadingHTTPServer", lambda *_args: primary)
+    monkeypatch.setattr(daemon, "capture_support_environment", capture_environment)
+    monkeypatch.setattr(daemon, "_try_serve_ipv6_loopback", capture_ipv6)
+    monkeypatch.setattr(daemon, "begin_index_health_check", lambda: None)
+    monkeypatch.setattr(
+        daemon,
+        "initialize_index_health",
+        lambda: {"status": "unavailable", "message": "test"},
+    )
+    monkeypatch.setattr(daemon, "_warn_if_frontend_stale", lambda **_kwargs: None)
+    monkeypatch.setattr(selfupdate, "_package_repo_root", lambda: None)
+
+    daemon.run_server(
+        port=0,
+        open_browser=False,
+        startup_head="c" * 40,
+        frontend_snapshot=None,
+    )
+
+    assert primary._support_environment is environment
+    assert captured["environment"] is environment
+    assert captured["scanner"] is scanner
+    assert capture_calls == [{
+        "revision": "c" * 40,
+        "expected_user_version": index.WORKBENCH_SCHEMA_VERSION,
+        "sqlite_version": sqlite3.sqlite_version,
+    }]


### PR DESCRIPTION
## Summary

Part of #198. This is the first, local-only phase and intentionally does **not** close the issue.

- adds a global **Report a problem** entry that remains available in the normal Workbench, index recovery/unavailable screens, and the React render-error fallback;
- builds a fully editable Markdown draft in browser memory with bounded Summary, reproduction, and expected-behavior fields;
- provides explicit **Copy draft**, fixed-name `.md` download, and **Open blank GitHub issue** actions;
- adds authenticated `GET /api/support-context` before the unhealthy-index gate, returning only a versioned diagnostic allowlist;
- separates coarse browser-host information from daemon-host runtime information, which matters for SSH/cluster use;
- degrades to a fixed `Diagnostics unavailable` draft when the daemon is down, slow, unhealthy, or returns an unexpected schema.

## Privacy and failure boundaries

- Clicking the launcher does not capture a screenshot, upload a report, submit an issue, or emit telemetry.
- The draft is not stored in SQLite, localStorage, or sessionStorage.
- The GitHub link is always the blank `/issues/new` URL with `rel="noopener noreferrer"`; no report text, route, ID, or query value is placed in the URL.
- The support endpoint remains bearer-authenticated and sends `Cache-Control: no-store`.
- After authentication, the handler reads only an immutable startup environment and a non-blocking in-memory health snapshot. It does not open/migrate SQLite or run Git, subprocesses, filesystem classification, or network probes.
- A busy recovery-health lock produces an immediate safe partial response instead of waiting behind storage I/O.
- Server and browser both independently project strict allowlists. Paths, raw URLs, query strings, session/project/share IDs, raw error messages/stacks, hostname, username, email, IP/proxy/environment values, tokens, logs, and the full browser user-agent are excluded.
- Browser context is reduced to a fixed browser enum/major version plus bounded viewport/DPR values; unknown values fail closed.
- The reporter has its own error boundary and the modal provides focus trapping, Escape handling, focus restoration, clipboard-denial fallback, and Blob URL cleanup.

## Non-goals

- No private support-intake service or automatic GitHub submission is introduced.
- No screenshot capture is introduced. That requires a separate private receiver, retention/access policy, explicit capture/preview/remove consent flow, and image safety limits.
- A daemon that never starts cannot render a browser button; `clawjournal --version` and `clawjournal doctor index --json` remain the terminal fallback.

## Verification

- support context/unit/API/concurrency tests: **13 passed**
- complete daemon test file: **262 passed**
- complete frontend suite: **18 files / 145 tests passed**
- final focused frontend gate: **4 files / 26 tests passed**
- ESLint, TypeScript, Vite production build, `compileall`, and `git diff --check` passed
- three independent privacy/integration reviews found no blocker, high, or medium issue
