### PR TITLE
Fix flaky ownership-certification test race

### DIFF
--- a/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
+++ b/clawjournal/web/frontend/src/components/AutoUploadControls.test.tsx
@@ -363,7 +363,7 @@ describe('AutoUploadPanel authorization', () => {
     const checkboxes = screen.getAllByRole('checkbox');
     expect(checkboxes).toHaveLength(1);
     expect(screen.getByRole('button', { name: 'Enable automatic upload' })).toBeDisabled();
-    fireEvent.click(screen.getByLabelText('Certify bundle ownership'));
+    fireEvent.click(await screen.findByLabelText('Certify bundle ownership'));
     fireEvent.click(screen.getByRole('button', { name: 'Enable automatic upload' }));
 
     await waitFor(() => expect(enableSpy).toHaveBeenCalledTimes(2));
@@ -430,7 +430,7 @@ describe('AutoUploadPanel authorization', () => {
     await openPanelDetails();
     fireEvent.click(await screen.findByRole('button', { name: 'Review scope and terms' }));
     await screen.findByRole('heading', { name: 'Enable automatic uploads?' });
-    fireEvent.click(screen.getByLabelText('Certify bundle ownership'));
+    fireEvent.click(await screen.findByLabelText('Certify bundle ownership'));
     fireEvent.click(screen.getByRole('button', { name: 'Enable automatic upload' }));
 
     expect(screen.getByText(
@@ -492,7 +492,7 @@ describe('AutoUploadPanel authorization', () => {
     fireEvent.click(await screen.findByRole('button', { name: 'Review scope and terms' }));
     await screen.findByRole('heading', { name: 'Enable automatic uploads?' });
 
-    fireEvent.click(screen.getByLabelText('Certify bundle ownership'));
+    fireEvent.click(await screen.findByLabelText('Certify bundle ownership'));
     fireEvent.click(screen.getByRole('button', { name: 'Enable automatic upload' }));
 
     expect(await screen.findByText(/single-use email verification/i)).toBeInTheDocument();


### PR DESCRIPTION
## Summary

The `Tests` run on main failed at `332dd2b` (smoke job): `AutoUploadControls.test.tsx:495` clicked **Certify bundle ownership** with a synchronous `getByLabelText` right after awaiting the dialog heading — but the heading renders while the authorization challenge is still loading, so on a slow runner the checkbox isn't there yet. Two of the three call sites had this race (the third already sat behind challenge-content assertions); all three now use `await screen.findByLabelText(...)`.

Pre-existing flake from the streamlined enrollment tests (#144); the docs-only #209 merge just happened to be the push that hit it.

## Tests

Full frontend suite after `npm ci`: 21 files, 170/170 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)