### PR TITLE
Index real sessions opened with a bare slash command

### DIFF
--- a/clawjournal/workbench/index.py
+++ b/clawjournal/workbench/index.py
@@ -3570,8 +3570,15 @@ def upsert_sessions(
         files = badges["files_touched"]
         commands = badges["commands_run"]
 
-        # Skip sessions that are just slash commands (not real traces)
-        if display_title.startswith("/") and " " not in display_title.strip():
+        # Skip sessions that are just slash commands (not real traces).
+        # The title is derived from the *first* user message, so gate on
+        # message count too: a long session opened with a bare `/model`
+        # is still a real trace (#196).
+        if (
+            display_title.startswith("/")
+            and " " not in display_title.strip()
+            and len(session.get("messages", [])) <= 2
+        ):
             continue
 
         # A fork rollout replays its parent's opening message, so its derived

--- a/tests/workbench/test_index.py
+++ b/tests/workbench/test_index.py
@@ -137,6 +137,25 @@ class TestUpsertSessions:
         new_count = upsert_sessions(index_conn, sessions)
         assert new_count == 2
 
+    def test_bare_slash_command_only_session_skipped(self, index_conn):
+        # A session that is just `/model` (no real work) stays out of the index
+        new_count = upsert_sessions(index_conn, [_make_session(content="/model")])
+        assert new_count == 0
+
+    def test_bare_slash_command_opening_real_session_indexed(self, index_conn):
+        # A real trace whose *first* message is a bare slash command must not
+        # be dropped (#196)
+        session = _make_session(content="/model")
+        session["messages"].extend(
+            [
+                {"role": "user", "content": "Now fix the login bug", "tool_uses": []},
+                {"role": "assistant", "content": "Done.", "tool_uses": []},
+            ]
+        )
+        new_count = upsert_sessions(index_conn, [session])
+        assert new_count == 1
+        assert get_session_detail(index_conn, "sess-1") is not None
+
     @pytest.mark.parametrize(
         "session_id",
         ("claude-science:org-1:frame-1", "../outside-the-blob-directory"),


### PR DESCRIPTION
## Summary

`display_title` derives from the first user message, so a long trace whose opening message was a bare slash command (e.g. `/model`) was silently dropped by the slash-command filter in `upsert_sessions` — the reporter lost 60- and 441-message traces with no warning.

The skip is now gated on message count as well: command-only sessions (≤ 2 messages) are still filtered out, anything longer is indexed.

## Tests

2 new tests in `tests/workbench/test_index.py`: a command-only session stays out of the index; a real trace opened with `/model` is indexed. The existing `/clear` filtered-checkpoint test (2-message helper sessions) still passes unchanged.

Fixes #196

🤖 Generated with [Claude Code](https://claude.com/claude-code)