### PR TITLE
Fix durable scoring backlogs and long-session stalls

### DIFF
--- a/clawjournal/cli.py
+++ b/clawjournal/cli.py
@@ -3032,10 +3032,17 @@ def _score_single_session(
     backend: str = "auto",
     dry_run: bool = False,
     redaction_settings: dict[str, Any] | None = None,
+    force: bool = False,
 ) -> dict[str, Any]:
     """Score a single session using the structured pipeline. Returns result dict."""
-    from .workbench.index import get_session_detail, update_session
+    import inspect
+    import sqlite3
+
+    from .scoring.egress_lock import scoring_egress_lock
+    from .workbench import scoring_queue
+    from .workbench.index import get_session_detail, open_index, update_session
     from .scoring.scoring import (
+        ScoringAborted,
         compute_basic_metrics,
         format_session_for_judge,
         score_session,
@@ -3059,45 +3066,164 @@ def _score_single_session(
             "total_steps": metrics["total_steps"],
         }
 
-    try:
-        score_kwargs: dict[str, Any] = {"model": model, "backend": backend}
-        if redaction_settings is not None:
-            score_kwargs["redaction_settings"] = redaction_settings
-        result = score_session(conn, session_id, **score_kwargs)
-    except FileNotFoundError as e:
-        missing = getattr(e, "filename", None) or str(e)
-        return {
-            "session_id": session_id,
-            "error": f"Missing file or command during scoring: {missing}",
-        }
-    except RuntimeError as e:
-        return {
-            "session_id": session_id,
-            "error": f"Judge failed: {e}",
-        }
+    revision_aware = isinstance(conn, sqlite3.Connection)
+    initial = None
+    if revision_aware:
+        initial_row = conn.execute(
+            "SELECT * FROM sessions WHERE session_id = ?", (session_id,)
+        ).fetchone()
+        if initial_row is None:
+            return {"session_id": session_id, "error": "Session not found"}
+        initial = dict(initial_row)
 
-    ok = update_session(
-        conn, session_id,
-        ai_quality_score=result.quality,
-        ai_score_reason=result.reason,
-        ai_scoring_detail=result.detail_json,
-        ai_task_type=result.task_type,
-        ai_outcome_badge=result.outcome_label or None,
-        ai_value_badges=json.dumps(result.value_labels),
-        ai_risk_badges=json.dumps(result.risk_level),
-        ai_display_title=result.display_title or None,
-        ai_effort_estimate=result.effort_estimate,
-        ai_summary=result.summary or None,
-        ai_failure_value_score=getattr(result, "failure_value_score", None),
-        ai_recovery_labels=json.dumps(getattr(result, "recovery_labels", [])),
-        ai_failure_attribution=getattr(result, "failure_attribution", "") or None,
-        ai_failure_modes=json.dumps(getattr(result, "failure_modes", [])),
-        ai_learning_summary=getattr(result, "learning_summary", "") or None,
-        ai_scorer_backend=getattr(result, "scorer_backend", "") or None,
-        ai_scorer_model=getattr(result, "scorer_model", "") or None,
-        ai_rubric_git_sha=getattr(result, "rubric_git_sha", "") or None,
-        ai_scored_at=getattr(result, "scored_at", "") or None,
-    )
+    with scoring_egress_lock(blocking=True) as acquired:
+        if not acquired:  # pragma: no cover - blocking without a timeout
+            return {"session_id": session_id, "error": "Scoring is busy"}
+
+        expected_revision: str | None = None
+        if revision_aware:
+            current_row = conn.execute(
+                "SELECT * FROM sessions WHERE session_id = ?", (session_id,)
+            ).fetchone()
+            if current_row is None:
+                return {"session_id": session_id, "error": "Session not found"}
+            current = dict(current_row)
+            expected_revision = str(current.get("content_revision") or "")
+            initial_revision = str((initial or {}).get("content_revision") or "")
+            initial_had_score = bool(
+                (initial or {}).get("ai_quality_score") is not None
+                or (initial or {}).get("ai_failure_value_score") is not None
+            )
+            current_has_score = bool(
+                current.get("ai_quality_score") is not None
+                and current.get("ai_failure_value_score") is not None
+            )
+            explicit_rescore = (
+                force and initial_had_score and initial_revision == expected_revision
+            )
+            if current_has_score and not explicit_rescore:
+                def stored_list(field: str) -> list[Any]:
+                    value = current.get(field)
+                    if isinstance(value, str):
+                        try:
+                            value = json.loads(value)
+                        except (TypeError, ValueError):
+                            value = []
+                    return value if isinstance(value, list) else []
+
+                return {
+                    "session_id": session_id,
+                    "ai_quality_score": current.get("ai_quality_score"),
+                    "ai_failure_value_score": current.get("ai_failure_value_score"),
+                    "ai_recovery_labels": stored_list("ai_recovery_labels"),
+                    "ai_failure_attribution": current.get("ai_failure_attribution") or "",
+                    "ai_failure_modes": stored_list("ai_failure_modes"),
+                    "ai_learning_summary": current.get("ai_learning_summary") or "",
+                    "reason": current.get("ai_score_reason") or "",
+                    "task_type": current.get("ai_task_type") or "unknown",
+                    "resolution": current.get("ai_outcome_badge") or "",
+                    "session_tags": stored_list("ai_value_badges"),
+                    "privacy_flags": stored_list("ai_risk_badges"),
+                    "effort_estimate": current.get("ai_effort_estimate"),
+                    "summary": current.get("ai_summary") or "",
+                    "cached": True,
+                    "ok": True,
+                }
+
+        def before_egress() -> None:
+            if expected_revision is None:
+                return
+            check_conn = open_index()
+            try:
+                row = check_conn.execute(
+                    "SELECT content_revision FROM sessions WHERE session_id = ?",
+                    (session_id,),
+                ).fetchone()
+            finally:
+                check_conn.close()
+            if row is None or str(row["content_revision"] or "") != expected_revision:
+                raise ScoringAborted("stale_revision")
+
+        try:
+            score_kwargs: dict[str, Any] = {"model": model, "backend": backend}
+            if redaction_settings is not None:
+                score_kwargs["redaction_settings"] = redaction_settings
+            try:
+                signature = inspect.signature(score_session)
+                supports_guard = "before_egress" in signature.parameters or any(
+                    parameter.kind is inspect.Parameter.VAR_KEYWORD
+                    for parameter in signature.parameters.values()
+                )
+            except (TypeError, ValueError):
+                supports_guard = True
+            if supports_guard:
+                score_kwargs["before_egress"] = before_egress
+            result = score_session(conn, session_id, **score_kwargs)
+        except FileNotFoundError as e:
+            missing = getattr(e, "filename", None) or str(e)
+            return {
+                "session_id": session_id,
+                "error": f"Missing file or command during scoring: {missing}",
+            }
+        except ScoringAborted:
+            return {
+                "session_id": session_id,
+                "error": "Session changed during scoring; retry the current revision.",
+                "block_reason": "stale_revision",
+            }
+        except RuntimeError as e:
+            return {
+                "session_id": session_id,
+                "error": f"Judge failed: {e}",
+            }
+
+        if revision_aware:
+            conn.execute("BEGIN IMMEDIATE")
+        try:
+            ok = update_session(
+                conn, session_id,
+                ai_quality_score=result.quality,
+                ai_score_reason=result.reason,
+                ai_scoring_detail=result.detail_json,
+                ai_task_type=result.task_type,
+                ai_outcome_badge=result.outcome_label or None,
+                ai_value_badges=json.dumps(result.value_labels),
+                ai_risk_badges=json.dumps(result.risk_level),
+                ai_display_title=result.display_title or None,
+                ai_effort_estimate=result.effort_estimate,
+                ai_summary=result.summary or None,
+                ai_failure_value_score=getattr(result, "failure_value_score", None),
+                ai_recovery_labels=json.dumps(getattr(result, "recovery_labels", [])),
+                ai_failure_attribution=getattr(result, "failure_attribution", "") or None,
+                ai_failure_modes=json.dumps(getattr(result, "failure_modes", [])),
+                ai_learning_summary=getattr(result, "learning_summary", "") or None,
+                ai_scorer_backend=getattr(result, "scorer_backend", "") or None,
+                ai_scorer_model=getattr(result, "scorer_model", "") or None,
+                ai_rubric_git_sha=getattr(result, "rubric_git_sha", "") or None,
+                ai_scored_at=getattr(result, "scored_at", "") or None,
+                expected_content_revision=expected_revision,
+                commit=not revision_aware,
+            )
+            if ok and revision_aware and expected_revision is not None:
+                scoring_queue.complete_revision_jobs(
+                    conn,
+                    session_id,
+                    expected_revision,
+                    commit=False,
+                )
+                conn.commit()
+            elif revision_aware:
+                conn.rollback()
+        except Exception:
+            if revision_aware:
+                conn.rollback()
+            raise
+        if not ok:
+            return {
+                "session_id": session_id,
+                "error": "Session changed during scoring; retry the current revision.",
+                "block_reason": "stale_revision",
+            }
 
     return {
         "session_id": session_id,
@@ -3241,7 +3367,14 @@ def _run_score(args) -> None:
 
         results = []
         for sid in session_ids:
-            result = _score_single_session(conn, sid, model=model, backend=backend, dry_run=dry_run)
+            result = _score_single_session(
+                conn,
+                sid,
+                model=model,
+                backend=backend,
+                dry_run=dry_run,
+                force=True,
+            )
             results.append(result)
 
         if len(results) == 1:
@@ -3313,7 +3446,14 @@ def _run_rescore(args) -> None:
             f"[{i}/{len(sessions)}] Rescoring: {_truncate(title, 60)} ({sid[:12]}...)",
             file=sys.stderr,
         )
-        result = _score_single_session(conn, sid, model=model, backend=backend, dry_run=dry_run)
+        result = _score_single_session(
+            conn,
+            sid,
+            model=model,
+            backend=backend,
+            dry_run=dry_run,
+            force=True,
+        )
         results.append(result)
         if result.get("ai_quality_score"):
             failure = result.get("ai_failure_value_score")

--- a/clawjournal/scoring/egress_lock.py
+++ b/clawjournal/scoring/egress_lock.py
@@ -1,0 +1,104 @@
+"""Cross-process serialization for every AI scoring egress.
+
+The durable queue lease protects ownership metadata in SQLite, but a scoring
+call can legitimately outlive that lease.  This kernel-owned lock is the
+second line of defence: background workers, explicit HTTP/CLI scoring, and
+the Share workflow all take the same lock before reading the revision that
+will be sent to a judge and hold it until the revision-CAS write completes.
+The OS releases the lock automatically if a process crashes.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from contextlib import contextmanager
+from pathlib import Path
+from typing import BinaryIO, Iterator
+
+
+SCORING_EGRESS_LOCK_FILENAME = "scoring-egress.lock"
+_LOCK_POLL_SECONDS = 0.05
+
+
+def _lock_path() -> Path:
+    # Import lazily so tests that isolate INDEX_DB before entering the context
+    # receive an equally isolated lock file, without creating an import cycle.
+    from ..workbench.index import INDEX_DB
+
+    return Path(str(INDEX_DB)).parent / SCORING_EGRESS_LOCK_FILENAME
+
+
+def _try_lock(file: BinaryIO) -> bool:
+    if os.name == "nt":
+        import msvcrt
+
+        try:
+            if os.fstat(file.fileno()).st_size == 0:
+                file.write(b"0")
+                file.flush()
+            file.seek(0)
+            msvcrt.locking(file.fileno(), msvcrt.LK_NBLCK, 1)
+            return True
+        except OSError:
+            return False
+
+    import fcntl
+
+    try:
+        fcntl.flock(file.fileno(), fcntl.LOCK_EX | fcntl.LOCK_NB)
+        return True
+    except BlockingIOError:
+        return False
+
+
+def _unlock(file: BinaryIO) -> None:
+    if os.name == "nt":
+        import msvcrt
+
+        file.seek(0)
+        msvcrt.locking(file.fileno(), msvcrt.LK_UNLCK, 1)
+        return
+
+    import fcntl
+
+    fcntl.flock(file.fileno(), fcntl.LOCK_UN)
+
+
+@contextmanager
+def scoring_egress_lock(
+    *,
+    blocking: bool,
+    timeout: float | None = None,
+) -> Iterator[bool]:
+    """Yield whether the installation-wide scoring egress lock was acquired.
+
+    Background workers use ``blocking=False`` so a second daemon never claims
+    work that could expire while it waits.  Explicit user actions block by
+    default; callers may provide a finite timeout when their transport has a
+    deadline.  Keeping the file handle open holds the OS lock.
+    """
+
+    if timeout is not None and timeout < 0:
+        raise ValueError("timeout must be non-negative")
+    path = _lock_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    file = path.open("a+b")
+    acquired = False
+    deadline = None if timeout is None else time.monotonic() + timeout
+    try:
+        while True:
+            acquired = _try_lock(file)
+            if acquired or not blocking:
+                break
+            if deadline is not None and time.monotonic() >= deadline:
+                break
+            time.sleep(_LOCK_POLL_SECONDS)
+        yield acquired
+    finally:
+        if acquired:
+            try:
+                _unlock(file)
+            except OSError:
+                pass
+        file.close()

--- a/clawjournal/scoring/scoring.py
+++ b/clawjournal/scoring/scoring.py
@@ -12,8 +12,10 @@ from __future__ import annotations
 
 import json
 import hashlib
+import math
 import subprocess
 import tempfile
+import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -86,6 +88,14 @@ class ScoringResult:
     scored_at: str = ""
 
 
+class ScoringAborted(RuntimeError):
+    """A local control/revision check stopped scoring before its next egress."""
+
+
+class ScoringDeadlineExceeded(RuntimeError):
+    """The bounded wall-clock budget expired before scoring could finish."""
+
+
 @dataclass(frozen=True)
 class LocatorChunk:
     """A bounded, overlapping slice of segment-formatted scoring input."""
@@ -101,6 +111,27 @@ FINAL_SCORE_MAX_CHARS = 48_000
 LOCATOR_OVERLAP_SEGMENTS = 2
 LOCATOR_MAX_WORKERS = 3
 LOCATOR_TIMEOUT_SECONDS = 90
+JUDGE_TIMEOUT_SECONDS = 120
+# Keep the default below the durable worker's ten-minute lease so a normal
+# timeout is recorded before another process can recover the same job.
+SCORING_TOTAL_TIMEOUT_SECONDS = 8 * 60
+
+
+def _remaining_provider_timeout(
+    deadline_at: float | None,
+    per_call_timeout: int,
+) -> int:
+    """Return a positive provider timeout bounded by the overall deadline."""
+
+    if deadline_at is None:
+        return per_call_timeout
+    remaining = deadline_at - time.monotonic()
+    if remaining <= 0:
+        raise ScoringDeadlineExceeded("Scoring timeout: total time budget exceeded")
+    # Provider adapters take whole seconds. Rounding up avoids turning a
+    # positive sub-second remainder into an invalid zero-second timeout; the
+    # total overrun remains bounded to less than one second plus teardown.
+    return max(1, min(per_call_timeout, math.ceil(remaining)))
 
 
 # ---------------------------------------------------------------------------
@@ -1158,6 +1189,7 @@ def call_judge(
     session_data: dict[str, Any] | None = None,
     metadata: dict[str, Any] | None = None,
     backend: str = "auto",
+    timeout_seconds: int = JUDGE_TIMEOUT_SECONDS,
 ) -> dict:
     """Call the resolved scoring backend and return a validated judge result."""
     rubric = load_scoring_rubric()
@@ -1205,7 +1237,7 @@ def call_judge(
             system_prompt_file=_SCORER_PROMPT_FILE,
             task_prompt=task_prompt,
             model=effective_model,
-            timeout_seconds=120,
+            timeout_seconds=timeout_seconds,
             codex_sandbox="read-only",
             codex_output_schema=JUDGE_SCHEMA,
             codex_output_file="scoring.json",
@@ -1226,6 +1258,7 @@ def call_signal_locator(
     *,
     backend: str = "auto",
     model: str | None = None,
+    timeout_seconds: int = LOCATOR_TIMEOUT_SECONDS,
 ) -> dict[str, Any]:
     """Locate high-signal segment ranges in one anonymized long-session chunk."""
     from ..benchmark.generate import run_agent_json_call
@@ -1242,7 +1275,7 @@ def call_signal_locator(
             "Return a JSON object matching the supplied schema. Segment numbers must refer "
             "to the stable segment-NNNN labels in this chunk.\n\n" + chunk.text
         ),
-        timeout_seconds=LOCATOR_TIMEOUT_SECONDS,
+        timeout_seconds=timeout_seconds,
         codex_output_schema=LOCATOR_SCHEMA,
         claude_bare=True,
         claude_safe_mode=True,
@@ -1260,6 +1293,8 @@ def prepare_prompt_for_judge(
     model: str | None = None,
     locator: Callable[[LocatorChunk], Any] | None = None,
     progress: Callable[[str], None] | None = None,
+    before_egress: Callable[[], None] | None = None,
+    deadline_at: float | None = None,
     direct_max_chars: int = DIRECT_SCORE_MAX_CHARS,
     final_max_chars: int = FINAL_SCORE_MAX_CHARS,
 ) -> str:
@@ -1271,12 +1306,31 @@ def prepare_prompt_for_judge(
     chunks = build_locator_chunks(segments, task_context)
     if progress is not None:
         progress(f"Long session: locating high-signal evidence in {len(chunks)} chunks")
-    locate = locator or (lambda chunk: call_signal_locator(chunk, backend=backend, model=model))
+
+    def guarded_locate(chunk: LocatorChunk) -> Any:
+        # Futures are deliberately guarded at execution time rather than at
+        # submission time.  If Pause/hold/scope/revision changes while three
+        # locators are running, queued chunks abort before opening a new AI
+        # request. Calls already in flight are allowed to finish.
+        if before_egress is not None:
+            before_egress()
+        timeout_seconds = _remaining_provider_timeout(
+            deadline_at, LOCATOR_TIMEOUT_SECONDS
+        )
+        if locator is not None:
+            return locator(chunk)
+        return call_signal_locator(
+            chunk,
+            backend=backend,
+            model=model,
+            timeout_seconds=timeout_seconds,
+        )
+
     signals: list[dict[str, Any]] = []
     failed_chunks: list[LocatorChunk] = []
     workers = max(1, min(LOCATOR_MAX_WORKERS, len(chunks)))
     with ThreadPoolExecutor(max_workers=workers) as pool:
-        futures = {pool.submit(locate, chunk): chunk for chunk in chunks}
+        futures = {pool.submit(guarded_locate, chunk): chunk for chunk in chunks}
         completed = 0
         for future in as_completed(futures):
             chunk = futures[future]
@@ -1296,6 +1350,10 @@ def prepare_prompt_for_judge(
                         )
                         signal["end_segment"] = min(chunk_end, signal["end_segment"])
                         signals.append(signal)
+            except (ScoringAborted, ScoringDeadlineExceeded):
+                for pending in futures:
+                    pending.cancel()
+                raise
             except Exception:
                 failed_chunks.append(chunk)
             completed += 1
@@ -1693,9 +1751,22 @@ def score_session(
     backend: str = "auto",
     redaction_settings: dict[str, Any] | None = None,
     progress: Callable[[str], None] | None = None,
+    before_egress: Callable[[], None] | None = None,
+    overall_timeout_seconds: float | None = SCORING_TOTAL_TIMEOUT_SECONDS,
 ) -> ScoringResult:
     """Score a session: format → judge → store. No aggregation formulas."""
     from ..workbench.index import get_session_detail, resolve_blob_path
+
+    if overall_timeout_seconds is None:
+        deadline_at = None
+    else:
+        if (
+            isinstance(overall_timeout_seconds, bool)
+            or not isinstance(overall_timeout_seconds, (int, float))
+            or overall_timeout_seconds <= 0
+        ):
+            raise ValueError("overall_timeout_seconds must be positive or None")
+        deadline_at = time.monotonic() + float(overall_timeout_seconds)
 
     detail = get_session_detail(conn, session_id)
     if not detail:
@@ -1773,14 +1844,24 @@ def score_session(
         backend=backend,
         model=model,
         progress=progress,
+        before_egress=before_egress,
+        deadline_at=deadline_at,
     )
 
+    if progress is not None:
+        progress("Scoring final judge")
+    if before_egress is not None:
+        before_egress()
+    judge_timeout = _remaining_provider_timeout(
+        deadline_at, JUDGE_TIMEOUT_SECONDS
+    )
     result = call_judge(
         prompt,
         model,
         session_data=detail,
         metadata=metrics,
         backend=backend,
+        timeout_seconds=judge_timeout,
     )
 
     # Effort: use judge override if provided, otherwise heuristic

--- a/clawjournal/share_cli.py
+++ b/clawjournal/share_cli.py
@@ -378,20 +378,18 @@ def _backend_chain(backend: str) -> list[str]:
 def score_traces(conn, rows: list[dict], *, backend: str = "auto",
                  model: str | None = None, cap: int | None = None, workers: int = 6,
                  force_ids: set[str] | None = None) -> int:
-    """Score unscored rows for failure value, IN PARALLEL.
+    """Score unscored rows for failure value under the global egress lock.
 
     Scores rows with no failure value, plus any row whose session_id is in
     `force_ids` — used to re-score sessions that grew since they were last graded
     (the web's `include_stale_scored` behavior), so a stale early grade is
     overwritten with one that reflects the current content.
 
-    The slow AI-judge step runs in worker threads (each with its own read
-    connection via share_flow.score_compute), while DB writes happen serially on
-    `conn` (single writer; WAL handles the readers) — so N traces take about one
-    judge call, not N. Only `workers` judge calls are submitted at a time; on
-    Ctrl-C we stop queueing new calls, cancel any submitted calls that have not
-    started, and return what's done (in-flight calls may still finish). Mutates
-    rows in place and persists.
+    The slow AI-judge step runs in one worker with its own connection via
+    ``share_flow.score_compute``. It holds the installation-wide scoring lock
+    through its revision-CAS write. On Ctrl-C we stop queueing new calls and
+    return what's done (the one in-flight call may still finish). Mutates rows
+    in place and persists.
 
     If the chosen backend turns out unusable (no credits / not logged in / CLI
     missing), traces are automatically retried on the next installed backend
@@ -409,9 +407,12 @@ def score_traces(conn, rows: list[dict], *, backend: str = "auto",
     total = len(unscored)
     restale = sum(1 for r in unscored if r.get("ai_failure_value_score") is not None)
     suffix = f" ({restale} re-scored after new activity)" if restale else ""
-    n_workers = max(1, min(workers, total))
+    # All scoring entry points share one installation-wide egress lock. Keep a
+    # single submitted future so Ctrl-C can still cancel work that has not
+    # started instead of leaving several threads blocked on that lock.
+    n_workers = 1
     print(f"  {DIM}Scoring {total} trace(s) for failure value{suffix} "
-          f"({n_workers} in parallel, AI judge — Ctrl-C to skip the rest)…{RST}")
+          f"(serialized AI judge — Ctrl-C to skip the rest)…{RST}")
     done = 0
     pool = ThreadPoolExecutor(max_workers=n_workers)
     rows_iter = iter(unscored)
@@ -427,8 +428,14 @@ def score_traces(conn, rows: list[dict], *, backend: str = "auto",
         be = active_backend()
         if be is None:
             return False
-        futures[pool.submit(share_flow.score_compute, r["session_id"],
-                            backend=be, model=model)] = (r, be)
+        score_kwargs = {"backend": be, "model": model}
+        if r["session_id"] in force_ids:
+            score_kwargs["force"] = True
+        futures[pool.submit(
+            share_flow.score_compute,
+            r["session_id"],
+            **score_kwargs,
+        )] = (r, be)
         return True
 
     def submit_next() -> bool:
@@ -451,7 +458,6 @@ def score_traces(conn, rows: list[dict], *, backend: str = "auto",
                 sid = r["session_id"]
                 res = fut.result()
                 if res.get("ok"):
-                    share_flow.persist_score(conn, sid, res["fields"])  # serial write on main conn
                     r["ai_failure_value_score"] = res.get("failure_value")
                     if res.get("display_title"):
                         r["ai_display_title"] = res["display_title"]

--- a/clawjournal/share_flow.py
+++ b/clawjournal/share_flow.py
@@ -341,32 +341,169 @@ def _scoring_result_fields(r) -> dict:
     )
 
 
-def score_compute(session_id: str, *, backend: str = "auto", model: str | None = None) -> dict:
-    """Run the existing failure-value scoring (the slow AI-judge step) on one
-    trace WITHOUT writing. Opens its own short-lived read connection, so it's
-    safe to call from worker threads in parallel (the DB write is the caller's
-    job — see persist_score). Returns {ok, fields, failure_value, display_title}
-    or {ok: False, error}."""
-    from .workbench.index import open_index
-    from .scoring.scoring import score_session
+def score_compute(
+    session_id: str,
+    *,
+    backend: str = "auto",
+    model: str | None = None,
+    force: bool = False,
+) -> dict:
+    """Run failure-value scoring and revision-CAS persist under the egress lock.
+
+    It opens its own short-lived connection for worker-thread safety. The
+    global lock stays held through the revision-CAS write. Returns a bounded
+    result payload or an error payload.
+    """
+    import inspect
+
+    from .scoring.egress_lock import scoring_egress_lock
+    from .workbench import scoring_queue
+    from .workbench.index import open_index, update_session
+    from .scoring.scoring import ScoringAborted, score_session
     conn = open_index()
     try:
-        r = score_session(conn, session_id, model=model, backend=backend)
+        initial_row = conn.execute(
+            "SELECT * FROM sessions WHERE session_id = ?", (session_id,)
+        ).fetchone()
+        if initial_row is None:
+            return {"ok": False, "error": "Session not found"}
+        initial = dict(initial_row)
+
+        with scoring_egress_lock(blocking=True) as acquired:
+            if not acquired:  # pragma: no cover - blocking without a timeout
+                return {"ok": False, "error": "Scoring is busy"}
+            current_row = conn.execute(
+                "SELECT * FROM sessions WHERE session_id = ?", (session_id,)
+            ).fetchone()
+            if current_row is None:
+                return {"ok": False, "error": "Session not found"}
+            current = dict(current_row)
+            revision = str(current.get("content_revision") or "")
+            current_has_score = (
+                current.get("ai_quality_score") is not None
+                and current.get("ai_failure_value_score") is not None
+            )
+            initial_had_score = (
+                initial.get("ai_quality_score") is not None
+                or initial.get("ai_failure_value_score") is not None
+            )
+            explicit_rescore = (
+                force
+                and initial_had_score
+                and str(initial.get("content_revision") or "") == revision
+            )
+            if current_has_score and not explicit_rescore:
+                fields = {
+                    field: current.get(field)
+                    for field in (
+                        "ai_quality_score", "ai_score_reason", "ai_scoring_detail",
+                        "ai_task_type", "ai_outcome_badge", "ai_value_badges",
+                        "ai_risk_badges", "ai_display_title", "ai_effort_estimate",
+                        "ai_summary", "ai_failure_value_score", "ai_recovery_labels",
+                        "ai_failure_attribution", "ai_failure_modes",
+                        "ai_learning_summary", "ai_scorer_backend", "ai_scorer_model",
+                        "ai_rubric_git_sha", "ai_scored_at",
+                    )
+                }
+                return {
+                    "ok": True,
+                    "cached": True,
+                    "persisted": True,
+                    "revision": revision,
+                    "fields": fields,
+                    "failure_value": fields["ai_failure_value_score"],
+                    "display_title": fields["ai_display_title"],
+                }
+
+            def before_egress() -> None:
+                check_conn = open_index()
+                try:
+                    row = check_conn.execute(
+                        "SELECT content_revision FROM sessions WHERE session_id = ?",
+                        (session_id,),
+                    ).fetchone()
+                finally:
+                    check_conn.close()
+                if row is None or str(row["content_revision"] or "") != revision:
+                    raise ScoringAborted("stale_revision")
+
+            score_kwargs = {"model": model, "backend": backend}
+            try:
+                signature = inspect.signature(score_session)
+                supports_guard = "before_egress" in signature.parameters or any(
+                    parameter.kind is inspect.Parameter.VAR_KEYWORD
+                    for parameter in signature.parameters.values()
+                )
+            except (TypeError, ValueError):
+                supports_guard = True
+            if supports_guard:
+                score_kwargs["before_egress"] = before_egress
+            r = score_session(conn, session_id, **score_kwargs)
+            fields = _scoring_result_fields(r)
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                persisted_ok = update_session(
+                    conn,
+                    session_id,
+                    expected_content_revision=revision,
+                    commit=False,
+                    **fields,
+                )
+                if persisted_ok:
+                    scoring_queue.complete_revision_jobs(
+                        conn,
+                        session_id,
+                        revision,
+                        commit=False,
+                    )
+                    conn.commit()
+                else:
+                    conn.rollback()
+            except Exception:
+                conn.rollback()
+                raise
+            if not persisted_ok:
+                return {
+                    "ok": False,
+                    "error": "Session changed during scoring; retry the current revision.",
+                    "block_reason": "stale_revision",
+                }
+            return {
+                "ok": True,
+                "persisted": True,
+                "revision": revision,
+                "fields": fields,
+                "failure_value": fields["ai_failure_value_score"],
+                "display_title": fields["ai_display_title"],
+            }
+    except ScoringAborted:
+        return {
+            "ok": False,
+            "error": "Session changed during scoring; retry the current revision.",
+            "block_reason": "stale_revision",
+        }
     except Exception as exc:  # noqa: BLE001
         return {"ok": False, "error": str(exc)}
     finally:
         conn.close()
-    fields = _scoring_result_fields(r)
-    return {"ok": True, "fields": fields,
-            "failure_value": fields["ai_failure_value_score"],
-            "display_title": fields["ai_display_title"]}
 
 
-def persist_score(conn, session_id: str, fields: dict) -> None:
+def persist_score(
+    conn,
+    session_id: str,
+    fields: dict,
+    *,
+    expected_content_revision: str | None = None,
+) -> bool:
     """Persist a score_compute() result. Call serially on the main connection
     (single writer; WAL handles the concurrent reader connections)."""
     from .workbench.index import update_session
-    update_session(conn, session_id, **fields)
+    return update_session(
+        conn,
+        session_id,
+        expected_content_revision=expected_content_revision,
+        **fields,
+    )
 
 
 def build_zip(export_dir: Path) -> bytes:

--- a/clawjournal/web/frontend/src/api.test.ts
+++ b/clawjournal/web/frontend/src/api.test.ts
@@ -403,3 +403,45 @@ describe('share creation API', () => {
     });
   });
 });
+
+describe('durable scoring queue API', () => {
+  afterEach(() => {
+    delete window.__CLAWJOURNAL_API_TOKEN__;
+    vi.unstubAllGlobals();
+  });
+
+  it('reads aggregate status and sends a strict control action', async () => {
+    window.__CLAWJOURNAL_API_TOKEN__ = 'scoring-queue-token';
+    const status = {
+      enabled: true,
+      backend: 'codex',
+      worker_state: 'idle' as const,
+      counts: { pending: 4, running: 0, retry_wait: 1, succeeded: 20, failed: 2 },
+      current: null,
+      next_retry_at: '2026-08-16T12:00:00Z',
+      action_required_code: null,
+    };
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200, json: async () => status })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ ok: true, action: 'retry_failed', retried: 2, status }),
+      });
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(api.scoringStatus()).resolves.toEqual(status);
+    await expect(api.scoringControl('retry_failed')).resolves.toMatchObject({
+      ok: true,
+      action: 'retry_failed',
+      retried: 2,
+    });
+
+    expect(fetchMock).toHaveBeenNthCalledWith(1, '/api/scoring/status', { headers: { Authorization: 'Bearer scoring-queue-token' } });
+    expect(fetchMock).toHaveBeenNthCalledWith(2, '/api/scoring/control', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer scoring-queue-token' },
+      body: JSON.stringify({ action: 'retry_failed' }),
+    });
+  });
+});

--- a/clawjournal/web/frontend/src/api.ts
+++ b/clawjournal/web/frontend/src/api.ts
@@ -33,6 +33,8 @@ import type {
   SupportReportDeleteResponse,
   SupportReportListResponse,
   SupportReportStatus,
+  ScoringControlResponse,
+  ScoringQueueStatus,
 } from './types.ts';
 
 const BASE = '/api';
@@ -620,6 +622,18 @@ export const api = {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(body ?? {}),
+    });
+  },
+
+  scoringStatus(): Promise<ScoringQueueStatus> {
+    return request('/scoring/status');
+  },
+
+  scoringControl(action: 'pause' | 'resume' | 'retry_failed'): Promise<ScoringControlResponse> {
+    return request('/scoring/control', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ action }),
     });
   },
 

--- a/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
@@ -347,7 +347,7 @@ describe('AutoUploadPanel authorization', () => {
     expect(screen.getByText(/automatically upload up to 5 eligible/i)).toBeInTheDocument();
     expect(screen.queryByText('Claude Code - matches exact upload scope')).not.toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('button', { name: 'View scope and terms' }));
+    fireEvent.click(await screen.findByRole('button', { name: 'View scope and terms' }));
     expect(screen.getByText('Claude Code - matches exact upload scope')).toBeInTheDocument();
     expect(screen.getByText('I authorize capped recurring uploads of eligible future traces.')).toBeInTheDocument();
     expect(screen.getByText('Hosted retention terms for recurring uploads.')).toBeInTheDocument();

--- a/clawjournal/web/frontend/src/components/ScoringQueueStatus.test.tsx
+++ b/clawjournal/web/frontend/src/components/ScoringQueueStatus.test.tsx
@@ -1,0 +1,51 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { api } from '../api.ts';
+import type { ScoringQueueStatus as QueueStatus } from '../types.ts';
+import { ToastProvider } from './Toast.tsx';
+import { ScoringQueueStatus } from './ScoringQueueStatus.tsx';
+
+const status: QueueStatus = {
+  enabled: true,
+  backend: 'codex',
+  worker_state: 'running',
+  counts: { pending: 382, running: 1, retry_wait: 15, succeeded: 20, failed: 2 },
+  current: { job_id: 'opaque-job', stage: 'locating_evidence', progress_current: 2, progress_total: 5 },
+  next_retry_at: null,
+  action_required_code: null,
+};
+
+describe('ScoringQueueStatus', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('shows bounded aggregate progress without session identifiers', async () => {
+    vi.spyOn(api, 'scoringStatus').mockResolvedValue(status);
+    render(<ToastProvider><ScoringQueueStatus compact /></ToastProvider>);
+
+    expect(await screen.findByText(/382 pending/)).toHaveTextContent('1 scoring');
+    expect(screen.getByText('Locating evidence 2/5')).toBeInTheDocument();
+    expect(screen.queryByText('opaque-job')).not.toBeInTheDocument();
+  });
+
+  it('can retry failed jobs and replaces the snapshot with the response', async () => {
+    vi.spyOn(api, 'scoringStatus').mockResolvedValue(status);
+    const control = vi.spyOn(api, 'scoringControl').mockResolvedValue({
+      ok: true,
+      action: 'retry_failed',
+      retried: 2,
+      status: { ...status, counts: { ...status.counts, pending: 384, failed: 0 } },
+    });
+    render(<ToastProvider><ScoringQueueStatus controls /></ToastProvider>);
+
+    fireEvent.click(await screen.findByRole('button', { name: 'Retry failed' }));
+    await waitFor(() => expect(control).toHaveBeenCalledWith('retry_failed'));
+    expect(await screen.findByText(/384 pending/)).toBeInTheDocument();
+  });
+
+  it('does not block its parent when status cannot be loaded', async () => {
+    vi.spyOn(api, 'scoringStatus').mockRejectedValue(new Error('raw private failure'));
+    render(<ToastProvider><ScoringQueueStatus compact /></ToastProvider>);
+    await waitFor(() => expect(api.scoringStatus).toHaveBeenCalled());
+    expect(screen.queryByText(/raw private failure/)).not.toBeInTheDocument();
+  });
+});

--- a/clawjournal/web/frontend/src/components/ScoringQueueStatus.tsx
+++ b/clawjournal/web/frontend/src/components/ScoringQueueStatus.tsx
@@ -1,0 +1,138 @@
+import { useCallback, useEffect, useState } from 'react';
+import { api } from '../api.ts';
+import type { ScoringQueueStatus as QueueStatus } from '../types.ts';
+import { colors, btnSecondary } from '../theme.ts';
+import { useToast } from './Toast.tsx';
+
+const POLL_INTERVAL_MS = 5_000;
+
+const ACTION_REQUIRED_COPY: Record<string, string> = {
+  backend_missing: 'Choose and confirm an AI scoring backend to continue.',
+  backend_auth: 'The scoring backend needs you to sign in again.',
+  backend_unavailable: 'The scoring backend is unavailable. Retry after fixing it.',
+};
+
+const STAGE_COPY: Record<string, string> = {
+  queued: 'Queued',
+  preparing: 'Preparing trace',
+  locating_evidence: 'Locating evidence',
+  final_scoring: 'Final scoring',
+  persisting: 'Saving score',
+};
+
+interface Props {
+  compact?: boolean;
+  controls?: boolean;
+}
+
+export function ScoringQueueStatus({ compact = false, controls = false }: Props) {
+  const { toast } = useToast();
+  const [status, setStatus] = useState<QueueStatus | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+  const [busy, setBusy] = useState(false);
+
+  const refresh = useCallback(async () => {
+    try {
+      setStatus(await api.scoringStatus());
+      setUnavailable(false);
+    } catch {
+      // Queue observability must never block Inbox or Settings. Keep the last
+      // successful snapshot if one exists and expose only a fixed local error.
+      setUnavailable(true);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    const timer = window.setInterval(() => void refresh(), POLL_INTERVAL_MS);
+    return () => window.clearInterval(timer);
+  }, [refresh]);
+
+  async function control(action: 'pause' | 'resume' | 'retry_failed') {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const result = await api.scoringControl(action);
+      setStatus(result.status);
+      setUnavailable(false);
+      if (action === 'retry_failed') {
+        toast(`${result.retried ?? 0} failed scoring job${result.retried === 1 ? '' : 's'} queued`, 'success');
+      } else {
+        toast(action === 'pause' ? 'Background scoring paused' : 'Background scoring resumed', 'success');
+      }
+    } catch (error) {
+      toast(error instanceof Error ? error.message : 'Could not update background scoring', 'error');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  if (!status) {
+    if (!controls || !unavailable) return null;
+    return <p role="status" style={{ margin: 0, fontSize: 12.5, color: colors.gray500 }}>Scoring queue status is temporarily unavailable.</p>;
+  }
+
+  const counts = status.counts;
+  const total = counts.pending + counts.running + counts.retry_wait + counts.succeeded + counts.failed;
+  if (compact && total === 0 && status.worker_state === 'idle' && status.enabled) return null;
+
+  const current = status.current;
+  const progress = current?.progress_current != null && current.progress_total != null
+    ? ` ${current.progress_current}/${current.progress_total}`
+    : '';
+  const actionRequired = status.action_required_code
+    ? ACTION_REQUIRED_COPY[status.action_required_code] ?? 'The scoring backend needs attention.'
+    : null;
+
+  return (
+    <div
+      aria-live="polite"
+      style={{
+        display: 'flex', alignItems: compact ? 'center' : 'flex-start', gap: 10,
+        flexWrap: 'wrap', padding: compact ? '7px 10px' : 0,
+        marginBottom: compact ? 8 : 0,
+        border: compact ? `1px solid ${colors.gray200}` : undefined,
+        borderRadius: compact ? 8 : undefined,
+        background: compact ? colors.gray50 : undefined,
+        color: colors.gray700, fontSize: 12.5,
+      }}
+    >
+      <strong style={{ color: colors.gray800 }}>AI scoring</strong>
+      <span>
+        {counts.pending} pending · {counts.running} scoring · {counts.retry_wait} retrying ·{' '}
+        {counts.failed} failed · {counts.succeeded} completed
+      </span>
+      {current && (
+        <span style={{ color: colors.primary500, fontWeight: 600 }}>
+          {STAGE_COPY[current.stage] ?? 'Working'}{progress}
+        </span>
+      )}
+      {!status.enabled && <span style={{ color: colors.gray500 }}>Paused</span>}
+      {status.worker_state === 'cooldown' && <span style={{ color: colors.yellow700 }}>Backend cooldown</span>}
+      {actionRequired && <span role="alert" style={{ color: colors.red700 }}>{actionRequired}</span>}
+      {unavailable && <span style={{ color: colors.gray500 }}>Status refresh unavailable</span>}
+      {controls && (
+        <div style={{ display: 'flex', gap: 8, marginLeft: compact ? 'auto' : 0 }}>
+          <button
+            type="button"
+            disabled={busy}
+            onClick={() => void control(status.enabled ? 'pause' : 'resume')}
+            style={{ ...btnSecondary, padding: '4px 9px', fontSize: 12 }}
+          >
+            {status.enabled ? 'Pause' : 'Resume'}
+          </button>
+          {counts.failed > 0 && (
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => void control('retry_failed')}
+              style={{ ...btnSecondary, padding: '4px 9px', fontSize: 12 }}
+            >
+              Retry failed
+            </button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clawjournal/web/frontend/src/types.ts
+++ b/clawjournal/web/frontend/src/types.ts
@@ -361,6 +361,53 @@ export interface WorkbenchConfig {
   scorer_backend_detected: string | null;
 }
 
+export type ScoringWorkerState =
+  | 'disabled'
+  | 'idle'
+  | 'running'
+  | 'cooldown'
+  | 'action_required';
+
+export type ScoringQueueStage =
+  | 'queued'
+  | 'preparing'
+  | 'locating_evidence'
+  | 'final_scoring'
+  | 'persisting';
+
+export type ScoringActionRequiredCode =
+  | 'backend_missing'
+  | 'backend_auth'
+  | 'backend_unavailable';
+
+export interface ScoringQueueStatus {
+  enabled: boolean;
+  backend: string | null;
+  worker_state: ScoringWorkerState;
+  counts: {
+    pending: number;
+    running: number;
+    retry_wait: number;
+    succeeded: number;
+    failed: number;
+  };
+  current: {
+    job_id: string;
+    stage: ScoringQueueStage;
+    progress_current: number | null;
+    progress_total: number | null;
+  } | null;
+  next_retry_at: string | null;
+  action_required_code: ScoringActionRequiredCode | null;
+}
+
+export interface ScoringControlResponse {
+  ok: true;
+  action: 'pause' | 'resume' | 'retry_failed';
+  retried?: number;
+  status: ScoringQueueStatus;
+}
+
 export type AutoUploadMode = 'off' | 'enabled' | 'paused';
 export type AutoUploadHealth = 'ready' | 'action_required' | 'retrying';
 export type AutoUploadOverlay = 'running' | 'revocation_pending' | 'enrollment_pending' | null;

--- a/clawjournal/web/frontend/src/views/Inbox.test.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.test.tsx
@@ -1,6 +1,6 @@
 import { act, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { api } from '../api.ts';
 import { ToastProvider } from '../components/Toast.tsx';
 import type { Session } from '../types.ts';
@@ -92,6 +92,18 @@ function renderInbox(sessions: Session[]) {
   );
   return { statsSpy };
 }
+
+beforeEach(() => {
+  vi.spyOn(api, 'scoringStatus').mockResolvedValue({
+    enabled: true,
+    backend: 'codex',
+    worker_state: 'idle',
+    counts: { pending: 0, running: 0, retry_wait: 0, succeeded: 0, failed: 0 },
+    current: null,
+    next_retry_at: null,
+    action_required_code: null,
+  });
+});
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -372,4 +384,49 @@ describe('Inbox bulk status updates', () => {
     expect(screen.getByText('100 sessions approved')).toBeInTheDocument();
     expect(screen.getByText('1 session could not be updated; visible items remain selected')).toBeInTheDocument();
   }, 15_000);
+
+  it('approves 400 loaded sessions in four bounded requests', async () => {
+    const allSessions = Array.from({ length: 400 }, (_, index) => session(`s${index + 1}`));
+    vi.spyOn(api.sessions, 'list').mockImplementation(async (params = {}) => {
+      const start = params.offset ?? 0;
+      return allSessions.slice(start, start + (params.limit ?? 50));
+    });
+    vi.spyOn(api, 'stats').mockResolvedValue(stats(allSessions.length));
+    const bulkStatus = vi.spyOn(api.sessions, 'bulkStatus').mockImplementation(async ids => ({
+      updated_ids: ids,
+      missing_ids: [],
+    }));
+    localStorage.setItem('cj.gettingStartedGuideV2Dismissed', '1');
+    render(
+      <MemoryRouter>
+        <ToastProvider><Inbox /></ToastProvider>
+      </MemoryRouter>,
+    );
+
+    await screen.findByRole('checkbox', { name: 'Select session: Session s1' });
+    fireEvent.change(screen.getByRole('combobox', { name: 'Sessions per page' }), {
+      target: { value: '100' },
+    });
+    await screen.findByText('100 selected');
+
+    for (const expected of [200, 300, 400]) {
+      fireEvent.click(screen.getByRole('button', { name: 'Load more' }));
+      await screen.findByText(`${expected} selected`);
+    }
+
+    fireEvent.click(screen.getByRole('button', { name: 'Approve' }));
+    fireEvent.click(within(screen.getByRole('dialog')).getByRole('button', { name: 'Approve' }));
+
+    await waitFor(() => expect(bulkStatus).toHaveBeenCalledTimes(4));
+    expect(bulkStatus.mock.calls.map(([ids, status]) => [ids.length, status])).toEqual([
+      [100, 'approved'],
+      [100, 'approved'],
+      [100, 'approved'],
+      [100, 'approved'],
+    ]);
+    expect(bulkStatus.mock.calls.flatMap(([ids]) => ids)).toEqual(
+      allSessions.map(item => item.session_id),
+    );
+    await screen.findByText('400 sessions approved');
+  }, 45_000);
 });

--- a/clawjournal/web/frontend/src/views/Inbox.tsx
+++ b/clawjournal/web/frontend/src/views/Inbox.tsx
@@ -7,6 +7,7 @@ import { ConfirmDialog } from '../components/ConfirmDialog.tsx';
 import { Spinner } from '../components/Spinner.tsx';
 import { LABELS } from '../components/BadgeChip.tsx';
 import { GettingStartedGuide } from '../components/GettingStartedGuide.tsx';
+import { ScoringQueueStatus } from '../components/ScoringQueueStatus.tsx';
 import { ZeroState } from '../components/ZeroState.tsx';
 import { colors, selectStyle, btnPrimary, btnDanger, btnSecondary } from '../theme.ts';
 
@@ -560,6 +561,8 @@ export function Inbox() {
           </button>
         </div>
       </div>
+
+      <ScoringQueueStatus compact />
 
       {loaded && stats.total === 0 && sessions.length === 0 && !typeFilter && (
         <ZeroState />

--- a/clawjournal/web/frontend/src/views/Settings.tsx
+++ b/clawjournal/web/frontend/src/views/Settings.tsx
@@ -3,6 +3,7 @@ import { api } from '../api.ts';
 import type { ProjectSummary, WorkbenchConfig } from '../types.ts';
 import { useToast } from '../components/Toast.tsx';
 import { AutoUploadPanel } from '../components/AutoUploadControls.tsx';
+import { ScoringQueueStatus } from '../components/ScoringQueueStatus.tsx';
 import { colors, selectStyle, btnPrimary } from '../theme.ts';
 
 type ConfigPatch = Partial<{
@@ -220,15 +221,7 @@ export function Settings() {
           backend (each trace is anonymized on this machine before it is sent, and the agent may
           incur usage cost). Turn it off to stop the auto-scorer and the first-run prompt.
         </p>
-        <label style={{ display: 'flex', alignItems: 'center', gap: 8, fontSize: 13, color: colors.gray700 }}>
-          <input
-            type="checkbox"
-            checked={!cfg.scoring_warmup_declined}
-            disabled={saving}
-            onChange={e => save({ scoring_warmup_declined: !e.target.checked })}
-          />
-          Enable background AI scoring
-        </label>
+        <ScoringQueueStatus controls />
       </div>
 
       {/* Benchmark tab visibility */}

--- a/clawjournal/workbench/daemon.py
+++ b/clawjournal/workbench/daemon.py
@@ -1,6 +1,7 @@
 """Local daemon for the scientist workbench — scanner + HTTP API."""
 
 import hashlib
+import inspect
 import json
 import logging
 import os
@@ -35,11 +36,9 @@ from ..auto_upload_client import (
 from ..redaction.anonymizer import Anonymizer
 from ..scoring.badges import compute_all_badges
 from ..scoring.backends import (
-    PERMANENT_BACKEND_FAILURE_MARKERS,
     SUPPORTED_BACKENDS,
     detect_available_backend,
     installed_fallback_chain,
-    is_backend_unavailable_error,
     require_backend_command,
     resolve_backend,
 )
@@ -138,6 +137,7 @@ from .timeline import (
     render_not_found_html,
     render_timeline_html,
 )
+from . import scoring_queue
 from ..parsing.parser import (
     AIDER_SOURCE,
     CLAUDE_SOURCE,
@@ -339,6 +339,8 @@ SCAN_INTERVAL = 60  # seconds
 # than falling arbitrarily far behind.
 MAX_SCAN_BACKOFF = 900  # seconds
 AUTO_SCORE_BATCH_SIZE = 20
+SCORING_QUEUE_ENQUEUE_LIMIT = 10_000
+SCORING_EXPLICIT_LOCK_WAIT_SECONDS = 30.0
 _NO_MATCHING_WARMUP_SOURCE = "__clawjournal_no_matching_warmup_source__"
 SCORING_DISPLAY_NAMES = {
     "claude": "Claude Code",
@@ -499,7 +501,14 @@ _FRONTEND_BUILD_INPUT_FILES = (
 )
 
 
-def _persist_scoring_result(conn: sqlite3.Connection, session_id: str, result: Any) -> bool:
+def _persist_scoring_result(
+    conn: sqlite3.Connection,
+    session_id: str,
+    result: Any,
+    *,
+    expected_content_revision: str | None = None,
+    commit: bool = True,
+) -> bool:
     """Persist a scoring result into the sessions table."""
     return update_session(
         conn, session_id,
@@ -522,7 +531,42 @@ def _persist_scoring_result(conn: sqlite3.Connection, session_id: str, result: A
         ai_scorer_model=getattr(result, "scorer_model", "") or None,
         ai_rubric_git_sha=getattr(result, "rubric_git_sha", "") or None,
         ai_scored_at=getattr(result, "scored_at", "") or None,
+        expected_content_revision=expected_content_revision,
+        commit=commit,
     )
+
+
+def _scoring_response_from_session(
+    session: sqlite3.Row | dict[str, Any], *, cached: bool
+) -> dict[str, Any]:
+    """Return the established manual-score response from a persisted row."""
+
+    row = dict(session)
+
+    def json_list(field: str) -> list[Any]:
+        value = row.get(field)
+        if not isinstance(value, str) or not value:
+            return []
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError):
+            return []
+        return parsed if isinstance(parsed, list) else []
+
+    return {
+        "ok": True,
+        "cached": cached,
+        "ai_quality_score": row.get("ai_quality_score"),
+        "ai_failure_value_score": row.get("ai_failure_value_score"),
+        "ai_recovery_labels": json_list("ai_recovery_labels"),
+        "ai_failure_attribution": row.get("ai_failure_attribution") or "",
+        "ai_failure_modes": json_list("ai_failure_modes"),
+        "ai_learning_summary": row.get("ai_learning_summary") or "",
+        "reason": row.get("ai_score_reason") or "",
+        "task_type": row.get("ai_task_type") or "unknown",
+        "outcome": row.get("ai_outcome_badge") or "",
+        "summary": row.get("ai_summary") or "",
+    }
 
 
 def _env_scoring_backend() -> str | None:
@@ -575,6 +619,16 @@ def _fallback_chain_has_installed_backend(backend: str) -> bool:
             continue
         return True
     return False
+
+
+def _scoring_backend_chain(backend: str) -> list[str]:
+    """Return the ordered durable-state keys for primary plus fallbacks."""
+
+    try:
+        chain = installed_fallback_chain(resolve_backend(backend))
+    except Exception:  # noqa: BLE001
+        chain = [backend]
+    return list(dict.fromkeys(str(candidate) for candidate in chain if candidate))
 
 
 def trigger_scoring_warmup(
@@ -755,6 +809,99 @@ def _next_scan_delay(elapsed_seconds: float) -> float:
     if not elapsed_seconds or elapsed_seconds <= SCAN_INTERVAL:
         return SCAN_INTERVAL
     return min(elapsed_seconds, MAX_SCAN_BACKOFF)
+
+
+def _enqueue_scoring_candidates(
+    conn: sqlite3.Connection,
+    *,
+    since: str | None,
+    effective_settings: dict[str, Any],
+) -> int:
+    """Reconcile the current eligible revisions into the durable queue."""
+
+    candidates = _query_scoreable_warmup_sessions(
+        conn,
+        limit=SCORING_QUEUE_ENQUEUE_LIMIT,
+        since=since,
+        source_filter=_warmup_source_filter(effective_settings),
+        excluded_projects=list(effective_settings.get("excluded_projects") or []),
+    )
+    return scoring_queue.enqueue_session_ids(
+        conn, [str(candidate["session_id"]) for candidate in candidates]
+    )
+
+
+def _scoring_job_preflight(
+    conn: sqlite3.Connection,
+    job: dict[str, Any],
+) -> tuple[dict[str, Any] | None, dict[str, Any] | None, str | None]:
+    """Recheck every background-egress gate for a claimed revision."""
+
+    if load_config().get("scoring_warmup_declined"):
+        return None, None, "ineligible"
+    row = conn.execute(
+        "SELECT session_id, content_revision, source, project, checkpoint_active, "
+        "ai_quality_score, ai_failure_value_score FROM sessions WHERE session_id = ?",
+        (job["session_id"],),
+    ).fetchone()
+    if row is None or row["content_revision"] != job["content_revision"]:
+        return None, None, "stale_revision"
+    session = dict(row)
+    if not bool(session.get("checkpoint_active", 1)):
+        return None, None, "ineligible"
+    if (
+        session.get("ai_quality_score") is not None
+        and session.get("ai_failure_value_score") is not None
+    ):
+        return None, None, "already_scored"
+
+    settings = get_effective_share_settings(conn, load_config())
+    allowed = _warmup_source_filter(settings)
+    source = str(session.get("source") or "")
+    if isinstance(allowed, tuple):
+        source_allowed = source in allowed
+    else:
+        source_allowed = source == allowed
+    if not source_allowed or session_matches_excluded_projects(
+        session, list(settings.get("excluded_projects") or [])
+    ):
+        return None, None, "ineligible"
+    if release_gate_blockers(conn, [str(job["session_id"])]):
+        return None, None, "ineligible"
+    return session, _score_redaction_settings(settings), None
+
+
+def _scoring_progress_fields(message: str) -> tuple[str, int | None, int | None]:
+    """Project human progress callbacks onto the bounded queue status schema."""
+
+    locator_total = re.search(r"in (\d+) chunks", message)
+    if locator_total:
+        return "locating_evidence", 0, int(locator_total.group(1))
+    locator_done = re.search(r"Locator chunks completed: (\d+)/(\d+)", message)
+    if locator_done:
+        return "locating_evidence", int(locator_done.group(1)), int(locator_done.group(2))
+    if message.startswith("Scoring selected timeline") or message.startswith("Scoring final judge"):
+        return "final_scoring", None, None
+    return "preparing", None, None
+
+
+def _score_accepts_parameter(
+    score_function: Callable[..., Any], parameter_name: str
+) -> bool:
+    """Keep old monkeypatched scorer callables compatible in tests/plugins."""
+
+    try:
+        signature = inspect.signature(score_function)
+    except (TypeError, ValueError):
+        return True
+    return parameter_name in signature.parameters or any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+
+
+def _score_accepts_progress(score_function: Callable[..., Any]) -> bool:
+    return _score_accepts_parameter(score_function, "progress")
 
 
 class Scanner:
@@ -1202,10 +1349,8 @@ class Scanner:
         since: str | None = None,
         backend: str = "auto",
     ) -> int:
-        """Score the latest failure-corpus traces using the selected backend."""
-        if self._auto_score_disabled_reason:
-            return 0
-        if not self._score_lock.acquire(blocking=False):
+        """Drain a bounded number of jobs from the durable scoring queue."""
+        if limit <= 0 or not self._score_lock.acquire(blocking=False):
             return 0
 
         from ..scoring.scoring import score_session
@@ -1213,98 +1358,241 @@ class Scanner:
         try:
             conn = open_index()
             try:
-                effective_settings = get_effective_share_settings(conn, load_config())
-                excluded_projects = list(effective_settings.get("excluded_projects") or [])
-                redaction_settings = _score_redaction_settings(effective_settings)
-                # Warmup deliberately scores the latest `limit` unscored
-                # failure-corpus traces ordered by start_time DESC with no
-                # age cap (`since` is None for the background path). The
-                # `limit` bounds cost; callers that want a rolling window
-                # (CLI `--window`) pass `since` explicitly.
-                #
-                # `include_stale_scored` also re-selects sessions that were
-                # graded mid-flight and then grew (end_time advanced past
-                # ai_scored_at); `settle_seconds` defers sessions that are still
-                # active so we don't grade them prematurely in the first place.
-                sessions = _query_scoreable_warmup_sessions(
-                    conn,
-                    limit=limit,
-                    since=since,
-                    source_filter=_warmup_source_filter(effective_settings),
-                    excluded_projects=excluded_projects,
+                settings = get_effective_share_settings(conn, load_config())
+                _enqueue_scoring_candidates(
+                    conn, since=since, effective_settings=settings
                 )
-                if not sessions:
+                if load_config().get("scoring_warmup_declined"):
                     return 0
-
-                # Build a fallback chain so a backend that runs out mid-batch
-                # (e.g. codex out of credits / not logged in) is replaced by the
-                # next installed backend instead of failing every remaining trace.
-                # If nothing resolves up front, fall through to the per-session
-                # handling below (which arms the permanent-failure breaker).
                 try:
                     chain = installed_fallback_chain(resolve_backend(backend))
                 except Exception:  # noqa: BLE001
                     chain = [backend]
-                dead: set[str] = set()
 
+                owner = f"{os.getpid()}:{uuid.uuid4()}"
                 scored = 0
-                for s in sessions:
-                    # Honor a mid-batch opt-out: if the user turns off background
-                    # scoring (Settings / decline) while this batch is running,
-                    # stop before egressing the next trace. Re-read config each
-                    # iteration — it's the source of truth and cheap relative to a
-                    # scoring call.
-                    if load_config().get("scoring_warmup_declined"):
-                        logger.info("Automatic scoring stopped: background scoring turned off")
-                        break
-                    sid = s["session_id"]
-                    while True:
-                        active = next((b for b in chain if b not in dead), None)
-                        if active is None:
-                            self._auto_score_disabled_reason = (
-                                self._auto_score_disabled_reason
-                                or "All scoring backends are unavailable")
-                            logger.info("Automatic scoring disabled: %s",
-                                        self._auto_score_disabled_reason)
-                            break
-                        try:
-                            score_kwargs: dict[str, Any] = {"backend": active}
-                            if redaction_settings is not None:
-                                score_kwargs["redaction_settings"] = redaction_settings
-                            result = score_session(conn, sid, **score_kwargs)
-                        except RuntimeError as exc:
-                            message = str(exc)
-                            backend_dead = is_backend_unavailable_error(message) or any(
-                                m in message for m in PERMANENT_BACKEND_FAILURE_MARKERS)
-                            if backend_dead:
-                                dead.add(active)
-                                if next((b for b in chain if b not in dead), None) is not None:
-                                    logger.info("Scoring backend '%s' unavailable (%s); "
-                                                "switching to '%s'", active, message,
-                                                next(b for b in chain if b not in dead))
-                                    continue  # retry this session on the next backend
-                                self._auto_score_disabled_reason = message
-                                logger.info("Automatic scoring disabled: %s", message)
-                                break
-                            logger.warning("Automatic scoring failed for %s: %s", sid, message)
-                            break
-                        except Exception:
-                            logger.exception("Automatic scoring crashed for %s", sid)
-                            break
-                        else:
-                            if _persist_scoring_result(conn, sid, result):
-                                scored += 1
-                                _maybe_create_trace_note(conn, sid)
-                            break
-
-                    if self._auto_score_disabled_reason:
-                        break  # stop the batch — no usable backend remains
-
+                processed = 0
+                while processed < limit:
+                    outcome = self._score_next_queued_job(
+                        conn,
+                        chain=chain,
+                        owner=owner,
+                        score_session=score_session,
+                    )
+                    if outcome == "scored":
+                        scored += 1
+                        processed += 1
+                        continue
+                    if outcome == "processed":
+                        processed += 1
+                        continue
+                    break
                 return scored
             finally:
                 conn.close()
         finally:
             self._score_lock.release()
+
+    def _score_next_queued_job(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        chain: list[str],
+        owner: str,
+        score_session: Callable[..., Any],
+    ) -> str:
+        """Run at most one queue job while holding the global egress lock."""
+
+        from ..scoring.egress_lock import scoring_egress_lock
+        from ..scoring.scoring import ScoringAborted
+
+        # Claim only after taking the OS lock.  Otherwise a second daemon could
+        # wait behind a long judge call until its lease expires, recover it, and
+        # send the same revision to a judge a second time.
+        with scoring_egress_lock(blocking=False) as acquired:
+            if not acquired:
+                return "busy"
+            if load_config().get("scoring_warmup_declined"):
+                logger.info(
+                    "Automatic scoring stopped: background scoring turned off"
+                )
+                return "paused"
+
+            available: list[str] = []
+            blockers: list[dict[str, Any]] = []
+            for candidate_backend in chain:
+                blocker = scoring_queue.backend_blocker(conn, candidate_backend)
+                if blocker is None:
+                    available.append(candidate_backend)
+                else:
+                    blockers.append(blocker)
+            if not available:
+                if any(
+                    blocker.get("state") == "action_required"
+                    for blocker in blockers
+                ):
+                    self._auto_score_disabled_reason = (
+                        "backend_action_required"
+                    )
+                else:
+                    self._auto_score_disabled_reason = "backend_cooldown"
+                return "blocked"
+
+            job = scoring_queue.claim_next_job(conn, owner=owner)
+            if job is None:
+                return "idle"
+
+            for active_index, active in enumerate(available):
+                # Re-read every mutable privacy/control input immediately before
+                # *each* possible AI call, including a fallback retry.
+                _, redaction_settings, gate_error = _scoring_job_preflight(
+                    conn, job
+                )
+                if gate_error is not None:
+                    scoring_queue.cancel_job(
+                        conn, str(job["job_id"]), owner, gate_error
+                    )
+                    return "processed"
+
+                def progress(message: str) -> None:
+                    stage, current, total = _scoring_progress_fields(message)
+                    scoring_queue.update_job_stage(
+                        conn,
+                        str(job["job_id"]),
+                        owner,
+                        stage,
+                        current=current,
+                        total=total,
+                    )
+
+                def before_egress() -> None:
+                    # Locator calls run in their own threads; use a fresh
+                    # connection instead of sharing this worker's sqlite handle.
+                    check_conn = open_index()
+                    try:
+                        _session, _settings, current_gate_error = (
+                            _scoring_job_preflight(check_conn, job)
+                        )
+                    finally:
+                        check_conn.close()
+                    if current_gate_error is not None:
+                        raise ScoringAborted(current_gate_error)
+
+                try:
+                    score_kwargs: dict[str, Any] = {"backend": active}
+                    if redaction_settings is not None:
+                        score_kwargs["redaction_settings"] = redaction_settings
+                    if _score_accepts_progress(score_session):
+                        score_kwargs["progress"] = progress
+                    if _score_accepts_parameter(score_session, "before_egress"):
+                        score_kwargs["before_egress"] = before_egress
+                    result = score_session(
+                        conn, str(job["session_id"]), **score_kwargs
+                    )
+                except ScoringAborted as exc:
+                    code = str(exc)
+                    if code not in {
+                        "stale_revision",
+                        "ineligible",
+                        "already_scored",
+                    }:
+                        code = "score_timeout"
+                    if code == "score_timeout":
+                        scoring_queue.retry_job_failure(
+                            conn, str(job["job_id"]), owner, code
+                        )
+                    else:
+                        scoring_queue.cancel_job(
+                            conn, str(job["job_id"]), owner, code
+                        )
+                    return "processed"
+                except Exception as exc:  # noqa: BLE001
+                    category, code = scoring_queue.classify_scoring_error(exc)
+                    has_fallback = active_index + 1 < len(available)
+                    if category == "cooldown":
+                        retry_at = scoring_queue.record_backend_cooldown(
+                            conn, active, code
+                        )
+                        if has_fallback:
+                            logger.info(
+                                "Scoring backend '%s' is cooling down; switching backend",
+                                active,
+                            )
+                            continue
+                        scoring_queue.defer_job_for_backend(
+                            conn,
+                            str(job["job_id"]),
+                            owner,
+                            next_attempt_at=retry_at,
+                            action_required=False,
+                        )
+                        self._auto_score_disabled_reason = code
+                        return "blocked"
+                    if category == "action_required":
+                        scoring_queue.record_backend_action_required(
+                            conn, active, code
+                        )
+                        if has_fallback:
+                            logger.info(
+                                "Scoring backend '%s' requires attention; switching backend",
+                                active,
+                            )
+                            continue
+                        scoring_queue.defer_job_for_backend(
+                            conn,
+                            str(job["job_id"]),
+                            owner,
+                            next_attempt_at=None,
+                            action_required=True,
+                        )
+                        self._auto_score_disabled_reason = code
+                        return "blocked"
+                    scoring_queue.retry_job_failure(
+                        conn, str(job["job_id"]), owner, code
+                    )
+                    logger.warning(
+                        "Automatic scoring failed for one queued session (%s)",
+                        code,
+                    )
+                    return "processed"
+
+                scoring_queue.update_job_stage(
+                    conn, str(job["job_id"]), owner, "persisting"
+                )
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    persisted = _persist_scoring_result(
+                        conn,
+                        str(job["session_id"]),
+                        result,
+                        expected_content_revision=str(job["content_revision"]),
+                        commit=False,
+                    )
+                    finished = persisted and scoring_queue.complete_job(
+                        conn,
+                        str(job["job_id"]),
+                        owner,
+                        commit=False,
+                    )
+                    if not finished:
+                        conn.rollback()
+                        scoring_queue.cancel_job(
+                            conn,
+                            str(job["job_id"]),
+                            owner,
+                            "stale_revision",
+                        )
+                        return "processed"
+                    conn.commit()
+                except Exception:
+                    conn.rollback()
+                    raise
+                scoring_queue.clear_backend_state(conn, active)
+                self._auto_score_disabled_reason = None
+                _maybe_create_trace_note(conn, str(job["session_id"]))
+                return "scored"
+
+            return "processed"
 
     def trigger_auto_score(
         self,
@@ -1313,11 +1601,46 @@ class Scanner:
         since: str | None = None,
         backend: str = "auto",
     ) -> dict[str, Any]:
-        """Start background scoring for the latest failure-corpus sessions if idle."""
-        if self._auto_score_disabled_reason:
-            return {"status": "disabled", "reason": self._auto_score_disabled_reason}
+        """Start durable background scoring if no worker is already active."""
         if self._score_thread and self._score_thread.is_alive():
             return {"status": "already_running"}
+
+        # Durable state, across the complete fallback chain, is the sole
+        # circuit-breaker authority.  A primary that needs login must not keep
+        # a recovered fallback disabled forever.
+        chain = _scoring_backend_chain(backend)
+        blockers: list[dict[str, Any]] = []
+        conn = open_index()
+        try:
+            for candidate_backend in chain:
+                blocker = scoring_queue.backend_blocker(conn, candidate_backend)
+                if blocker is None:
+                    self._auto_score_disabled_reason = None
+                    break
+                blockers.append(blocker)
+            else:
+                action_codes = [
+                    str(blocker.get("last_error_code"))
+                    for blocker in blockers
+                    if blocker.get("state") == "action_required"
+                ]
+                retry_times = [
+                    str(blocker["next_attempt_at"])
+                    for blocker in blockers
+                    if blocker.get("state") == "cooldown"
+                    and blocker.get("next_attempt_at")
+                ]
+                reason = action_codes[0] if action_codes else "backend_cooldown"
+                self._auto_score_disabled_reason = reason
+                response: dict[str, Any] = {
+                    "status": "disabled",
+                    "reason": reason,
+                }
+                if retry_times:
+                    response["next_retry_at"] = min(retry_times)
+                return response
+        finally:
+            conn.close()
 
         def _run() -> None:
             scored = self.score_unscored_once(limit=limit, since=since, backend=backend)
@@ -4245,6 +4568,8 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             self._handle_auto_upload_preview(refresh=False)
         elif path == "/api/scoring/backend":
             self._handle_scoring_backend()
+        elif path == "/api/scoring/status":
+            self._handle_scoring_status()
         elif path == "/api/bundles":
             self._handle_list_shares()
         elif path.startswith("/api/bundles/") and path.endswith("/preview"):
@@ -4379,6 +4704,8 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             self._handle_add_findings_allowlist()
         elif path == "/api/scoring/warmup":
             self._handle_scoring_warmup()
+        elif path == "/api/scoring/control":
+            self._handle_scoring_control()
         elif path == "/api/config":
             self._handle_update_config()
         elif path == "/api/desktop/opened":
@@ -4902,7 +5229,8 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
         backend = body.get("backend", "auto")
         model = body.get("model")
 
-        from ..scoring.scoring import score_session
+        from ..scoring.egress_lock import scoring_egress_lock
+        from ..scoring.scoring import ScoringAborted, score_session
 
         conn = open_index()
         try:
@@ -4920,43 +5248,141 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
                 }, 409)
                 return
             representative_id = str(members[0]["session_id"])
-            # Manual scoring is AI egress too: scrub configured redaction
-            # strings/usernames/blocked-domains before the prompt leaves the
-            # machine, matching the background warmup path. Unlike warmup we do
-            # not gate on hold/embargo/excluded-project here — scoring a
-            # specific session is an explicit user request for that session.
-            redaction_settings = _score_redaction_settings(
-                get_effective_share_settings(conn, load_config())
-            )
-            score_kwargs: dict[str, Any] = {"model": model, "backend": backend}
-            if redaction_settings is not None:
-                score_kwargs["redaction_settings"] = redaction_settings
-            try:
-                result = score_session(conn, representative_id, **score_kwargs)
-            except RuntimeError as e:
-                _json_response(self, {"error": str(e)}, 503)
-                return
-
-            ok = _persist_scoring_result(conn, representative_id, result)
-            if not ok:
+            initial = conn.execute(
+                "SELECT * FROM sessions WHERE session_id = ?",
+                (representative_id,),
+            ).fetchone()
+            if initial is None:
                 _json_response(self, {"error": "Session not found"}, 404)
                 return
+            initial_revision = str(initial["content_revision"] or "")
+            initial_had_score = (
+                initial["ai_quality_score"] is not None
+                or initial["ai_failure_value_score"] is not None
+            )
 
-            _maybe_create_trace_note(conn, representative_id)
+            with scoring_egress_lock(
+                blocking=True, timeout=SCORING_EXPLICIT_LOCK_WAIT_SECONDS
+            ) as acquired:
+                if not acquired:
+                    _json_response(
+                        self,
+                        {
+                            "error": "Another scoring request is still running.",
+                            "block_reason": "scoring_busy",
+                        },
+                        409,
+                    )
+                    return
 
-            _json_response(self, {
-                "ok": True,
-                "ai_quality_score": result.quality,
-                "ai_failure_value_score": getattr(result, "failure_value_score", None),
-                "ai_recovery_labels": getattr(result, "recovery_labels", []),
-                "ai_failure_attribution": getattr(result, "failure_attribution", ""),
-                "ai_failure_modes": getattr(result, "failure_modes", []),
-                "ai_learning_summary": getattr(result, "learning_summary", ""),
-                "reason": result.reason,
-                "task_type": result.task_type,
-                "outcome": result.outcome_label,
-                "summary": result.summary,
-            })
+                current = conn.execute(
+                    "SELECT * FROM sessions WHERE session_id = ?",
+                    (representative_id,),
+                ).fetchone()
+                if current is None:
+                    _json_response(self, {"error": "Session not found"}, 404)
+                    return
+                expected_revision = str(current["content_revision"] or "")
+                current_has_score = (
+                    current["ai_quality_score"] is not None
+                    and current["ai_failure_value_score"] is not None
+                )
+                explicit_rescore = (
+                    initial_had_score and expected_revision == initial_revision
+                )
+                if current_has_score and not explicit_rescore:
+                    _json_response(
+                        self, _scoring_response_from_session(current, cached=True)
+                    )
+                    return
+
+                def before_egress() -> None:
+                    check_conn = open_index()
+                    try:
+                        row = check_conn.execute(
+                            "SELECT content_revision FROM sessions "
+                            "WHERE session_id = ?",
+                            (representative_id,),
+                        ).fetchone()
+                    finally:
+                        check_conn.close()
+                    if (
+                        row is None
+                        or str(row["content_revision"] or "") != expected_revision
+                    ):
+                        raise ScoringAborted("stale_revision")
+
+                redaction_settings = _score_redaction_settings(
+                    get_effective_share_settings(conn, load_config())
+                )
+                score_kwargs: dict[str, Any] = {
+                    "model": model,
+                    "backend": backend,
+                }
+                if redaction_settings is not None:
+                    score_kwargs["redaction_settings"] = redaction_settings
+                if _score_accepts_parameter(score_session, "before_egress"):
+                    score_kwargs["before_egress"] = before_egress
+                try:
+                    result = score_session(
+                        conn, representative_id, **score_kwargs
+                    )
+                except ScoringAborted:
+                    _json_response(
+                        self,
+                        {
+                            "error": "Session changed while scoring; retry the current revision.",
+                            "block_reason": "stale_revision",
+                        },
+                        409,
+                    )
+                    return
+                except RuntimeError as exc:
+                    _json_response(self, {"error": str(exc)}, 503)
+                    return
+
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    persisted_ok = _persist_scoring_result(
+                        conn,
+                        representative_id,
+                        result,
+                        expected_content_revision=expected_revision,
+                        commit=False,
+                    )
+                    if persisted_ok:
+                        scoring_queue.complete_revision_jobs(
+                            conn,
+                            representative_id,
+                            expected_revision,
+                            commit=False,
+                        )
+                        conn.commit()
+                    else:
+                        conn.rollback()
+                except Exception:
+                    conn.rollback()
+                    raise
+                if not persisted_ok:
+                    _json_response(
+                        self,
+                        {
+                            "error": "Session changed while scoring; retry the current revision.",
+                            "block_reason": "stale_revision",
+                        },
+                        409,
+                    )
+                    return
+
+                _maybe_create_trace_note(conn, representative_id)
+                persisted = conn.execute(
+                    "SELECT * FROM sessions WHERE session_id = ?",
+                    (representative_id,),
+                ).fetchone()
+                _json_response(
+                    self, _scoring_response_from_session(persisted, cached=False)
+                )
+                return
         finally:
             conn.close()
 
@@ -5683,6 +6109,89 @@ class WorkbenchHandler(BaseHTTPRequestHandler):
             "confirmed": backend is not None,
             "needs_confirmation": backend is None and suggested is not None,
         })
+
+    def _scoring_status_payload(self) -> dict[str, Any]:
+        backend = _confirmed_scoring_backend()
+        enabled = bool(
+            backend and not load_config().get("scoring_warmup_declined")
+        )
+        conn = open_index()
+        try:
+            return scoring_queue.queue_status(
+                conn,
+                backend=backend,
+                backends=_scoring_backend_chain(backend) if backend else [],
+                enabled=enabled,
+            )
+        finally:
+            conn.close()
+
+    def _handle_scoring_status(self) -> None:
+        """Return content-free aggregate state for the local scoring worker."""
+
+        _json_response(self, self._scoring_status_payload())
+
+    def _handle_scoring_control(self) -> None:
+        """Pause/resume scoring or explicitly retry quarantined revisions."""
+
+        body = _read_body(self)
+        if not isinstance(body, dict) or set(body) != {"action"}:
+            _json_response(
+                self,
+                {"error": "Request body must contain only action"},
+                400,
+            )
+            return
+        action = body.get("action")
+        if not isinstance(action, str) or action not in {
+            "pause", "resume", "retry_failed"
+        }:
+            _json_response(
+                self,
+                {"error": "action must be pause, resume, or retry_failed"},
+                400,
+            )
+            return
+
+        config = load_config()
+        scanner = getattr(self.server, "_scanner", None)
+        retried = 0
+        if action == "pause":
+            config["scoring_warmup_declined"] = True
+            if save_config(config) is False:
+                _json_response(self, {"error": "Could not save scoring control"}, 500)
+                return
+        else:
+            config.pop("scoring_warmup_declined", None)
+            if save_config(config) is False:
+                _json_response(self, {"error": "Could not save scoring control"}, 500)
+                return
+            backend = _confirmed_scoring_backend()
+            conn = open_index()
+            try:
+                if backend:
+                    for candidate in _scoring_backend_chain(backend):
+                        scoring_queue.clear_backend_state(conn, candidate)
+                if action == "retry_failed":
+                    retried = scoring_queue.retry_failed_jobs(conn)
+                settings = get_effective_share_settings(conn, load_config())
+                _enqueue_scoring_candidates(
+                    conn, since=None, effective_settings=settings
+                )
+            finally:
+                conn.close()
+            if scanner is not None:
+                scanner._auto_score_disabled_reason = None
+                trigger_scoring_warmup(scanner)
+
+        payload: dict[str, Any] = {
+            "ok": True,
+            "action": action,
+            "status": self._scoring_status_payload(),
+        }
+        if action == "retry_failed":
+            payload["retried"] = retried
+        _json_response(self, payload)
 
     def _handle_scoring_warmup(self) -> None:
         """Start background scoring for share-ready recommendations."""

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -282,7 +282,8 @@ def open_existing_index(
 # version 11 records which share predecessors the hosted receiver dictated
 # so a retried submission can tell them apart from a locally stale claim, and
 # version 12 separates append-only upload checkpoints from the logical
-# conversation projected by the local workbench.
+# conversation projected by the local workbench, and version 13 adds the
+# durable, revision-keyed background scoring queue.
 SECURITY_SCHEMA_VERSION = 2
 SESSION_IDENTITY_SCHEMA_VERSION = 3
 WIDENED_MESSAGE_SCHEMA_VERSION = 4
@@ -294,7 +295,8 @@ RECURRING_PROTOCOL_V2_SCHEMA_VERSION = 9
 EXACT_SCOPE_PAIRS_SCHEMA_VERSION = 10
 RECEIVER_PREDECESSOR_SCHEMA_VERSION = 11
 LOGICAL_CHECKPOINT_SCHEMA_VERSION = 12
-WORKBENCH_SCHEMA_VERSION = LOGICAL_CHECKPOINT_SCHEMA_VERSION
+SCORING_QUEUE_SCHEMA_VERSION = 13
+WORKBENCH_SCHEMA_VERSION = SCORING_QUEUE_SCHEMA_VERSION
 
 # `share_sessions.predecessor_source` values. NULL means the predecessor is the
 # create-time local baseline; RECEIVER means the hosted lineage preflight
@@ -1174,6 +1176,7 @@ def open_index() -> sqlite3.Connection:
     _migrate_exact_scope_pairs(conn)
     _migrate_receiver_predecessor(conn)
     _migrate_logical_checkpoint_projection(conn)
+    _migrate_scoring_queue(conn)
 
     # Clean up ai_outcome_badge values that the judge wrote before the
     # resolution validator rejected invalid labels. Idempotent: after
@@ -1926,6 +1929,75 @@ def _migrate_logical_checkpoint_projection(conn: sqlite3.Connection) -> None:
             "WHERE logical_session_id IS NOT NULL"
         )
         conn.execute(f"PRAGMA user_version = {LOGICAL_CHECKPOINT_SCHEMA_VERSION}")
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def _create_scoring_queue_schema(conn: sqlite3.Connection) -> None:
+    """Create the revision-keyed scoring queue and backend circuit state."""
+
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS scoring_jobs (
+            job_id            TEXT PRIMARY KEY,
+            session_id        TEXT NOT NULL REFERENCES sessions(session_id) ON DELETE CASCADE,
+            content_revision  TEXT NOT NULL,
+            state             TEXT NOT NULL CHECK (
+                state IN ('pending', 'running', 'retry_wait', 'succeeded', 'failed', 'cancelled')
+            ),
+            priority          INTEGER NOT NULL DEFAULT 0,
+            attempt_count     INTEGER NOT NULL DEFAULT 0 CHECK (attempt_count >= 0),
+            next_attempt_at   TEXT,
+            lease_owner       TEXT,
+            lease_expires_at  TEXT,
+            stage             TEXT NOT NULL DEFAULT 'queued',
+            stage_current     INTEGER,
+            stage_total       INTEGER,
+            last_error_code   TEXT,
+            last_error_at     TEXT,
+            created_at        TEXT NOT NULL,
+            updated_at        TEXT NOT NULL,
+            UNIQUE(session_id, content_revision)
+        )"""
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_scoring_jobs_due "
+        "ON scoring_jobs(state, next_attempt_at, priority DESC, created_at, job_id)"
+    )
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_scoring_jobs_session_revision "
+        "ON scoring_jobs(session_id, content_revision)"
+    )
+    conn.execute(
+        """CREATE TABLE IF NOT EXISTS scoring_backend_state (
+            backend              TEXT PRIMARY KEY,
+            state                TEXT NOT NULL CHECK (
+                state IN ('ready', 'cooldown', 'action_required')
+            ),
+            next_attempt_at      TEXT,
+            consecutive_failures INTEGER NOT NULL DEFAULT 0
+                CHECK (consecutive_failures >= 0),
+            last_error_code      TEXT,
+            updated_at           TEXT NOT NULL
+        )"""
+    )
+
+
+def _migrate_scoring_queue(conn: sqlite3.Connection) -> None:
+    """Advance v12 -> v13 by adding rebuildable scoring scheduler state."""
+
+    version_row = conn.execute("PRAGMA user_version").fetchone()
+    version = version_row[0] if version_row else 0
+    if version >= SCORING_QUEUE_SCHEMA_VERSION:
+        _create_scoring_queue_schema(conn)
+        conn.commit()
+        return
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        _create_scoring_queue_schema(conn)
+        conn.execute(f"PRAGMA user_version = {SCORING_QUEUE_SCHEMA_VERSION}")
         conn.commit()
     except Exception:
         conn.rollback()
