### PR TITLE
Match redaction targets adjacent to CJK text

### DIFF
--- a/clawjournal/redaction/anonymizer.py
+++ b/clawjournal/redaction/anonymizer.py
@@ -64,7 +64,13 @@ def anonymize_text(text: str, username: str) -> str:
     # Final pass: replace bare username in remaining contexts (ls output, prose, etc.)
     # Only if username is >= 4 chars to avoid false positives
     if len(username) >= 4:
-        text = re.sub(rf"\b{escaped}\b", _USERNAME_PLACEHOLDER, text)
+        # ASCII-only boundaries: `\b` treats CJK as word characters, so a
+        # username adjacent to CJK prose would never match.
+        text = re.sub(
+            rf"(?<![A-Za-z0-9_]){escaped}(?![A-Za-z0-9_])",
+            _USERNAME_PLACEHOLDER,
+            text,
+        )
 
     return text
 

--- a/clawjournal/redaction/secrets.py
+++ b/clawjournal/redaction/secrets.py
@@ -636,7 +636,13 @@ def redact_custom_strings(text: str, strings: list[str]) -> tuple[str, int]:
         if not target or len(target) < 3:
             continue
         escaped = re.escape(target)
-        pattern = rf"\b{escaped}\b" if len(target) >= 4 else escaped
+        # ASCII-only boundaries: `\b` treats CJK as word characters, so a
+        # target adjacent to CJK text (e.g. `用myuser这`) would never match.
+        pattern = (
+            rf"(?<![A-Za-z0-9_]){escaped}(?![A-Za-z0-9_])"
+            if len(target) >= 4
+            else escaped
+        )
         text, replacements = re.subn(pattern, "[REDACTED_CUSTOM]", text)
         count += replacements
 
