### PR TITLE
Preselect only approved traces in the share queue

### DIFF
--- a/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
+++ b/clawjournal/web/frontend/src/views/Share/QueueStep.tsx
@@ -306,7 +306,12 @@ export function QueueStep(p: QueueStepProps) {
                   </>)}
                   {s.review_status && s.review_status !== 'approved' && (<>
                     <span style={{ opacity: 0.5 }}>&middot;</span>
-                    <span style={{ color: colors.gray400, fontStyle: 'italic' }}>{s.review_status}</span>
+                    <span
+                      style={{ color: colors.yellow700, fontStyle: 'italic' }}
+                      title="This trace has not been approved in review, so it is not preselected. Selecting it here includes it after you redact and review it."
+                    >
+                      not approved ({s.review_status})
+                    </span>
                   </>)}
                 </div>
               </div>

--- a/clawjournal/web/frontend/src/views/Share/helpers.test.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.test.ts
@@ -73,6 +73,36 @@ describe('Share queue selection encoding', () => {
     expect(queueFromSelectionParams(stats, new URLSearchParams())).toEqual(expected);
   });
 
+  it('preselects only approved traces from the widened pool', () => {
+    const sessions = [
+      readySession('s1'),
+      { ...readySession('s2'), review_status: 'new' },
+      readySession('s3'),
+      { ...readySession('s4'), review_status: 'shortlisted' },
+    ];
+    const stats: ShareReadyStats = { ...readyStats(0), count: sessions.length, sessions };
+
+    expect(queueFromStats(stats)).toEqual(['s1', 's3']);
+    expect(queueFromSelectionParams(stats, new URLSearchParams())).toEqual(['s1', 's3']);
+    // Unapproved traces stay individually selectable from the picker.
+    expect(expandLogicalQueueSelection(stats, ['s2'])).toEqual(['s2']);
+  });
+
+  it('does not let a recommendation preselect an unapproved trace', () => {
+    const sessions = [
+      { ...readySession('s1'), review_status: 'new' },
+      readySession('s2'),
+    ];
+    const stats: ShareReadyStats = {
+      ...readyStats(0),
+      count: sessions.length,
+      recommended_session_ids: ['s1'],
+      sessions,
+    };
+
+    expect(queueFromStats(stats)).toEqual(['s2']);
+  });
+
   it('keeps default and exclusion URLs compact while preserving explicit empty and ordered subsets', () => {
     const stats = readyStats();
     const defaults = queueFromStats(stats);
@@ -187,6 +217,17 @@ describe('logical conversation queue projection', () => {
     expect(queueFromStats(stats)).not.toContain('conversation-1');
     expect(queueFromStats(stats)).not.toContain('conversation-1_seg-0001');
     expect(queueFromStats(stats)).toContain('fits-after-group');
+  });
+
+  it('does not preselect a checkpoint family with an unapproved member', () => {
+    const sessions = [
+      checkpoint('conversation-1', 0),
+      { ...checkpoint('conversation-1_seg-0001', 1), review_status: 'new' },
+      readySession('standalone'),
+    ];
+    const stats: ShareReadyStats = { ...readyStats(0), count: sessions.length, sessions };
+
+    expect(queueFromStats(stats)).toEqual(['standalone']);
   });
 
   it('rejects conflicting logical revisions before packaging', () => {

--- a/clawjournal/web/frontend/src/views/Share/helpers.ts
+++ b/clawjournal/web/frontend/src/views/Share/helpers.ts
@@ -297,6 +297,14 @@ export function collectExpectedLogicalRevisions(
   return expected;
 }
 
+// The widened share-ready pool (`include_unapproved=1`) deliberately contains
+// review_status new/shortlisted traces so the picker can offer them for
+// explicit selection — but only user-approved traces may be *preselected* as
+// "will be shared" (issue #201). Fail closed on a missing status.
+function groupApproved(group: LogicalReadySessionGroup): boolean {
+  return group.members.every((session) => session.review_status === 'approved');
+}
+
 export function queueFromStats(stats: ShareReadyStats): string[] {
   const groups = groupReadySessions(stats.sessions);
   const groupById = new Map<string, LogicalReadySessionGroup>();
@@ -317,7 +325,7 @@ export function queueFromStats(stats: ShareReadyStats): string[] {
   // logical conversation at the physical-checkpoint cap.
   const selected: string[] = [];
   orderedGroups.forEach((group) => {
-    if (group.logical_incomplete) return;
+    if (group.logical_incomplete || !groupApproved(group)) return;
     const checkpointIds = group.members.map((session) => session.session_id);
     if (selected.length + checkpointIds.length <= MAX_SHARE_QUEUE_SIZE) {
       selected.push(...checkpointIds);

--- a/clawjournal/web/frontend/src/views/Share/index.test.tsx
+++ b/clawjournal/web/frontend/src/views/Share/index.test.tsx
@@ -109,6 +109,43 @@ describe('Share selection defaults', () => {
     });
   });
 
+  it('preselects only approved traces and counts them, keeping unapproved ones pickable', async () => {
+    // Regression test for issue #201: the widened pool returns unapproved
+    // (new/shortlisted) traces for the picker, but they must not appear as
+    // "will be shared" nor inflate the selection counter.
+    mockInitialLoad({
+      ...readyStats(0),
+      count: 4,
+      total_approved: 2,
+      recommended_session_ids: [],
+      sessions: [
+        readySession('s1'),
+        { ...readySession('s2'), review_status: 'new' },
+        readySession('s3'),
+        { ...readySession('s4'), review_status: 'shortlisted' },
+      ],
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/share']}>
+        <ToastProvider><Share /></ToastProvider>
+      </MemoryRouter>,
+    );
+
+    expect(await screen.findByText('2 traces selected')).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { name: 'Include trace: Trace s1' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Include trace: Trace s3' })).toBeChecked();
+    const unapproved = screen.getByRole('checkbox', { name: 'Include trace: Trace s2' });
+    expect(unapproved).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { name: 'Include trace: Trace s4' })).not.toBeChecked();
+    expect(screen.getByText('not approved (new)')).toBeInTheDocument();
+    expect(screen.getByText('not approved (shortlisted)')).toBeInTheDocument();
+
+    // Explicitly opting an unapproved trace in still works from the picker.
+    fireEvent.click(unapproved);
+    expect(await screen.findByText('3 traces selected')).toBeInTheDocument();
+  });
+
   it('shows one conversation while selecting and redacting every eligible checkpoint', async () => {
     const root: ReadySession = {
       ...readySession('long-trace'),


### PR DESCRIPTION
## Summary

The Share view loads the widened share-ready pool (`include_unapproved=1`) so the picker can offer never-shared traces for explicit selection — but `queueFromStats` preselected **every** eligible group into the default "will be shared" queue (regression from #116's default-select-all). With 2 approved + 2 unapproved sessions, all 4 appeared queued and every queue-derived counter showed 4.

Now only groups whose members are all `review_status = 'approved'` are preselected (fails closed on a missing status; a checkpoint family with one unapproved member stays out of the default queue). Unapproved traces remain individually selectable from the picker, labeled **not approved (\<status\>)** in yellow with an explanatory tooltip.

Deliberately no backend change: the widened pool is what lets the share workflow offer unapproved traces for explicit review, and export remains protected by the existing hold-state and secret-scan gates.

## Judgment calls

- The issue's "Session section counter" was read as the Share queue selection counters (now show the approved count). The Inbox header counters are explicitly labeled full-corpus counts and were left unchanged — flag if the reporter meant those.
- Deep-linked explicit `ids=` selections containing unapproved sessions are still honored as the user's explicit choice; only the default selection changed.

## Tests

4 new tests (3 in `helpers.test.ts`, 1 integration test in `index.test.tsx` reproducing the exact 2+2 scenario). Frontend: 170/170 passed, eslint clean. Backend `tests/workbench/`: 831 passed, 1 skipped, 1 pre-existing Windows-only file-mode failure.

Fixes #201

🤖 Generated with [Claude Code](https://claude.com/claude-code)