@@ -4731,6 +4803,8 @@ def update_session(
     ai_scorer_model: str | None = None,
     ai_rubric_git_sha: str | None = None,
     ai_scored_at: str | None = None,
+    expected_content_revision: str | None = None,
+    commit: bool = True,
 ) -> bool:
     """Update review fields on a session.
 
@@ -4747,10 +4821,15 @@ def update_session(
             return False
 
     row = conn.execute(
-        "SELECT session_id, review_status FROM sessions WHERE session_id = ?",
+        "SELECT session_id, review_status, content_revision FROM sessions WHERE session_id = ?",
         (session_id,),
     ).fetchone()
     if row is None:
+        return False
+    if (
+        expected_content_revision is not None
+        and row["content_revision"] != expected_content_revision
+    ):
         return False
 
     updates: list[str] = []
@@ -4854,13 +4933,18 @@ def update_session(
     updates.append("updated_at = ?")
     params.append(now)
     params.append(session_id)
+    where = "session_id = ?"
+    if expected_content_revision is not None:
+        where += " AND content_revision = ?"
+        params.append(expected_content_revision)
 
-    conn.execute(
-        f"UPDATE sessions SET {', '.join(updates)} WHERE session_id = ?",
+    cursor = conn.execute(
+        f"UPDATE sessions SET {', '.join(updates)} WHERE {where}",
         params,
     )
-    conn.commit()
-    return True
+    if commit:
+        conn.commit()
+    return cursor.rowcount == 1
 
 
 REVIEW_BULK_STATUSES = frozenset({"approved", "blocked"})

--- a/clawjournal/workbench/index_recovery.py
+++ b/clawjournal/workbench/index_recovery.py
@@ -273,6 +273,11 @@ _NON_SAFETY_RELATIONAL_TABLES = _EXECUTION_RECORDER_TABLES | frozenset({
     "benchmarks",
     "benchmark_tasks",
     "benchmark_exports",
+    # Derived scheduler state is rebuilt from the current session revisions
+    # after recovery; an orphan here must not make readable review/hold state
+    # look unsafe to restore.
+    "scoring_jobs",
+    "scoring_backend_state",
 })
 
 

--- a/clawjournal/workbench/scoring_queue.py
+++ b/clawjournal/workbench/scoring_queue.py
@@ -1,0 +1,742 @@
+"""Durable, revision-keyed scheduling primitives for background scoring.
+
+The queue stores control-plane metadata only.  Transcript content and raw
+backend errors never belong in these tables: workers persist a small fixed
+error code and keep all session content in the existing private blob store.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+from datetime import datetime, timedelta, timezone
+from typing import Any, Sequence
+
+
+SCORING_JOB_STATES = frozenset(
+    {"pending", "running", "retry_wait", "succeeded", "failed", "cancelled"}
+)
+SCORING_BACKEND_STATES = frozenset({"ready", "cooldown", "action_required"})
+SCORING_LEASE_SECONDS = 10 * 60
+SCORING_SESSION_BACKOFF_SECONDS = (5 * 60, 30 * 60, 6 * 60 * 60)
+SCORING_MAX_SESSION_ATTEMPTS = len(SCORING_SESSION_BACKOFF_SECONDS) + 1
+SCORING_BACKEND_BACKOFF_SECONDS = (5 * 60, 30 * 60, 6 * 60 * 60)
+
+JOB_ERROR_CODES = frozenset(
+    {
+        "lease_expired",
+        "stale_revision",
+        "ineligible",
+        "already_scored",
+        "score_timeout",
+        "score_failed",
+        "transcript_unavailable",
+        "backend_cooldown",
+        "backend_action_required",
+    }
+)
+BACKEND_ERROR_CODES = frozenset(
+    {
+        "backend_rate_limited",
+        "backend_temporary",
+        "backend_missing",
+        "backend_auth",
+        "backend_unavailable",
+    }
+)
+ACTION_REQUIRED_CODES = frozenset(
+    {"backend_missing", "backend_auth", "backend_unavailable"}
+)
+
+
+def _utc(value: datetime | None = None) -> datetime:
+    current = value or datetime.now(timezone.utc)
+    if current.tzinfo is None:
+        current = current.replace(tzinfo=timezone.utc)
+    return current.astimezone(timezone.utc)
+
+
+def _iso(value: datetime | None = None) -> str:
+    return _utc(value).isoformat()
+
+
+def _chunks(values: Sequence[str], size: int = 400) -> list[list[str]]:
+    return [list(values[start:start + size]) for start in range(0, len(values), size)]
+
+
+def enqueue_session_ids(
+    conn: sqlite3.Connection,
+    session_ids: Sequence[str],
+    *,
+    priority: int = 0,
+    now: datetime | None = None,
+) -> int:
+    """Idempotently queue each current non-empty content revision.
+
+    A cancelled revision may become eligible again after a hold or scope
+    change, so a fresh eligibility pass reactivates it.  Failed jobs require
+    an explicit retry and succeeded jobs remain immutable audit rows.
+    """
+
+    requested = list(dict.fromkeys(
+        session_id for session_id in session_ids
+        if isinstance(session_id, str) and session_id
+    ))
+    if not requested:
+        return 0
+    if not isinstance(priority, int) or isinstance(priority, bool):
+        raise ValueError("priority must be an integer")
+    if conn.in_transaction:
+        raise RuntimeError("queue enqueue requires a connection without an active transaction")
+
+    stamp = _iso(now)
+    rows: list[sqlite3.Row] = []
+    for batch in _chunks(requested):
+        placeholders = ",".join("?" for _ in batch)
+        rows.extend(conn.execute(
+            "SELECT session_id, content_revision FROM sessions "
+            f"WHERE session_id IN ({placeholders}) "
+            "AND content_revision IS NOT NULL AND content_revision != '' "
+            "AND COALESCE(checkpoint_active, 1) = 1",
+            batch,
+        ).fetchall())
+    current = {
+        str(row["session_id"]): str(row["content_revision"])
+        for row in rows
+    }
+    if not current:
+        return 0
+
+    existing: dict[tuple[str, str], str] = {}
+    for batch in _chunks(list(current)):
+        placeholders = ",".join("?" for _ in batch)
+        for row in conn.execute(
+            "SELECT session_id, content_revision, state FROM scoring_jobs "
+            f"WHERE session_id IN ({placeholders})",
+            batch,
+        ).fetchall():
+            existing[(str(row["session_id"]), str(row["content_revision"]))] = str(
+                row["state"]
+            )
+
+    queued = sum(
+        1
+        for session_id, revision in current.items()
+        if existing.get((session_id, revision)) in (None, "cancelled")
+    )
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        for session_id, revision in current.items():
+            conn.execute(
+                "UPDATE scoring_jobs SET state = 'cancelled', "
+                "lease_owner = NULL, lease_expires_at = NULL, "
+                "next_attempt_at = NULL, stage = 'queued', "
+                "stage_current = NULL, stage_total = NULL, "
+                "last_error_code = 'stale_revision', last_error_at = ?, updated_at = ? "
+                "WHERE session_id = ? AND content_revision != ? "
+                "AND state IN ('pending', 'running', 'retry_wait')",
+                (stamp, stamp, session_id, revision),
+            )
+            conn.execute(
+                "INSERT INTO scoring_jobs "
+                "(job_id, session_id, content_revision, state, priority, attempt_count, "
+                " stage, created_at, updated_at) "
+                "VALUES (?, ?, ?, 'pending', ?, 0, 'queued', ?, ?) "
+                "ON CONFLICT(session_id, content_revision) DO UPDATE SET "
+                "priority = MAX(scoring_jobs.priority, excluded.priority), "
+                "state = CASE WHEN scoring_jobs.state = 'cancelled' "
+                "             THEN 'pending' ELSE scoring_jobs.state END, "
+                "next_attempt_at = CASE WHEN scoring_jobs.state = 'cancelled' "
+                "                       THEN NULL ELSE scoring_jobs.next_attempt_at END, "
+                "lease_owner = CASE WHEN scoring_jobs.state = 'cancelled' "
+                "                   THEN NULL ELSE scoring_jobs.lease_owner END, "
+                "lease_expires_at = CASE WHEN scoring_jobs.state = 'cancelled' "
+                "                        THEN NULL ELSE scoring_jobs.lease_expires_at END, "
+                "last_error_code = CASE WHEN scoring_jobs.state = 'cancelled' "
+                "                       THEN NULL ELSE scoring_jobs.last_error_code END, "
+                "last_error_at = CASE WHEN scoring_jobs.state = 'cancelled' "
+                "                     THEN NULL ELSE scoring_jobs.last_error_at END, "
+                "stage = CASE WHEN scoring_jobs.state = 'cancelled' "
+                "             THEN 'queued' ELSE scoring_jobs.stage END, "
+                "updated_at = excluded.updated_at",
+                (str(uuid.uuid4()), session_id, revision, priority, stamp, stamp),
+            )
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    return queued
+
+
+def recover_expired_leases(
+    conn: sqlite3.Connection, *, now: datetime | None = None, commit: bool = True
+) -> int:
+    """Return expired running jobs to the due queue without consuming a retry."""
+
+    stamp = _iso(now)
+    cursor = conn.execute(
+        "UPDATE scoring_jobs SET state = 'retry_wait', next_attempt_at = ?, "
+        "lease_owner = NULL, lease_expires_at = NULL, stage = 'queued', "
+        "stage_current = NULL, stage_total = NULL, "
+        "last_error_code = 'lease_expired', last_error_at = ?, updated_at = ? "
+        "WHERE state = 'running' AND lease_expires_at IS NOT NULL "
+        "AND lease_expires_at <= ?",
+        (stamp, stamp, stamp, stamp),
+    )
+    if commit:
+        conn.commit()
+    return max(cursor.rowcount, 0)
+
+
+def _cancel_noncurrent_or_inactive_jobs(
+    conn: sqlite3.Connection, *, now: datetime | None = None
+) -> int:
+    """Fail closed jobs whose exact checkpoint can no longer be scored.
+
+    Logical-session reconciliation can retire a checkpoint without changing
+    its content revision.  Such a job must not remain visible forever merely
+    because claim eligibility correctly skips it.  Keep succeeded rows as an
+    audit trail, but cancel every unfinished/quarantined job that is stale or
+    belongs to an inactive checkpoint.
+    """
+
+    stamp = _iso(now)
+    cursor = conn.execute(
+        "UPDATE scoring_jobs SET state = 'cancelled', "
+        "lease_owner = NULL, lease_expires_at = NULL, next_attempt_at = NULL, "
+        "stage = 'queued', stage_current = NULL, stage_total = NULL, "
+        "last_error_code = CASE WHEN EXISTS ("
+        " SELECT 1 FROM sessions current_session "
+        " WHERE current_session.session_id = scoring_jobs.session_id "
+        " AND current_session.content_revision = scoring_jobs.content_revision"
+        ") THEN 'ineligible' ELSE 'stale_revision' END, "
+        "last_error_at = ?, updated_at = ? "
+        "WHERE (state IN ('pending', 'running', 'retry_wait') "
+        " AND NOT EXISTS ("
+        "  SELECT 1 FROM sessions eligible_session "
+        "  WHERE eligible_session.session_id = scoring_jobs.session_id "
+        "  AND eligible_session.content_revision = scoring_jobs.content_revision "
+        "  AND COALESCE(eligible_session.checkpoint_active, 1) = 1"
+        " )) OR (state = 'failed' AND EXISTS ("
+        "  SELECT 1 FROM sessions retired_session "
+        "  WHERE retired_session.session_id = scoring_jobs.session_id "
+        "  AND retired_session.content_revision = scoring_jobs.content_revision "
+        "  AND COALESCE(retired_session.checkpoint_active, 1) = 0"
+        " ))",
+        (stamp, stamp),
+    )
+    return max(cursor.rowcount, 0)
+
+
+def claim_next_job(
+    conn: sqlite3.Connection,
+    *,
+    owner: str,
+    now: datetime | None = None,
+    lease_seconds: int = SCORING_LEASE_SECONDS,
+) -> dict[str, Any] | None:
+    """Atomically lease the oldest due job within the highest priority."""
+
+    if not isinstance(owner, str) or not owner:
+        raise ValueError("owner must be a non-empty string")
+    if lease_seconds <= 0:
+        raise ValueError("lease_seconds must be positive")
+    if conn.in_transaction:
+        raise RuntimeError("queue claim requires a connection without an active transaction")
+    clock = _utc(now)
+    stamp = clock.isoformat()
+    expires = (clock + timedelta(seconds=lease_seconds)).isoformat()
+
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        recover_expired_leases(conn, now=clock, commit=False)
+        _cancel_noncurrent_or_inactive_jobs(conn, now=clock)
+        row = conn.execute(
+            "SELECT j.* FROM scoring_jobs j "
+            "JOIN sessions s ON s.session_id = j.session_id "
+            " AND s.content_revision = j.content_revision "
+            "WHERE (j.state = 'pending' OR (j.state = 'retry_wait' "
+            " AND (j.next_attempt_at IS NULL OR j.next_attempt_at <= ?))) "
+            "AND COALESCE(s.checkpoint_active, 1) = 1 "
+            "ORDER BY j.priority DESC, "
+            "CASE WHEN s.start_time IS NULL OR s.start_time = '' "
+            "     THEN j.created_at ELSE s.start_time END ASC, "
+            "j.created_at ASC, j.job_id ASC LIMIT 1",
+            (stamp,),
+        ).fetchone()
+        if row is None:
+            conn.commit()
+            return None
+        cursor = conn.execute(
+            "UPDATE scoring_jobs SET state = 'running', lease_owner = ?, "
+            "lease_expires_at = ?, next_attempt_at = NULL, stage = 'preparing', "
+            "stage_current = NULL, stage_total = NULL, updated_at = ? "
+            "WHERE job_id = ? AND state IN ('pending', 'retry_wait')",
+            (owner, expires, stamp, row["job_id"]),
+        )
+        if cursor.rowcount != 1:
+            conn.rollback()
+            return None
+        claimed = conn.execute(
+            "SELECT * FROM scoring_jobs WHERE job_id = ?", (row["job_id"],)
+        ).fetchone()
+        conn.commit()
+        return dict(claimed) if claimed is not None else None
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def update_job_stage(
+    conn: sqlite3.Connection,
+    job_id: str,
+    owner: str,
+    stage: str,
+    *,
+    current: int | None = None,
+    total: int | None = None,
+    now: datetime | None = None,
+) -> bool:
+    if stage not in {"queued", "preparing", "locating_evidence", "final_scoring", "persisting"}:
+        raise ValueError("invalid scoring stage")
+    if current is not None and current < 0:
+        raise ValueError("current must be non-negative")
+    if total is not None and total < 0:
+        raise ValueError("total must be non-negative")
+    cursor = conn.execute(
+        "UPDATE scoring_jobs SET stage = ?, stage_current = ?, stage_total = ?, "
+        "updated_at = ? WHERE job_id = ? AND state = 'running' AND lease_owner = ?",
+        (stage, current, total, _iso(now), job_id, owner),
+    )
+    conn.commit()
+    return cursor.rowcount == 1
+
+
+def complete_job(
+    conn: sqlite3.Connection,
+    job_id: str,
+    owner: str,
+    *,
+    now: datetime | None = None,
+    commit: bool = True,
+) -> bool:
+    stamp = _iso(now)
+    cursor = conn.execute(
+        "UPDATE scoring_jobs SET state = 'succeeded', lease_owner = NULL, "
+        "lease_expires_at = NULL, next_attempt_at = NULL, stage = 'persisting', "
+        "stage_current = NULL, stage_total = NULL, last_error_code = NULL, "
+        "last_error_at = NULL, updated_at = ? "
+        "WHERE job_id = ? AND state = 'running' AND lease_owner = ?",
+        (stamp, job_id, owner),
+    )
+    if commit:
+        conn.commit()
+    return cursor.rowcount == 1
+
+
+def complete_revision_jobs(
+    conn: sqlite3.Connection,
+    session_id: str,
+    content_revision: str,
+    *,
+    now: datetime | None = None,
+    commit: bool = True,
+) -> int:
+    """Reconcile explicit scoring success into the durable queue atomically.
+
+    Callers must hold the installation-wide scoring egress lock. Therefore a
+    ``running`` row for this revision cannot belong to a live peer; it is an
+    orphan from a crashed process and can safely be completed by the explicit
+    score that just succeeded.
+    """
+
+    stamp = _iso(now)
+    cursor = conn.execute(
+        "UPDATE scoring_jobs SET state = 'succeeded', next_attempt_at = NULL, "
+        "lease_owner = NULL, lease_expires_at = NULL, stage = 'persisting', "
+        "stage_current = NULL, stage_total = NULL, last_error_code = NULL, "
+        "last_error_at = NULL, updated_at = ? "
+        "WHERE session_id = ? AND content_revision = ? "
+        "AND state IN ('pending', 'running', 'retry_wait', 'failed')",
+        (stamp, session_id, content_revision),
+    )
+    if commit:
+        conn.commit()
+    return max(cursor.rowcount, 0)
+
+
+def cancel_job(
+    conn: sqlite3.Connection,
+    job_id: str,
+    owner: str,
+    code: str,
+    *,
+    now: datetime | None = None,
+) -> bool:
+    if code not in JOB_ERROR_CODES:
+        raise ValueError("invalid scoring job error code")
+    stamp = _iso(now)
+    cursor = conn.execute(
+        "UPDATE scoring_jobs SET state = 'cancelled', lease_owner = NULL, "
+        "lease_expires_at = NULL, next_attempt_at = NULL, stage = 'queued', "
+        "stage_current = NULL, stage_total = NULL, last_error_code = ?, "
+        "last_error_at = ?, updated_at = ? "
+        "WHERE job_id = ? AND state = 'running' AND lease_owner = ?",
+        (code, stamp, stamp, job_id, owner),
+    )
+    conn.commit()
+    return cursor.rowcount == 1
+
+
+def retry_job_failure(
+    conn: sqlite3.Connection,
+    job_id: str,
+    owner: str,
+    code: str,
+    *,
+    now: datetime | None = None,
+) -> str | None:
+    """Apply bounded per-session backoff; return the resulting state."""
+
+    if code not in {"score_timeout", "score_failed", "transcript_unavailable"}:
+        raise ValueError("invalid retryable scoring error code")
+    row = conn.execute(
+        "SELECT attempt_count FROM scoring_jobs "
+        "WHERE job_id = ? AND state = 'running' AND lease_owner = ?",
+        (job_id, owner),
+    ).fetchone()
+    if row is None:
+        return None
+    attempt = int(row["attempt_count"]) + 1
+    clock = _utc(now)
+    if attempt >= SCORING_MAX_SESSION_ATTEMPTS:
+        state = "failed"
+        next_attempt = None
+    else:
+        state = "retry_wait"
+        delay = SCORING_SESSION_BACKOFF_SECONDS[attempt - 1]
+        next_attempt = (clock + timedelta(seconds=delay)).isoformat()
+    stamp = clock.isoformat()
+    cursor = conn.execute(
+        "UPDATE scoring_jobs SET state = ?, attempt_count = ?, next_attempt_at = ?, "
+        "lease_owner = NULL, lease_expires_at = NULL, stage = 'queued', "
+        "stage_current = NULL, stage_total = NULL, last_error_code = ?, "
+        "last_error_at = ?, updated_at = ? "
+        "WHERE job_id = ? AND state = 'running' AND lease_owner = ?",
+        (state, attempt, next_attempt, code, stamp, stamp, job_id, owner),
+    )
+    conn.commit()
+    return state if cursor.rowcount == 1 else None
+
+
+def defer_job_for_backend(
+    conn: sqlite3.Connection,
+    job_id: str,
+    owner: str,
+    *,
+    next_attempt_at: str | None,
+    action_required: bool,
+    now: datetime | None = None,
+) -> bool:
+    stamp = _iso(now)
+    cursor = conn.execute(
+        "UPDATE scoring_jobs SET state = 'retry_wait', next_attempt_at = ?, "
+        "lease_owner = NULL, lease_expires_at = NULL, stage = 'queued', "
+        "stage_current = NULL, stage_total = NULL, last_error_code = ?, "
+        "last_error_at = ?, updated_at = ? "
+        "WHERE job_id = ? AND state = 'running' AND lease_owner = ?",
+        (
+            next_attempt_at,
+            "backend_action_required" if action_required else "backend_cooldown",
+            stamp,
+            stamp,
+            job_id,
+            owner,
+        ),
+    )
+    conn.commit()
+    return cursor.rowcount == 1
+
+
+def get_backend_state(conn: sqlite3.Connection, backend: str) -> dict[str, Any] | None:
+    row = conn.execute(
+        "SELECT * FROM scoring_backend_state WHERE backend = ?", (backend,)
+    ).fetchone()
+    return dict(row) if row is not None else None
+
+
+def clear_backend_state(
+    conn: sqlite3.Connection, backend: str, *, now: datetime | None = None
+) -> None:
+    stamp = _iso(now)
+    conn.execute(
+        "INSERT INTO scoring_backend_state "
+        "(backend, state, next_attempt_at, consecutive_failures, last_error_code, updated_at) "
+        "VALUES (?, 'ready', NULL, 0, NULL, ?) "
+        "ON CONFLICT(backend) DO UPDATE SET state = 'ready', next_attempt_at = NULL, "
+        "consecutive_failures = 0, last_error_code = NULL, updated_at = excluded.updated_at",
+        (backend, stamp),
+    )
+    conn.commit()
+
+
+def record_backend_cooldown(
+    conn: sqlite3.Connection,
+    backend: str,
+    code: str,
+    *,
+    now: datetime | None = None,
+) -> str:
+    if code not in {"backend_rate_limited", "backend_temporary"}:
+        raise ValueError("invalid backend cooldown code")
+    clock = _utc(now)
+    current = get_backend_state(conn, backend)
+    failures = int(current.get("consecutive_failures") or 0) + 1 if current else 1
+    delay = SCORING_BACKEND_BACKOFF_SECONDS[
+        min(failures - 1, len(SCORING_BACKEND_BACKOFF_SECONDS) - 1)
+    ]
+    retry_at = (clock + timedelta(seconds=delay)).isoformat()
+    conn.execute(
+        "INSERT INTO scoring_backend_state "
+        "(backend, state, next_attempt_at, consecutive_failures, last_error_code, updated_at) "
+        "VALUES (?, 'cooldown', ?, ?, ?, ?) "
+        "ON CONFLICT(backend) DO UPDATE SET state = 'cooldown', "
+        "next_attempt_at = excluded.next_attempt_at, "
+        "consecutive_failures = excluded.consecutive_failures, "
+        "last_error_code = excluded.last_error_code, updated_at = excluded.updated_at",
+        (backend, retry_at, failures, code, clock.isoformat()),
+    )
+    conn.commit()
+    return retry_at
+
+
+def record_backend_action_required(
+    conn: sqlite3.Connection,
+    backend: str,
+    code: str,
+    *,
+    now: datetime | None = None,
+) -> None:
+    if code not in ACTION_REQUIRED_CODES:
+        raise ValueError("invalid backend action-required code")
+    stamp = _iso(now)
+    conn.execute(
+        "INSERT INTO scoring_backend_state "
+        "(backend, state, next_attempt_at, consecutive_failures, last_error_code, updated_at) "
+        "VALUES (?, 'action_required', NULL, 0, ?, ?) "
+        "ON CONFLICT(backend) DO UPDATE SET state = 'action_required', "
+        "next_attempt_at = NULL, last_error_code = excluded.last_error_code, "
+        "updated_at = excluded.updated_at",
+        (backend, code, stamp),
+    )
+    conn.commit()
+
+
+def backend_blocker(
+    conn: sqlite3.Connection, backend: str, *, now: datetime | None = None
+) -> dict[str, Any] | None:
+    state = get_backend_state(conn, backend)
+    if not state or state["state"] == "ready":
+        return None
+    if state["state"] == "cooldown":
+        retry_at = state.get("next_attempt_at")
+        if not retry_at or retry_at <= _iso(now):
+            clear_backend_state(conn, backend, now=now)
+            return None
+    return state
+
+
+def retry_failed_jobs(conn: sqlite3.Connection, *, now: datetime | None = None) -> int:
+    stamp = _iso(now)
+    if conn.in_transaction:
+        raise RuntimeError("queue retry requires a connection without an active transaction")
+    conn.execute("BEGIN IMMEDIATE")
+    try:
+        _cancel_noncurrent_or_inactive_jobs(conn, now=now)
+        cursor = conn.execute(
+            "UPDATE scoring_jobs SET state = 'pending', attempt_count = 0, "
+            "next_attempt_at = NULL, lease_owner = NULL, lease_expires_at = NULL, "
+            "stage = 'queued', stage_current = NULL, stage_total = NULL, "
+            "last_error_code = NULL, last_error_at = NULL, updated_at = ? "
+            "WHERE state = 'failed' AND EXISTS ("
+            " SELECT 1 FROM sessions s WHERE s.session_id = scoring_jobs.session_id "
+            " AND s.content_revision = scoring_jobs.content_revision "
+            " AND COALESCE(s.checkpoint_active, 1) = 1"
+            ")",
+            (stamp,),
+        )
+        conn.commit()
+        return max(cursor.rowcount, 0)
+    except Exception:
+        conn.rollback()
+        raise
+
+
+def queue_status(
+    conn: sqlite3.Connection,
+    *,
+    backend: str | None,
+    enabled: bool,
+    backends: Sequence[str] | None = None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    counts = {state: 0 for state in ("pending", "running", "retry_wait", "succeeded", "failed")}
+    rows = conn.execute(
+        "SELECT j.state, COUNT(*) AS count FROM scoring_jobs j "
+        "JOIN sessions s ON s.session_id = j.session_id "
+        " AND s.content_revision = j.content_revision "
+        "WHERE j.state != 'cancelled' "
+        "AND COALESCE(s.checkpoint_active, 1) = 1 GROUP BY j.state"
+    ).fetchall()
+    for row in rows:
+        state = str(row["state"])
+        if state in counts:
+            counts[state] = int(row["count"])
+    active = conn.execute(
+        "SELECT job_id, stage, stage_current, stage_total FROM scoring_jobs j "
+        "WHERE state = 'running' AND EXISTS ("
+        " SELECT 1 FROM sessions s WHERE s.session_id = j.session_id "
+        " AND s.content_revision = j.content_revision "
+        " AND COALESCE(s.checkpoint_active, 1) = 1"
+        ") ORDER BY updated_at ASC, job_id ASC LIMIT 1"
+    ).fetchone()
+    current = None
+    if active is not None:
+        current = {
+            "job_id": str(active["job_id"]),
+            "stage": str(active["stage"]),
+            "progress_current": active["stage_current"],
+            "progress_total": active["stage_total"],
+        }
+    retry_row = conn.execute(
+        "SELECT MIN(next_attempt_at) AS next_retry_at FROM scoring_jobs j "
+        "WHERE state = 'retry_wait' AND next_attempt_at IS NOT NULL AND EXISTS ("
+        " SELECT 1 FROM sessions s WHERE s.session_id = j.session_id "
+        " AND s.content_revision = j.content_revision "
+        " AND COALESCE(s.checkpoint_active, 1) = 1"
+        ")"
+    ).fetchone()
+    next_retry = retry_row["next_retry_at"] if retry_row is not None else None
+    backend_names = list(dict.fromkeys(
+        candidate for candidate in (backends or ([backend] if backend else []))
+        if candidate
+    ))
+    clock = _iso(now)
+    backend_states = [
+        state
+        for candidate in backend_names
+        if (state := get_backend_state(conn, candidate)) is not None
+    ]
+    state_by_backend = {
+        str(state["backend"]): state for state in backend_states
+    }
+    usable_backend = False
+    future_cooldowns: list[dict[str, Any]] = []
+    action_blockers: list[dict[str, Any]] = []
+    for candidate in backend_names:
+        state = state_by_backend.get(candidate)
+        if state is None or state["state"] == "ready":
+            usable_backend = True
+            continue
+        if state["state"] == "cooldown":
+            retry_at = state.get("next_attempt_at")
+            if not retry_at or retry_at <= clock:
+                usable_backend = True
+            else:
+                future_cooldowns.append(state)
+                if next_retry is None or retry_at < next_retry:
+                    next_retry = retry_at
+            continue
+        action_blockers.append(state)
+
+    if not enabled or backend is None:
+        worker_state = "disabled"
+    elif counts["running"]:
+        worker_state = "running"
+    elif usable_backend:
+        worker_state = "idle"
+    elif future_cooldowns:
+        worker_state = "cooldown"
+    elif action_blockers:
+        worker_state = "action_required"
+    else:
+        worker_state = "idle"
+
+    action_code = None
+    if worker_state == "action_required":
+        for state in action_blockers:
+            if state.get("last_error_code") in ACTION_REQUIRED_CODES:
+                action_code = state["last_error_code"]
+                break
+    return {
+        "enabled": enabled,
+        "backend": backend,
+        "worker_state": worker_state,
+        "counts": counts,
+        "current": current,
+        "next_retry_at": next_retry,
+        "action_required_code": action_code,
+    }
+
+
+def get_job(conn: sqlite3.Connection, job_id: str) -> dict[str, Any] | None:
+    row = conn.execute("SELECT * FROM scoring_jobs WHERE job_id = ?", (job_id,)).fetchone()
+    return dict(row) if row is not None else None
+
+
+def classify_scoring_error(error: BaseException) -> tuple[str, str]:
+    """Map an arbitrary backend exception to a fixed, content-free code.
+
+    The first element is ``job``, ``cooldown`` or ``action_required``.  The
+    raw message is inspected in memory only and must never be persisted.
+    """
+
+    message = str(error).lower()
+    if "timed out" in message or "timeout" in message:
+        return "job", "score_timeout"
+    if any(marker in message for marker in (
+        "transcript is unavailable",
+        "transcript is unreadable",
+        "transcript is invalid",
+    )):
+        return "job", "transcript_unavailable"
+    if any(marker in message for marker in (
+        "cli not found",
+        "command not found",
+        "not installed",
+        "could not detect a supported scoring backend",
+    )):
+        return "action_required", "backend_missing"
+    if any(marker in message for marker in (
+        "not logged in",
+        "not signed in",
+        "unauthoriz",
+        "authentication required",
+        "forbidden",
+        " 401",
+        " 403",
+    )):
+        return "action_required", "backend_auth"
+    if any(marker in message for marker in (
+        "429",
+        "rate limit",
+        "too many requests",
+        "quota",
+        "out of credits",
+        "usage limit",
+        "limit reached",
+    )):
+        return "cooldown", "backend_rate_limited"
+    if any(marker in message for marker in (
+        "network is unreachable",
+        "could not reach",
+        "could not resolve",
+        "name resolution",
+        "temporary failure",
+        "connection reset",
+        "service unavailable",
+    )):
+        return "cooldown", "backend_temporary"
+    if "unsupported backend" in message or "unsupported clawjournal_scorer_backend" in message:
+        return "action_required", "backend_unavailable"
+    return "job", "score_failed"

--- a/tests/scoring/test_scoring.py
+++ b/tests/scoring/test_scoring.py
@@ -28,6 +28,8 @@ from clawjournal.scoring.scoring import (
     LocatorChunk,
     SCORING_BACKEND_CHOICES,
     Segment,
+    ScoringAborted,
+    ScoringDeadlineExceeded,
     ScoringResult,
     Step,
     _SCORER_PROMPT_FILE,
@@ -44,6 +46,7 @@ from clawjournal.scoring.scoring import (
     get_message_text,
     load_scoring_rubric,
     prepare_prompt_for_judge,
+    score_session,
     segment_session,
 )
 
@@ -509,6 +512,187 @@ class TestLongSessionSelection:
             final_max_chars=12_000,
         )
         assert "segment-0050" not in prompt
+
+    def test_local_abort_before_a_queued_locator_is_not_swallowed(self, monkeypatch):
+        monkeypatch.setattr("clawjournal.scoring.scoring.LOCATOR_MAX_WORKERS", 1)
+        segments = self._segments(60)
+        assert len(build_locator_chunks(segments, "large task")) > 1
+        checks = 0
+        located: list[int] = []
+
+        def before_egress():
+            nonlocal checks
+            checks += 1
+            if checks == 2:
+                raise ScoringAborted("background scoring was paused")
+
+        def locator(chunk):
+            located.append(chunk.chunk_index)
+            return {"signals": []}
+
+        with pytest.raises(ScoringAborted, match="paused"):
+            prepare_prompt_for_judge(
+                segments,
+                "large task",
+                {"total_steps": 60},
+                locator=locator,
+                before_egress=before_egress,
+                direct_max_chars=1,
+            )
+
+        assert located == [0]
+
+    def test_locator_provider_timeout_uses_remaining_total_budget(self, monkeypatch):
+        observed_timeouts: list[int] = []
+
+        def fake_locator(chunk, *, backend, model, timeout_seconds):
+            observed_timeouts.append(timeout_seconds)
+            return {"signals": []}
+
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.call_signal_locator", fake_locator
+        )
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.time.monotonic", lambda: 100.25
+        )
+
+        prepare_prompt_for_judge(
+            self._segments(2),
+            "large task",
+            {"total_steps": 2},
+            deadline_at=106.0,
+            direct_max_chars=1,
+        )
+
+        assert observed_timeouts == [6]
+
+    def test_locator_deadline_abort_is_not_treated_as_chunk_fallback(self, monkeypatch):
+        locator_called = False
+
+        def locator(_chunk):
+            nonlocal locator_called
+            locator_called = True
+            return {"signals": []}
+
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.time.monotonic", lambda: 101.0
+        )
+        with pytest.raises(ScoringDeadlineExceeded, match="total time budget"):
+            prepare_prompt_for_judge(
+                self._segments(2),
+                "large task",
+                {"total_steps": 2},
+                locator=locator,
+                deadline_at=100.0,
+                direct_max_chars=1,
+            )
+        assert locator_called is False
+
+
+class TestScoringEgressControls:
+    @staticmethod
+    def _patch_scorable_session(monkeypatch, tmp_path):
+        detail = {
+            "session_id": "session-1",
+            "project": "project",
+            "source": "claude",
+            "messages": [
+                _user_msg("Fix the failing command"),
+                _asst_msg(
+                    "I will inspect it",
+                    [_tool_use("Bash", "test.sh", "tests passed")],
+                ),
+                _asst_msg("The command now passes"),
+            ],
+        }
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.get_session_detail",
+            lambda _conn, _session_id: detail,
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.resolve_blob_path",
+            lambda _session_id, _stored: tmp_path / "unused.json",
+        )
+
+    def test_final_judge_rechecks_before_egress(self, monkeypatch, tmp_path):
+        self._patch_scorable_session(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.prepare_prompt_for_judge",
+            lambda *args, **kwargs: "bounded prompt",
+        )
+        judge_called = False
+
+        def call_judge_should_not_run(*args, **kwargs):
+            nonlocal judge_called
+            judge_called = True
+            return _VALID_JUDGE
+
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.call_judge", call_judge_should_not_run
+        )
+
+        def abort():
+            raise ScoringAborted("session is no longer eligible")
+
+        with pytest.raises(ScoringAborted, match="no longer eligible"):
+            score_session(object(), "session-1", before_egress=abort)
+        assert judge_called is False
+
+    def test_final_judge_timeout_uses_remaining_total_budget(self, monkeypatch, tmp_path):
+        self._patch_scorable_session(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.prepare_prompt_for_judge",
+            lambda *args, **kwargs: "bounded prompt",
+        )
+        monotonic_values = iter((100.0, 103.2))
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.time.monotonic",
+            lambda: next(monotonic_values),
+        )
+        observed: dict[str, int] = {}
+
+        def fake_judge(*args, timeout_seconds, **kwargs):
+            observed["timeout_seconds"] = timeout_seconds
+            return _VALID_JUDGE
+
+        monkeypatch.setattr("clawjournal.scoring.scoring.call_judge", fake_judge)
+        result = score_session(
+            object(),
+            "session-1",
+            overall_timeout_seconds=5,
+        )
+
+        assert result.quality == 4
+        assert observed == {"timeout_seconds": 2}
+
+    def test_expired_total_budget_blocks_final_judge(self, monkeypatch, tmp_path):
+        self._patch_scorable_session(monkeypatch, tmp_path)
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.prepare_prompt_for_judge",
+            lambda *args, **kwargs: "bounded prompt",
+        )
+        monotonic_values = iter((100.0, 106.0))
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.time.monotonic",
+            lambda: next(monotonic_values),
+        )
+        judge_called = False
+
+        def call_judge_should_not_run(*args, **kwargs):
+            nonlocal judge_called
+            judge_called = True
+            return _VALID_JUDGE
+
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.call_judge", call_judge_should_not_run
+        )
+        with pytest.raises(ScoringDeadlineExceeded, match="total time budget"):
+            score_session(
+                object(),
+                "session-1",
+                overall_timeout_seconds=5,
+            )
+        assert judge_called is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2433,6 +2433,141 @@ class TestScore:
         assert result["session_id"] == "sess-1"
         assert "Judge failed: backend auth failed" in result["error"]
 