@@ -802,10 +808,15 @@ def _apply_redaction_set(text: str, secret_map: dict[str, str]) -> tuple[str, in
     # Sort by length descending so longer matches replace first
     for secret in sorted(secret_map, key=len, reverse=True):
         replacement = secret_map[secret]
-        # Short alphanumeric strings need word boundaries to avoid matching
+        # Short alphanumeric strings need boundaries to avoid matching
         # inside unrelated words (e.g. custom redact_strings like "Kai").
+        # ASCII-only lookarounds rather than `\b`, which treats CJK
+        # neighbours as word characters and silently skips the match.
         if len(secret) < 20 and secret.isalnum():
-            pattern = re.compile(rf"\b{re.escape(secret)}\b", re.IGNORECASE)
+            pattern = re.compile(
+                rf"(?<![A-Za-z0-9_]){re.escape(secret)}(?![A-Za-z0-9_])",
+                re.IGNORECASE,
+            )
             text, n = pattern.subn(replacement, text)
             count += n
         elif secret in text:

--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -2507,9 +2507,14 @@ def _compile_blocked_domain_pattern(domain: str) -> re.Pattern[str] | None:
         suffix = normalized[2:].strip(".")
         if not suffix:
             return None
-        pattern = rf"\b(?:[a-z0-9-]+\.)+{re.escape(suffix)}\b"
+        # ASCII-only boundaries: `\b` treats CJK neighbours as word
+        # characters, silently skipping domains embedded in CJK prose.
+        pattern = (
+            rf"(?<![A-Za-z0-9_])(?:[a-z0-9-]+\.)+"
+            rf"{re.escape(suffix)}(?![A-Za-z0-9_])"
+        )
     else:
-        pattern = rf"\b{re.escape(normalized)}\b"
+        pattern = rf"(?<![A-Za-z0-9_]){re.escape(normalized)}(?![A-Za-z0-9_])"
     return re.compile(pattern, re.IGNORECASE)
 
 

--- a/tests/redaction/test_anonymizer.py
+++ b/tests/redaction/test_anonymizer.py
@@ -108,6 +108,12 @@ class TestAnonymizeText:
         assert "alice" not in result
         assert _USERNAME_PLACEHOLDER in result
 
+    def test_bare_username_adjacent_cjk_replaced(self):
+        # `\b` never fires between CJK and ASCII word chars (#195)
+        result = anonymize_text("请把alice的文件发我", "alice")
+        assert "alice" not in result
+        assert _USERNAME_PLACEHOLDER in result
+
     def test_short_username_not_replaced_bare(self):
         # Usernames < 4 chars should NOT be replaced as bare words
         result = anonymize_text(

--- a/tests/redaction/test_secrets.py
+++ b/tests/redaction/test_secrets.py
@@ -7,6 +7,7 @@ from clawjournal.redaction.secrets import (
     REDACTED,
     SECRET_PLACEHOLDER,
     SECRET_PATTERNS,
+    _apply_redaction_set,
     _check_user_allowlist,
     _has_mixed_char_types,
     _shannon_entropy,
@@ -361,6 +362,41 @@ class TestRedactCustomStrings:
         result, count = redact_custom_strings("fooabc bar abc", ["abc"])
         # With no word boundary for 3-char, should match in "fooabc" as escaped substring
         assert count >= 1
+
+    def test_cjk_adjacent_target_redacted(self):
+        # `\b` never fires between CJK and ASCII word chars (#195)
+        result, count = redact_custom_strings("只用myuser这个目录", ["myuser"])
+        assert result == "只用[REDACTED_CUSTOM]这个目录"
+        assert count == 1
+
+    def test_cjk_after_path_target_redacted(self):
+        result, count = redact_custom_strings("帮我看看/data/myuser里面", ["myuser"])
+        assert result == "帮我看看/data/[REDACTED_CUSTOM]里面"
+        assert count == 1
+
+    def test_ascii_embedded_target_still_untouched(self):
+        result, count = redact_custom_strings(
+            "run mymyuser and myuser2024 now", ["myuser"]
+        )
+        assert result == "run mymyuser and myuser2024 now"
+        assert count == 0
+
+
+# --- _apply_redaction_set ---
+
+
+class TestApplyRedactionSetBoundaries:
+    def test_cjk_adjacent_short_secret_replaced(self):
+        # Short alnum secrets go through the boundary-matched branch; `\b`
+        # would skip them next to CJK text (#195)
+        text, count = _apply_redaction_set("在tok3nvalue后面", {"tok3nvalue": "[X]"})
+        assert text == "在[X]后面"
+        assert count == 1
+
+    def test_ascii_embedded_short_secret_still_untouched(self):
+        text, count = _apply_redaction_set("xtok3nvaluey", {"tok3nvalue": "[X]"})
+        assert text == "xtok3nvaluey"
+        assert count == 0
 
 
 # --- redact_session ---

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -10,6 +10,7 @@ from clawjournal.session_titles import resolve_session_title
 from clawjournal.workbench.index import (
     LogicalProjectionError,
     RevisionConflictError,
+    _compile_blocked_domain_pattern,
     _migrate_bundles_to_shares,
     add_policy,
     backfill_session_keys,
@@ -2398,3 +2399,21 @@ class TestMigration:
         assert conn.execute("PRAGMA user_version").fetchone()[0] == 1
 
         conn.close()
+
+
+# --- _compile_blocked_domain_pattern ---
+
+
+class TestBlockedDomainPatternBoundaries:
+    def test_wildcard_matches_adjacent_cjk(self):
+        # `\b` never fires between CJK and ASCII word chars (#195)
+        pattern = _compile_blocked_domain_pattern("*.internal")
+        assert pattern.search("访问api.internal的接口")
+
+    def test_exact_matches_adjacent_cjk(self):
+        pattern = _compile_blocked_domain_pattern("api.internal")
+        assert pattern.search("在api.internal上部署")
+
+    def test_ascii_embedded_domain_still_untouched(self):
+        pattern = _compile_blocked_domain_pattern("api.internal")
+        assert not pattern.search("xapi.internally")


### PR DESCRIPTION
## Summary

`\b` treats CJK characters as word characters, so configured redaction targets sitting next to Chinese/Japanese/Korean text were silently left in place while the UI reported success — and the affected fields (`display_title`, `messages`) are in `EXPORT_FIELDS`, so unredacted text could reach share bundles.

Replaces `\b` with ASCII-only lookarounds `(?<![A-Za-z0-9_])` / `(?![A-Za-z0-9_])` in all four affected engines:

- `redaction/secrets.py` — `redact_custom_strings()` (`--redact`)
- `redaction/secrets.py` — `_apply_redaction_set()` short-secret boundary branch (same bug class, found while fixing)
- `redaction/anonymizer.py` — bare-username pass (`--redact-usernames`)
- `workbench/index.py` — `_compile_blocked_domain_pattern()` (blocked domains)

ASCII-embedded occurrences (`myuser2024`, `mymyuser`) remain untouched, preserving existing behaviour for ASCII neighbours.

## Tests

8 new regression tests across `tests/redaction/test_secrets.py`, `tests/redaction/test_anonymizer.py`, `tests/workbench/test_index.py`. Local run: 282 passed; the single failure (`TestCostAccounting::test_upsert_derives_local_agent_session_key_from_wrapper`) is a pre-existing Windows MAX_PATH environment issue, verified to fail identically on unmodified main.

Fixes #195

🤖 Generated with [Claude Code](https://claude.com/claude-code)