+    def test_score_single_session_revision_cas_never_overwrites_new_content(
+        self, tmp_path, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        from clawjournal.cli import _score_single_session
+        from clawjournal.workbench.index import open_index, upsert_sessions
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db"
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs"
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.CONFIG_DIR", tmp_path / "config"
+        )
+        conn = open_index()
+        upsert_sessions(conn, [{
+            "session_id": "cas-session",
+            "project": "project",
+            "source": "codex",
+            "start_time": datetime.now(timezone.utc).isoformat(),
+            "messages": [
+                {"role": "user", "content": "old revision", "tool_uses": []},
+                {"role": "assistant", "content": "done", "tool_uses": []},
+            ],
+            "stats": {"user_messages": 1, "assistant_messages": 1},
+        }])
+
+        def fake_score(_conn, session_id, **_kwargs):
+            writer = open_index()
+            try:
+                writer.execute(
+                    "UPDATE sessions SET content_revision = 'new-revision' "
+                    "WHERE session_id = ?",
+                    (session_id,),
+                )
+                writer.commit()
+            finally:
+                writer.close()
+            return SimpleNamespace(
+                quality=5,
+                reason="old result",
+                detail_json="{}",
+                task_type="debugging",
+                outcome_label="resolved",
+                value_labels=[],
+                risk_level=[],
+                display_title="Old",
+                effort_estimate=0.5,
+                summary="old",
+                failure_value_score=5,
+                recovery_labels=[],
+                failure_attribution="agent_caused",
+                failure_modes=[],
+                learning_summary="old",
+                scorer_backend="codex",
+                scorer_model="test",
+                rubric_git_sha="sha",
+                scored_at=datetime.now(timezone.utc).isoformat(),
+            )
+
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.score_session", fake_score
+        )
+        result = _score_single_session(conn, "cas-session")
+
+        assert result["block_reason"] == "stale_revision"
+        row = conn.execute(
+            "SELECT content_revision, ai_quality_score FROM sessions "
+            "WHERE session_id = 'cas-session'"
+        ).fetchone()
+        assert tuple(row) == ("new-revision", None)
+        conn.close()
+
+    def test_score_single_session_atomically_completes_current_queue_job(
+        self, tmp_path, monkeypatch
+    ):
+        from types import SimpleNamespace
+
+        from clawjournal.cli import _score_single_session
+        from clawjournal.workbench import scoring_queue
+        from clawjournal.workbench.index import open_index, upsert_sessions
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db"
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.index.BLOBS_DIR", tmp_path / "blobs"
+        )
+        conn = open_index()
+        upsert_sessions(conn, [{
+            "session_id": "queued-cli-session",
+            "project": "project",
+            "source": "codex",
+            "start_time": datetime.now(timezone.utc).isoformat(),
+            "messages": [{"role": "user", "content": "score me"}],
+            "stats": {"user_messages": 1, "assistant_messages": 0},
+        }])
+        scoring_queue.enqueue_session_ids(conn, ["queued-cli-session"])
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.score_session",
+            lambda _conn, _session_id, **_kwargs: SimpleNamespace(
+                quality=4,
+                reason="done",
+                detail_json="{}",
+                task_type="debugging",
+                outcome_label="resolved",
+                value_labels=[],
+                risk_level=[],
+                display_title="Done",
+                effort_estimate=0.5,
+                summary="done",
+                failure_value_score=4,
+                recovery_labels=[],
+                failure_attribution="agent_caused",
+                failure_modes=[],
+                learning_summary="done",
+                scorer_backend="codex",
+                scorer_model="test",
+                rubric_git_sha="sha",
+                scored_at=datetime.now(timezone.utc).isoformat(),
+            ),
+        )
+
+        result = _score_single_session(conn, "queued-cli-session")
+
+        assert result["ok"] is True
+        assert tuple(conn.execute(
+            "SELECT state, lease_owner, last_error_code FROM scoring_jobs "
+            "WHERE session_id = 'queued-cli-session'"
+        ).fetchone()) == ("succeeded", None, None)
+        conn.close()
+
     def test_score_help_includes_default_limit_20(self, capsys, monkeypatch):
         monkeypatch.setattr(sys, "argv", ["clawjournal", "score", "--help"])
         with pytest.raises(SystemExit) as excinfo:

--- a/tests/test_share_cli.py
+++ b/tests/test_share_cli.py
@@ -637,7 +637,7 @@ def test_score_traces_keyboard_interrupt_is_graceful(monkeypatch):
     assert all(r.get("ai_failure_value_score") is None for r in rows)
 
 
-def test_score_traces_keyboard_interrupt_does_not_submit_beyond_workers(monkeypatch):
+def test_score_traces_keyboard_interrupt_stops_serialized_queue(monkeypatch):
     started = []
     release = threading.Event()
     u2_started = threading.Event()
@@ -662,7 +662,7 @@ def test_score_traces_keyboard_interrupt_does_not_submit_beyond_workers(monkeypa
         release.set()
 
     assert result == 0
-    assert set(started) == {"u1", "u2"}
+    assert started == ["u1"]
 
 
 def test_score_traces_rescores_stale_via_force_ids(monkeypatch):

--- a/tests/workbench/test_auto_upload_index.py
+++ b/tests/workbench/test_auto_upload_index.py
@@ -15,6 +15,7 @@ from clawjournal.workbench.index import (
     RECEIVER_PREDECESSOR_SCHEMA_VERSION,
     RECURRING_PROTOCOL_V2_SCHEMA_VERSION,
     RevisionConflictError,
+    SCORING_QUEUE_SCHEMA_VERSION,
     WORKBENCH_SCHEMA_VERSION,
     already_shared_revision_blockers,
     auto_upload_review_blockers,
@@ -114,7 +115,8 @@ def _mark_shared(conn, session_id: str) -> str:
 
 def test_fresh_schema_has_auto_upload_foundation(index_conn):
     assert index_conn.execute("PRAGMA user_version").fetchone()[0] == WORKBENCH_SCHEMA_VERSION
-    assert WORKBENCH_SCHEMA_VERSION == LOGICAL_CHECKPOINT_SCHEMA_VERSION
+    assert WORKBENCH_SCHEMA_VERSION == SCORING_QUEUE_SCHEMA_VERSION
+    assert SCORING_QUEUE_SCHEMA_VERSION > LOGICAL_CHECKPOINT_SCHEMA_VERSION
     assert EXACT_SCOPE_PAIRS_SCHEMA_VERSION == 10
     assert RECEIVER_PREDECESSOR_SCHEMA_VERSION == 11
     assert LOGICAL_CHECKPOINT_SCHEMA_VERSION == 12

--- a/tests/workbench/test_daemon.py
+++ b/tests/workbench/test_daemon.py
@@ -14,6 +14,7 @@ from io import BytesIO
 from pathlib import Path
 from threading import Event, Lock, Thread
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import patch, MagicMock
 
 import pytest
@@ -2912,9 +2913,7 @@ class TestScanner:
         assert row["ai_summary"] == "Useful fix"
 
     def test_score_unscored_once_disables_on_no_backend_error(self, tmp_path, monkeypatch):
-        """A 'no usable backend' RuntimeError must trip the circuit breaker so the
-        scan loop stops retrying. Guards against the disable sentinel drifting away
-        from resolve_backend's message."""
+        """A missing backend must trip the durable fixed-code circuit breaker."""
         from clawjournal.scoring.backends import NO_BACKEND_DETECTED_ERROR
 
         monkeypatch.setattr("clawjournal.workbench.index.INDEX_DB", tmp_path / "index.db")
@@ -2945,8 +2944,7 @@ class TestScanner:
 
         scanner = Scanner(source_filter="claude")
         assert scanner.score_unscored_once(limit=5) == 0
-        assert scanner._auto_score_disabled_reason is not None
-        assert NO_BACKEND_DETECTED_ERROR in scanner._auto_score_disabled_reason
+        assert scanner._auto_score_disabled_reason == "backend_missing"
 
     def _settled_session(self, sid, now):
         return {
@@ -3460,6 +3458,556 @@ class TestScoringWarmupAPI:
         result = trigger_scoring_warmup(scanner)
 
         assert result["status"] == "disabled"
+
+
+class TestDurableScoringAPI:
+    def test_status_and_control_require_bearer_auth(self, server):
+        assert _get(server, "/api/scoring/status", skip_auth=True)[0] == 401
+        assert _post(
+            server,
+            "/api/scoring/control",
+            {"action": "pause"},
+            skip_auth=True,
+        )[0] == 401
+
+    @pytest.mark.parametrize(
+        "body",
+        [
+            {},
+            {"action": "unknown"},
+            {"action": "pause", "extra": True},
+            {"action": ["pause"]},
+        ],
+    )
+    def test_control_rejects_every_non_contract_body(self, server, body):
+        status, response = _post(server, "/api/scoring/control", body)
+
+        assert status == 400
+        assert set(response) == {"error"}
+
+    def test_status_uses_complete_fallback_chain_and_discloses_no_session(
+        self, server, monkeypatch
+    ):
+        from clawjournal.workbench import scoring_queue
+
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config",
+            lambda: {"scorer_backend": "codex"},
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.installed_fallback_chain",
+            lambda _primary: ["codex", "claude"],
+        )
+        conn = open_index()
+        try:
+            scoring_queue.enqueue_session_ids(conn, ["sess-0"])
+            job = scoring_queue.claim_next_job(conn, owner="worker")
+            scoring_queue.update_job_stage(
+                conn,
+                job["job_id"],
+                "worker",
+                "locating_evidence",
+                current=2,
+                total=7,
+            )
+            scoring_queue.record_backend_action_required(
+                conn, "codex", "backend_auth"
+            )
+        finally:
+            conn.close()
+
+        status, response = _get(server, "/api/scoring/status")
+
+        assert status == 200
+        assert response == {
+            "enabled": True,
+            "backend": "codex",
+            "worker_state": "running",
+            "counts": {
+                "pending": 0,
+                "running": 1,
+                "retry_wait": 0,
+                "succeeded": 0,
+                "failed": 0,
+            },
+            "current": {
+                "job_id": job["job_id"],
+                "stage": "locating_evidence",
+                "progress_current": 2,
+                "progress_total": 7,
+            },
+            "next_retry_at": None,
+            "action_required_code": None,
+        }
+        assert "sess-0" not in json.dumps(response)
+
+    def test_pause_and_resume_round_trip_persisted_control(
+        self, server, monkeypatch
+    ):
+        config = {"scorer_backend": "codex"}
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config", lambda: dict(config)
+        )
+
+        def save(updated):
+            config.clear()
+            config.update(updated)
+            return True
+
+        monkeypatch.setattr("clawjournal.workbench.daemon.save_config", save)
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.installed_fallback_chain",
+            lambda _primary: ["codex"],
+        )
+
+        status, paused = _post(
+            server, "/api/scoring/control", {"action": "pause"}
+        )
+        assert status == 200
+        assert paused["status"]["worker_state"] == "disabled"
+        assert config["scoring_warmup_declined"] is True
+
+        status, resumed = _post(
+            server, "/api/scoring/control", {"action": "resume"}
+        )
+        assert status == 200
+        assert resumed["status"]["enabled"] is True
+        assert resumed["status"]["worker_state"] == "idle"
+        assert "scoring_warmup_declined" not in config
+
+
+class TestDurableScoringWorker:
+    @staticmethod
+    def _result() -> SimpleNamespace:
+        now = datetime.now(timezone.utc).isoformat()
+        return SimpleNamespace(
+            quality=4,
+            reason="ok",
+            detail_json="{}",
+            task_type="debugging",
+            outcome_label="resolved",
+            value_labels=[],
+            risk_level=[],
+            display_title="Scored",
+            effort_estimate=0.5,
+            summary="summary",
+            failure_value_score=4,
+            recovery_labels=[],
+            failure_attribution="agent_caused",
+            failure_modes=[],
+            learning_summary="learning",
+            scorer_backend="codex",
+            scorer_model="test",
+            rubric_git_sha="sha",
+            scored_at=now,
+        )
+
+    @staticmethod
+    def _one_backend(monkeypatch) -> None:
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.resolve_backend", lambda _backend: "codex"
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.installed_fallback_chain",
+            lambda _primary: ["codex"],
+        )
+
+    def test_second_worker_cannot_claim_while_first_process_lock_is_held(
+        self, index_setup, monkeypatch
+    ):
+        self._one_backend(monkeypatch)
+        entered = Event()
+        release = Event()
+        calls: list[str] = []
+
+        def fake_score(_conn, session_id, **_kwargs):
+            calls.append(session_id)
+            entered.set()
+            assert release.wait(timeout=5)
+            return self._result()
+
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.score_session", fake_score
+        )
+        first = Scanner(source_filter="claude")
+        second = Scanner(source_filter="claude")
+        completed: list[int] = []
+        thread = Thread(
+            target=lambda: completed.append(first.score_unscored_once(limit=1))
+        )
+        thread.start()
+        assert entered.wait(timeout=5)
+
+        assert second.score_unscored_once(limit=1) == 0
+        conn = open_index()
+        try:
+            states = {
+                row["state"]: row["count"]
+                for row in conn.execute(
+                    "SELECT state, COUNT(*) AS count FROM scoring_jobs GROUP BY state"
+                )
+            }
+        finally:
+            conn.close()
+        assert states == {"pending": 2, "running": 1}
+        assert len(calls) == 1
+
+        release.set()
+        thread.join(timeout=5)
+        assert completed == [1]
+
+    def test_revision_cas_discards_result_if_session_changes_during_call(
+        self, index_setup, monkeypatch
+    ):
+        self._one_backend(monkeypatch)
+
+        def fake_score(_conn, session_id, **_kwargs):
+            writer = open_index()
+            try:
+                writer.execute(
+                    "UPDATE sessions SET content_revision = 'new-revision' "
+                    "WHERE session_id = ?",
+                    (session_id,),
+                )
+                writer.commit()
+            finally:
+                writer.close()
+            return self._result()
+
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.score_session", fake_score
+        )
+
+        assert Scanner(source_filter="claude").score_unscored_once(limit=1) == 0
+        conn = open_index()
+        try:
+            session = conn.execute(
+                "SELECT content_revision, ai_quality_score FROM sessions "
+                "WHERE session_id = 'sess-0'"
+            ).fetchone()
+            job = conn.execute(
+                "SELECT state, last_error_code FROM scoring_jobs "
+                "WHERE session_id = 'sess-0'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert tuple(session) == ("new-revision", None)
+        assert tuple(job) == ("cancelled", "stale_revision")
+
+    @pytest.mark.parametrize(
+        ("mutation", "expected_code"),
+        [
+            ("pause", "ineligible"),
+            ("hold", "ineligible"),
+            ("revision", "stale_revision"),
+            ("source", "ineligible"),
+            ("exclude", "ineligible"),
+        ],
+    )
+    def test_control_change_aborts_before_next_locator_egress(
+        self, index_setup, monkeypatch, mutation, expected_code
+    ):
+        self._one_backend(monkeypatch)
+        config: dict[str, Any] = {}
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config", lambda: dict(config)
+        )
+        provider_calls: list[str] = []
+
+        def fake_score(_conn, session_id, **kwargs):
+            guard = kwargs["before_egress"]
+            guard()
+            provider_calls.append("locator-1")
+            if mutation == "pause":
+                config["scoring_warmup_declined"] = True
+            elif mutation == "source":
+                config["source"] = "codex"
+            else:
+                writer = open_index()
+                try:
+                    if mutation == "hold":
+                        set_hold_state(
+                            writer,
+                            session_id,
+                            "pending_review",
+                            changed_by="test",
+                            reason="test",
+                        )
+                    elif mutation == "exclude":
+                        add_policy(writer, "exclude_project", "test-project")
+                    else:
+                        writer.execute(
+                            "UPDATE sessions SET content_revision = 'changed-mid-score' "
+                            "WHERE session_id = ?",
+                            (session_id,),
+                        )
+                        writer.commit()
+                finally:
+                    writer.close()
+            guard()
+            provider_calls.append("locator-2")
+            return self._result()
+
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.score_session", fake_score
+        )
+
+        assert Scanner(source_filter="claude").score_unscored_once(limit=1) == 0
+        assert provider_calls == ["locator-1"]
+        conn = open_index()
+        try:
+            job = conn.execute(
+                "SELECT state, last_error_code FROM scoring_jobs "
+                "WHERE session_id = 'sess-0'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert tuple(job) == ("cancelled", expected_code)
+
+    def test_http_waiting_for_background_returns_cached_same_revision(
+        self, server, monkeypatch
+    ):
+        from clawjournal.scoring import egress_lock
+
+        self._one_backend(monkeypatch)
+        entered = Event()
+        release = Event()
+        waiter_attempted = Event()
+        calls: list[str] = []
+        try_lock = egress_lock._try_lock
+        attempts = {"count": 0}
+
+        def observed_try_lock(file):
+            attempts["count"] += 1
+            if attempts["count"] >= 2:
+                waiter_attempted.set()
+            return try_lock(file)
+
+        monkeypatch.setattr(egress_lock, "_try_lock", observed_try_lock)
+
+        def fake_score(_conn, session_id, **_kwargs):
+            calls.append(session_id)
+            entered.set()
+            assert release.wait(timeout=5)
+            return self._result()
+
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.score_session", fake_score
+        )
+        scanner = Scanner(source_filter="claude")
+        background = Thread(target=lambda: scanner.score_unscored_once(limit=1))
+        background.start()
+        assert entered.wait(timeout=5)
+
+        responses: list[tuple[int, dict]] = []
+        request = Thread(
+            target=lambda: responses.append(
+                _post(server, "/api/sessions/sess-0/score", {"backend": "codex"})
+            )
+        )
+        request.start()
+        assert waiter_attempted.wait(timeout=5)
+        release.set()
+        background.join(timeout=5)
+        request.join(timeout=5)
+
+        assert len(calls) == 1
+        assert responses[0][0] == 200
+        assert responses[0][1]["cached"] is True
+        assert responses[0][1]["ai_quality_score"] == 4
+
+    def test_429_cooldown_restarts_same_scanner_after_deadline(
+        self, index_setup, monkeypatch
+    ):
+        self._one_backend(monkeypatch)
+        calls = {"count": 0}
+
+        def fake_score(_conn, _session_id, **_kwargs):
+            calls["count"] += 1
+            if calls["count"] == 1:
+                raise RuntimeError("429 Too Many Requests")
+            return self._result()
+
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.score_session", fake_score
+        )
+        scanner = Scanner(source_filter="claude")
+        assert scanner.score_unscored_once(limit=1, backend="codex") == 0
+
+        # Advance durable deadlines without replacing/restarting Scanner.
+        conn = open_index()
+        try:
+            past = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+            conn.execute(
+                "UPDATE scoring_jobs SET next_attempt_at = ? "
+                "WHERE session_id = 'sess-0'",
+                (past,),
+            )
+            conn.execute(
+                "UPDATE scoring_backend_state SET next_attempt_at = ? "
+                "WHERE backend = 'codex'",
+                (past,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        assert scanner.trigger_auto_score(
+            limit=1, backend="codex"
+        )["status"] == "started"
+        scanner._score_thread.join(timeout=5)
+        assert not scanner._score_thread.is_alive()
+        assert scanner.last_scored_count == 1
+        assert calls["count"] == 2
+        conn = open_index()
+        try:
+            assert conn.execute(
+                "SELECT ai_quality_score FROM sessions WHERE session_id = 'sess-0'"
+            ).fetchone()[0] == 4
+            assert conn.execute(
+                "SELECT state FROM scoring_jobs WHERE session_id = 'sess-0'"
+            ).fetchone()[0] == "succeeded"
+        finally:
+            conn.close()
+
+    def test_http_manual_score_atomically_completes_pending_revision_job(
+        self, server, monkeypatch
+    ):
+        from clawjournal.workbench import scoring_queue
+
+        self._one_backend(monkeypatch)
+        conn = open_index()
+        try:
+            conn.execute(
+                "UPDATE sessions SET ai_quality_score = 3, "
+                "ai_failure_value_score = 3 WHERE session_id != 'sess-0'"
+            )
+            conn.commit()
+            scoring_queue.enqueue_session_ids(conn, ["sess-0"])
+        finally:
+            conn.close()
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.score_session",
+            lambda _conn, _session_id, **_kwargs: self._result(),
+        )
+
+        status, response = _post(
+            server, "/api/sessions/sess-0/score", {"backend": "codex"}
+        )
+
+        assert status == 200
+        assert response["cached"] is False
+        conn = open_index()
+        try:
+            assert tuple(conn.execute(
+                "SELECT state, lease_owner, last_error_code FROM scoring_jobs "
+                "WHERE session_id = 'sess-0'"
+            ).fetchone()) == ("succeeded", None, None)
+        finally:
+            conn.close()
+
+    def test_share_score_persists_before_unlock_and_queue_cancels_as_complete(
+        self, index_setup, monkeypatch
+    ):
+        from clawjournal import share_flow
+        from clawjournal.workbench import scoring_queue
+
+        self._one_backend(monkeypatch)
+        conn = open_index()
+        try:
+            conn.execute(
+                "UPDATE sessions SET ai_quality_score = 3, "
+                "ai_failure_value_score = 3 WHERE session_id != 'sess-0'"
+            )
+            conn.commit()
+            scoring_queue.enqueue_session_ids(conn, ["sess-0"])
+        finally:
+            conn.close()
+        calls: list[str] = []
+
+        def fake_score(_conn, session_id, **_kwargs):
+            calls.append(session_id)
+            return self._result()
+
+        monkeypatch.setattr(
+            "clawjournal.scoring.scoring.score_session", fake_score
+        )
+        result = share_flow.score_compute("sess-0", backend="codex")
+        assert result["ok"] is True
+        assert result["persisted"] is True
+
+        conn = open_index()
+        try:
+            assert tuple(conn.execute(
+                "SELECT state, last_error_code FROM scoring_jobs "
+                "WHERE session_id = 'sess-0'"
+            ).fetchone()) == ("succeeded", None)
+        finally:
+            conn.close()
+
+        assert Scanner(source_filter="claude").score_unscored_once(limit=1) == 0
+        assert calls == ["sess-0"]
+        conn = open_index()
+        try:
+            job = conn.execute(
+                "SELECT state, last_error_code FROM scoring_jobs "
+                "WHERE session_id = 'sess-0'"
+            ).fetchone()
+        finally:
+            conn.close()
+        assert tuple(job) == ("succeeded", None)
+
+    def test_retry_failed_clears_all_fallback_state_and_requeues(
+        self, server, monkeypatch
+    ):
+        from clawjournal.workbench import scoring_queue
+
+        config = {"scorer_backend": "codex"}
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.load_config", lambda: dict(config)
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.save_config",
+            lambda updated: config.clear() or config.update(updated) or True,
+        )
+        monkeypatch.setattr(
+            "clawjournal.workbench.daemon.installed_fallback_chain",
+            lambda _primary: ["codex", "claude"],
+        )
+        conn = open_index()
+        try:
+            scoring_queue.enqueue_session_ids(conn, ["sess-0"])
+            conn.execute(
+                "UPDATE scoring_jobs SET state = 'failed', attempt_count = 4, "
+                "last_error_code = 'score_failed' WHERE session_id = 'sess-0'"
+            )
+            conn.commit()
+            scoring_queue.record_backend_action_required(
+                conn, "codex", "backend_auth"
+            )
+            scoring_queue.record_backend_cooldown(
+                conn, "claude", "backend_rate_limited"
+            )
+        finally:
+            conn.close()
+
+        status, response = _post(
+            server, "/api/scoring/control", {"action": "retry_failed"}
+        )
+
+        assert status == 200
+        assert response["ok"] is True
+        assert response["action"] == "retry_failed"
+        assert response["retried"] == 1
+        conn = open_index()
+        try:
+            assert scoring_queue.get_backend_state(conn, "codex")["state"] == "ready"
+            assert scoring_queue.get_backend_state(conn, "claude")["state"] == "ready"
+            assert conn.execute(
+                "SELECT state FROM scoring_jobs WHERE session_id = 'sess-0'"
+            ).fetchone()[0] == "pending"
+        finally:
+            conn.close()
 
 
 class TestProjectsAPI:

--- a/tests/workbench/test_daemon_config.py
+++ b/tests/workbench/test_daemon_config.py
@@ -272,8 +272,10 @@ class TestScoringBatchCancel:
         monkeypatch.setattr("clawjournal.scoring.scoring.score_session", fake_score)
 
         scored = dmod.Scanner().score_unscored_once()
-        # Only the first trace was scored; the loop broke before egressing more.
-        assert calls == ["s0"]
+        # Only one trace was scored; the durable queue deliberately chooses
+        # the oldest due revision first, then the loop stops before another
+        # egress after the user disables background scoring.
+        assert calls == ["s2"]
         assert scored == 1
 
 

--- a/tests/workbench/test_scoring_egress_lock.py
+++ b/tests/workbench/test_scoring_egress_lock.py
@@ -1,0 +1,48 @@
+"""Cross-process ownership tests for scoring AI egress."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from clawjournal.scoring.egress_lock import scoring_egress_lock
+from clawjournal.workbench import index
+
+
+def test_second_process_cannot_enter_scoring_egress(tmp_path, monkeypatch):
+    database = tmp_path / "index.db"
+    monkeypatch.setattr(index, "INDEX_DB", database)
+    script = """
+import pathlib
+import sys
+from clawjournal.workbench import index
+from clawjournal.scoring.egress_lock import scoring_egress_lock
+
+index.INDEX_DB = pathlib.Path(sys.argv[1])
+with scoring_egress_lock(blocking=True) as acquired:
+    print("LOCKED" if acquired else "FAILED", flush=True)
+    sys.stdin.readline()
+"""
+    child = subprocess.Popen(
+        [sys.executable, "-c", script, str(database)],
+        cwd=Path(__file__).resolve().parents[2],
+        stdin=subprocess.PIPE,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+    try:
+        assert child.stdout is not None
+        assert child.stdout.readline().strip() == "LOCKED"
+        with scoring_egress_lock(blocking=False) as acquired:
+            assert acquired is False
+    finally:
+        if child.stdin is not None:
+            child.stdin.write("release\n")
+            child.stdin.flush()
+        _stdout, stderr = child.communicate(timeout=10)
+    assert child.returncode == 0, stderr
+
+    with scoring_egress_lock(blocking=False) as acquired:
+        assert acquired is True

--- a/tests/workbench/test_scoring_queue.py
+++ b/tests/workbench/test_scoring_queue.py
@@ -1,0 +1,335 @@
+"""Durability, fairness, and privacy tests for the AI scoring queue."""
+
+from __future__ import annotations
+
+import threading
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from clawjournal.workbench import index
+from clawjournal.workbench import scoring_queue as queue
+
+
+BASE = datetime(2026, 8, 16, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def queue_db(tmp_path, monkeypatch):
+    monkeypatch.setattr(index, "INDEX_DB", tmp_path / "index.db")
+    monkeypatch.setattr(index, "BLOBS_DIR", tmp_path / "blobs")
+    conn = index.open_index()
+    yield conn
+    conn.close()
+
+
+def _session(number: int, *, start_offset: int | None = None) -> dict:
+    start = BASE + timedelta(minutes=start_offset if start_offset is not None else number)
+    return {
+        "session_id": f"session-{number:04d}",
+        "project": "project",
+        "source": "claude",
+        "start_time": start.isoformat(),
+        "end_time": (start + timedelta(minutes=1)).isoformat(),
+        "messages": [
+            {"role": "user", "content": f"task {number}"},
+            {"role": "assistant", "content": "done"},
+        ],
+        "stats": {"user_messages": 1, "assistant_messages": 1},
+    }
+
+
+def _seed(conn, count: int) -> list[str]:
+    index.upsert_sessions(conn, [_session(number) for number in range(count)])
+    return [f"session-{number:04d}" for number in range(count)]
+
+
+def test_v12_to_v13_migration_creates_queue_schema(queue_db):
+    queue_db.execute("DROP TABLE scoring_jobs")
+    queue_db.execute("DROP TABLE scoring_backend_state")
+    queue_db.execute("PRAGMA user_version = 12")
+    queue_db.commit()
+    queue_db.close()
+
+    reopened = index.open_index()
+    try:
+        assert reopened.execute("PRAGMA user_version").fetchone()[0] == 13
+        names = {
+            row[0]
+            for row in reopened.execute(
+                "SELECT name FROM sqlite_master WHERE type = 'table'"
+            )
+        }
+        assert {"scoring_jobs", "scoring_backend_state"} <= names
+    finally:
+        reopened.close()
+
+
+def test_400_revisions_enqueue_once(queue_db):
+    session_ids = _seed(queue_db, 400)
+
+    assert queue.enqueue_session_ids(queue_db, session_ids, now=BASE) == 400
+    assert queue.enqueue_session_ids(queue_db, session_ids, now=BASE) == 0
+    assert queue_db.execute("SELECT COUNT(*) FROM scoring_jobs").fetchone()[0] == 400
+    assert queue_db.execute(
+        "SELECT COUNT(DISTINCT session_id || ':' || content_revision) FROM scoring_jobs"
+    ).fetchone()[0] == 400
+
+
+def test_400_revision_backlog_drains_oldest_first(queue_db):
+    session_ids = _seed(queue_db, 400)
+    assert queue.enqueue_session_ids(queue_db, session_ids, now=BASE) == 400
+
+    drained: list[str] = []
+    for _ in range(400):
+        job = queue.claim_next_job(queue_db, owner="worker", now=BASE)
+        assert job is not None
+        drained.append(job["session_id"])
+        assert queue.complete_job(queue_db, job["job_id"], "worker", now=BASE)
+
+    assert drained == session_ids
+    assert queue.claim_next_job(queue_db, owner="worker", now=BASE) is None
+    assert queue.queue_status(
+        queue_db, backend="codex", enabled=True, now=BASE
+    )["counts"] == {
+        "pending": 0,
+        "running": 0,
+        "retry_wait": 0,
+        "succeeded": 400,
+        "failed": 0,
+    }
+
+
+def test_high_priority_failure_waits_while_old_healthy_job_progresses(queue_db):
+    ids = _seed(queue_db, 3)
+    queue.enqueue_session_ids(queue_db, ids, now=BASE)
+    queue_db.execute(
+        "UPDATE scoring_jobs SET priority = 100 WHERE session_id = ?", (ids[-1],)
+    )
+    queue_db.commit()
+
+    failing = queue.claim_next_job(queue_db, owner="worker", now=BASE)
+    assert failing["session_id"] == ids[-1]
+    assert queue.retry_job_failure(
+        queue_db, failing["job_id"], "worker", "score_failed", now=BASE
+    ) == "retry_wait"
+
+    healthy = queue.claim_next_job(queue_db, owner="worker", now=BASE)
+    assert healthy["session_id"] == ids[0]
+
+
+def test_claim_is_atomic_across_connections(queue_db):
+    ids = _seed(queue_db, 1)
+    queue.enqueue_session_ids(queue_db, ids, now=BASE)
+    barrier = threading.Barrier(2)
+    claimed: list[str | None] = []
+
+    def worker(owner: str) -> None:
+        conn = index.open_index()
+        try:
+            barrier.wait(timeout=5)
+            job = queue.claim_next_job(conn, owner=owner, now=BASE)
+            claimed.append(job["job_id"] if job else None)
+        finally:
+            conn.close()
+
+    threads = [threading.Thread(target=worker, args=(f"worker-{i}",)) for i in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=10)
+
+    assert len(claimed) == 2
+    assert sum(value is not None for value in claimed) == 1
+
+
+def test_expired_lease_is_recovered_after_restart(queue_db):
+    ids = _seed(queue_db, 1)
+    queue.enqueue_session_ids(queue_db, ids, now=BASE)
+    first = queue.claim_next_job(
+        queue_db, owner="old-process", now=BASE, lease_seconds=60
+    )
+    assert first is not None
+
+    assert queue.claim_next_job(
+        queue_db, owner="new-process", now=BASE + timedelta(seconds=59)
+    ) is None
+    recovered = queue.claim_next_job(
+        queue_db, owner="new-process", now=BASE + timedelta(seconds=61)
+    )
+    assert recovered["job_id"] == first["job_id"]
+    assert recovered["lease_owner"] == "new-process"
+
+
+def test_explicit_score_reconciles_orphan_running_revision(queue_db):
+    ids = _seed(queue_db, 1)
+    queue.enqueue_session_ids(queue_db, ids, now=BASE)
+    job = queue.claim_next_job(queue_db, owner="crashed-worker", now=BASE)
+
+    assert queue.complete_revision_jobs(
+        queue_db,
+        ids[0],
+        job["content_revision"],
+        now=BASE + timedelta(seconds=1),
+    ) == 1
+    stored = queue.get_job(queue_db, job["job_id"])
+    assert stored["state"] == "succeeded"
+    assert stored["lease_owner"] is None
+    assert stored["lease_expires_at"] is None
+    assert stored["last_error_code"] is None
+
+
+def test_bounded_retry_backoff_quarantines_fourth_failure(queue_db):
+    ids = _seed(queue_db, 1)
+    queue.enqueue_session_ids(queue_db, ids, now=BASE)
+    clock = BASE
+    expected_delays = [300, 1800, 21600]
+    for attempt, delay in enumerate(expected_delays, start=1):
+        job = queue.claim_next_job(queue_db, owner="worker", now=clock)
+        assert job is not None
+        assert queue.retry_job_failure(
+            queue_db, job["job_id"], "worker", "score_timeout", now=clock
+        ) == "retry_wait"
+        stored = queue.get_job(queue_db, job["job_id"])
+        assert stored["attempt_count"] == attempt
+        clock += timedelta(seconds=delay)
+
+    job = queue.claim_next_job(queue_db, owner="worker", now=clock)
+    assert queue.retry_job_failure(
+        queue_db, job["job_id"], "worker", "score_timeout", now=clock
+    ) == "failed"
+    assert queue.get_job(queue_db, job["job_id"])["next_attempt_at"] is None
+
+
+def test_backend_cooldown_recovers_without_process_restart(queue_db):
+    retry_at = queue.record_backend_cooldown(
+        queue_db, "codex", "backend_rate_limited", now=BASE
+    )
+    assert retry_at == (BASE + timedelta(minutes=5)).isoformat()
+    assert queue.backend_blocker(
+        queue_db, "codex", now=BASE + timedelta(minutes=4)
+    )["state"] == "cooldown"
+    assert queue.backend_blocker(
+        queue_db, "codex", now=BASE + timedelta(minutes=5)
+    ) is None
+    assert queue.get_backend_state(queue_db, "codex")["state"] == "ready"
+
+
+def test_revision_change_cancels_old_job_and_enqueues_exactly_one_new_job(queue_db):
+    ids = _seed(queue_db, 1)
+    queue.enqueue_session_ids(queue_db, ids, now=BASE)
+    old = queue_db.execute("SELECT * FROM scoring_jobs").fetchone()
+    queue_db.execute(
+        "UPDATE sessions SET content_revision = 'new-revision', "
+        "ai_quality_score = NULL, ai_failure_value_score = NULL WHERE session_id = ?",
+        (ids[0],),
+    )
+    queue_db.commit()
+
+    assert queue.enqueue_session_ids(queue_db, ids, now=BASE) == 1
+    assert queue.enqueue_session_ids(queue_db, ids, now=BASE) == 0
+    rows = queue_db.execute(
+        "SELECT content_revision, state FROM scoring_jobs ORDER BY created_at, job_id"
+    ).fetchall()
+    assert len(rows) == 2
+    assert {tuple(row) for row in rows} == {
+        (old["content_revision"], "cancelled"),
+        ("new-revision", "pending"),
+    }
+    assert index.update_session(
+        queue_db,
+        ids[0],
+        ai_quality_score=5,
+        expected_content_revision=old["content_revision"],
+    ) is False
+
+
+def test_raw_backend_error_never_enters_queue_or_status(queue_db):
+    ids = _seed(queue_db, 1)
+    queue.enqueue_session_ids(queue_db, ids, now=BASE)
+    job = queue.claim_next_job(queue_db, owner="worker", now=BASE)
+    secret = "PRIVATE_TRANSCRIPT_VALUE_123"
+    category, code = queue.classify_scoring_error(
+        RuntimeError(f"judge exploded while reading {secret}")
+    )
+    assert (category, code) == ("job", "score_failed")
+    queue.retry_job_failure(
+        queue_db, job["job_id"], "worker", code, now=BASE
+    )
+
+    stored_text = " ".join(
+        str(value)
+        for row in queue_db.execute("SELECT * FROM scoring_jobs").fetchall()
+        for value in row
+        if value is not None
+    )
+    status_text = str(
+        queue.queue_status(queue_db, backend="codex", enabled=True, now=BASE)
+    )
+    assert secret not in stored_text
+    assert secret not in status_text
+    assert ids[0] not in status_text
+
+
+def test_retry_failed_only_resets_current_revisions(queue_db):
+    ids = _seed(queue_db, 2)
+    queue.enqueue_session_ids(queue_db, ids, now=BASE)
+    queue_db.execute(
+        "UPDATE scoring_jobs SET state = 'failed', attempt_count = 4, "
+        "last_error_code = 'score_failed'"
+    )
+    queue_db.execute(
+        "UPDATE sessions SET content_revision = 'changed' WHERE session_id = ?",
+        (ids[1],),
+    )
+    queue_db.commit()
+
+    assert queue.retry_failed_jobs(queue_db, now=BASE) == 1
+    states = {
+        row["session_id"]: row["state"]
+        for row in queue_db.execute("SELECT session_id, state FROM scoring_jobs")
+    }
+    assert states == {ids[0]: "pending", ids[1]: "failed"}
+
+
+@pytest.mark.parametrize("state", ["pending", "running", "retry_wait", "failed"])
+def test_retired_checkpoint_job_is_hidden_unretryable_and_cancelled(queue_db, state):
+    ids = _seed(queue_db, 1)
+    queue.enqueue_session_ids(queue_db, ids, now=BASE)
+    queue_db.execute(
+        "UPDATE scoring_jobs SET state = ?, lease_owner = ?, lease_expires_at = ?, "
+        "next_attempt_at = ?, last_error_code = ? WHERE session_id = ?",
+        (
+            state,
+            "old-worker" if state == "running" else None,
+            (BASE + timedelta(minutes=10)).isoformat() if state == "running" else None,
+            (BASE + timedelta(minutes=5)).isoformat() if state == "retry_wait" else None,
+            "score_failed" if state == "failed" else None,
+            ids[0],
+        ),
+    )
+    queue_db.execute(
+        "UPDATE sessions SET checkpoint_active = 0 WHERE session_id = ?",
+        (ids[0],),
+    )
+    queue_db.commit()
+
+    status = queue.queue_status(queue_db, backend="codex", enabled=True, now=BASE)
+    assert status["counts"] == {
+        "pending": 0,
+        "running": 0,
+        "retry_wait": 0,
+        "succeeded": 0,
+        "failed": 0,
+    }
+    assert status["current"] is None
+    assert status["next_retry_at"] is None
+    assert queue.retry_failed_jobs(queue_db, now=BASE) == 0
+    assert queue.claim_next_job(queue_db, owner="new-worker", now=BASE) is None
+
+    stored = queue_db.execute(
+        "SELECT state, last_error_code, lease_owner, lease_expires_at, "
+        "next_attempt_at FROM scoring_jobs WHERE session_id = ?",
+        (ids[0],),
+    ).fetchone()
+    assert tuple(stored) == ("cancelled", "ineligible", None, None, None)


### PR DESCRIPTION
## Summary

- add a revision-keyed durable scoring queue with atomic leases, oldest-first fairness, bounded retry/backoff, backend cooldown, and restart recovery
- serialize daemon, HTTP, CLI, rescore, and Share scoring through one cross-process egress lock and persist results with a content-revision CAS
- recheck pause, source scope, excluded projects, hold state, and revision before every locator/final-judge AI call; bound a complete score to eight minutes
- expose aggregate, content-free scoring status and pause/resume/retry controls in Inbox and Settings
- cover the reported 400-session path with an exact four-by-100 bulk-review regression test

Together with #200's network-filesystem guard/recovery diagnostics and the earlier bulk review fix, this closes the client-side failure modes reported in #197.

## Verification

- scoring queue/engine/cross-process lock: 93 passed in an independent run
- daemon/API/queue/lock/migrations: 301 passed
- scoring suite: 270 passed
- CLI/share: 219 passed
- index: 115 passed
- recovery/migrations: 83 passed, 1 skipped
- frontend: 161 tests passed; lint and production build passed
- independent final review: no blockers

The local full-suite collector found 4,072 tests. Three unrelated trace-note files could not collect in this Windows environment because an installed `tests` package shadows the repository namespace; one existing Windows-only chmod assertion reports 0666 instead of 0600. The affected code paths are covered by the explicit suites above and will run again in clean CI.

Fixes #197